### PR TITLE
Add support for Joker on WSL

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,16 @@
                     "type": "string",
                     "default": ".",
                     "description": "The root directory of your Clojure project, relative to the Workspace root"
+                },
+                "calva.jokerPath": {
+                    "type": "string",
+                    "default": "joker",
+                    "description": "Sets the path in which the Joker executable can be found"
+                },
+                "calva.useJokerOnWSL": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies if Joker will run through WSL"
                 }
             }
         },

--- a/src/main/calva/repl/middleware/lint.js
+++ b/src/main/calva/repl/middleware/lint.js
@@ -1,5 +1,6 @@
 import vscode from 'vscode';
 import { spawn } from 'child_process';
+import path from 'path';
 import * as state from '../../state';
 import * as util from '../../utilities';
 
@@ -36,12 +37,16 @@ function markMessage(msg) {
     }
 }
 
+function buildJokerPath(jokerPath, join) {
+    return jokerPath === "joker" ? "joker" : join(jokerPath, "joker");
+}
+
 function jokerChildProcess(fileName) {
     let { jokerPath, useJokerOnWSL } = state.config();
     if (useJokerOnWSL) {
-        return spawn("wsl", [jokerPath, "--lint", `\$(wslpath '${fileName}')`]);
+        return spawn("wsl", [buildJokerPath(jokerPath, path.posix.join), "--lint", `\$(wslpath '${fileName}')`]);
     }
-    return spawn(jokerPath, ["--lint", fileName]);
+    return spawn(buildJokerPath(jokerPath, path.join), ["--lint", fileName]);
 }
 
 function lintDocument(document = {}) {

--- a/src/main/calva/state.js
+++ b/src/main/calva/state.js
@@ -45,7 +45,9 @@ function config() {
         autoConnect: configOptions.get("autoConnect"),
         autoAdjustIndent: configOptions.get("autoAdjustIndent"),
         connectREPLCommand: configOptions.get("connectREPLCommand"),
-        projectRootDirectory: configOptions.get("projectRootDirectory").replace(/^\/|\/$/g, "")
+        projectRootDirectory: configOptions.get("projectRootDirectory").replace(/^\/|\/$/g, ""),
+        jokerPath: configOptions.get("jokerPath"),
+        useJokerOnWSL: configOptions.get("useJokerOnWSL")
     };
 }
 


### PR DESCRIPTION
Hi, thanks for making this extension!

Currently I'm working with Visual Studio Code using the Windows Subsystem for Linux (WSL) for the integrated terminal while having the editor installed on Windows.

Since I installed Joker on the WSL (Ubuntu 16.04), Visual Studio Code wasn't able to find the executable of the linter through its path.

To fix this, I decided to add two new configuration options:
```json
"calva.jokerPath": {
    "type": "string",
    "default": "joker",
    "description": "Sets the path in which the Joker executable can be found"
},
"calva.useJokerOnWSL": {
    "type": "boolean",
    "default": false,
    "description": "Specifies if Joker will run through WSL"
}
```

I decided to add the `jokerPath` option in case the Joker executable is installed somewhere not included in the path environment variable.

If there is something else I must add to accept this change, please tell me.