### PR TITLE
feature: command to evaluate the current forms parent

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,8 +152,8 @@
                 "category": "Calva"
             },
             {
-                "command": "calva.evaluateSelectionParent",
-                "title": "Evaluate the parent form of the current cursor position",
+                "command": "calva.evaluateCurrentTopLevelForm",
+                "title": "Evaluate the current top level form at selection or cursor",
                 "category": "Calva"
             },
             {
@@ -246,6 +246,10 @@
             {
                 "command": "calva.evaluateSelection",
                 "key": "ctrl+alt+v e"
+            },
+            {
+                "command": "calva.evaluateCurrentTopLevelForm",
+                "key": "ctrl+alt+v shift+e"
             },
             {
                 "command": "calva.evaluateSelectionPrettyPrint",

--- a/package.json
+++ b/package.json
@@ -152,6 +152,11 @@
                 "category": "Calva"
             },
             {
+                "command": "calva.evaluateSelectionParent",
+                "title": "Evaluate the parent form of the current cursor position",
+                "category": "Calva"
+            },
+            {
                 "command": "calva.evaluateSelectionPrettyPrint",
                 "title": "Evaluate selection or current form, and pretty print",
                 "category": "Calva"

--- a/src/main/calva/extension.js
+++ b/src/main/calva/extension.js
@@ -67,7 +67,7 @@ function activate(context) {
     context.subscriptions.push(vscode.commands.registerCommand('calva.selectCurrentForm', select.selectCurrentForm));
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateFile', EvaluateMiddleWare.evaluateFile));
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateSelection', EvaluateMiddleWare.evaluateSelection));
-    context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateSelectionParent', EvaluateMiddleWare.evaluateSelectionParent));
+    context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateCurrentTopLevelForm', EvaluateMiddleWare.evaluateCurrentTopLevelForm));
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateSelectionPrettyPrint', EvaluateMiddleWare.evaluateSelectionPrettyPrint));
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateSelectionReplace', EvaluateMiddleWare.evaluateSelectionReplace));
     context.subscriptions.push(vscode.commands.registerCommand('calva.lintFile', LintMiddleWare.lintDocument));

--- a/src/main/calva/extension.js
+++ b/src/main/calva/extension.js
@@ -67,6 +67,7 @@ function activate(context) {
     context.subscriptions.push(vscode.commands.registerCommand('calva.selectCurrentForm', select.selectCurrentForm));
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateFile', EvaluateMiddleWare.evaluateFile));
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateSelection', EvaluateMiddleWare.evaluateSelection));
+    context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateSelectionParent', EvaluateMiddleWare.evaluateSelectionParent));
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateSelectionPrettyPrint', EvaluateMiddleWare.evaluateSelectionPrettyPrint));
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateSelectionReplace', EvaluateMiddleWare.evaluateSelectionReplace));
     context.subscriptions.push(vscode.commands.registerCommand('calva.lintFile', LintMiddleWare.lintDocument));

--- a/src/main/calva/repl/middleware/evaluate.js
+++ b/src/main/calva/repl/middleware/evaluate.js
@@ -116,7 +116,7 @@ function evaluateSelectionPrettyPrint(document = {}, options = {}) {
     evaluateSelection(document, Object.assign({}, options, { pprint: true }));
 }
 
-function evaluateSelectionParent(document = {}, options = {}) {
+function evaluateCurrentTopLevelForm(document = {}, options = {}) {
     evaluateSelection(document, Object.assign({}, options, { parent: true }));
 }
 
@@ -151,7 +151,7 @@ function evaluateFile(document = {}, callback = () => { }) {
 export default {
     evaluateFile,
     evaluateSelection,
-    evaluateSelectionParent,
+    evaluateCurrentTopLevelForm,
     evaluateSelectionPrettyPrint,
     evaluateSelectionReplace
 };

--- a/src/main/calva/repl/middleware/evaluate.js
+++ b/src/main/calva/repl/middleware/evaluate.js
@@ -46,6 +46,7 @@ function evaluateSelection(document = {}, options = {}) {
         doc = util.getDocument(document),
         pprint = options.pprint || false,
         replace = options.replace || false,
+        parent = options.parent || false,
         session = util.getSession(util.getFileType(doc));
 
     if (current.get('connected')) {
@@ -57,7 +58,7 @@ function evaluateSelection(document = {}, options = {}) {
         annotations.clearEvaluationDecorations(editor);
 
         if (selection.isEmpty) {
-            codeSelection = select.getFormSelection(doc, selection.active);
+            codeSelection = select.getFormSelection(doc, selection.active, parent);
             code = doc.getText(codeSelection);
         } else {
             codeSelection = selection,
@@ -115,6 +116,10 @@ function evaluateSelectionPrettyPrint(document = {}, options = {}) {
     evaluateSelection(document, Object.assign({}, options, { pprint: true }));
 }
 
+function evaluateSelectionParent(document = {}, options = {}) {
+    evaluateSelection(document, Object.assign({}, options, { parent: true }));
+}
+
 function evaluateFile(document = {}, callback = () => { }) {
     let current = state.deref(),
         doc = util.getDocument(document),
@@ -146,6 +151,7 @@ function evaluateFile(document = {}, callback = () => { }) {
 export default {
     evaluateFile,
     evaluateSelection,
+    evaluateSelectionParent,
     evaluateSelectionPrettyPrint,
     evaluateSelectionReplace
 };

--- a/src/main/calva/repl/middleware/select.js
+++ b/src/main/calva/repl/middleware/select.js
@@ -2,11 +2,20 @@ import vscode from 'vscode';
 import * as util from '../../utilities';
 const paredit = require('paredit.js');
 
+function getParentForm(ast, offset) {
+    const previous = paredit.navigator.backwardUpSexp(ast, offset)
+    if (previous === offset) {
+        return paredit.navigator.sexpRange(ast, previous)
+    }
+    return getParentForm(ast, previous)
+}
 
-function getFormSelection(doc, pos) {
+function getFormSelection(doc, pos, parent) {
     let allText = doc.getText(),
         ast = paredit.parse(allText),
-        range = paredit.navigator.sexpRange(ast, doc.offsetAt(pos));
+        idx = doc.offsetAt(pos),
+        range = parent ? getParentForm(ast, idx) : paredit.navigator.sexpRange(ast, idx);
+
     if (range) {
         return new vscode.Range(doc.positionAt(range[0]), doc.positionAt(range[1]));
     } else {

--- a/src/main/calva/repl/middleware/select.js
+++ b/src/main/calva/repl/middleware/select.js
@@ -2,19 +2,11 @@ import vscode from 'vscode';
 import * as util from '../../utilities';
 const paredit = require('paredit.js');
 
-function getParentForm(ast, offset) {
-    const previous = paredit.navigator.backwardUpSexp(ast, offset)
-    if (previous === offset) {
-        return paredit.navigator.sexpRange(ast, previous)
-    }
-    return getParentForm(ast, previous)
-}
-
 function getFormSelection(doc, pos, parent) {
     let allText = doc.getText(),
         ast = paredit.parse(allText),
         idx = doc.offsetAt(pos),
-        range = parent ? getParentForm(ast, idx) : paredit.navigator.sexpRange(ast, idx);
+        range = parent ? paredit.navigator.rangeForDefun(ast, idx) : paredit.navigator.sexpRange(ast, idx);
 
     if (range) {
         return new vscode.Range(doc.positionAt(range[0]), doc.positionAt(range[1]));


### PR DESCRIPTION
Given the code block with cursor at position of `|`

```clojure
(defn x []
  (a (b (+| 1 2))))
```

Calling `calva.evaluateSelection` will give me `=> 3`. This is nice but I often want to be able to evaluate the root form `(defn x)` without having to precisely position my cursor.

This PR adds an additional command `calva.evaluateSelectionParent` which does this.