### PR TITLE
Bug in selectCurrentForm.  Type mismatch in editor.selection assignment.

### DIFF
--- a/calva/repl/middleware/select.ts
+++ b/calva/repl/middleware/select.ts
@@ -33,7 +33,7 @@ function getFormSelection(doc, pos, topLevel) : vscode.Selection {
         ast = paredit.parse(allText),
         idx = doc.offsetAt(pos),
         range = topLevel ? paredit.navigator.rangeForDefun(ast, idx) : paredit.navigator.sexpRange(ast, idx),
-        vsSelection = range? new vscode.Selection(doc.positionAt(range[0]), doc.positionAt(range[1])) : new vscode.Selection(pos, pos);
+        vsSelection = range ? new vscode.Selection(doc.positionAt(range[0]), doc.positionAt(range[1])) : new vscode.Selection(pos, pos);
 
     return vsSelection;
 }

--- a/calva/repl/middleware/select.ts
+++ b/calva/repl/middleware/select.ts
@@ -28,14 +28,14 @@ function adjustRangeIgnoringComment(doc, range) {
 }
 
 
-function getFormSelection(doc, pos, topLevel) : vscode.Range {
+function getFormSelection(doc, pos, topLevel) : vscode.Selection {
     let allText = doc.getText(),
         ast = paredit.parse(allText),
         idx = doc.offsetAt(pos),
         range = topLevel ? paredit.navigator.rangeForDefun(ast, idx) : paredit.navigator.sexpRange(ast, idx),
-        vsRange = range ? new vscode.Range(doc.positionAt(range[0]), doc.positionAt(range[1])) : new vscode.Range(pos, pos);
+        vsSelection = range? new vscode.Selection(doc.positionAt(range[0]), doc.positionAt(range[1])) : new vscode.Selection(pos, pos);
 
-    return vsRange;
+    return vsSelection;
 }
 
 
@@ -47,7 +47,7 @@ function selectCurrentForm(document = {}) {
     if (selection.isEmpty) {
         let codeSelection = getFormSelection(doc, selection.active, false);
         if (codeSelection) {
-            editor.selection = new vscode.Selection(codeSelection.start, codeSelection.end);
+            editor.selection = codeSelection;
         }
     }
 }

--- a/calva/repl/middleware/select.ts
+++ b/calva/repl/middleware/select.ts
@@ -28,7 +28,7 @@ function adjustRangeIgnoringComment(doc, range) {
 }
 
 
-function getFormSelection(doc, pos, topLevel) {
+function getFormSelection(doc, pos, topLevel) : vscode.Range {
     let allText = doc.getText(),
         ast = paredit.parse(allText),
         idx = doc.offsetAt(pos),
@@ -42,13 +42,12 @@ function getFormSelection(doc, pos, topLevel) {
 function selectCurrentForm(document = {}) {
     let editor = vscode.window.activeTextEditor,
         doc = util.getDocument(document),
-        selection = editor.selection,
-        codeSelection = null;
+        selection = editor.selection;
 
     if (selection.isEmpty) {
-        codeSelection = getFormSelection(doc, selection.active, false);
+        let codeSelection = getFormSelection(doc, selection.active, false);
         if (codeSelection) {
-            editor.selection = codeSelection;
+            editor.selection = new vscode.Selection(codeSelection.start, codeSelection.end);
         }
     }
 }


### PR DESCRIPTION
I noticed a problem with selectCurrentForm.  It always failed on my setup, both Windows 10 and macOS, code version 1.26.1 and Calva version 1.3.36.

I tracked the problem to a type mismatch in select.ts:selectCurrentForm when assigning to editor.selection.  getFormSelection returns a vscode.Range type but editor.selection is vscode.Selection type.

I fixed by type annotating getFormSelection and then using the returned vscode.Range to construct a vscode.Selection and then assign to editor.selection.

I posted the differences in the Slack channel as well.

Let me know what you think.

Thank you,
Martin
