### PR TITLE
Update namespace regex check to support comments

### DIFF
--- a/calva/utilities.ts
+++ b/calva/utilities.ts
@@ -25,7 +25,7 @@ function getShadowCljsReplStartCode(build) {
 }
 
 function getNamespace(text) {
-    let match = text.match(/^[\s\t]*\((?:[\s\t\n]*(?:in-){0,1}ns)[\s\t\n]+'?([\w.\-\/]+)[\s\S]*\)[\s\S]*/);
+    let match = text.match(/^[\s\t]*(?:;.*\s)*[\s\t]*\((?:[\s\t\n]*(?:in-){0,1}ns)[\s\t\n]+'?([\w.\-\/]+)[\s\S]*\)[\s\S]*/);
     return match ? match[1] : 'user';
 }
 


### PR DESCRIPTION
Hi team, thank you for this! I tried Cursive/Light Table/Emacs for Clojure dev, but settled on Calva + vscode.

I ran into an issue in using the `"calva.syncReplNamespaceToCurrentFile": true` configuration: the extension was not detecting the namespace in my `.clj` files correctly. This was because my namespace declarations were prefixed with some comments. For example:

This worked: if a file starts with any whitespace, followed by namespace declaration

```

(ns advent.2017.day20
  (:require [clojure.string :as str]))
```

This did not work: file starts with a comment, followed by namespace declaration.

```
; http://adventofcode.com/2018/day/20

(ns advent.2017.day20
  (:require [clojure.string :as str]))
```

This PR updates the namespace check to ignore comments and fix this issue. To summarize the change:

Earlier regex check: (0 or more whitespace) + (namespace check)
New regex check: (0 or more whitespace) + (0 or more comment lines) + (0 or more whitespace) + (existing namespace check)