### PR TITLE
Fix evaluateCurrentFormInREPLTerminal to not use toplevel form

### DIFF
--- a/calva/terminal.ts
+++ b/calva/terminal.ts
@@ -126,7 +126,7 @@ function evalCurrentFormInREPLTerminal(topLevel = false) {
 }
 
 function evalCurrentFormInREPLTerminalCommand() {
-    evalCurrentFormInREPLTerminal(true);
+    evalCurrentFormInREPLTerminal(false);
 }
 
 function evalCurrentTopLevelFormInREPLTerminalCommand() {


### PR DESCRIPTION
A bug introduced by https://github.com/BetterThanTomorrow/calva/commit/6b587bb8992b14c55b66e6e9344cdb33eedcf812#diff-8df9e3e120042e77ce02d69fc87fbdecL127 means that `evaluateCurrentFormInREPLTerminal` evaluates the toplevel form, not the current one.