### PR TITLE
Make figwheel a bit more optional for people not using it

### DIFF
--- a/calva/connector.ts
+++ b/calva/connector.ts
@@ -105,10 +105,8 @@ async function makeCljsSessionClone(session, shadowBuild) {
         if (build)
             return makeCljsSessionClone(session, build);
     } else {
-        console.log(cljSession);
         cljsSession = await cljSession.clone();
         if (cljsSession) {
-            console.log(cljsSession);
             let isFigwheel = !shadowBuild;
             let initCode = shadowBuild ? shadowCljsReplStart(shadowBuild) : util.getCljsReplStartCode();
             let err = [];


### PR DESCRIPTION
Instead of assuming that everybody wants Figwheel and showing
error messages if figwheel is not started, we inform them about how
to get Figwheel working with Calva.