### PR TITLE
Show full error line in output

### DIFF
--- a/calva/repl/middleware/evaluate.ts
+++ b/calva/repl/middleware/evaluate.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as _ from 'lodash';
+import * as path from 'path';
 import * as clipboardy from 'clipboardy';
 import * as state from '../../state';
 import annotations from '../../providers/annotations';
@@ -32,7 +33,7 @@ async function evaluateSelection(document = {}, options = {}) {
         if (code.length > 0) {
             annotations.decorateSelection(codeSelection, editor, annotations.AnnotationStatus.PENDING);
             let c = codeSelection.start.character
-            
+
             let err: string[] = [], out: string[] = [];
 
             let res = await client.eval("(in-ns '"+util.getNamespace(doc.getText())+")").value;
@@ -53,7 +54,7 @@ async function evaluateSelection(document = {}, options = {}) {
                 } else {
                     annotations.decorateSelection(codeSelection, editor, annotations.AnnotationStatus.SUCCESS);
                     if (!pprint)
-                        annotations.decorateResults(' => ' + value.replace(/\n/gm, " ") + " ", false, codeSelection, editor);                        
+                        annotations.decorateResults(' => ' + value.replace(/\n/gm, " ") + " ", false, codeSelection, editor);
                 }
 
                 if (out.length > 0) {
@@ -66,7 +67,7 @@ async function evaluateSelection(document = {}, options = {}) {
                     chan.show(true);
                     chan.appendLine(value);
                 } else chan.appendLine(value);
-                
+
                 if (err.length > 0) {
                     chan.append("Error: ")
                     chan.append(err.join("\n"));
@@ -112,16 +113,18 @@ async function evaluateFile(document = {}, callback = () => { }) {
         fileName = util.getFileName(doc),
         fileType = util.getFileType(doc),
         client = util.getSession(util.getFileType(doc)),
-        chan = state.outputChannel();
+        chan = state.outputChannel(),
+        shortFileName = path.basename(fileName);
 
     if (doc.languageId == "clojure" && fileType != "edn" && current.get('connected')) {
         chan.appendLine("Evaluating file: " + fileName);
+        chan.show(true);
 
         let value = await client.loadFile(doc.getText(), {
             fileName: fileName,
             filePath: doc.fileName,
-            stdout: m => chan.appendLine(m),
-            stderr: m => chan.appendLine(m)
+            stdout: m => chan.appendLine(m.replace(shortFileName, fileName)),
+            stderr: m => chan.appendLine(m.replace(shortFileName, fileName))
         }).value;
 
         if (value !== null)


### PR DESCRIPTION
This PR improves "evaluate current file" productivity in two ways:
1. It shows the output.
2. It expands a short location of error into a long one that VSCode can convert to a link, so it is now:

```
Evaluating file: /Users/user/src/project/file.clj
Syntax error compiling at (/Users/user/src/project/file.clj:49:1).
```