### PR TITLE
Improve build tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ pom.xml
 ## TS
 out/
 html/main.js
+tsconfig.tsbuildinfo

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,27 +1,40 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "Watch CLJS",
-            "type": "npm",
-            "script": "watch-cljs",
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "problemMatcher": []
-        },
-        {
-            "label": "Watch TS",
-            "type": "npm",
-            "script": "watch-ts",
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "problemMatcher": []
-        }
-    ]
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Watch CLJS",
+      "type": "npm",
+      "script": "watch-cljs",
+      "isBackground": true,
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Watch TS",
+      "type": "npm",
+      "script": "watch-ts",
+      "isBackground": true,
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": "$tsc-watch"
+    },
+    {
+      "label": "Watch Webpack",
+      "type": "npm",
+      "script": "watch-webpack",
+      "isBackground": true,
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -899,7 +899,8 @@
     },
     "scripts": {
         "watch-cljs": "npx shadow-cljs watch :test :calva-lib",
-        "watch-ts": "concurrently \"tsc -watch -p ./\" \"npx webpack -w\"",
+        "watch-ts": "tsc -watch -p ./tsconfig.json",
+        "watch-webpack": "npx webpack -w",
         "release-cljs": "npx shadow-cljs release :calva-lib",
         "compile-cljs": "npx shadow-cljs compile :calva-lib",
         "update-grammar": "node ./calva/calva-fmt/update-grammar.js ./calva/calva-fmt/atom-language-clojure/grammars/clojure.cson clojure.tmLanguage.json",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "incremental": true,
         "module": "commonjs",
         "target": "es6",
         "outDir": "out",


### PR DESCRIPTION
In this PR a did a few changes to the build process that hopefully will help in uncovering lingering problems in the code base:

- Make TS compilation faster by enabling --incremental
- Break TS compile task into two that run independently inside vscode: tsc and webpack
- Add problem matcher in the tsc task to enable global error visibility in vscode
- Declare these tasks as background tasks so they play nicely with vscode 
