### PR TITLE
[Bug Fix] lein jack-in command

### DIFF
--- a/calva/nrepl/jack-in.ts
+++ b/calva/nrepl/jack-in.ts
@@ -103,7 +103,7 @@ const projectTypes: { [id: string]: connector.ProjectType } = {
 
             const useMiddleware = includeCljs ? [...middleware, ...cljsMiddleware] : middleware;
             for (let mw of useMiddleware) {
-                out.push("update-in", `${q + '[:repl-options' + s + ':nrepl-middleware]' + q}`, "conj", `["${mw}"]`, '--');
+                out.push("update-in", `${q + '[:repl-options' + s + ':nrepl-middleware]' + q}`, "conj", `'["${mw}"]'`, '--');
             }
 
             if (profiles.length) {


### PR DESCRIPTION
With the latest version, the `jack-in` command tries the execute the below command 

```batch
> lein update-in :dependencies conj '[nrepl"0.6.0"]' -- update-in :plugins conj '[cider/cider-nrepl"0.21.1"]' -- update-in '[:repl-options :nrepl-middleware]' conj ["cider.nrepl/cider-middleware"] -- repl :headless
```

It results in below error.

```batch
zsh: no matches found: [cider.nrepl/cider-middleware]
```

If I ran the same command after wrapping ` ["cider.nrepl/cider-middleware"]` with a single quote it works as expected.

```batch
> lein update-in :dependencies conj '[nrepl"0.6.0"]' -- update-in :plugins conj '[cider/cider-nrepl"0.21.1"]' -- update-in '[:repl-options :nrepl-middleware]' conj '["cider.nrepl/cider-middleware"]' -- repl :headless

nREPL server started on port 62505 on host 127.0.0.1 - nrepl://127.0.0.1:62505
```