### PR TITLE
[WIP] Add myLeinProfiles settings for jack-in

### DIFF
--- a/calva/nrepl/jack-in.ts
+++ b/calva/nrepl/jack-in.ts
@@ -95,11 +95,12 @@ const projectTypes: { [id: string]: connector.ProjectType } = {
             }
 
             if (defproject != undefined) {
-                let profilesIndex = defproject.indexOf("profiles");
+                const profilesIndex = defproject.indexOf("profiles"),
+                    myProfiles = state.config().myLeinProfiles;
                 if (profilesIndex > -1) {
                     try {
-                        const profilesMap = defproject[profilesIndex + 1];
-                        profiles = [...profiles, ...Object.keys(profilesMap).map((v, k) => { return ":" + v })];
+                        const profilesList = [...Object.keys(defproject[profilesIndex + 1]), ...myProfiles];
+                        profiles = [...profiles, ...profilesList.map(v => { return ":" + v })];
                         if (profiles.length) {
                             profiles = await utilities.quickPickMulti({ values: profiles, saveAs: `${connector.getProjectRoot()}/lein-cli-profiles`, placeHolder: "Pick any profiles to launch with" });
                         }

--- a/calva/state.ts
+++ b/calva/state.ts
@@ -74,6 +74,10 @@ function reset() {
     data = Immutable.fromJS(initialData);
 }
 
+function _trimAliasName(name: string): string {
+    return name.replace(/^[\s,:]*/, "").replace(/[\s,:]*$/, "")
+}
+
 function config() {
     let configOptions = vscode.workspace.getConfiguration('calva');
     return {
@@ -87,10 +91,8 @@ function config() {
         jackInEnv: configOptions.get("jackInEnv"),
         openBrowserWhenFigwheelStarted: configOptions.get("openBrowserWhenFigwheelStarted"),
         customCljsRepl: configOptions.get("customCljsRepl", null),
-        myLeinProfiles: configOptions.get("myLeinProfiles", []).map(v => {
-            return v.replace(/^[\s,:]*/, "").replace(/[\s,:]*$/, "")
-        }),
-        myCljAliases: configOptions.get("myCljAliases", []),
+        myLeinProfiles: configOptions.get("myLeinProfiles", []).map(_trimAliasName),
+        myCljAliases: configOptions.get("myCljAliases", []).map(_trimAliasName),
     };
 }
 

--- a/calva/state.ts
+++ b/calva/state.ts
@@ -86,7 +86,11 @@ function config() {
         syncReplNamespaceToCurrentFile: configOptions.get("syncReplNamespaceToCurrentFile"),
         jackInEnv: configOptions.get("jackInEnv"),
         openBrowserWhenFigwheelStarted: configOptions.get("openBrowserWhenFigwheelStarted"),
-        customCljsRepl: configOptions.get("customCljsRepl", null)
+        customCljsRepl: configOptions.get("customCljsRepl", null),
+        myLeinProfiles: configOptions.get("myLeinProfiles", []).map(v => {
+            return v.replace(/^[\s,:]*/, "").replace(/[\s,:]*$/, "")
+        }),
+        myCljAliases: configOptions.get("myCljAliases", []),
     };
 }
 

--- a/calva/state.ts
+++ b/calva/state.ts
@@ -74,6 +74,12 @@ function reset() {
     data = Immutable.fromJS(initialData);
 }
 
+/**
+ * Trims EDN alias and profile names from any surrounding whitespace or `:` characters.
+ * This in order to free the user from having to figure out how the name should be entered.
+ * @param  {string} name 
+ * @return {string} The trimmed name
+ */
 function _trimAliasName(name: string): string {
     return name.replace(/^[\s,:]*/, "").replace(/[\s,:]*$/, "")
 }

--- a/package.json
+++ b/package.json
@@ -207,6 +207,20 @@
                         "type": "boolean",
                         "default": true,
                         "description": "Should Calva open the Figwheel app for you when Figwheel has been started?"
+                    },
+                    "calva.myLeinProfiles": {
+                        "type": "array",
+                        "description": "At Jack in, any profiles listed here will be added to the profiles found in the `project.clj` file.",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "calva.myCljAliases": {
+                        "type": "array",
+                        "description": "At Jack in, any aliases listed here will be added to the aliases found in the projects's `deps.edn` file.",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             },


### PR DESCRIPTION
Addressing #288 (which is about clj-deps aliases, but I started with Leiningen profiles, just because).

This is one way to do it. It adds a setting `myLeinProfiles`, which is an array of strings. These strings are then added to the Jack-in quick-pick menu and if selected to the jack-in command at `--with-profile`. Thus the user needs to specify this ”an extra time”, and risk getting it wrong. 

Another way to do it would be to read `~/.lein/profiles.clj`, `~/.clojure/deps.edn` and populate from there. But it is more work to get it right on all various operating systems and setups, and also would maybe pick up a lot of aliases/profiles, that don't make sense...

This is more KISS, I would say. What say you?