### PR TITLE
Added rimraf to the build config to be platform independent.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1098,6 +1098,15 @@
                         "yallist": "^3.0.2"
                     }
                 },
+                "rimraf": {
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
                 "yallist": {
                     "version": "3.0.3",
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
@@ -1574,6 +1583,17 @@
                 "mkdirp": "^0.5.1",
                 "rimraf": "^2.5.4",
                 "run-queue": "^1.0.0"
+            },
+            "dependencies": {
+                "rimraf": {
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                }
             }
         },
         "copy-descriptor": {
@@ -1991,6 +2011,15 @@
                     "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
                     "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
                     "dev": true
+                },
+                "rimraf": {
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
                 }
             }
         },
@@ -3006,6 +3035,17 @@
                 "graceful-fs": "^4.1.2",
                 "rimraf": "~2.6.2",
                 "write": "^0.2.1"
+            },
+            "dependencies": {
+                "rimraf": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+                    "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                }
             }
         },
         "flush-write-stream": {
@@ -4806,7 +4846,8 @@
         "json": {
             "version": "9.0.6",
             "resolved": "https://registry.npmjs.org/json/-/json-9.0.6.tgz",
-            "integrity": "sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU="
+            "integrity": "sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=",
+            "dev": true
         },
         "json-parse-better-errors": {
             "version": "1.0.2",
@@ -5415,6 +5456,17 @@
                 "mkdirp": "^0.5.1",
                 "rimraf": "^2.5.4",
                 "run-queue": "^1.0.3"
+            },
+            "dependencies": {
+                "rimraf": {
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                }
             }
         },
         "ms": {
@@ -5525,6 +5577,15 @@
                 "which": "1"
             },
             "dependencies": {
+                "rimraf": {
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
                 "semver": {
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -10047,9 +10108,9 @@
             "dev": true
         },
         "rimraf": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.3"
@@ -10189,11 +10250,6 @@
             "requires": {
                 "node-forge": "0.7.5"
             }
-        },
-        "semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "semver-diff": {
             "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1144,7 +1144,7 @@
     },
     "scripts": {
         "watch-webpack": "webpack --mode development --watch",
-        "watch-ts": "rm -rf ./out/* ./tsconfig.tsbuildinfo && npm run compile-cljs && tsc -watch -p ./tsconfig.json",
+        "watch-ts": "rimraf ./out && rimraf ./tsconfig.tsbuildinfo && npm run compile-cljs && tsc -watch -p ./tsconfig.json",
         "release-cljs": "npx shadow-cljs release :calva-lib",
         "NOT-USED-start": "ts-node --inspect=5858 webview-src/server/main.ts",
         "NOT-USED-repl-window-dev-server": "concurrently \"npx nodemon -- ./webview-src/client/index.js\" \"npx webpack-dev-server\"",
@@ -1155,7 +1155,7 @@
         "update-grammar": "node ./calva/calva-fmt/update-grammar.js ./calva/calva-fmt/atom-language-clojure/grammars/clojure.cson clojure.tmLanguage.json",
         "release": "npm i && npm run update-grammar && npm run release-cljs && npm run webpack-release",
         "disabled-release": "npm i && npm run update-grammar && npm run release-cljs && tsc -p ./",
-        "vscode:prepublish": "rm -rf ./out/* && npm run release",
+        "vscode:prepublish": "rimraf ./out && npm run release",
         "disabled-vscode:prepublish": "npm run release",
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
@@ -1207,6 +1207,7 @@
         "webpack": "^4.33.0",
         "webpack-cli": "^3.3.3",
         "webpack-dev-server": "^3.8.0",
-        "vsce": "^1.66.0"
+        "vsce": "^1.66.0",
+        "rimraf": "^2.7.1"
     }
 }


### PR DESCRIPTION
I added the rimraf node module to the build configuration to replace the rm calls in the "watch_ts" and "vscode:prepublish" script definitions. This way the scripts will run both under Windows an UNIX flavor systems. So it's easier to start development under Windows without handle some error messages first. 

I hope this pull request is created correctly and you may accept the changes.

Thanks! 