### PR TITLE
Wip/fix issue 305

### DIFF
--- a/calva/extension.ts
+++ b/calva/extension.ts
@@ -228,6 +228,7 @@ function activate(context: vscode.ExtensionContext) {
 
 function deactivate() {
     state.analytics().logEvent("LifeCycle", "Dectivated").send();
+    jackIn.calvaJackout();
     paredit.deactivate()
 }
 

--- a/calva/nrepl/jack-in.ts
+++ b/calva/nrepl/jack-in.ts
@@ -11,7 +11,7 @@ import { askForConnectSequence, ReplConnectSequence, CljsTypes } from "./connect
 import { stringify } from "querystring";
 import * as projectTypes from './project-types';
 
-export let JackinExecution:vscode.TaskExecution = undefined;
+let JackinExecution:vscode.TaskExecution = undefined;
 
 let watcher: fs.FSWatcher;
 const TASK_NAME = "Calva Jack-in";

--- a/calva/nrepl/jack-in.ts
+++ b/calva/nrepl/jack-in.ts
@@ -94,6 +94,12 @@ export function calvaJackout() {
             // repl process from the repl client because the 
             // ShellExecution under Windows will not terminate 
             // all child processes.
+            //
+            // the clojure code to terminate the repl process 
+            // was taken from this comment on github:
+            //
+            // https://github.com/clojure-emacs/cider/issues/390#issuecomment-317791387
+            //
             if (nClient && nClient.session) {
                 nClient.session.eval("(do (.start (Thread. (fn [] (Thread/sleep 5000) (shutdown-agents) (System/exit 0)))) nil)");
             }

--- a/calva/repl-window.ts
+++ b/calva/repl-window.ts
@@ -1,4 +1,6 @@
 import * as vscode from "vscode";
+import * as jackIn from './nrepl/jack-in';
+import * as connector from "./connector";
 import { cljSession, cljsSession } from "./connector"
 import * as path from "path";
 import * as fs from "fs";
@@ -134,8 +136,12 @@ class REPLWindow {
             this.panel.webview.postMessage(msg)
     }
 
-    onClose = () =>
+    onClose = () => {
+        jackIn.calvaJackout();
+        connector.default.disconnect();
         this.postMessage({ type: "disconnected" });
+    }
+        
 
     ns: string = "user";
 


### PR DESCRIPTION
The current task API for vscode provides no callback to allow some house keeping before the task execution is terminated. The vscode.tasks.onDidEndTask handler is called after execution is terminated. This is too late to terminate the repl processes from the repl client. I implemented a solution which handles all situations where the task can be terminated from the extension itself:

- the extension is deactivated
- the extension created a new repl task
- the repl window is closes

If the user chooses to terminate the task from the task management UI (e.g main menu) there still will be a leftover java process. Due to this I removed the message to do so from the output channel.

Take a close look on this and perhaps you can accept the request. 

Thank You and have a nice weekend!
