### PR TITLE
Fix/figwheel main deps when no cljs 317

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changes to Calva. (We really will try to keep this updated now.)
 - [Support for custom project/workflow commands](https://github.com/BetterThanTomorrow/calva/issues/281)
 
 ## [Unreleased]
-- Nothing to see here
+- Fix [Figwheel Main deps added to non-cljs projects](https://github.com/BetterThanTomorrow/calva/issues/317)
 
 ## [2.0.36] - 12.09.2019
 - Fix [REPL Window namespace being reset to user](https://github.com/BetterThanTomorrow/calva/issues/302)

--- a/calva/nrepl/jack-in.ts
+++ b/calva/nrepl/jack-in.ts
@@ -92,11 +92,9 @@ export async function calvaJackIn() {
     state.extensionContext.workspaceState.update('selectedCljTypeName', projectConnectSequence.projectType);
     let selectedCljsType: CljsTypes;
 
-    if (projectConnectSequence.cljsType == undefined) {
-        selectedCljsType = CljsTypes["Figwheel Main"];
-    } else if (typeof projectConnectSequence.cljsType == "string") {
+    if (typeof projectConnectSequence.cljsType == "string") {
         selectedCljsType = projectConnectSequence.cljsType;
-    } else {
+    } else if (projectConnectSequence.cljsType) {
         selectedCljsType = projectConnectSequence.cljsType.dependsOn;
     }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Calva: Clojure & Clojurescript Interactive Programming",
     "description": "Integrated REPL, formatter, Paredit, and more. Powered by nREPL.",
     "icon": "assets/calva.png",
-    "version": "2.0.36",
+    "version": "2.0.37",
     "publisher": "betterthantomorrow",
     "author": {
         "name": "Better Than Tomorrow",


### PR DESCRIPTION
We were throwing in Figwheel Main dependencies when we didn't know which cljs dependencies to use. **Even when there was no cljs involved in the project**. I have confirmed that this was the issue in #317. 