### PR TITLE
Added task "create-vsix" to build local visx.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1164,7 +1164,7 @@
         "disabled-release": "npm i && npm run update-grammar && npm run release-cljs && tsc -p ./",
         "vscode:prepublish": "rimraf ./out && npm run release",
         "disabled-vscode:prepublish": "npm run release",
-        "create-vsix": "rimraf ./out && vsce package",
+        "create-vsix": "vsce package",
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1164,6 +1164,7 @@
         "disabled-release": "npm i && npm run update-grammar && npm run release-cljs && tsc -p ./",
         "vscode:prepublish": "rimraf ./out && npm run release",
         "disabled-vscode:prepublish": "npm run release",
+        "create-vsix": "rimraf ./out && vsce package",
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "dependencies": {


### PR DESCRIPTION
I think it would be nice to have a UI callable task to build a release vsix file locally. The "vsce package" command runs the "vscode:prepublish" task implicitly to compile everything as release. Perhaps you do not mind adding this small change.

Thanks!