### PR TITLE
Revert disconnecting and jacking out on closing of REPL window, resolves #326

### DIFF
--- a/calva/repl-window.ts
+++ b/calva/repl-window.ts
@@ -1,6 +1,4 @@
 import * as vscode from "vscode";
-import * as jackIn from './nrepl/jack-in';
-import * as connector from "./connector";
 import { cljSession, cljsSession } from "./connector"
 import * as path from "path";
 import * as fs from "fs";
@@ -137,11 +135,8 @@ class REPLWindow {
     }
 
     onClose = () => {
-        jackIn.calvaJackout();
-        connector.default.disconnect();
         this.postMessage({ type: "disconnected" });
     }
-        
 
     ns: string = "user";
 


### PR DESCRIPTION
This reverts part of the changes, introduced by #316. The point of the current change is to allow closing the REPL window without disconnecting the repl session.

@PEZ @cfehse 