### PR TITLE
Add a hover to results annotation w/ full results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - [Escape HTML in stdout and stderr in REPL window](https://github.com/BetterThanTomorrow/calva/issues/321)
+- [Add hover to inline result display, containing the full results](https://github.com/BetterThanTomorrow/calva/pull/336)
 
 ## [2.0.39] - 20.09.2019
 - [Revert disconnecting and jacking out on closing of REPL window](https://github.com/BetterThanTomorrow/calva/issues/326)

--- a/calva/evaluate.ts
+++ b/calva/evaluate.ts
@@ -66,8 +66,7 @@ async function evaluateSelection(document = {}, options = {}) {
                     chan.appendLine("Evaluated as comment.")
                 } else {
                     annotations.decorateSelection(codeSelection, editor, annotations.AnnotationStatus.SUCCESS);
-                    if (!pprint)
-                        annotations.decorateResults(' => ' + value.replace(/\n/gm, " ") + " ", false, codeSelection, editor);
+                    annotations.decorateResults(value, false, codeSelection, editor);
                 }
 
                 if (out.length > 0) {
@@ -94,8 +93,8 @@ async function evaluateSelection(document = {}, options = {}) {
                 }
 
                 annotations.decorateSelection(codeSelection, editor, annotations.AnnotationStatus.ERROR);
-                const annotation = err.join();
-                annotations.decorateResults(' => ' + annotation.replace(/\n/gm, " ") + " ", true, codeSelection, editor);
+                const annotation = err.join("\n");
+                annotations.decorateResults(annotation, true, codeSelection, editor);
             }
         }
     } else
@@ -167,8 +166,10 @@ async function copyLastResultCommand() {
     let client = replWindow ? replWindow.session : util.getSession(util.getFileType(util.getDocument({})));
 
     let value = await client.eval("*1").value;
-    if (value !== null)
+    if (value !== null) {
         vscode.env.clipboard.writeText(value);
+        vscode.window.showInformationMessage("Results copied to the clipboard.");
+    }
     else
         chan.appendLine("Nothing to copy");
 }

--- a/calva/providers/annotations.ts
+++ b/calva/providers/annotations.ts
@@ -28,26 +28,34 @@ const evalResultsDecorationType = vscode.window.createTextEditorDecorationType({
         textDecoration: 'none',
         fontWeight: 'normal',
         fontStyle: 'normal',
-    },
+        width: "250px",
+},
     rangeBehavior: vscode.DecorationRangeBehavior.ClosedOpen
 });
 
-function evaluated(contentText, hasError) {
+
+//<a href="#" data-href="command:gitlens.showQuickCommitDetails?%7B%22sha%22%3A%22ec09a1477b748da5d0d59b6e9f1eaff031aca4e2%22%7D" title="Show Commit Details"><code>ec09a14</code></a>
+
+function evaluated(contentText, hoverText, hasError) {
+    const commandUri = vscode.Uri.parse("command:calva.copyLastResults"),
+    commandMd = `[Copy](${commandUri} "Copy results to the clipboard")`;
+    let hoverMessage = new vscode.MarkdownString(commandMd + '\n```clojure\n' + hoverText + '\n```');
+    hoverMessage.isTrusted = true;
     return {
+        hoverMessage: hasError ? hoverText : hoverMessage,
         renderOptions: {
             before: {
                 contentText: contentText,
+                overflow: "hidden"
             },
             light: {
                 before: {
                     color: hasError ? 'rgb(255, 127, 127)' : 'black',
-                    backgroundColor: 'white',
                 },
             },
             dark: {
                 before: {
                     color: hasError ? 'rgb(255, 175, 175)' : 'white',
-                    backgroundColor: 'black',
                 }
             },
         },
@@ -99,7 +107,7 @@ function decorateResults(resultString, hasError, codeSelection: vscode.Range, ed
     let uri = editor.document.uri,
         key = uri + ':resultDecorationRanges',
         decorationRanges = state.deref().get(key) || [],
-        decoration = evaluated(resultString, hasError);
+        decoration = evaluated(` => ${resultString} `, resultString, hasError);
     decorationRanges = _.filter(decorationRanges, (o) => { return !o.codeRange.intersection(codeSelection) });
     decoration["codeRange"] = codeSelection;
     decoration["range"] = new vscode.Selection(codeSelection.end, codeSelection.end);


### PR DESCRIPTION
This pull request:

Fixes #104, and addresses #79.

Introduces the following change(s):
- Inline result annotation now have a hover showing the full results.
- The hover has a `Copy` link, that copies the results to the clipboard.
- The inline displayed result takes up less width.

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Referenced the issue I am fixing/addressing.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Updated the `[Unrleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

Ping: @kstehn