### PR TITLE
Make REPL prompt reflect current NS reliably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 - [Support for custom project/workflow commands](https://github.com/BetterThanTomorrow/calva/issues/281)
 
 ## [Unreleased]
+- [REPL ns prompt does not change with (ns ..) form](https://github.com/BetterThanTomorrow/calva/issues/280)
 - [Better inline evaluation error reports with file context](https://github.com/BetterThanTomorrow/calva/issues/329)
 - [Escape HTML in stdout and stderr in REPL window](https://github.com/BetterThanTomorrow/calva/issues/321)
 - [Adding default message handler for the nrepl](https://github.com/BetterThanTomorrow/calva/issues/218)

--- a/calva/repl-window.ts
+++ b/calva/repl-window.ts
@@ -169,6 +169,10 @@ class REPLWindow {
         })
         try {
             this.postMessage({ type: "repl-response", value: await this.evaluation.value, ns: this.ns = ns || this.evaluation.ns || this.ns });
+            if(this.evaluation.ns && this.ns != this.evaluation.ns) {
+                // the evaluation changed the namespace so set the new namespace.
+                this.setNamespace(this.evaluation.ns);
+            }
         } catch (e) {
             this.postMessage({ type: "repl-error", ex: e });
             let stacktrace = await this.session.stacktrace();


### PR DESCRIPTION
If an evaluation changes the namespace the change is populated back to the REPL window.

This pull request:

Fixes #280.

Introduces the following change(s):
- `CANGELOG.md` as requested
- `calva/repl-window.ts` `REPLWindow.replEval()` method to populate a namespace change from the evaluation back to the repl window.
- 

(If you have considered alternative ways to introduce the change, replace this paragrah with a brief reasoning about why you made the choices you did. Otherwise just remove this paragraph.)

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Referenced the issue I am fixing/addressing.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [ ] Created the issue I am fixing/addressing, if it was not present.
- [x] Updated the `[Unrleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

Ping: @pez, @kstehn