### PR TITLE
Add content security policy to webview and remove image load error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 - [Support for custom project/workflow commands](https://github.com/BetterThanTomorrow/calva/issues/281)
 
 ## [Unreleased]
+- [Add content security policy to webview and remove image load error](https://github.com/BetterThanTomorrow/calva/issues/341)
 - [Better inline evaluation error reports with file context](https://github.com/BetterThanTomorrow/calva/issues/329)
 - [Escape HTML in stdout and stderr in REPL window](https://github.com/BetterThanTomorrow/calva/issues/321)
 - [Adding default message handler for the nrepl](https://github.com/BetterThanTomorrow/calva/issues/218)

--- a/calva/repl-window.ts
+++ b/calva/repl-window.ts
@@ -109,17 +109,16 @@ class REPLWindow {
         const cljTypeSlug = `clj-type-${cljType.replace(/ /, "-").toLowerCase()}`;
         const cljsTypeSlug = `cljs-type-${cljsType.replace(/ /, "-").toLowerCase()}`;
         let html = readFileSync(path.join(ctx.extensionPath, "html/index.html")).toString();
-        html = html.replace("{{baseUri}}", getUrl());
-        html = html.replace("{{script}}", getUrl("/main.js"));
-        html = html.replace("{{font}}", getUrl("/fira_code.css"));
-        html = html.replace("{{logo-symbol}}", getUrl(`/images/calva-symbol-logo.svg`));
+        let script = vscode.Uri.file(path.join(ctx.extensionPath, "html/main.js")).with({ scheme: 'vscode-resource' }).toString()
+        html = html.replace("{{script}}", script);
+        html = html.replace("{{logo-symbol}}", getImageUrl(`calva-symbol-logo.svg`));
         html = html.replace(/{{hero-classes}}/g, `${type} ${cljTypeSlug} ${cljsTypeSlug}`);
         html = html.replace("{{clj-type}}", `${cljType.replace(/ /g, "&nbsp;")}`);
+        html = html.replace("{{clj-type-logo}}", getImageUrl(`${cljTypeSlug}.svg`));
+        html = html.replace("{{clj-logo}}", getImageUrl(`clj.svg`));
         html = html.replace("{{cljs-type}}", `${cljsType.replace(/ /g, "&nbsp;")}`);
-        html = html.replace("{{clj-type-logo}}", getUrl(`/images/${cljTypeSlug}.svg`));
-        html = html.replace("{{clj-logo}}", getUrl(`/images/clj.svg`));
-        html = html.replace("{{cljs-type-logo}}", getUrl((`/images/${cljsTypeSlug}.svg`)));
-        html = html.replace("{{cljs-logo}}", getUrl(`/images/cljs.svg`));
+        html = html.replace("{{cljs-type-logo}}", getImageUrl((`${cljsTypeSlug}.svg`)));
+        html = html.replace("{{cljs-logo}}", getImageUrl(`cljs.svg`));
         panel.webview.html = html;
 
         this.connect().catch(reason => {
@@ -190,11 +189,17 @@ let ctx: vscode.ExtensionContext
 
 let replWindows: { [id: string]: REPLWindow } = {};
 
-function getUrl(name?: string) {
-    if (name)
-        return vscode.Uri.file(path.join(ctx.extensionPath, "html", name)).with({ scheme: 'vscode-resource' }).toString()
+function getImageUrl(name: string) {
+    let imagepath = "";
+    if (!name)
+         imagepath = path.join(ctx.extensionPath, "html/images/empty.svg");
     else
-        return vscode.Uri.file(path.join(ctx.extensionPath, "html")).with({ scheme: 'vscode-resource' }).toString()
+         imagepath = path.join(ctx.extensionPath, "html/images/", name);
+
+    if(!fs.existsSync(imagepath)) {
+        imagepath = path.join(ctx.extensionPath, "html/images/empty.svg");
+    }
+    return vscode.Uri.file(imagepath).with({ scheme: 'vscode-resource' }).toString()
 }
 
 export async function reconnectReplWindow(mode: "clj" | "cljs") {

--- a/html/images/empty.svg
+++ b/html/images/empty.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
+              "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="0.00333333in" height="0.00333333in"
+     viewBox="0 0 1 1">
+  <path id="Pfad"
+        fill="none" stroke="black" stroke-width="1"
+        d="" />
+</svg>

--- a/html/index.html
+++ b/html/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src vscode-resource:; script-src 'unsafe-inline' data: vscode-resource:; style-src 'unsafe-inline' data: vscode-resource:; img-src data: vscode-resource:; font-src 'unsafe-inline' data: vscode-resource:">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1">
 </head>
 


### PR DESCRIPTION
This pull request:

Fixes #341 .

Introduces the following change(s):
- Added content security policy to `html/index.html `.
- Changed handling of image URL retrieval in `calva/repl-window.ts`. 
- Added an empty SVG image in `html/images`.

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Referenced the issue I am fixing/addressing.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Updated the `[Unrleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

Ping: @pez, @kstehn