### PR TITLE
[Fix] Simplify build system

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,8 +16,7 @@
             "sourceMaps": true,
             "env": {
                 "CALVA_DEV_GA": "FUBAR-69796730-4",
-                "DEBUG": "no-debug-universal-analytics",
-                "IS_DEV_BUILD": "YES"
+                "DEBUG": "no-debug-universal-analytics"
             },
             "outFiles": [
                 "${workspaceFolder}/dist/**/*.js"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,31 +4,15 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Watch TS source",
+      "label": "Calva Watch",
       "type": "npm",
-      "script": "watch-ts-src",
+      "script": "watch",
       "isBackground": true,
       "group": {
         "kind": "build",
         "isDefault": true
       },
       "problemMatcher": "$tsc-watch"
-    },
-    {
-      "label": "Watch REPL Webview src",
-      "type": "npm",
-      "script": "watch-repl-webview-src",
-      "isBackground": true,
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      },
-      "options": {
-        "env": {
-          "IS_DEV_BUILD": "YES"
-        }
-      },
-      "problemMatcher": []
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10991,7 +10991,7 @@
         },
         "strip-eof": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -1178,19 +1178,19 @@
         }
     },
     "scripts": {
-        "watch-repl-webview-src": "webpack --mode development --watch",
-        "watch-ts-src": "rimraf ./out && rimraf ./tsconfig.tsbuildinfo && npm run compile-cljs && tsc -watch -p ./tsconfig.json",
-        "release-cljs": "npx shadow-cljs release :calva-lib",
-        "NOT-USED-start": "ts-node --inspect=5858 webview-src/server/main.ts",
-        "NOT-USED-repl-window-dev-server": "concurrently \"npx nodemon -- ./webview-src/client/index.js\" \"npx webpack-dev-server\"",
-        "webpack-release": "webpack --mode production",
-        "bump-version": "npm set git-tag-version false && npm version patch",
+        "clean": "rimraf ./out && rimraf ./html/main.js && rimraf ./html/main.js.map && rimraf ./tsconfig.tsbuildinfo && rimraf ./cljs-out",
         "compile-cljs": "npx shadow-cljs compile :calva-lib :test",
-        "compile": "npm run compile-cljs && npm run webpack",
+        "prewatch": "npm run clean && npm run compile-cljs",
+        "watch": "concurrently \"webpack --mode development --watch\" \"tsc -watch -p ./tsconfig.json\"",
+        "release-cljs": "npx shadow-cljs release :calva-lib",
         "update-grammar": "node ./calva/calva-fmt/update-grammar.js ./calva/calva-fmt/atom-language-clojure/grammars/clojure.cson clojure.tmLanguage.json",
-        "release": "npm i && npm run update-grammar && npm run release-cljs && npm run webpack-release",
-        "vscode:prepublish": "rimraf ./out && npm run release",
-        "postinstall": "node ./node_modules/vscode/bin/install"
+        "release": "npm i && npm run clean && npm run update-grammar && npm run release-cljs && webpack --mode production",
+        "postrelease": "rimraf ./cljs-out",
+        "vscode:prepublish": "npm run release",
+        "bump-version": "npm set git-tag-version false && npm version patch",
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "NOT-USED-start": "ts-node --inspect=5858 webview-src/server/main.ts",
+        "NOT-USED-repl-window-dev-server": "concurrently \"npx nodemon -- ./webview-src/client/index.js\" \"npx webpack-dev-server\""
     },
     "dependencies": {
         "@types/escape-html": "0.0.20",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,15 @@
 const path = require('path');
 
 const CALVA_MAIN = {
-  target: 'node', // vscode extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
-  entry: './calva/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
+  // vscode extensions run in a Node.js-context 
+  // 📖 -> https://webpack.js.org/configuration/node/
+  target: 'node', 
+  // the entry point of this extension, 
+  // 📖 -> https://webpack.js.org/configuration/entry-context/
+  entry: path.resolve(__dirname, 'calva/extension.ts'), 
   output: {
-    // the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
+    // the bundle is stored in the 'dist' folder (check package.json), 
+    // 📖 -> https://webpack.js.org/configuration/output/
     path: path.resolve(__dirname, 'out'),
     filename: 'extension.js',
     libraryTarget: 'commonjs2',
@@ -12,38 +17,81 @@ const CALVA_MAIN = {
   },
   devtool: 'source-map',
   externals: {
-    vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+    // the vscode-module is created on-the-fly and must be excluded. 
+    // Add other modules that cannot be webpack'ed, 
+    // 📖 -> https://webpack.js.org/configuration/externals/
+    vscode: 'commonjs vscode'
   },
   resolve: {
-    // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
+    // support reading TypeScript and JavaScript files, 
+    // 📖 -> https://github.com/TypeStrong/ts-loader
     extensions: ['.ts', '.js']
+  },
+  // Watch options for the webview. 
+  // 📖 -> https://webpack.js.org/configuration/watch/
+  watchOptions: {
+    aggregateTimeout: 200,
+    poll: 500,
+    ignored: /node_modules/
   },
   module: {
     rules: [
       {
         test: /\.ts$/,
         exclude: /node_modules/,
-        use: [
-          {
-            loader: 'ts-loader'
-          }
-        ]
+        loader: 'ts-loader',
+        options: {
+          configFile: path.resolve(__dirname, 'tsconfig.json')
+        }
       }
     ]
   }
 }
 
 const REPL_WINDOW = {
-  entry: './calva/webview-src/server/main.ts',
+  // vscode extensions run in a Node.js-context 
+  // 📖 -> https://webpack.js.org/configuration/node/
+  target: 'node', 
+  // the entry point of this webview, 
+  // 📖 -> https://webpack.js.org/configuration/entry-context/
+  entry: path.resolve(__dirname, 'calva/webview-src/server/main.ts'),
+  // the bundle is stored in the 'html' folder. 
+  // 📖 -> https://webpack.js.org/configuration/output/
+  output: {
+    filename: 'main.js',
+    path: path.resolve(__dirname, 'html'),
+    publicPath: './'
+  },
+  // Webpack dev server settings.
+  // 📖 -> https://webpack.js.org/configuration/dev-server/
+  devServer: {
+    historyApiFallback: true,
+    host: "0.0.0.0",
+    compress: true,
+    contentBase: path.join(__dirname, 'html'),
+    proxy: {
+      '/api': 'http://localhost:3000',
+    }
+  },
+  devtool: 'source-map',
+  resolve: {
+    // support reading TypeScript and JavaScript files, 
+    // 📖 -> https://github.com/TypeStrong/ts-loader
+    extensions: ['.tsx', '.ts', '.js']
+  },
   performance: {
+    // These options allows you to control how webpack notifies you 
+    // of assets and entry points that exceed a specific file limit.
+    // 📖 -> https://webpack.js.org/configuration/performance/
     maxEntrypointSize: 1024000,
     maxAssetSize: 1024000,
   },
-  mode: "development",
-  externals: {
-  },
-  resolve: {
-    modules: ['node_modules']
+  // Watch options for the webview. 
+  // 📖 -> https://webpack.js.org/configuration/watch/
+  watchOptions: {
+    aggregateTimeout: 200,
+    poll: 500,
+    ignored: /node_modules/
   },
   module: {
     rules: [
@@ -53,9 +101,8 @@ const REPL_WINDOW = {
         options: {
           transpileOnly: true,
           experimentalWatchApi: true,
-          configFile: 'calva/webview-src/tsconfig.json'
+          configFile: path.resolve(__dirname, 'calva/webview-src/tsconfig.json')
         },
-        exclude: /node_modules/
       },
       {
         test: /\.scss$/,
@@ -69,34 +116,23 @@ const REPL_WINDOW = {
         }
       }
     ]
-  },
-  watchOptions: {
-    aggregateTimeout: 200,
-    poll: 500,
-    ignored: /node_modules/
-  },
-  resolve: {
-    extensions: ['.tsx', '.ts', '.js']
-  },
-  output: {
-    filename: 'main.js',
-    path: path.resolve(__dirname, 'html')
-  },
-  devServer: {
-    historyApiFallback: true,
-    host: "0.0.0.0",
-    compress: true,
-    contentBase: path.join(__dirname, 'html'),
-    proxy: {
-      '/api': 'http://localhost:3000',
-    }
-  },
-  devtool: 'source-map'
+  }
 }
 
-let configs = [REPL_WINDOW];
-if (!(process.env.IS_DEV_BUILD == "YES")) {
-  configs.unshift(CALVA_MAIN);
+// Build the configuration based on production
+// or development mode. The extenion is only 
+// webpacked for production.
+function buildConfig(isProduction) {
+  let configs = [REPL_WINDOW];
+  if (isProduction) {
+    configs.unshift(CALVA_MAIN)
+  } 
+  //return configs
+  return configs
 }
 
-module.exports = configs;
+// Get the mode from the argv array.
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === 'production'
+  return buildConfig(isProduction)
+}


### PR DESCRIPTION
This pull request:

Fixes #346

Tested on following platform(s):
- [x] Windows
- [x] Linux
- [x] macOS

Introduces the following change(s):

`webpack.config.js`
- Added comments to make the configuration more explainable. 
- Replaced all relative path values with resolved full qualified ones.
- The selection which packages to create is changed to evaluate the webpack `--mode`parameter.

`package.json` / `.vscode/tasks.json` / `.vscode/launch.json`
- Only one build task. This is simpler and  no order of execution required.
- Using the `concurrently` module for the `watch` script allows to see the output from both watchers (`webpack` and `tsc`).
- Removed the environment `IS_DEV_BUILD` because the the webpack `--mode`parameter is now used instead (see `webpack.config.js`).
- The build is now able to build from a clean `git clone` directory by only running `npx vsce package`.

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Referenced the issue I am fixing/addressing.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

Ping: @pez, @kstehn