### PR TITLE
Add command evaluating top level to comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - [Stop writing results from **Evaluate to Comment** to output pane](https://github.com/BetterThanTomorrow/calva/issues/347)
+- [Add command for evaluating top level form as comment](https://github.com/BetterThanTomorrow/calva/issues/349)
 
 ## [2.0.40] - 25.09.2019
 - [Add command for connecting to a non-project REPL](https://github.com/BetterThanTomorrow/calva/issues/328)

--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ Demo: switch between `clj` and `cljs` repl sessions for `cljc` files:
   - Evaluate code at cursor and show the results as annotation in the editor: `ctrl+alt+c e` (`ctrl+alt+c v` on Windows)
     - Dismiss the display of results by pressing `escape` (there is info on the wiki for **vim** extension users).
   - Evaluate code and replace it in the editor, inline: `ctrl+alt+c r`
-  - Pretty printing evaluation results: `ctrl+alt+c p` (Currently broken, see issues on Github).
+  - Evaluate code and add as comment: `ctrl+alt+c c` (current form), `ctrl+alt+c ctrl space` (current _top level_ form)
+  - Pretty printing evaluation results: `ctrl+alt+c p`
   - Evaluate current top level form (based on where the cursor is) and show results inline: `ctrl+alt+c space`
-    - Send the current top level form to the REPL terminal: `ctrl+alt+c ctrl+alt+space`
+    - Send the current top level form to the REPL window: `ctrl+alt+c ctrl+alt+space`
   - Error information when evaluation fails (at least a hint)
   - Support for `cljc` files and you can choose if they should be evaluated by the `clj` or the `cljc` repl session.
   - Enables `clj` REPL for all files/editors. You now can evaluate those Clojure code snippets in Markdown files.

--- a/calva/evaluate.ts
+++ b/calva/evaluate.ts
@@ -120,6 +120,10 @@ function evaluateSelectionAsComment(document = {}, options = {}) {
     evaluateSelection(document, Object.assign({}, options, { comment: true, pprint: true }));
 }
 
+function evaluateTopLevelFormAsComment(document = {}, options = {}) {
+    evaluateSelection(document, Object.assign({}, options, { comment: true, topLevel: true, pprint: true }));
+}
+
 function evaluateSelectionPrettyPrint(document = {}, options = {}) {
     evaluateSelection(document, Object.assign({}, options, { pprint: true }));
 }
@@ -193,6 +197,7 @@ export default {
     evaluateCurrentTopLevelFormPrettyPrint,
     evaluateSelectionReplace,
     evaluateSelectionAsComment,
+    evaluateTopLevelFormAsComment,
     copyLastResultCommand,
     requireREPLUtilitiesCommand
 };

--- a/calva/extension.ts
+++ b/calva/extension.ts
@@ -133,6 +133,7 @@ function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateCurrentTopLevelFormPrettyPrint', EvaluateMiddleWare.evaluateCurrentTopLevelFormPrettyPrint));
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateSelectionReplace', EvaluateMiddleWare.evaluateSelectionReplace));
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateSelectionAsComment', EvaluateMiddleWare.evaluateSelectionAsComment));
+    context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateTopLevelFormAsComment', EvaluateMiddleWare.evaluateTopLevelFormAsComment));
     context.subscriptions.push(vscode.commands.registerCommand('calva.lintFile', LintMiddleWare.lintDocument));
     context.subscriptions.push(vscode.commands.registerCommand('calva.runTestUnderCursor', TestRunnerMiddleWare.runTestUnderCursorCommand));
     context.subscriptions.push(vscode.commands.registerCommand('calva.runNamespaceTests', TestRunnerMiddleWare.runNamespaceTestsCommand));

--- a/package.json
+++ b/package.json
@@ -536,7 +536,12 @@
             },
             {
                 "command": "calva.evaluateSelectionAsComment",
-                "title": "Evaluate current form, and append a comment with the result",
+                "title": "Evaluate current form, append a comment with the result",
+                "category": "Calva"
+            },
+            {
+                "command": "calva.evaluateTopLevelFormAsComment",
+                "title": "Evaluate current top level form, append a comment with the result",
                 "category": "Calva"
             },
             {
@@ -894,6 +899,10 @@
             {
                 "command": "calva.evaluateSelectionAsComment",
                 "key": "ctrl+alt+c c"
+            },
+            {
+                "command": "calva.evaluateTopLevelFormAsComment",
+                "key": "ctrl+alt+c ctrl+space"
             },
             {
                 "command": "calva.copyLastResults",


### PR DESCRIPTION
Resolves #349.

Introduces the following change(s):
- Adds a command for evaluating the top level form, appending the result as a comment
- See #349 for rationale

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Referenced the issue I am fixing/addressing.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Updated the `[Unrleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. 😀-->

Ping: @cfehse, @kstehn