### PR TITLE
Update status bar when configuration changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - [Adding selected calva commands to the editors context menu](https://github.com/BetterThanTomorrow/calva/issues/338)
+- [Update status bar when configuration changed](https://github.com/BetterThanTomorrow/calva/issues/358)
 
 ## [2.0.41] - 28.09.2019
 - [Add pretty print mode](https://github.com/BetterThanTomorrow/calva/issues/327)

--- a/calva/extension.ts
+++ b/calva/extension.ts
@@ -66,7 +66,6 @@ function activate(context: vscode.ExtensionContext) {
 
     const chan = state.outputChannel();
 
-
     const legacyExtension = vscode.extensions.getExtension('cospaia.clojure4vscode'),
         fmtExtension = vscode.extensions.getExtension('cospaia.calva-fmt'),
         pareEditExtension = vscode.extensions.getExtension('cospaia.paredit-revived'),
@@ -204,9 +203,9 @@ function activate(context: vscode.ExtensionContext) {
         chan.dispose();
     }));
 
-    // context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((event) => {
-    //     console.log(event);
-    // }));
+    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((_: vscode.ConfigurationChangeEvent) => {
+        statusbar.update();
+    }));
 
     vscode.commands.executeCommand('setContext', 'calva:activated', true);
 

--- a/package.json
+++ b/package.json
@@ -640,7 +640,6 @@
             {
                 "command": "calva.refreshAll",
                 "title": "Refresh All Namespaces",
-                
                 "category": "Calva"
             },
             {
@@ -1249,7 +1248,7 @@
                     "when": "editorLangId == clojure  && calva:connected",
                     "command": "calva.loadFile",
                     "group": "calva/c-load"
-                },                
+                },
                 {
                     "when": "editorLangId == clojure && calva:connected",
                     "command": "calva.loadNamespace",


### PR DESCRIPTION
Fixes #358.

Introduces the following change(s):
- When "Pretty Print" setting is changed in settings (checked/unchecked) the "pprint" button in the status bar updates immediately

I have:

- [x ] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x ] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x ] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x ] Created the issue I am fixing/addressing, if it was not present.
- [x ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

Ping: @pez, @kstehn