### PR TITLE
Fix typo in jack-in command

### DIFF
--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -164,9 +164,9 @@ export async function calvaJackInOrConnect() {
         commands["Connect to a running REPL server in your project"] = "calva.connect";
         commands["Connect to a running REPL server, not in your project"] = "calva.connectNonProjectREPL";
     } else {
-        // if connected add the disconnect command and the 
+        // if connected add the disconnect command and the
         // REPL window open commands if needed.
-        commands["Disonnect from the REPL server"] = "calva.disconnect";
+        commands["Disconnect from the REPL server"] = "calva.disconnect";
         if(utilities.getSession("clj") && !isReplWindowOpen("clj")) {
             commands["Open the Clojure REPL Window"] = "calva.openCljReplWindow";
         }


### PR DESCRIPTION
Introduces the following change(s):
- Fixes a typo in the `calva.disconnect` command.

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)

Ping: @pez, @kstehn