### PR TITLE
Stop opening REPL window on async output

### DIFF
--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -165,7 +165,7 @@ export class NReplSession {
         const msgType: string = msgData.out? "stdout" : "stderr";
 
         if (msgValue && this.replType) {
-            const window = await replWindow.openReplWindow(this.replType, true);
+            const window = replWindow.getReplWindow(this.replType);
             const windowMsg = {
                 type: msgType,
                 value: msgValue

--- a/src/repl-window.ts
+++ b/src/repl-window.ts
@@ -201,6 +201,10 @@ let replWindows: { [id: string]: REPLWindow } = {};
 let replViewColum: { [id: string]: vscode.ViewColumn } = {"clj": vscode.ViewColumn.Two, 
                                                           "cljs": vscode.ViewColumn.Two};
 
+export function getReplWindow(mode: "clj" | "cljs") {
+    return replWindows[mode];
+}
+
 function getImageUrl(name: string) {
     let imagepath = "";
     if (!name)


### PR DESCRIPTION
Fixes #371

Introduces the following change(s):
- Add function for getting current REPL window without opening it
- Using this to stop opening the window in the default message handler
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

Ping: @kstehn, @cfehse