### PR TITLE
Fix broken link to Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Let Calva start your project (_a.k.a. **Jack-in**_).
 
 When Calva has connected, it will open a REPL window giving you some getting started tips, and you can start hacking. The first thing you should always do to ”wake” Calva is to load/evaluate the current Clojure(Script) file: `ctrl+alt+c enter`.
 
-Troubles connecting? [Check here](https://github.com/BetterThanTomorrow/calva/wiki/About-Calva-Jack-in). (Please help keep that wiki page updated.)
+Troubles connecting? [Check here](https://github.com/BetterThanTomorrow/calva/wiki/Connect-Calva-to-Your-Project). (Please help keep that wiki page updated.)
 
 ## Something to try first
 


### PR DESCRIPTION
The link to About-Calva-Jack-in should be (I believe!) to Connect-Calva-to-Your-Project

Fixes #.

Introduces the following change(s):
- 
- 
- 

<!-- If you have considered alternative ways to introduce the change, replace this paragrah with a brief reasoning about why you made the choices you did. Otherwise just remove this paragraph. -->

I have:

- [ ] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [ ] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [ ] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [ ] Created the issue I am fixing/addressing, if it was not present.
- [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. 😀-->

Ping: @pez, @kstehn, @cfehse