### PR TITLE
[WIP] Inspect data structures

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -14,7 +14,8 @@
                              :jsify calva.js-utils/jsify
                              :cljify calva.js-utils/cljify
                              :parseEdn calva.js-utils/parse-edn-js
-                             :parseForms calva.js-utils/parse-forms-js}
+                             :parseForms calva.js-utils/parse-forms-js
+                             :inspect calva.inspector/inspect}
                  :output-to "out/cljs-lib/cljs-lib.js"}
                 :test
                 {:target    :node-test

--- a/src/cljs-lib/src/calva/inspector.cljs
+++ b/src/cljs-lib/src/calva/inspector.cljs
@@ -2,10 +2,11 @@
   "Utilities for supporting Calva's inspection of data structures."
   (:require [calva.js-utils :refer [jsify parse-edn]]))
 
-(defn- inspector-annotate
-  "Recursively annotates ClojureScript values with .
-  sets/vectors/lists become Arrays, Keywords and Symbol become Strings,
-  Maps become Objects. Arbitrary keys are encoded to by `inspector-key->js`."
+(defn- annotate
+  "Recursively annotates ClojureScript values with Clojure data type information.
+  Sets/vectors/lists become arrays, keywords and symbol become strings. Maps become
+  objects. All these are wrapped in objects containing `type` and `value`.
+  Values that map to JavaScript primitives are not annotated."
   [x]
   (letfn [(thisfn [x]
             (cond
@@ -29,14 +30,14 @@
   [s]
   (-> s
       (parse-edn)
-      (inspector-annotate)
+      (annotate)
       (jsify)))
 
 (comment
   (map (fn [[k v]] [k (inc v)]) (seq {:foo 1 :bar 2}))
   (into {} (for [[k v] (seq {:foo 1 :bar 2})] [k (inc v)])) 
-  (clj->js (inspector-annotate {:foo (vec (repeat 3 :empty))}))
-  (clj->js (inspector-annotate [1 2 3 4 5]))
-  (clj->js (inspector-annotate #([1 2 3 4 5])))
-  (clj->js (inspector-annotate {:foo 1 :bar ["a", "b", "c"]}))
-  (clj->js (inspector-annotate (def s [1 2 3 4 5]))))
+  (clj->js (annotate {:foo (vec (repeat 3 :empty))}))
+  (clj->js (annotate [1 2 3 4 5]))
+  (clj->js (annotate #([1 2 3 4 5])))
+  (clj->js (annotate {:foo 1 :bar ["a", "b", "c"]}))
+  (clj->js (annotate (def s [1 2 3 4 5]))))

--- a/src/cljs-lib/src/calva/inspector.cljs
+++ b/src/cljs-lib/src/calva/inspector.cljs
@@ -1,0 +1,42 @@
+(ns  calva.inspector
+  "Utilities for supporting Calva's inspection of data structures."
+  (:require [calva.js-utils :refer [jsify parse-edn]]))
+
+(defn- inspector-annotate
+  "Recursively annotates ClojureScript values with .
+  sets/vectors/lists become Arrays, Keywords and Symbol become Strings,
+  Maps become Objects. Arbitrary keys are encoded to by `inspector-key->js`."
+  [x]
+  (letfn [(thisfn [x]
+            (cond
+              (keyword? x) {:type "keyword" :value (name x)}
+              (symbol? x) {:type "symbol" :value (str x)}
+              (map? x) {:type "map" :value (into {} (for [[k v] x] [k (thisfn v)]))}
+              (coll? x) (let [type (cond
+                                     (vector? x) "vector"
+                                     (list? x) "list"
+                                     (set? x) "set"
+                                     :else "coll")]
+                          {:type type :value (map thisfn x)})
+              :else x))]
+    (thisfn x)))
+
+(defn inspect
+  "Reads the string `s`, which should be a string containing a Clojure form,
+   and returns it js-ified as either:
+   * The single value, if the form parses to a JS primitive, (number, string etcetera)
+   * An object annotated with Clojure types"
+  [s]
+  (-> s
+      (parse-edn)
+      (inspector-annotate)
+      (jsify)))
+
+(comment
+  (map (fn [[k v]] [k (inc v)]) (seq {:foo 1 :bar 2}))
+  (into {} (for [[k v] (seq {:foo 1 :bar 2})] [k (inc v)])) 
+  (clj->js (inspector-annotate {:foo (vec (repeat 3 :empty))}))
+  (clj->js (inspector-annotate [1 2 3 4 5]))
+  (clj->js (inspector-annotate #([1 2 3 4 5])))
+  (clj->js (inspector-annotate {:foo 1 :bar ["a", "b", "c"]}))
+  (clj->js (inspector-annotate (def s [1 2 3 4 5]))))

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -7,7 +7,8 @@ import select from './select';
 import * as util from './utilities';
 import { activeReplWindow } from './repl-window';
 import { NReplSession } from './nrepl';
-import statusbar from './statusbar'
+import statusbar from './statusbar';
+import * as inspector from './providers/inspector';
 
 function addAsComment(c: number, result: string, codeSelection: vscode.Selection, editor: vscode.TextEditor, selection: vscode.Selection) {
     const indent = `${' '.repeat(c)}`, output = result.replace(/\n\r?$/, "").split(/\n\r?/).join(`\n${indent};;    `), edit = vscode.TextEdit.insert(codeSelection.end, `\n${indent};; => ${output}\n`), wsEdit = new vscode.WorkspaceEdit();
@@ -64,6 +65,8 @@ async function evaluateSelection(document = {}, options = {}) {
                     });
                 let value = await context.value;
                 value = util.stripAnsi(context.pprintOut || value);
+
+                inspector.inspectForm(value);
 
                 if (replace) {
                     const indent = `${' '.repeat(c)}`,

--- a/src/providers/inspector.ts
+++ b/src/providers/inspector.ts
@@ -1,0 +1,6 @@
+const { inspect } = require('../../out/cljs-lib/cljs-lib');
+
+export function inspectForm(form: string) {
+    const inspected = inspect(form);
+    console.log(inspected);
+}


### PR DESCRIPTION
Console logs out a type annotated object of the evaluation results.
Addresses #228

This is very, very much just work in progress and a request for feedback.

I want to add an inspector to Calva, to make it so that I don't have to use the rather clunky `clojure.inspector/inspect-tree` to navigate data structures when they get a bit large.

My idea is to use a VS Code Tree View for this and populate it with the parsed result. I'm thinking this could happen as automatically as the inline result decorations and hovers. And also be cleared together with those, probably with a way to pin results so that they can survive clearing of the decorations.

For now I have only started to try see what shape the data structure should have in order to be easy to traverse and use to populate the tree view. And right now all I do with it is `console.log()` it out when the evaluation results come in. To try it out, evaluate some code and check the Developer Tools Console.

I'd like to know if you think I am going about this the right way. And if so also what types I should annotate, I just took a few from the top of my head for now.

The interesting stuff happens in `inspector.cljs`. 

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [ ] Created the issue I am fixing/addressing, if it was not present.
- [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

Ping: @slipset, @kstehn, @cfehse, @Gnurdle 