### PR TITLE
No onEnterRule when Calva is not auto-indenting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - [Warnings/Errors should be made more "prominent" in the "Calva says" channel](https://github.com/BetterThanTomorrow/calva/issues/356)
+- [Don't remove default indents when Calva is not the auto-formatter](https://github.com/BetterThanTomorrow/calva/pull/383)
 
 ## [2.0.44] - 05.10.2019
 - [Support for custom project/workflow commands](https://github.com/BetterThanTomorrow/calva/issues/281)

--- a/src/calva-fmt/src/config.ts
+++ b/src/calva-fmt/src/config.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 function readConfiguration() {
     let workspaceConfig = vscode.workspace.getConfiguration("calva.fmt");
     return {
-        "format-as-you-type": workspaceConfig.get("formatAsYouType"),
+        "format-as-you-type": workspaceConfig.get("formatAsYouType") as boolean,
         "indentation?": workspaceConfig.get("indentation"),
         "remove-surrounding-whitespace?": workspaceConfig.get("removeSurroundingWhitespace"),
         "remove-trailing-whitespace?": workspaceConfig.get("removeTrailingWhitespace"),


### PR DESCRIPTION
Don't remove default indentation when formatAsYouType is off. (Calva does this when it is responsible for auto indentation in order to get the cursor to end up at the beginning of the line outside top-level forms.)

Fix #253

I've added a config listener that toggles the `onEnterRule` off when `calva.fmt.formatAsYouType` is disabled.

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - x ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

Ping: @kstehn, @cfehse