### PR TITLE
Fix issue 374

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 Changes to Calva.
 
 ## [Unreleased]
--[calva.evalCurrentTopLevelFormInREPLWindow fails in specific condition](https://github.com/BetterThanTomorrow/calva/issues/374)
+- [calva.evalCurrentTopLevelFormInREPLWindow fails in specific condition](https://github.com/BetterThanTomorrow/calva/issues/374)
 
 ## [2.0.47] - 10.10.2019
 - [Fix dimming out of stacked ignored forms](https://github.com/BetterThanTomorrow/calva/issues/385)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 Changes to Calva.
 
 ## [Unreleased]
+-[calva.evalCurrentTopLevelFormInREPLWindow fails in specific condition](https://github.com/BetterThanTomorrow/calva/issues/374)
 
+## [2.0.47] - 10.10.2019
 - [Fix dimming out of stacked ignored forms](https://github.com/BetterThanTomorrow/calva/issues/385)
 - [The extension should specify the default schemes for document selectors](https://github.com/BetterThanTomorrow/calva/issues/368)
 - [Make code more robust in case Jack-in task fails](https://github.com/BetterThanTomorrow/calva/issues/367)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to Calva.
 ## [Unreleased]
 - [Fix dimming out of stacked ignored forms](https://github.com/BetterThanTomorrow/calva/issues/385)
 
-## [2.0.45] - 08.10.2019
+## [2.0.46] - 08.10.2019
 - [Connect warnings and errors as popups](https://github.com/BetterThanTomorrow/calva/issues/356)
 - [Don't remove default indents when Calva is not the auto-formatter](https://github.com/BetterThanTomorrow/calva/pull/383)
 

--- a/src/select.ts
+++ b/src/select.ts
@@ -13,7 +13,7 @@ function _adjustRangeIgnoringComment(doc, range) {
             postTextLength = 0,
             // find the beginning '(comment...`in the text.
             preMatch = text.match(/^\(\s*comment\s+/m),
-            // find only the last ')' in the text.
+            // find the last ')' in the text.
             postMatch = text.match(/(\))(?!.*\))/m);
         if (preMatch) {
             preTextLength = preMatch[0].length;

--- a/src/select.ts
+++ b/src/select.ts
@@ -36,10 +36,8 @@ function _getFormSelection(doc, pos: vscode.Position, topLevel): vscode.Selectio
         peRange = topLevel ? paredit.navigator.rangeForDefun(ast, idx) : paredit.navigator.sexpRange(ast, idx);
     if (peRange) {
         let range = new vscode.Selection(doc.positionAt(peRange[0]), doc.positionAt(peRange[1]));
-        let rangeText = doc.getText(range);
         if (pos.isAfter(range.start) && pos.isBefore(range.end)) {
             range = _adjustRangeIgnoringComment(doc, range);
-            rangeText = doc.getText(range);
             if (topLevel) {
                 const idxOffset = doc.offsetAt(range.start);
                 ast = paredit.parse(doc.getText(range));

--- a/src/select.ts
+++ b/src/select.ts
@@ -11,8 +11,10 @@ function _adjustRangeIgnoringComment(doc, range) {
             preTextLength = 0,
             end = doc.offsetAt(range.end),
             postTextLength = 0,
+            // find the beginning '(comment...`in the text.
             preMatch = text.match(/^\(\s*comment\s+/m),
-            postMatch = text.match(/\s*\)\s*$/m);
+            // find only the last ')' in the text.
+            postMatch = text.match(/(\))(?!.*\))/m);
         if (preMatch) {
             preTextLength = preMatch[0].length;
         }

--- a/src/select.ts
+++ b/src/select.ts
@@ -43,7 +43,11 @@ function _getFormSelection(doc, pos: vscode.Position, topLevel): vscode.Selectio
                 ast = paredit.parse(doc.getText(range));
                 idx = idx - idxOffset;
                 peRange = paredit.navigator.rangeForDefun(ast, idx);
-                range = new vscode.Selection(doc.positionAt(peRange[0] + idxOffset), doc.positionAt(peRange[1] + idxOffset));
+                if (peRange) {
+                    return new vscode.Selection(doc.positionAt(peRange[0] + idxOffset), doc.positionAt(peRange[1] + idxOffset));
+                } else {
+                    return new vscode.Selection(pos, pos);
+                } 
             }
         }
         return range;

--- a/src/select.ts
+++ b/src/select.ts
@@ -5,25 +5,12 @@ const paredit = require('paredit.js');
 
 function _adjustRangeIgnoringComment(doc, range) {
     let text = doc.getText(range);
-
     if (text.match(/^\(\s*comment\s+/m)) {
-        let start = doc.offsetAt(range.start),
-            preTextLength = 0,
-            end = doc.offsetAt(range.end),
-            postTextLength = 0,
-            // find the beginning '(comment...`in the text.
-            preMatch = text.match(/^\(\s*comment\s+/m),
-            // find the last ')' in the text.
-            postMatch = text.match(/(\))(?!.*\))/m);
-        if (preMatch) {
-            preTextLength = preMatch[0].length;
-        }
-        if (postMatch) {
-            postTextLength = postMatch[0].length;
-        }
-        start += preTextLength;
-        end -= postTextLength;
-        return new vscode.Range(doc.positionAt(start), doc.positionAt(end));
+        // Create a new top level context by removing the first and last characters of the range.
+        // These will always be the opening and the closing parens of the `(comment ...)` form.
+        const start = doc.offsetAt(range.start),
+            end = doc.offsetAt(range.end);
+        return new vscode.Range(doc.positionAt(start + 1), doc.positionAt(end - 1));
     } else {
         return range;
     }


### PR DESCRIPTION
Fixes #374.

Introduces the following change(s):
- `select.ts` function `_adjustRangeIgnoringComment()` changed regex for `postMatch` to find the last ` )`.

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. 😀-->

Ping: @pez, @kstehn, @cfehse