### PR TITLE
[WIP/Discussion] Mark compilation errors on form evaluation

### DIFF
--- a/src/providers/annotations.ts
+++ b/src/providers/annotations.ts
@@ -93,6 +93,7 @@ function clearEvaluationDecorations(editor?: vscode.TextEditor) {
         state.cursor.delete(editor.document.uri + ':selectionDecorationRanges:' + status);
         setSelectionDecorations(editor, [], status);
     }
+    clearCompilationErrors();
 }
 
 function decorateResults(resultString, hasError, codeSelection: vscode.Range, editor) {
@@ -144,11 +145,24 @@ function copyHoverTextCommand(args: { [x: string]: string; }) {
     vscode.env.clipboard.writeText(args["text"]);
 }
 
+function markCompilationError(range: vscode.Range, message: string, documentUri: vscode.Uri) {
+    const diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Error);
+    const diagnosticCollection = <vscode.DiagnosticCollection>state.deref().get('compilationDiagnosticCollection');
+    diagnosticCollection.set(documentUri, [diagnostic]);
+}
+
+function clearCompilationErrors() {
+    const diagnosticCollection = state.deref().get('compilationDiagnosticCollection');
+    diagnosticCollection.clear();
+}
+
 export default {
     AnnotationStatus,
     clearEvaluationDecorations,
     decorateResults,
     decorateSelection,
     onDidChangeTextDocument,
-    copyHoverTextCommand
+    copyHoverTextCommand,
+    markCompilationError,
+    clearCompilationErrors,
 };

--- a/src/select.ts
+++ b/src/select.ts
@@ -57,7 +57,19 @@ function selectCurrentForm(document = {}) {
     }
 }
 
+function selectContainingForm(doc, position): vscode.Range {
+    const allText = doc.getText(),
+        ast = paredit.parse(allText),
+        idx = doc.offsetAt(position),
+        parentForm = paredit.navigator.sexpRange(ast, idx),
+        startPosition = doc.positionAt(parentForm[0]),
+        endPosition = doc.positionAt(parentForm[1]),
+        range = new vscode.Range(startPosition, endPosition);
+    return range;
+}
+
 export default {
     getFormSelection: getFormSelection,
-    selectCurrentForm: selectCurrentForm
+    selectCurrentForm: selectCurrentForm,
+    selectContainingForm: selectContainingForm,
 };

--- a/src/state.ts
+++ b/src/state.ts
@@ -37,6 +37,7 @@ const initialData = {
     outputChannel: vscode.window.createOutputChannel("Calva says"),
     connectionLogChannel: vscode.window.createOutputChannel("Calva Connection Log"),
     diagnosticCollection: vscode.languages.createDiagnosticCollection('calva: Evaluation errors'),
+    compilationDiagnosticCollection: vscode.languages.createDiagnosticCollection('Calva: Compilation errors'),
     analytics: null
 };
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -18,6 +18,10 @@ export function stripAnsi(str: string) {
     return str.replace(/[\u001B\u009B][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-ntqry=><~]))/g, "")
 }
 
+function stripClass(str: string) {
+    return str.replace(/^class /, "");
+}
+
 async function quickPickSingle(opts: { values: string[], saveAs?: string, placeHolder: string, autoSelect?: boolean }) {
     if (opts.values.length == 0)
         return;
@@ -450,4 +454,5 @@ export {
     quickPickSingle,
     quickPickMulti,
     getTestUnderCursor,
+    stripClass,
 };


### PR DESCRIPTION
### PR is WIP and for Discussion

Hi Calva maintainers!

There was issue #89 where user wanted to have a red marking on compiler errors. @cfehse mentioned that this was implemented in version 2.0.49. 🎉 

However, I tried the feature but I didn't see what I was expecting. This might totally be just a my fault about not knowing how it should show up in the editor. 🤷‍♂

I had an idea how the error should be shown in the editor and implemented it here. I would like to get some feedback if it's a good idea. I added a screenshot how it shows in the editor when evaluating a form with a compiler error.

<img width="770" alt="mark-compilation-error" src="https://user-images.githubusercontent.com/4200280/67149713-3f830980-f2b7-11e9-9f9d-c5829edc0dd8.png">
