### PR TITLE
[WIP] Pretty printing does only that (not also expanding the result)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Fix Pretty printing Datomic transaction results, dumps the whole database, twice](https://github.com/BetterThanTomorrow/calva/issues/415)
+- [Fix pretty printing in repl doesn't emit reader literals](https://github.com/BetterThanTomorrow/calva/issues/378)
 
 ## [2.0.52] - 10.19.2019
 - [Add info box for VIM Extension users](https://github.com/BetterThanTomorrow/calva/issues/396)

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,4 +1,5 @@
-{:dependencies [[pez/cljfmt "0.0.4-SNAPSHOT"]]
+{:dependencies [[pez/cljfmt "0.0.4-SNAPSHOT"]
+                [zprint "0.4.16"]]
 
  :source-paths ["src/cljs-lib/src"
                 "src/cljs-lib/test"]
@@ -14,7 +15,8 @@
                              :jsify calva.js-utils/jsify
                              :cljify calva.js-utils/cljify
                              :parseEdn calva.js-utils/parse-edn-js
-                             :parseForms calva.js-utils/parse-forms-js}
+                             :parseForms calva.js-utils/parse-forms-js
+                             :prettyPrint calva.pprint.printer/pretty-print-js}
                  :output-to "out/cljs-lib/cljs-lib.js"}
                 :test
                 {:target    :node-test

--- a/src/cljs-lib/src/calva/pprint/printer.cljs
+++ b/src/cljs-lib/src/calva/pprint/printer.cljs
@@ -1,0 +1,23 @@
+(ns calva.pprint.printer
+  (:require [zprint.core :refer [zprint-str]]
+            [calva.js-utils :refer [jsify]]))
+
+
+(defn pretty-print
+  "Parses the string `s` as EDN and returns it pretty printed as a string.
+   Accepts that s is an EDN form already, and skips the parsing, if so.
+   Formats the result to fit the width `w`."
+  ([s]
+   (pretty-print s 0))
+  ([s w]
+   (let [result
+         (try
+           {:value
+            (zprint-str s w {:parse-string? (string? s)})}
+           (catch js/Error e
+             {:value s
+              :error (str "Plain printing, b/c pprint failed. (" e.message ")")}))]
+     result)))
+
+(defn pretty-print-js [& args]
+  (jsify (apply pretty-print args)))

--- a/src/cljs-lib/test/calva/pprint/printer_test.cljs
+++ b/src/cljs-lib/test/calva/pprint/printer_test.cljs
@@ -7,7 +7,7 @@
     (is (= (sut/pretty-print :foo) (sut/pretty-print ":foo"))))
   
   (testing "Pretty prints"
-    (let [result (sut/pretty-print (repeat 2 (repeat 2 {:foo :bar})) 15)]
+    (let [result (sut/pretty-print (repeat 5 (repeat 5 {:foo :bar})) 15)]
       (is (re-find #"\n" (:value result)))
       (is (nil? (:error result)))))
   

--- a/src/cljs-lib/test/calva/pprint/printer_test.cljs
+++ b/src/cljs-lib/test/calva/pprint/printer_test.cljs
@@ -1,0 +1,17 @@
+(ns calva.pprint.printer-test
+  (:require [cljs.test :include-macros true :refer [testing deftest is]]
+            [calva.pprint.printer :as sut]))
+
+(deftest pretty-print
+  (testing "Parses strings"
+    (is (= (sut/pretty-print :foo) (sut/pretty-print ":foo"))))
+  
+  (testing "Pretty prints"
+    (let [result (sut/pretty-print (repeat 2 (repeat 2 {:foo :bar})) 15)]
+      (is (re-find #"\n" (:value result)))
+      (is (nil? (:error result)))))
+  
+  (testing "Prints original on pprint error"
+    (let [croaking-s "{:db-before datomic.db.Db@f76b7417, :db-after datomic.db.Db@9ac71f6, :tx-data [#datom[13194139534320 50 #inst \"2019-10-19T16:22:36.906-00:00\" 13194139534320 true] #datom[17592186045425 62 \"Hello world\" 13194139534320 true]], :tempids {-9223301668109598139 17592186045425}}"]
+      (is (= croaking-s (:value (sut/pretty-print croaking-s))))
+      (is (some? (:error (sut/pretty-print croaking-s)))))))

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -230,7 +230,10 @@ export class NReplSession {
     eval(code: string, opts: { line?: number, column?: number, eval?: string, file?: string, stderr?: (x: string) => void, stdout?: (x: string) => void, pprint?: boolean } = {}) {
         const id = this.client.nextId,
             pprintOpts = opts.pprint ? {
-                "nrepl.middleware.print/print": "cider.nrepl.pprint/puget-pprint",
+                // "nrepl.middleware.print/print": "clojure.pprint/pprint", // boring
+                // "nrepl.middleware.print/print": "cider.nrepl.pprint/puget-pprint", // Error printing return value at clojure.lang.Util/runtimeException (Util.java:221). Unable to convert: class datomic.btset.BTSet to Object[]
+                // "nrepl.middleware.print/print": "cider.nrepl.pprint/fipp-pprint", //
+                "nrepl.middleware.print/print": "cider.nrepl.pprint/zprint-pprint", // dumps the whole database, schema and all
                 "nrepl.middleware.print/options": {
                     "width": 120,
                 }

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -47,7 +47,7 @@ export function shadowBuilds(): string[] {
 
 const cliDependencies = {
     "nrepl": "0.6.0",
-    "cider/cider-nrepl": "0.22.1",
+    "cider/cider-nrepl": "0.22.4",
 }
 
 const cljsCommonDependencies = {
@@ -62,7 +62,7 @@ const cljsDependencies: { [id: string]: Object } = {
         "com.bhauman/figwheel-main": "0.2.3"
     },
     "shadow-cljs": {
-        "cider/cider-nrepl": "0.22.1",
+        "cider/cider-nrepl": "0.22.4",
     },
     "Nashorn": {
     },
@@ -71,7 +71,7 @@ const cljsDependencies: { [id: string]: Object } = {
 }
 
 const leinPluginDependencies = {
-    "cider/cider-nrepl": "0.22.1"
+    "cider/cider-nrepl": "0.22.4"
 }
 const leinDependencies = {
     "nrepl": "0.6.0",


### PR DESCRIPTION
## What has Changed?
- Pretty printing is now performed using `calva-lib` on the plain-printed results from nrepl. Instead of doing it via nrepl.
- Since we need to first parse the result string in order to prettify it, there are situations when the string doesn't parse. (E.g. Datomic `:db-before` values.) In these cases we print the result plain instead and show the parsing error causing the pprint to not happen. 
- This way of doing the pprint also means data readers are left alone. Which should fix #378 
- This also avoids having values ”expanded” by pretty printing, which can get pretty hairy, as #415 shows.

To test the change, you can use this project: https://github.com/PEZ/nrepl-pprint-datomic
See #415 for the repro steps.

Fixes #378 #415

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.) You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. (For now you'll need to opt in to the CircleCI _New Experience_ UI to see the Artifacts tab, because bug.)
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

## The Calva TEAM PR Checklist:

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse