### PR TITLE
Fix - find definition for derefed value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Fix hover definition for symbols derefed with `@`](https://github.com/BetterThanTomorrow/calva/issues/106)
 
 ## [2.0.57] - 2019-11-03
 - [Provide argument list help as you type the function's arguments](https://github.com/BetterThanTomorrow/calva/issues/361)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - [Fix hover definition for symbols derefed with `@`](https://github.com/BetterThanTomorrow/calva/issues/106)
+- Fix hover definition for var quoted symbols
 
 ## [2.0.57] - 2019-11-03
 - [Provide argument list help as you type the function's arguments](https://github.com/BetterThanTomorrow/calva/issues/361)

--- a/src/calva-fmt/src/extension.ts
+++ b/src/calva-fmt/src/extension.ts
@@ -9,7 +9,7 @@ import * as config from './config'
 
 function getLanguageConfiguration(autoIndentOn: boolean): vscode.LanguageConfiguration {
     return {
-        wordPattern: /[^\s,#()[\]{};"\\]+/,
+        wordPattern: /[^\s,#()[\]{};"\\\@]+/,
         onEnterRules: autoIndentOn ? [
             // This is madness, but the only way to stop vscode from indenting new lines
             {

--- a/src/calva-fmt/src/extension.ts
+++ b/src/calva-fmt/src/extension.ts
@@ -9,7 +9,7 @@ import * as config from './config'
 
 function getLanguageConfiguration(autoIndentOn: boolean): vscode.LanguageConfiguration {
     return {
-        wordPattern: /[^\s,#()[\]{};"\\\@]+/,
+        wordPattern: /[^\s,#()[\]{};"\\\@\']+/,
         onEnterRules: autoIndentOn ? [
             // This is madness, but the only way to stop vscode from indenting new lines
             {


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->
- Fix find definition / hover for derefed symbol

![image](https://user-images.githubusercontent.com/12722744/68092725-0021f480-fe43-11e9-9dcd-6fa84856aa46.png)

- Fix find definition / hover for var quoted symbol

![image](https://user-images.githubusercontent.com/12722744/68092729-0dd77a00-fe43-11e9-8c8b-6b8e55e9a134.png)




<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Fixes #106 

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.) You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. (For now you'll need to opt in to the CircleCI _New Experience_ UI to see the Artifacts tab, because bug.)
     - [x] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [ ] Created the issue I am fixing/addressing, if it was not present.
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [x] Made sure the PR is directed at the `dev` branch (unless reasons).
- [x] Read the source changes.
- [x] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [x] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse

NOTE: I thought I saw an issue in the past about the issue with hover definition for symbols (like `'some-thing`), but I can't find it now. Also, do you think changing the wordPattern as such would negatively affect any other part of the extension?

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->