### PR TITLE
[WIP] Lex quoted stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 Changes to Calva.
 
 ## [Unreleased]
-- [Fix: Lexing regex literal tokenisation](https://github.com/BetterThanTomorrow/calva/issues/463)
-- [paredit.deleteBackward sets cursor position wrong when deleting a line. ](https://github.com/BetterThanTomorrow/calva/issues/458)
-- [Calva Highlight sometimes incorrectly recognises form as a `comment` form](https://github.com/BetterThanTomorrow/calva/issues/403)
-- [Expand selection fails at the start and end of the input of the REPL window](https://github.com/BetterThanTomorrow/calva/issues/417)
+- Fix: [paredit.deleteBackward sets cursor position wrong when deleting a line. ](https://github.com/BetterThanTomorrow/calva/issues/458)
+- Fix: [Calva Highlight sometimes incorrectly recognises form as a `comment` form](https://github.com/BetterThanTomorrow/calva/issues/403)
+- Fix: [Expand selection fails at the start and end of the input of the REPL window](https://github.com/BetterThanTomorrow/calva/issues/417)
 - [Removed paredit inconsistencies](https://github.com/BetterThanTomorrow/calva/issues/170)
+- Fix: [Lexing regex literal tokenisation](https://github.com/BetterThanTomorrow/calva/issues/463)
+- Fix: [Tokenization errors with quotes, derefs, etcetera](https://github.com/BetterThanTomorrow/calva/issues/467)
+
 
 ## [2.0.60] - 2019-11-11
 - Re-enable default stylings for nREPL status bar items.

--- a/src/webview/clojure-lexer.ts
+++ b/src/webview/clojure-lexer.ts
@@ -1,3 +1,10 @@
+/**
+ * Calva Clojure Lexer
+ * 
+ * NB: The lexer tokenizes any combination of clojure quotes, `~`, and `@` prepending a list, symbol, or a literal
+ *     as one token, together with said list, symbol, or literal.
+ */
+
 import { LexicalGrammar, Token as LexerToken } from "./lexer"
 
 /** The 'toplevel' lexical grammar. This grammar contains all normal tokens. Multi-line strings are identified as
@@ -5,7 +12,12 @@ import { LexicalGrammar, Token as LexerToken } from "./lexer"
  */
 let toplevel = new LexicalGrammar()
 
-/** Returns true if open and close are compatible parentheses */
+
+/**
+ * Returns `true` if open and close are compatible parentheses
+ * @param open 
+ * @param close 
+ */
 export function validPair(open: string, close: string): boolean {
     let valid = false;
     switch (close) {
@@ -41,16 +53,16 @@ toplevel.terminal(/\)|\]|\}/, (l, m) => ({ type: "close" }))
 toplevel.terminal(/~@|~|'|#'|#:|#_|\^|`|#|\^:/, (l, m) => ({ type: "punc" }))
 
 toplevel.terminal(/['`~@]*(true|false|nil)/, (l, m) => ({ type: "lit" }))
-toplevel.terminal(/['`~@]([0-9]+[rR][0-9a-zA-Z]+)/, (l, m) => ({ type: "lit" }))
-toplevel.terminal(/['`~@]([-+]?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)?)/, (l, m) => ({ type: "lit" }))
+toplevel.terminal(/['`~@]*([0-9]+[rR][0-9a-zA-Z]+)/, (l, m) => ({ type: "lit" }))
+toplevel.terminal(/['`~@]*([-+]?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)?)/, (l, m) => ({ type: "lit" }))
 
-toplevel.terminal(/['`~@](:[^()[\]\{\}#,~@'`^\"\s;]*)/, (l, m) => ({ type: "kw" }))
+toplevel.terminal(/['`~@]*(:[^()[\]\{\}#,~@'`^\"\s;]*)/, (l, m) => ({ type: "kw" }))
 // this is a REALLY lose symbol definition, but similar to how clojure really collects it. numbers/true/nil are all 
 toplevel.terminal(/[^()[\]\{\}#,~@'`^\"\s:;][^()[\]\{\}#,~@'`^\"\s;]*/, (l, m) => ({ type: "id" }))
 
 // complete string on a single line
-toplevel.terminal(/['`~@](#?"([^"\\]|\\.)*")/, (l, m) => ({ type: "str" }))
-toplevel.terminal(/['`~@](#?"([^"\\]|\\.)*)/, (l, m) => ({ type: "str-start" }))
+toplevel.terminal(/['`~@]*(#?"([^"\\]|\\.)*")/, (l, m) => ({ type: "str" }))
+toplevel.terminal(/['`~@]*(#?"([^"\\]|\\.)*)/, (l, m) => ({ type: "str-start" }))
 toplevel.terminal(/./, (l, m) => ({ type: "junk" }))
 
 /** This is the multi-line string grammar. It spits out 'str-end' once it is time to switch back to the 'toplevel' grammar, and 'str-inside' if the string continues. */

--- a/src/webview/clojure-lexer.ts
+++ b/src/webview/clojure-lexer.ts
@@ -2,8 +2,14 @@
  * Calva Clojure Lexer
  * 
  * NB: The lexer tokenizes any combination of clojure quotes, `~`, and `@` prepending a list, symbol, or a literal
- *     as one token, together with said list, symbol, or literal.
+ *     as one token, together with said list, symbol, or literal, even if there is whitespace between the quoting characters.
+ *     All such combos won't actually be accepted by the Clojure Reader, but, hey, we're not writing a Clojure Reader here. 😀
+ *     See below for the regex used for this.
+ *     TODO: The newline as whitespace matching doesn't work. We only get one line at a time...
+ *           Investigate!.
  */
+
+ // Regex for the above mentioned behavior: /(['`~@][\s\r\n]*)*/
 
 import { LexicalGrammar, Token as LexerToken } from "./lexer"
 
@@ -45,24 +51,24 @@ toplevel.terminal(/(\r?\n)/, (l, m) => ({ type: "ws" }))
 toplevel.terminal(/;.*/, (l, m) => ({ type: "comment" }))
 // open parens
 //toplevel.terminal(/\(|\[|\{|@\(|['`]\(|#\(|#\?\(|#\{|#\?@\(/, (l, m) => ({ type: "open" }))
-toplevel.terminal(/[`'#@]*[\(\[\{]/, (l, m) => ({ type: "open" }))
+toplevel.terminal(/(['`~@][\s\r\n]*)*[\(\[\{]/, (l, m) => ({ type: "open" }))
 // close parens
 toplevel.terminal(/\)|\]|\}/, (l, m) => ({ type: "close" }))
 
 // punctuators
 toplevel.terminal(/~@|~|'|#'|#:|#_|\^|`|#|\^:/, (l, m) => ({ type: "punc" }))
 
-toplevel.terminal(/['`~@]*(true|false|nil)/, (l, m) => ({ type: "lit" }))
-toplevel.terminal(/['`~@]*([0-9]+[rR][0-9a-zA-Z]+)/, (l, m) => ({ type: "lit" }))
-toplevel.terminal(/['`~@]*([-+]?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)?)/, (l, m) => ({ type: "lit" }))
+toplevel.terminal(/(['`~@][\s\r\n]*)*(true|false|nil)/, (l, m) => ({ type: "lit" }))
+toplevel.terminal(/(['`~@][\s\r\n]*)*([0-9]+[rR][0-9a-zA-Z]+)/, (l, m) => ({ type: "lit" }))
+toplevel.terminal(/(['`~@][\s\r\n]*)*([-+]?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)?)/, (l, m) => ({ type: "lit" }))
 
-toplevel.terminal(/['`~@]*(:[^()[\]\{\}#,~@'`^\"\s;]*)/, (l, m) => ({ type: "kw" }))
+toplevel.terminal(/(['`~@][\s\r\n]*)*(:[^()[\]\{\}#,~@'`^\"\s;]*)/, (l, m) => ({ type: "kw" }))
 // this is a REALLY lose symbol definition, but similar to how clojure really collects it. numbers/true/nil are all 
-toplevel.terminal(/[^()[\]\{\}#,~@'`^\"\s:;][^()[\]\{\}#,~@'`^\"\s;]*/, (l, m) => ({ type: "id" }))
+toplevel.terminal(/(['`~@][\s\r\n]*)*([^()[\]\{\}#,~@'`^\"\s:;][^()[\]\{\}#,~@'`^\"\s;]*)/, (l, m) => ({ type: "id" }))
 
 // complete string on a single line
-toplevel.terminal(/['`~@]*(#?"([^"\\]|\\.)*")/, (l, m) => ({ type: "str" }))
-toplevel.terminal(/['`~@]*(#?"([^"\\]|\\.)*)/, (l, m) => ({ type: "str-start" }))
+toplevel.terminal(/(['`~@][\s\r\n]*)*(#?"([^"\\]|\\.)*")/, (l, m) => ({ type: "str" }))
+toplevel.terminal(/(['`~@][\s\r\n]*)*(#?"([^"\\]|\\.)*)/, (l, m) => ({ type: "str-start" }))
 toplevel.terminal(/./, (l, m) => ({ type: "junk" }))
 
 /** This is the multi-line string grammar. It spits out 'str-end' once it is time to switch back to the 'toplevel' grammar, and 'str-inside' if the string continues. */

--- a/src/webview/clojure-lexer.ts
+++ b/src/webview/clojure-lexer.ts
@@ -5,50 +5,20 @@ import { LexicalGrammar, Token as LexerToken } from "./lexer"
  */
 let toplevel = new LexicalGrammar()
 
-/** https://codereview.stackexchange.com/a/7042 */
-function combinations(chars) {
-    var result = [];
-    var f = function (prefix, chars) {
-        for (var i = 0; i < chars.length; i++) {
-            result.push(prefix + chars[i]);
-            f(prefix + chars[i], chars.slice(i + 1));
-        }
-    }
-    f('', chars);
-    return result;
-}
-
-/**
- * Create some quoted and unquoted variations of list opening with `open` and map to the `listClass`
- * @param open the opening bracket
- * @param listClass the class of the list, e.g. "()" for list
- */
-function canonicalOpens(open: string, listClass: string): { [id: string]: string } {
-    return combinations(['', '\'', '`', '~', '@']).map(quote => {
-        return [`${quote}${open}`, listClass]
-    }).reduce((o, [k, v]) => (o[k] = v, o), {});
-}
-
-/** Maps open and close parentheses to their class. */
-export const canonicalParens = {
-    ...canonicalOpens('(', '()'),
-    ...canonicalOpens('@(', '()'),
-    ...canonicalOpens('#?(', '()'),
-    ...canonicalOpens('#?@(', '()'),
-    ...canonicalOpens('#(', '()'),
-    ...canonicalOpens('#{', '{}'),
-    ...canonicalOpens('[', '[]'),
-    ...canonicalOpens('{', '{}'),
-    ')': '()',
-    ']': '[]',
-    '}': '{}'
-}
-
-console.log(canonicalParens);
-
 /** Returns true if open and close are compatible parentheses */
-export function validPair(open: string, close: string) {
-    return canonicalParens[open] == canonicalParens[close];
+export function validPair(open: string, close: string): boolean {
+    let valid = false;
+    switch (close) {
+        case `)`:
+            return open.endsWith("(");
+        case `]`:
+            return open.endsWith("[");
+        case `}`:
+            return open.endsWith("{");
+        default:
+            break;
+    };
+    return valid;
 }
 
 export interface Token extends LexerToken {


### PR DESCRIPTION
## What has Changed?

- In the REPL window, syntax highlighting, and Paredit commands regarding something like ``'`'`'@'(foo)``, now considers that as one token, instead of three, as it used to.
- This also fixes how the signature help matches active parameter for an argument like this.
- _NB: It does not fix Paredit commands in the editor, because they do not use our own Paredit yet._

This is fixed such that the tokenizer now considers all combinations of the characters ``'.`~@``, in any order and with any (one-line) whitespace between as one token, together with the list, symbol, or literal they prepend. I am using this regex: ``/(['`~@][\s\r\n]*)*/``, prepended in front of the token regexes for lists, literals, etc.

It also involves a different check for valid matching pairs. Where we used to have a dictionary of opening bracket character sequences, such as `#?(` matching against list type, I now instead just check if the opening token ends with `(`, `[`, or `{` and return true for `)`, `]`, and `}`, respectively.

This fixes #467, and then some.

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.) You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. (For now you'll need to opt in to the CircleCI _New Experience_ UI to see the Artifacts tab, because bug.)
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

## The Calva Team PR Checklist:
Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse

Also pinging @mseddon for sanity check, since you wrote this stuff originally. 😄 