### PR TITLE
Add test message to test runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Add test message to test runner](https://github.com/BetterThanTomorrow/calva/issues/425)
 - [Fix: Lexing regex literal tokenisation](https://github.com/BetterThanTomorrow/calva/issues/463)
 
 ## [2.0.60] - 2019-11-11

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -23,8 +23,16 @@ function reportTests(results, errorStr, log = true) {
                 let resultSet = result.results[ns];
                 for (const test in resultSet) {
                     for (const a of resultSet[test]) {
+                        const resultMessage = (resultItem) => {
+                          let msg = [];
+                          if(!_.isEmpty(resultItem.context) && resultItem.context !== "false")
+                            msg.push(resultItem.context);
+                          if(resultItem.message)
+                            msg.push(resultItem.message);
+                          return `${msg.join(": ")}${(msg.length > 0 ? "\n" : "")}`;
+                        }
                         if (a.type == "error" && log)
-                            chan.appendLine(`ERROR in: ${ns}: ${a.file}, line ${a.line}: ${test}: ${(a.context || "")}:\n  error: ${a.error} + "\n  expected: ${a.expected}`);
+                          chan.appendLine(`ERROR in ${ns}/${test} (line ${a.line}):\n${resultMessage(a)}   error: ${a.error} (${a.file})\nexpected: ${a.expected}`);
                         if (a.type == "fail") {
                             let msg = `failure in test: ${test} context: ${a.context}, expected ${a.expected}, got: ${a.actual}`,
                                 err = new vscode.Diagnostic(new vscode.Range(a.line - 1, 0, a.line - 1, 1000), msg, vscode.DiagnosticSeverity.Error);
@@ -32,7 +40,7 @@ function reportTests(results, errorStr, log = true) {
                                 diagnostics[a.file] = [];
                             diagnostics[a.file].push(err);
                             if (log)
-                                chan.appendLine(`FAIL in: ${a.file}: ${a.line}: ${test}: ${(a.context || "")}:\n  expected: ${a.expected}\n  actual: ${a.actual}`);
+                              chan.appendLine(`FAIL in ${ns}/${test} (${a.file}:${a.line}):\n${resultMessage(a)}expected: ${a.expected}  actual: ${a.actual}`);
                         }
                     }
                 }


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->
- Add test message to the test runner output
- Reformat error and failure test runner output

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Closes #425 

### Sample outputs
#### Failure test
```clj
(deftest fail-test
  (testing "The test context"
    (is (= 1 2) "Math is hard")
    (is (= 1 3))))
```
```
FAIL in my-project.upload-helpers-test/fail-test (upload_helpers_test.clj:10):
The test context: Math is hard
expected: 1
  actual: (2)

FAIL in my-project.upload-helpers-test/fail-test (upload_helpers_test.clj:11):
The test context
expected: 1
  actual: (3)
```
#### Without context or message 
```clj
(deftest fail-test-2
  (is (= 1 2)))
```
```
FAIL in my-project.upload-helpers-test/fail-test-2 (upload_helpers_test.clj:14):
expected: 1
  actual: (2)
```

#### Error test
```clj
(deftest error-test
  (testing "The test context"
    (is (= (/ 1 0) 1) "The test message")))
```
```
ERROR in my-project.upload-helpers-test/error-test (line 19):
The test context: The test message
   error: java.lang.ArithmeticException: Divide by zero (Numbers.java)
expected: (= (/ 1 0) 1)
```
Note on error outputs: The file in the error result references the source of the exception (`Numbers.java`), but the line number is from the test file (`upload_helpers_test.clj`), so I moved the file to the error message line.

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.) You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. (For now you'll need to opt in to the CircleCI _New Experience_ UI to see the Artifacts tab, because bug.)
     - [x] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)keywords.
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [x] Made sure the PR is directed at the `dev` branch (unless reasons).
- [x] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [x] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->