### PR TITLE
Use MarkdownString to format docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Use markdown in to format docstrings in hover.
 
 ## [2.0.66] - 2019-12-02
 - Fix: [Cursor moves forward after undoing wraparound commands in REPL window](https://github.com/BetterThanTomorrow/calva/issues/499)

--- a/package.json
+++ b/package.json
@@ -167,6 +167,11 @@
                         "default": false,
                         "description": "Run namespace tests when opening a new file and on file save"
                     },
+                    "calva.showDocstringInParameterHelp": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Show the docstring in the parameter hints"
+                    },
                     "calva.syncReplNamespaceToCurrentFile": {
                         "type": "boolean",
                         "default": false,

--- a/src/state.ts
+++ b/src/state.ts
@@ -102,6 +102,7 @@ function config() {
         format: configOptions.get("formatOnSave"),
         evaluate: configOptions.get("evalOnSave"),
         test: configOptions.get("testOnSave"),
+        showDocstringInParameterHelp: configOptions.get("showDocstringInParameterHelp") as boolean,
         syncReplNamespaceToCurrentFile: configOptions.get("syncReplNamespaceToCurrentFile"),
         jackInEnv: configOptions.get("jackInEnv"),
         openBrowserWhenFigwheelStarted: configOptions.get("openBrowserWhenFigwheelStarted") as boolean,


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->
- Format hover docstrings with `MarkdownString`
- Format completion docstring
- Add docstring to signature information

Currently multi-line docstrings are very hard to read because VS Code doesn't respect newlines.  I think this is behavior that should be fixed with VS Code, but this PR fixes this by using `MarkdownStrings` to format the hover text.

The fix was possible by formatting the docstring as a codeblock, which preserves most of the docstring formatting.  One thing to note is that this does seem to make my font a little bigger in the docstring portion, but I think this is fine since it is much more important to properly format the docstring.

### Hover
#### Before
![Screen Shot 2019-12-03 at 10 58 51 PM](https://user-images.githubusercontent.com/4265922/70120642-f1855380-1621-11ea-80a8-bbb9d3167b77.png)

#### After
![Screen Shot 2019-12-03 at 10 51 50 PM](https://user-images.githubusercontent.com/4265922/70120643-f1855380-1621-11ea-9bc1-76fa63a8ef99.png)

#### Embedded codeblock detection
<img width="509" alt="Screen Shot 2019-12-04 at 2 38 04 AM" src="https://user-images.githubusercontent.com/4265922/70164907-dee93980-1676-11ea-97e8-b7a15c7f8385.png">

### Signatures
I tested out adding the docstring to the signature since I think this is when the docstring is most useful, I'm not sure if others have a different opinion on this.
![Screen Shot 2019-12-03 at 11 20 06 PM](https://user-images.githubusercontent.com/4265922/70121480-8177cd00-1623-11ea-989a-efc483666473.png)

Signature formatting is sometimes broken for long lines of text
![Screen Shot 2019-12-03 at 11 22 05 PM](https://user-images.githubusercontent.com/4265922/70121726-0f53b800-1624-11ea-9bd0-02702816fb1b.png)

### Completion
![Screen Shot 2019-12-03 at 11 29 13 PM](https://user-images.githubusercontent.com/4265922/70122083-cf410500-1624-11ea-9c2f-f7ba6c732a4a.png)

### Issues
- Because clojure docstrings are formatted with all lines aligned with the start column of the first line, the extra whitespace is carried over to the docstrings.
```
(defn testfn-2
  "Multiline docstrings
   Will show in the signature window."
  ([a] (println a))
  ([a b] (println a b)))
```
![Screen Shot 2019-12-03 at 11 27 36 PM](https://user-images.githubusercontent.com/4265922/70121954-82f5c500-1624-11ea-86d5-af62a83ce8d3.png)

- The markdown header has a very large top padding

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.) You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. (For now you'll need to opt in to the CircleCI _New Experience_ UI to see the Artifacts tab, because bug.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->