### PR TITLE
Fix missing Windows keybinding in documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Fix Windows documentation for Evaluate current form](https://github.com/BetterThanTomorrow/calva/issues/533)
 
 ## [2.0.73] - 2019-12-25
 - [Add Paredit drag up/down commands](https://github.com/BetterThanTomorrow/calva/issues/500)

--- a/docs/readthedocs/source/commands-top10.md
+++ b/docs/readthedocs/source/commands-top10.md
@@ -4,7 +4,7 @@ There are not all that many Calva commands, you can learn them all. But there ar
 
 * **Grow/expand selection**: `ctrl+w`
 * **Load current file**: `alt+ctrl+c enter`, evaluates the namespace code in the active editor tab. This also loads any required namespaces, and generally gives Calva what it needs to work.
-* **Evaluate current form**:  `alt+ctrl+c e`, finds the form from the cursor position, evaluates it and displays the result inline. Hit `esc` to dismiss the results display.
+* **Evaluate current form**:  `alt+ctrl+c e` (`alt+ctrl+c v` on Windows), finds the form from the cursor position, evaluates it and displays the result inline. Hit `esc` to dismiss the results display.
 * **Evaluate current top-level form**: `alt+ctrl+c space`: inline evaluate the current top-level form. This also works inside `(comment)` forms. Use it to (re)define vars and then inside comment forms you can verify that they do what you want them to do.
 * **Dismiss the display of results**: `escape`: (VIM Extension users should read [Using Calva with the VIM Extension](vim.md)).
 

--- a/docs/readthedocs/source/try-first.md
+++ b/docs/readthedocs/source/try-first.md
@@ -2,7 +2,7 @@
 
 You might want to start with evaluating some code. This preferably starts with **Loading Current File and Dependencies**, `ctrl+alt+c enter`. 
 
-Then... Calva has this notion about the ”current” form. Issue the **Evaluate Current Form Inline** command, `ctrl+alt+c e` with the cursor placed in different locations to get a feeling for how the current form is determined. Dismiss the results display with `esc`.
+Then... Calva has this notion about the ”current” form. Issue the **Evaluate Current Form Inline** command, `ctrl+alt+c e` (`ctrl+alt+c v` on Windows) with the cursor placed in different locations to get a feeling for how the current form is determined. Dismiss the results display with `esc`.
 
 There is also a command for evaluating the current top level form. Good for evaluating  various `def`s `defn`, `defthis`, `defthat`. With your cursor placed anywhere inside such a form, issue the **Evaluate Current Top Level Form (defun)** command (`ctrl+alt+c space`).
 


### PR DESCRIPTION
## What has Changed?
Keybinding for Windows was not correct. Added a clarifier to the documentation to call out the difference.

Fixes #533

## My Calva PR Checklist
I have:

- [X] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [X] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [X] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [X] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [X] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [X] Created the issue I am fixing/addressing, if it was not present.
- [X] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->