### PR TITLE
Make token cursor handle reader tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - Use scope `variable.other.constant` for keywords, making them highlight nicely
+- [Highlight/parsing/etc: Data reader tags are part of the tagged form](https://github.com/BetterThanTomorrow/calva/issues/570)
 
 ## [2.0.78] - 2020-02-28
 - [Improve structural navigation through unbalanced brackets](https://github.com/BetterThanTomorrow/calva/issues/524)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Use scope `variable.other.constant` for keywords, making them highlight nicely
 
 ## [2.0.78] - 2020-02-28
 - [Improve structural navigation through unbalanced brackets](https://github.com/BetterThanTomorrow/calva/issues/524)

--- a/clojure.tmLanguage.json
+++ b/clojure.tmLanguage.json
@@ -114,7 +114,7 @@
 		},
 		"keyword": {
 			"match": "(?<=(\\s|\\(|\\[|\\{)):[\\w\\#\\.\\-\\_\\:\\+\\=\\>\\<\\/\\!\\?\\*]+(?=(\\s|\\)|\\]|\\}|\\,))",
-			"name": "constant.keyword.clojure"
+			"name": "variable.other.constant.clojure"
 		},
 		"keyfn": {
 			"patterns": [

--- a/docs/grammar/things-to-consider.md
+++ b/docs/grammar/things-to-consider.md
@@ -1,0 +1,15 @@
+
+From @sogaiu:
+@pez in processing clj-ish files from github using tree-sitter or clj-kondo, here are a few things that come up that can lead to errors / warnings:
+* template files - people do things like: (ns {{namespace}}.rendering or :{{name}} (mustache?) -- small number of instances of other styles too
+* missing, misplaced, or incorrectly placed closing delimiters
+* non-clojure text in (comment or #_ blocks
+* questionable(?) symbols and keywords - things that the repl might accept, but for which i didn't find a statement of support (e.g. # in keywords, keywords with multiple slashes in them) (edited)
+
+```
+Error: Property failed after 58 tests
+{ seed: -1913189269, path: "57:0:0:0:0:0:0:0:0:0:0:2:1:1:1:1:1:1:1:1:1:1:1:1:1:1:2:9:8:8:8:8:8:8:8:0:0:0:0:0:0", endOnFailure: true }
+Counterexample: ["##~"]
+Shrunk 40 time(s)
+Got error: AssertionError: expected 'junk' to equal 'id'
+```

--- a/docs/readthedocs/source/customizing.md
+++ b/docs/readthedocs/source/customizing.md
@@ -57,30 +57,6 @@ You are in charge of how brackets and comments are highlighted via the `calva.hi
 
 The extras are built from **Clojure Warrior**, created by [Nikita Prokopov, a.k.a. @tonsky](https://tonsky.me)'s. Please note that the default styling for `(comment ...)` forms now is to italicize them (instead of dimming). This is to promote using `comment` forms to work with the REPL.
 
-## Keyword highlighting
-Many VS Code themes lack special highlighting of keywords. You can amend your theme by putting something like this in your `settings.json`:
-
-```json
-{
-    "editor.tokenColorCustomizations": {
-        "[Default Dark+]": {
-            "textMateRules": [
-                {
-                    "scope": [
-                        "constant.keyword.clojure"
-                    ],
-                    "settings": {
-                        "foreground": "#9cdcfeff"
-                    }
-                }
-            ]
-        },
-    }
-}
-```
-
-Please update this with the settings you find you like for your theme.
-
 ## Key bindings
 * These key binds replace the default Calva ”prefix”, `ctrl+alt+v` to just `alt+v`: [WebWItch's keybindings.json](https://gist.github.com/conan/aa38688d7daa50804c8a433215dc6dc9) (Please note, that `alt+v` does not work for some locales, but for when it works it is much less clunky than the default prefix).
 * Here the Calva key is switched for `ctrl+,`: [manas_marthi's keybindings](https://gist.github.com/pikeview/317f639091f57c3055681b06f0dc791a)
@@ -98,7 +74,7 @@ Something I use in IntelliJ/Cursive is the ability to select an expression and h
 
 Here's how you can make this work with Calva Paredit: Update all of the `Paredit: Wrap Around ...` commands so that their respective shortcuts are the wrappers themselves and update the `when` clause to include `editorHasSelection` (otherwise when you open a paren and the next expression would get slurped in).
 
-The change would look like this in your `keybindings.json`: 
+The change would look like this in your `keybindings.json`:
 
 ```json
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2503,6 +2503,16 @@
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
+        "fast-check": {
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-1.22.2.tgz",
+            "integrity": "sha512-c5TzJXjw9q9BpUsszLvHHN1J/7kwPYbBvCuoc9+pGeF0DaKWBtK/htEHohz5Tfz4lDPI42oOla1HYeEndfYHKw==",
+            "dev": true,
+            "requires": {
+                "pure-rand": "^2.0.0",
+                "tslib": "^1.10.0"
+            }
+        },
         "fast-deep-equal": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -9093,6 +9103,12 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "pure-rand": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-2.0.0.tgz",
+            "integrity": "sha512-mk98aayyd00xbfHgE3uEmAUGzz3jCdm8Mkf5DUXUhc7egmOaGG2D7qhVlynGenNe9VaNJZvzO9hkc8myuTkDgw==",
+            "dev": true
         },
         "qs": {
             "version": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -1744,6 +1744,7 @@
         "eslint-plugin-node": "^6.0.1",
         "eslint-plugin-promise": "^3.7.0",
         "eslint-plugin-standard": "^3.0.1",
+        "fast-check": "^1.22.2",
         "file-loader": "^3.0.1",
         "glob": "^7.1.6",
         "json": "^9.0.6",

--- a/src/calva-fmt/atom-language-clojure/grammars/clojure.cson
+++ b/src/calva-fmt/atom-language-clojure/grammars/clojure.cson
@@ -142,7 +142,7 @@
     ]
   'keyword':
     'match': '(?<=(\\s|\\(|\\[|\\{)):[\\w\\#\\.\\-\\_\\:\\+\\=\\>\\<\\/\\!\\?\\*]+(?=(\\s|\\)|\\]|\\}|\\,))'
-    'name': 'constant.keyword.clojure'
+    'name': 'variable.other.constant.clojure'
   'keyfn':
     'patterns': [
       {

--- a/src/calva-fmt/atom-language-clojure/spec/clojure-spec.coffee
+++ b/src/calva-fmt/atom-language-clojure/spec/clojure-spec.coffee
@@ -99,14 +99,14 @@ describe "Clojure grammar", ->
     for metaScope, lines of tests
       for line in lines
         {tokens} = grammar.tokenizeLine line
-        expect(tokens[1]).toEqual value: ":foo", scopes: ["source.clojure", metaScope, "constant.keyword.clojure"]
+        expect(tokens[1]).toEqual value: ":foo", scopes: ["source.clojure", metaScope, "variable.other.constant.clojure"]
 
     {tokens} = grammar.tokenizeLine "(def foo :bar)"
-    expect(tokens[5]).toEqual value: ":bar", scopes: ["source.clojure", "meta.expression.clojure", "meta.definition.global.clojure", "constant.keyword.clojure"]
+    expect(tokens[5]).toEqual value: ":bar", scopes: ["source.clojure", "meta.expression.clojure", "meta.definition.global.clojure", "variable.other.constant.clojure"]
 
     # keywords can start with an uppercase non-ASCII letter
     {tokens} = grammar.tokenizeLine "(def foo :Öπ)"
-    expect(tokens[5]).toEqual value: ":Öπ", scopes: ["source.clojure", "meta.expression.clojure", "meta.definition.global.clojure", "constant.keyword.clojure"]
+    expect(tokens[5]).toEqual value: ":Öπ", scopes: ["source.clojure", "meta.expression.clojure", "meta.definition.global.clojure", "variable.other.constant.clojure"]
 
   it "tokenizes keyfns (keyword control)", ->
     keyfns = ["declare", "declare-", "ns", "in-ns", "import", "use", "require", "load", "compile", "def", "defn", "defn-", "defmacro", "defåπç"]
@@ -159,7 +159,7 @@ describe "Clojure grammar", ->
 
     {tokens} = grammar.tokenizeLine "^{:foo true}"
     expect(tokens[0]).toEqual value: "^{", scopes: ["source.clojure", "meta.metadata.map.clojure", "punctuation.section.metadata.map.begin.clojure"]
-    expect(tokens[1]).toEqual value: ":foo", scopes: ["source.clojure", "meta.metadata.map.clojure", "constant.keyword.clojure"]
+    expect(tokens[1]).toEqual value: ":foo", scopes: ["source.clojure", "meta.metadata.map.clojure", "variable.other.constant.clojure"]
     expect(tokens[2]).toEqual value: " ", scopes: ["source.clojure", "meta.metadata.map.clojure"]
     expect(tokens[3]).toEqual value: "true", scopes: ["source.clojure", "meta.metadata.map.clojure", "constant.language.boolean.clojure"]
     expect(tokens[4]).toEqual value: "}", scopes: ["source.clojure", "meta.metadata.map.clojure", "punctuation.section.metadata.map.end.trailing.clojure"]
@@ -270,21 +270,21 @@ describe "Clojure grammar", ->
     {tokens} = grammar.tokenizeLine "({:foo bar} :foo)"
     expect(tokens[0]).toEqual value: "(", scopes: ["source.clojure", "meta.expression.clojure", "punctuation.section.expression.begin.clojure"]
     expect(tokens[1]).toEqual value: "{", scopes: ["source.clojure", "meta.expression.clojure", "meta.map.clojure", "punctuation.section.map.begin.clojure"]
-    expect(tokens[2]).toEqual value: ":foo", scopes: ["source.clojure", "meta.expression.clojure", "meta.map.clojure", "constant.keyword.clojure"]
+    expect(tokens[2]).toEqual value: ":foo", scopes: ["source.clojure", "meta.expression.clojure", "meta.map.clojure", "variable.other.constant.clojure"]
     expect(tokens[3]).toEqual value: " ", scopes: ["source.clojure", "meta.expression.clojure", "meta.map.clojure"]
     expect(tokens[4]).toEqual value: "bar", scopes: ["source.clojure", "meta.expression.clojure", "meta.map.clojure", "meta.symbol.clojure"]
     expect(tokens[5]).toEqual value: "}", scopes: ["source.clojure", "meta.expression.clojure", "meta.map.clojure", "punctuation.section.map.end.clojure"]
     expect(tokens[6]).toEqual value: " ", scopes: ["source.clojure", "meta.expression.clojure"]
-    expect(tokens[7]).toEqual value: ":foo", scopes: ["source.clojure", "meta.expression.clojure", "constant.keyword.clojure"]
+    expect(tokens[7]).toEqual value: ":foo", scopes: ["source.clojure", "meta.expression.clojure", "variable.other.constant.clojure"]
     expect(tokens[8]).toEqual value: ")", scopes: ["source.clojure", "meta.expression.clojure", "punctuation.section.expression.end.trailing.clojure"]
 
   it "tokenizes sets used in functions", ->
     {tokens} = grammar.tokenizeLine "(\#{:foo :bar})"
     expect(tokens[0]).toEqual value: "(", scopes: ["source.clojure", "meta.expression.clojure", "punctuation.section.expression.begin.clojure"]
     expect(tokens[1]).toEqual value: "\#{", scopes: ["source.clojure", "meta.expression.clojure", "meta.set.clojure", "punctuation.section.set.begin.clojure"]
-    expect(tokens[2]).toEqual value: ":foo", scopes: ["source.clojure", "meta.expression.clojure", "meta.set.clojure", "constant.keyword.clojure"]
+    expect(tokens[2]).toEqual value: ":foo", scopes: ["source.clojure", "meta.expression.clojure", "meta.set.clojure", "variable.other.constant.clojure"]
     expect(tokens[3]).toEqual value: " ", scopes: ["source.clojure", "meta.expression.clojure", "meta.set.clojure"]
-    expect(tokens[4]).toEqual value: ":bar", scopes: ["source.clojure", "meta.expression.clojure", "meta.set.clojure", "constant.keyword.clojure"]
+    expect(tokens[4]).toEqual value: ":bar", scopes: ["source.clojure", "meta.expression.clojure", "meta.set.clojure", "variable.other.constant.clojure"]
     expect(tokens[5]).toEqual value: "}", scopes: ["source.clojure", "meta.expression.clojure", "meta.set.clojure", "punctuation.section.set.end.trailing.clojure"]
     expect(tokens[6]).toEqual value: ")", scopes: ["source.clojure", "meta.expression.clojure", "punctuation.section.expression.end.trailing.clojure"]
 

--- a/src/calva-fmt/clojure.tmLanguage.json
+++ b/src/calva-fmt/clojure.tmLanguage.json
@@ -114,7 +114,7 @@
 		},
 		"keyword": {
 			"match": "(?<=(\\s|\\(|\\[|\\{)):[\\w\\#\\.\\-\\_\\:\\+\\=\\>\\<\\/\\!\\?\\*]+(?=(\\s|\\)|\\]|\\}|\\,))",
-			"name": "constant.keyword.clojure"
+			"name": "keyword.control.clojure"
 		},
 		"keyfn": {
 			"patterns": [

--- a/src/cursor-doc/clojure-lexer.ts
+++ b/src/cursor-doc/clojure-lexer.ts
@@ -49,9 +49,17 @@ toplevel.terminal(/(\r|\n|\r\n)/, (l, m) => ({ type: "ws" }))
 // comments
 toplevel.terminal(/;.*/, (l, m) => ({ type: "comment" }))
 
+// prefixing patterns
+// opens ((?<!\p{Ll})['`~#@?^]\s*)*
+// id    (['`~#^@]\s*)*
+// lit   (['`~#]\s*)*
+// kw    (['`~^]\s*)*
+
+// idea for prefixing data reader
+// (#[^\(\)\[\]\{\}]+[\n\s,]*)*
 
 // open parens
-toplevel.terminal(/((?<!\w)['`~#@?^]\s*)*['`~#@?^]*[\(\[\{"]/, (l, m) => ({ type: "open" }))
+toplevel.terminal(/((?<=(^|[\(\)\[\]\{\}\s,]))['`~#@?^]\s*)*['`~#@?^]*[\(\[\{"]/, (l, m) => ({ type: "open" }))
 // close parens
 toplevel.terminal(/\)|\]|\}/, (l, m) => ({ type: "close" }))
 

--- a/src/cursor-doc/clojure-lexer.ts
+++ b/src/cursor-doc/clojure-lexer.ts
@@ -45,7 +45,7 @@ export interface Token extends LexerToken {
 // whitespace, excluding newlines
 toplevel.terminal(/[\t ,]+/, (l, m) => ({ type: "ws" }))
 // newlines, we want each one as a token of its own
-toplevel.terminal(/(\r?\n)/, (l, m) => ({ type: "ws" }))
+toplevel.terminal(/(\r|\n|\r\n)/, (l, m) => ({ type: "ws" }))
 // comments
 toplevel.terminal(/;.*/, (l, m) => ({ type: "comment" }))
 

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -262,10 +262,10 @@ export class LispTokenCursor extends TokenCursor {
                 case 'kw':
                 case 'ignore':
                 case 'junk':
-                case 'kw':
                 case 'comment':
                 case 'str-inside':
                     this.previous();
+                    this.backThroughAnyReader();
                     if (stack.length <= 0)
                         return true;
                     break;
@@ -282,6 +282,7 @@ export class LispTokenCursor extends TokenCursor {
                         }
                     }
                     this.previous();
+                    this.backThroughAnyReader();
                     if (stack.length <= 0)
                         return true;
                     break;
@@ -289,6 +290,15 @@ export class LispTokenCursor extends TokenCursor {
                     this.previous();
                     break;
             }
+        }
+    }
+
+    private backThroughAnyReader() {
+        const readerPeeker = this.clone();
+        readerPeeker.backwardWhitespace();
+        if (readerPeeker.getPrevToken().type === 'reader') {
+            this.backwardWhitespace();
+            this.previous();
         }
     }
 

--- a/src/extension-test/unit/cursor-doc/clojure-lexer-test.ts
+++ b/src/extension-test/unit/cursor-doc/clojure-lexer-test.ts
@@ -1,7 +1,39 @@
 import { expect } from 'chai';
+import * as fc from 'fast-check';
 import { Scanner } from '../../../cursor-doc/clojure-lexer';
 
 const MAX_LINE_LENGTH = 100;
+
+// fast-check Arbritraries
+
+// TODO: single quotes are valid in real Clojure, but Calva can't handle them in symbols yet
+const wsChars = [',', ' ', '\t', '\n', '\r'],
+    nonSymbolChars = [...wsChars, ...["'", '"', '(', ')', '[', ']', '{', '}']];
+
+function symbolChar(): fc.Arbitrary<string> {
+    // We need to filter away all kinds of whitespace, therefore the regex...
+    return fc.unicode().filter(c => !(nonSymbolChars.includes(c) || c.match(/\s/)));
+}
+
+function symbolStartChar(): fc.Arbitrary<string> {
+    return symbolChar().filter(c => c !== ':');
+}
+
+function symbol(): fc.Arbitrary<string> {
+    return fc.tuple(symbolStartChar(), fc.stringOf(symbolChar(), 1, 5)).map(([c, s]) => `${c}${s}`);
+}
+
+function keyword(): fc.Arbitrary<string> {
+    return fc.tuple(fc.constantFrom(":"), symbol()).map(([c, s]) => `${c}${s}`);
+}
+
+function wsChar(): fc.Arbitrary<string> {
+    return fc.constantFrom(...wsChars);
+}
+
+function ws(): fc.Arbitrary<string> {
+    return fc.stringOf(wsChar(), 1, 3);
+}
 
 describe('Scanner', () => {
     let scanner: Scanner;
@@ -12,19 +44,37 @@ describe('Scanner', () => {
 
     describe('simple', () => {
         it('tokenizes symbol', () => {
-            const tokens = scanner.processLine('foo');
-            expect(tokens[0].type).equals('id');
-            expect(tokens[0].raw).equals('foo');
+            fc.assert(
+                fc.property(symbol(), data => {
+                    const tokens = scanner.processLine(data);
+                    expect(tokens[0].type).equal('id');
+                    expect(tokens[0].raw).equal(data);
+                })
+            )
         });
         it('tokenizes whitespace', () => {
+            fc.assert(
+                fc.property(ws(), data => {
+                    // Remove extra eol put in there by the scanner
+                    const tokens = scanner.processLine(data).slice(0, -1);
+                    expect(tokens.map(t => t.raw).join("")).equal(data);
+                    tokens.forEach(t => {
+                        expect(t.type).equal('ws');
+                    });
+                })
+            )
             const tokens = scanner.processLine('foo   bar');
             expect(tokens[1].type).equals('ws');
             expect(tokens[1].raw).equals('   ');
         });
         it('tokenizes keyword', () => {
-            const tokens = scanner.processLine(':foo');
-            expect(tokens[0].type).equals('kw');
-            expect(tokens[0].raw).equals(':foo');
+            fc.assert(
+                fc.property(keyword(), data => {
+                    const tokens = scanner.processLine(data);
+                    expect(tokens[0].type).equal('kw');
+                    expect(tokens[0].raw).equal(data);
+                })
+            )
         });
         it('tokenizes literal character', () => {
             const tokens = scanner.processLine('\\a');
@@ -149,8 +199,9 @@ describe('Scanner', () => {
             expect(tokens[0].raw).equals(longLine);
         });
     });
-    describe('issues', () => {
-        it('literal quotes - #566', () => {
+    describe('Reported issues', () => {
+        it('handles literal quotes - #566', () => {
+            // https://github.com/BetterThanTomorrow/calva/issues/566
             const tokens = scanner.processLine("\\' foo");
             expect(tokens[0].type).equals('lit');
             expect(tokens[0].raw).equals("\\'");
@@ -159,7 +210,8 @@ describe('Scanner', () => {
             expect(tokens[2].type).equals('id');
             expect(tokens[2].raw).equals("foo");
         });
-        it('symbols ending in =? - #566', () => {
+        it('handles symbols ending in =? - #566', () => {
+            // https://github.com/BetterThanTomorrow/calva/issues/566
             const tokens = scanner.processLine("foo=? foo");
             expect(tokens[0].type).equals('id');
             expect(tokens[0].raw).equals("foo=?");

--- a/src/extension-test/unit/cursor-doc/clojure-lexer-test.ts
+++ b/src/extension-test/unit/cursor-doc/clojure-lexer-test.ts
@@ -8,7 +8,9 @@ const MAX_LINE_LENGTH = 100;
 
 // TODO: single quotes are valid in real Clojure, but Calva can't handle them in symbols yet
 const wsChars = [',', ' ', '\t', '\n', '\r'],
-    nonSymbolChars = [...wsChars, ...["'", '"', '(', ')', '[', ']', '{', '}']];
+    openChars = ['"', '(', '[', '{'],
+    closeChars = ['"', ')', ']', '}'],
+    nonSymbolChars = [...wsChars, ...["'", ";"], ...openChars, ...closeChars];
 
 function symbolChar(): fc.Arbitrary<string> {
     // We need to filter away all kinds of whitespace, therefore the regex...
@@ -34,6 +36,24 @@ function wsChar(): fc.Arbitrary<string> {
 function ws(): fc.Arbitrary<string> {
     return fc.stringOf(wsChar(), 1, 3);
 }
+
+function nonWsChar(): fc.Arbitrary<string> {
+    return fc.unicode().filter(c => !(wsChars.includes(c) || c.match(/\s/)));
+}
+
+function nonWs(): fc.Arbitrary<string> {
+    return fc.stringOf(nonWsChar(), 1, 3);
+}
+
+function quotedLiteralChar(): fc.Arbitrary<string> {
+    return fc.unicode().filter(c => !([...wsChars, ...openChars, ...closeChars].includes(c) || c.match(/\s/)));
+}
+
+function quotedLiteral(): fc.Arbitrary<string> {
+    return fc.tuple(fc.constantFrom('\\'), quotedLiteralChar()).map(([c, s]) => `${c}${s}`);
+}
+
+
 
 describe('Scanner', () => {
     let scanner: Scanner;
@@ -77,9 +97,13 @@ describe('Scanner', () => {
             )
         });
         it('tokenizes literal character', () => {
-            const tokens = scanner.processLine('\\a');
-            expect(tokens[0].type).equals('lit');
-            expect(tokens[0].raw).equals('\\a');
+            fc.assert(
+                fc.property(quotedLiteral(), data => {
+                    const tokens = scanner.processLine(data);
+                    expect(tokens[0].type).equal('lit');
+                    expect(tokens[0].raw).equal(data);
+                })
+            )
         });
         it('tokenizes literal named character', () => {
             const tokens = scanner.processLine('\\space');
@@ -97,6 +121,15 @@ describe('Scanner', () => {
             expect(tokens[0].raw).equals('#_');
             expect(tokens[1].type).equals('id');
             expect(tokens[1].raw).equals('foo');
+        });
+        it('tokenizes opens', () => {
+            fc.assert(
+                fc.property(keyword(), data => {
+                    const tokens = scanner.processLine(data);
+                    expect(tokens[0].type).equal('kw');
+                    expect(tokens[0].raw).equal(data);
+                })
+            )
         });
     });
     describe('lists', () => {

--- a/test-data/test2.clj
+++ b/test-data/test2.clj
@@ -2,8 +2,10 @@
   
   #foo :bar
   (foo #foo (foo :bar))
+  #_#_
   'abc #foo  @~#(foo :bar) \space
   \' {:foo (#foo '[1 2 3])} 'abc
+  #_#_
   #foo
    'bar
   #foo

--- a/test-data/test2.clj
+++ b/test-data/test2.clj
@@ -1,2 +1,5 @@
- \' [] abc
+#foo  @~#(:bar)
+#foo 
+:bar
+\' [] abc
 \a [] "a"

--- a/test-data/test2.clj
+++ b/test-data/test2.clj
@@ -1,5 +1,13 @@
-#foo  @~#(:bar)
-#foo 
-:bar
-\' [] abc
-\a [] "a"
+(comment
+  
+  #foo :bar
+  (foo #foo (foo :bar))
+  'abc #foo  @~#(foo :bar) \space
+  \' {:foo (#foo '[1 2 3])} 'abc
+  #foo
+   'bar
+  #foo
+   #{:foo (#foo '[1 2 3])}
+  \a [] "a"
+
+  )


### PR DESCRIPTION
# Fixes #570
- The lexer now produces one token for tokens that are preceded by a reader tag (like `#uuid`), for when the tag is on the same line.
- If the tag is on a separate line we produce a `reader` token, and the token cursor is made aware of this when doing `backward-sexp`.

This PR also introduces [fast-check](https://github.com/dubzzz/fast-check) for testing the scanner

Used for
- [x] symbols
- [x] keywords
- [x] whitespace
- [x] quoted literals

Should probably be used for 
- [ ] literals (of many types)
- [ ] lists
- [ ] vectors
- [ ] maps
- [ ] sets
- [ ] strings
And more.

Also we should use it for
- [ ] prefixes of symbols
- [ ] prefixes of lists, sets, maps, etcetera

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.) You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. (For now you'll need to opt in to the CircleCI _New Experience_ UI to see the Artifacts tab, because bug.)
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->