### PR TITLE
Tweak handling of nil, true, and false in grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 ## [Unreleased]
 - Fix so that Calva treats symbol containing the quote character correctly.
 - [Fix: Parameter hints popup should be off by default](https://github.com/BetterThanTomorrow/calva/issues/574)
+- [Fix: `nil` followed by comma not highlighted correctly](https://github.com/BetterThanTomorrow/calva/issues/577)
+- [Fix: The syntax highlightning fails with symbols named truesomething/falsesomething](https://github.com/BetterThanTomorrow/calva/issues/578)
 
 ## [2.0.79] - 2020-03-01
 - Use scope `variable.other.constant` for keywords, making them highlight nicely

--- a/clojure.tmLanguage.json
+++ b/clojure.tmLanguage.json
@@ -68,11 +68,11 @@
 		"constants": {
 			"patterns": [
 				{
-					"match": "(nil)(?=(\\s|\\)|\\]|\\}))",
+					"match": "(?<=^|\\s|,|\\(|\\[|\\{)(nil)(?=(\\s|,|\\)|\\]|\\}|\\^))",
 					"name": "constant.language.nil.clojure"
 				},
 				{
-					"match": "(true|false)",
+					"match": "(?<=^|\\s|,|\\(|\\[|\\{)(true|false)(?=(\\s|,|\\)|\\]|\\}|\\^))",
 					"name": "constant.language.boolean.clojure"
 				},
 				{

--- a/src/calva-fmt/atom-language-clojure/grammars/clojure.cson
+++ b/src/calva-fmt/atom-language-clojure/grammars/clojure.cson
@@ -97,11 +97,11 @@
   'constants':
     'patterns': [
       {
-        'match': '(nil)(?=(\\s|\\)|\\]|\\}))'
+        'match': '(?<=^|\\s|,|\\(|\\[|\\{)(nil)(?=(\\s|,|\\)|\\]|\\}|\\^))'
         'name': 'constant.language.nil.clojure'
       }
       {
-        'match': '(true|false)'
+        'match': '(?<=^|\\s|,|\\(|\\[|\\{)(true|false)(?=(\\s|,|\\)|\\]|\\}|\\^))'
         'name': 'constant.language.boolean.clojure'
       }
       {

--- a/src/calva-fmt/atom-language-clojure/spec/clojure-spec.coffee
+++ b/src/calva-fmt/atom-language-clojure/spec/clojure-spec.coffee
@@ -84,9 +84,42 @@ describe "Clojure grammar", ->
       for bool in bools
         {tokens} = grammar.tokenizeLine bool
         expect(tokens[0]).toEqual value: bool, scopes: ["source.clojure", scope]
+        {tokens} = grammar.tokenizeLine " " + bool
+        expect(tokens[1]).toEqual value: bool, scopes: ["source.clojure", scope]
+        {tokens} = grammar.tokenizeLine bool + " "
+        expect(tokens[0]).toEqual value: bool, scopes: ["source.clojure", scope]
+        {tokens} = grammar.tokenizeLine "," + bool
+        expect(tokens[1]).toEqual value: bool, scopes: ["source.clojure", scope]
+        {tokens} = grammar.tokenizeLine bool + ","
+        expect(tokens[0]).toEqual value: bool, scopes: ["source.clojure", scope]
+        {tokens} = grammar.tokenizeLine "(not " + bool + ")"
+        expect(tokens[3]).toEqual value: bool, scopes: ["source.clojure", "meta.expression.clojure", scope]
+        {tokens} = grammar.tokenizeLine "[" + bool + "]"
+        expect(tokens[1]).toEqual value: bool, scopes: ["source.clojure", "meta.vector.clojure", scope]
+        {tokens} = grammar.tokenizeLine "{:a " + bool + "}"
+        expect(tokens[3]).toEqual value: bool, scopes: ["source.clojure", "meta.map.clojure", scope]
+        {tokens} = grammar.tokenizeLine bool + "^{:hi 1}[]"
+        expect(tokens[0]).toEqual value: bool, scopes: ["source.clojure", scope]
+
 
   it "tokenizes nil", ->
     {tokens} = grammar.tokenizeLine "nil"
+    expect(tokens[0]).toEqual value: "nil", scopes: ["source.clojure", "constant.language.nil.clojure"]
+    {tokens} = grammar.tokenizeLine " nil"
+    expect(tokens[1]).toEqual value: "nil", scopes: ["source.clojure", "constant.language.nil.clojure"]
+    {tokens} = grammar.tokenizeLine "nil "
+    expect(tokens[0]).toEqual value: "nil", scopes: ["source.clojure", "constant.language.nil.clojure"]
+    {tokens} = grammar.tokenizeLine ",nil"
+    expect(tokens[1]).toEqual value: "nil", scopes: ["source.clojure", "constant.language.nil.clojure"]
+    {tokens} = grammar.tokenizeLine "nil,"
+    expect(tokens[0]).toEqual value: "nil", scopes: ["source.clojure", "constant.language.nil.clojure"]
+    {tokens} = grammar.tokenizeLine "(conj nil)"
+    expect(tokens[3]).toEqual value: "nil", scopes: ["source.clojure", "meta.expression.clojure", "constant.language.nil.clojure"]
+    {tokens} = grammar.tokenizeLine "[nil]"
+    expect(tokens[1]).toEqual value: "nil", scopes: ["source.clojure", "meta.vector.clojure", "constant.language.nil.clojure"]
+    {tokens} = grammar.tokenizeLine "{:a nil}"
+    expect(tokens[3]).toEqual value: "nil", scopes: ["source.clojure", "meta.map.clojure", "constant.language.nil.clojure"]
+    {tokens} = grammar.tokenizeLine "nil^{:hi 1}[]"
     expect(tokens[0]).toEqual value: "nil", scopes: ["source.clojure", "constant.language.nil.clojure"]
 
   it "tokenizes keywords", ->


### PR DESCRIPTION
`nil` followed by a comma was not being handled approriately for highlighting. #577

`true` and `false` had some issues too. #578

Handling of `nil`, `true`, and `false` should be improved.

The test for `nil` and that of booleans was also added to.

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [X] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.) You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. (For now you'll need to opt in to the CircleCI _New Experience_ UI to see the Artifacts tab, because bug.)
     - [X] Tested the particular change
     - [X] Figured if the change might have some side effects and tested those as well.
     - [X] Smoke tested the extension as such.
- [X] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [X] I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [X] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

Fixes #577 #578