### PR TITLE
Add projectRootDir setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 ## [Unreleased]
 
 ## [2.0.80] - 2020-03-07
+- Add replConnectSequences.menuSelections.projectRootDir for manually specifying the root directory in order to support jack-in for monorepo projects.
 - Fix so that Paredit treats symbols containing the quote character correctly.
 - [Fix: Parameter hints popup should be off by default](https://github.com/BetterThanTomorrow/calva/issues/574)
 - [Fix: `nil` followed by comma not highlighted correctly](https://github.com/BetterThanTomorrow/calva/issues/577)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Add option to manually specify project root directory](https://github.com/BetterThanTomorrow/calva/issues/579)
 
 ## [2.0.80] - 2020-03-07
-- Add replConnectSequences.menuSelections.projectRootDir for manually specifying the root directory in order to support jack-in for monorepo projects.
 - Fix so that Paredit treats symbols containing the quote character correctly.
 - [Fix: Parameter hints popup should be off by default](https://github.com/BetterThanTomorrow/calva/issues/574)
 - [Fix: `nil` followed by comma not highlighted correctly](https://github.com/BetterThanTomorrow/calva/issues/577)

--- a/docs/readthedocs/source/connect-sequences.md
+++ b/docs/readthedocs/source/connect-sequences.md
@@ -33,6 +33,7 @@ A connect sequence configures the following:
   * `cljAliases`: At Jack-in to a Clojure CLI project, use these aliases to launch the repl.
   * `cljsLaunchBuilds`: The cljs builds to start/watch at Jack-in/connect.
   * `cljsDefaultBuild`: Which cljs build to attach to at the initial connect.
+  * `projectRootDir`: The root directory to execute the Jack-in command from.  This will override the default behavior for determining the root directory relative to the current open file.  This is useful for working in monorepos.
 
 The [Calva built-in sequences](https://github.com/BetterThanTomorrow/calva/blob/master/calva/nrepl/connectSequence.ts) also uses this format, check them out to get a clearer picture of how these settings work.
 

--- a/docs/readthedocs/source/connect-sequences.md
+++ b/docs/readthedocs/source/connect-sequences.md
@@ -16,6 +16,7 @@ A connect sequence configures the following:
 * `projectType`: (required) This is either "Leiningen”, ”Clojure-CLI”, or ”shadow-cljs”.
 * `nReplPortFile`: An array of path segments with the project root-relative path to the nREPL port file for this connect sequence. E.g. For shadow-cljs this would be `[".shadow-cljs", "nrepl.port"]`.
 * `afterCLJReplJackInCode`: Here you can give Calva some Clojure code to evaluate in the CLJ REPL, once it has been created.
+* `projectRootDir`: The root directory to execute the Jack-in command from.  This will override the default behavior for determining the root directory relative to the current open file.  This is useful for working in monorepos.
 * `cljsType`: This can be either "Figwheel Main", "lein-figwheel", "shadow-cljs", "Nashorn", or a dictionary configuring a custom type. If omitted, Calva will skip connecting a ClojureScript repl. A custom type has the following fields:
   * `dependsOn`: (required) Calva will use this to determine which dependencies it will add when starting the project (Jacking in). This can be either "Figwheel Main", "lein-figwheel", "shadow-cljs", "Nashorn", or ”User provided”. If it is "User provided", then you need to provide the dependencies in the project, or launch with an alias (deps.edn), profile (Leiningen), or build (shadow-cljs) that provides the dependencies needed.
   * `isStarted`: Boolean. For CLJS REPLs that Calva does not need to start, set this to true. (If you base your custom cljs repl on a shadow-cljs workflow, for instance.)
@@ -33,7 +34,6 @@ A connect sequence configures the following:
   * `cljAliases`: At Jack-in to a Clojure CLI project, use these aliases to launch the repl.
   * `cljsLaunchBuilds`: The cljs builds to start/watch at Jack-in/connect.
   * `cljsDefaultBuild`: Which cljs build to attach to at the initial connect.
-  * `projectRootDir`: The root directory to execute the Jack-in command from.  This will override the default behavior for determining the root directory relative to the current open file.  This is useful for working in monorepos.
 
 The [Calva built-in sequences](https://github.com/BetterThanTomorrow/calva/blob/master/calva/nrepl/connectSequence.ts) also uses this format, check them out to get a clearer picture of how these settings work.
 

--- a/package.json
+++ b/package.json
@@ -414,6 +414,10 @@
                                         "cljsDefaultBuild": {
                                             "type": "string",
                                             "description": "Which cljs build to attach to at the initial connect."
+                                        },
+                                        "projectRootDir": {
+                                            "type": "string",
+                                            "descripion": "Defines the project root directory.  Useful for working with monorepos."
                                         }
                                     }
                                 },

--- a/package.json
+++ b/package.json
@@ -375,6 +375,11 @@
                                     "description": "Here you can give Calva some Clojure code to evaluate in the CLJ REPL, once it has been created.",
                                     "required": false
                                 },
+                                "projectRootDir": {
+                                    "type": "string",
+                                    "descripion": "Defines the project root directory.  Useful for working with monorepos.",
+                                    "required": false
+                                },
                                 "menuSelections": {
                                     "type": "object",
                                     "description": "Pre-selected menu options. If a slection is made here. Calva won't prompt for it.",
@@ -414,10 +419,6 @@
                                         "cljsDefaultBuild": {
                                             "type": "string",
                                             "description": "Which cljs build to attach to at the initial connect."
-                                        },
-                                        "projectRootDir": {
-                                            "type": "string",
-                                            "descripion": "Defines the project root directory.  Useful for working with monorepos."
                                         }
                                     }
                                 },

--- a/package.json
+++ b/package.json
@@ -377,7 +377,7 @@
                                 },
                                 "projectRootDir": {
                                     "type": "string",
-                                    "descripion": "Defines the project root directory.  Useful for working with monorepos.",
+                                    "descripion": "The root directory to execute the Jack-in command from.  This will override the default behavior for determining the root directory relative to the current open file.  This is useful for working in monorepos.",
                                     "required": false
                                 },
                                 "menuSelections": {

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -39,13 +39,13 @@ interface MenuSelections {
     cljAliases?: string[],
     cljsLaunchBuilds?: string[],
     cljsDefaultBuild?: string,
-    projectRootDir?: string,
 }
 
 interface ReplConnectSequence {
     name: string,
     projectType: ProjectTypes,
     afterCLJReplJackInCode?: string,
+    projectRootDir?: string,
     cljsType: CljsTypes | CljsTypeConfig,
     menuSelections?: MenuSelections,
     nReplPortFile?: string[]

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -38,7 +38,8 @@ interface MenuSelections {
     leinAlias?: string,
     cljAliases?: string[],
     cljsLaunchBuilds?: string[],
-    cljsDefaultBuild?: string
+    cljsDefaultBuild?: string,
+    projectRootDir?: string,
 }
 
 interface ReplConnectSequence {

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -26,7 +26,7 @@ vscode.tasks.onDidEndTask(((e) => {
     if(e.execution.task.name == TASK_NAME) {
        JackinExecution = undefined;
        connector.default.disconnect();
-       // make sure everything is set back 
+       // make sure everything is set back
        // even if the task failed to connect
        // to the repl server.
        utilities.setLaunchingState(null);
@@ -36,14 +36,16 @@ vscode.tasks.onDidEndTask(((e) => {
 
 function cancelJackInTask() {
     setTimeout(() => {
-        calvaJackout(); 
+        calvaJackout();
     }, 1000);
 }
 
 async function executeJackInTask(projectType: projectTypes.ProjectType, projectTypeSelection: any, executable: string, args: any, cljTypes: string[], outputChannel: vscode.OutputChannel, connectSequence: ReplConnectSequence) {
     // If the connection sequence specifies a project root dir, override the existing project dir
     const projectRootDir = connectSequence?.projectRootDir;
-    if(projectRootDir) state.setProjectRoot(projectRootDir);
+    if(projectRootDir) {
+        state.setProjectRoot(projectRootDir);
+    }
 
     utilities.setLaunchingState(projectTypeSelection);
     statusbar.update();

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -42,7 +42,7 @@ function cancelJackInTask() {
 
 async function executeJackInTask(projectType: projectTypes.ProjectType, projectTypeSelection: any, executable: string, args: any, cljTypes: string[], outputChannel: vscode.OutputChannel, connectSequence: ReplConnectSequence) {
     // If the connection sequence specifies a project root dir, override the existing project dir
-    const projectRootDir = connectSequence?.menuSelections?.projectRootDir;
+    const projectRootDir = connectSequence?.projectRootDir;
     if(projectRootDir) state.setProjectRoot(projectRootDir);
 
     utilities.setLaunchingState(projectTypeSelection);

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -41,6 +41,10 @@ function cancelJackInTask() {
 }
 
 async function executeJackInTask(projectType: projectTypes.ProjectType, projectTypeSelection: any, executable: string, args: any, cljTypes: string[], outputChannel: vscode.OutputChannel, connectSequence: ReplConnectSequence) {
+    // If the connection sequence specifies a project root dir, override the existing project dir
+    const projectRootDir = connectSequence?.menuSelections?.projectRootDir;
+    if(projectRootDir) state.setProjectRoot(projectRootDir);
+
     utilities.setLaunchingState(projectTypeSelection);
     statusbar.update();
     const nReplPortFile = projectTypes.nreplPortFile(connectSequence);

--- a/src/state.ts
+++ b/src/state.ts
@@ -177,6 +177,7 @@ export function getProjectWsFolder(): vscode.WorkspaceFolder {
  *    by looking for project files from the file's directory and up to
  *    the window root (for plain folder windows) or the file's
  *    workspace folder root (for workspaces) to find the project root.
+ *
  * If there is no project file found, throw an exception.
  */
 export async function initProjectDir(): Promise<void> {

--- a/src/state.ts
+++ b/src/state.ts
@@ -156,6 +156,10 @@ export function getProjectRoot(useCache = true): string {
     }
 }
 
+export function setProjectRoot(rootPath: string) {
+    cursor.set(PROJECT_DIR_KEY, rootPath);
+}
+
 export function getProjectWsFolder(): vscode.WorkspaceFolder {
     const doc = util.getDocument({});
     return doc ? vscode.workspace.getWorkspaceFolder(doc.uri) : null;
@@ -173,7 +177,6 @@ export function getProjectWsFolder(): vscode.WorkspaceFolder {
  *    by looking for project files from the file's directory and up to
  *    the window root (for plain folder windows) or the file's
  *    workspace folder root (for workspaces) to find the project root.
- *
  * If there is no project file found, throw an exception.
  */
 export async function initProjectDir(): Promise<void> {
@@ -223,7 +226,7 @@ export async function initProjectDir(): Promise<void> {
         for (let projectFile in projectFileNames) {
             const p = path.resolve(rootPath, projectFileNames[projectFile]);
             if (fs.existsSync(p)) {
-                cursor.set(PROJECT_DIR_KEY, rootPath);
+                setProjectRoot(rootPath);
                 return;
             }
         }


### PR DESCRIPTION
Hello again.  This PR proposes a small but meaningful feature that will allow us users working in monorepos to configure our replConnectSequence with a specific project root directory.  Previously, I've always had to open a specific file before doing jack-in.  This addition removes that step, and a lot of headaches that came with it.

## What has Changed?
- Add projectRootDir setting to `calva.connectionSequences.menuSelections` to manually override the project root directory.  This is useful for monorepo projects.

Addressed #579

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.) You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. (For now you'll need to opt in to the CircleCI _New Experience_ UI to see the Artifacts tab, because bug.)
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->