### PR TITLE
A reader aware token cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Fix: Structural editing is a bit broken when reader tags are involved](https://github.com/BetterThanTomorrow/calva/issues/581)
 
 ## [2.0.80] - 2020-03-07
 - Fix so that Paredit treats symbols containing the quote character correctly.

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -100,6 +100,7 @@ export function rangeToBackwardUpList(doc: EditableDocument, offset: number = Ma
 export function rangeToForwardDownList(doc: EditableDocument, offset: number = Math.max(doc.selection.anchor, doc.selection.active)): [number, number] {
     const cursor = doc.getTokenCursor(offset);
     do {
+        cursor.forwardThroughAnyReader();
         cursor.forwardWhitespace();
         if (cursor.getToken().type === 'open') {
             break;
@@ -522,6 +523,7 @@ export function raiseSexp(doc: EditableDocument, start = doc.selectionLeft, end 
     if (start == end) {
         let cursor = doc.getTokenCursor(end);
         cursor.forwardWhitespace();
+        cursor.backwardThroughAnyReader();
         let endCursor = cursor.clone();
         if (endCursor.forwardSexp()) {
             let raised = doc.model.getText(cursor.offsetStart, endCursor.offsetStart);

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -276,22 +276,37 @@ export class LispTokenCursor extends TokenCursor {
         }
     }
 
+    /**
+     * Moves this cursor past the previous non-ws token, if it is a `reader` token.
+     * Otherwise, this cursor is left unaffected.
+     */
     backwardThroughAnyReader() {
         const cursor = this.clone();
-        cursor.backwardWhitespace();
-        if (cursor.getPrevToken().type === 'reader') {
+        while (true) {
             cursor.backwardWhitespace();
-            cursor.previous();
-            this.set(cursor);
+            if (cursor.getPrevToken().type === 'reader') {
+                cursor.previous();
+                this.set(cursor);
+            } else {
+                break;
+            }
         }
     }
 
+    /**
+     * Moves this cursor past the next non-ws token, if it is a `reader` token.
+     * Otherwise, this cursor is left unaffected.
+     */
     forwardThroughAnyReader() {
         const cursor = this.clone();
-        cursor.forwardWhitespace();
-        if (cursor.getToken().type === 'reader') {
-            cursor.next();
-            this.set(cursor);
+        while (true) {
+            cursor.forwardWhitespace();
+            if (cursor.getToken().type === 'reader') {
+                cursor.next();
+                this.set(cursor);
+            } else {
+                break;
+            }
         }
     }
 

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -458,7 +458,7 @@ export class LispTokenCursor extends TokenCursor {
     /**
      * Figures out the `range` for the current form according to this priority:
      * 0. If `offset` is within a symbol, literal or keyword
-     * 1. If `offset` is adjacent after form
+     * 1. Else, if `offset` is adjacent after form
      * 2. Else, if `offset` is adjacent before a form
      * 3. Else, if the previous form is on the same line
      * 4. Else, if the next form is on the same line
@@ -482,11 +482,13 @@ export class LispTokenCursor extends TokenCursor {
             }
         }
         const beforeCursor = this.clone();
-        beforeCursor.backwardThroughAnyReader();
+        beforeCursor.forwardThroughAnyReader();
         beforeCursor.forwardWhitespace(true);
-        if (beforeCursor.offsetStart == offset) {
+        const readerCursor = beforeCursor.clone();
+        readerCursor.backwardThroughAnyReader();
+        if (beforeCursor.offsetStart == offset || readerCursor.offsetStart != beforeCursor.offsetStart) {
             if (beforeCursor.forwardSexp()) { // 2.
-                return [offset, beforeCursor.offsetStart];
+                return [readerCursor.offsetStart, beforeCursor.offsetStart];
             }
         }
         if (afterCursor.rowCol[0] == this.rowCol[0]) {

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -483,10 +483,10 @@ export class LispTokenCursor extends TokenCursor {
         }
         const beforeCursor = this.clone();
         beforeCursor.backwardThroughAnyReader();
-        if (beforeCursor.offsetStart <= offset || beforeCursor.offsetEnd >= offset) {
-            const start = beforeCursor.offsetStart;
+        beforeCursor.forwardWhitespace(true);
+        if (beforeCursor.offsetStart == offset) {
             if (beforeCursor.forwardSexp()) { // 2.
-                return [start, beforeCursor.offsetStart];
+                return [offset, beforeCursor.offsetStart];
             }
         }
         if (afterCursor.rowCol[0] == this.rowCol[0]) {

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -429,6 +429,7 @@ export class LispTokenCursor extends TokenCursor {
      */
     backwardUpList(): boolean {
         let cursor = this.clone();
+        cursor.backwardThroughAnyReader();
         cursor.backwardWhitespace();
         if (cursor.getPrevToken().type == "open") {
             cursor.previous();

--- a/src/extension-test/unit/cursor-doc/clojure-lexer-test.ts
+++ b/src/extension-test/unit/cursor-doc/clojure-lexer-test.ts
@@ -10,7 +10,7 @@ const MAX_LINE_LENGTH = 100;
 const wsChars = [',', ' ', '\t', '\n', '\r'],
     openChars = ['"', '(', '[', '{'],
     closeChars = ['"', ')', ']', '}'],
-    nonSymbolChars = [...wsChars, ...[";"], ...openChars, ...closeChars];
+    nonSymbolChars = [...wsChars, ...[';', '@', '^', '~', '`'], ...openChars, ...closeChars];
 
 function symbolChar(): fc.Arbitrary<string> {
     // We need to filter away all kinds of whitespace, therefore the regex...

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -164,7 +164,7 @@ describe('paredit', () => {
     });
 
     describe('Reader tags', () => {
-        const docText = '(c\n#f\n(#b \n[:f :b :z])\n#z\n1)';
+        const docText = '(a(b(c\n#f\n(#b \n[:f :b :z])\n#z\n1)))';
         let doc: mock.MockDocument;
 
         beforeEach(() => {
@@ -172,25 +172,30 @@ describe('paredit', () => {
             doc.insertString(docText);
         });
 
-        it('rangeToForwardDownList: (|c•#f•(#b •[:f :b :z])•#z•1) => (c•#f•(|#b •[:f :b :z])•#z•1)', () => {
-            doc.selection = new ModelEditSelection(1, 1);
+        it('rangeToForwardDownList: (a(b(|c•#f•(#b •[:f :b :z])•#z•1))) => (a(b(c•#f•(|#b •[:f :b :z])•#z•1)))', () => {
+            doc.selection = new ModelEditSelection(5, 5);
             const newRange = paredit.rangeToForwardDownList(doc);
-            expect(newRange).deep.equal([1, 7]);
+            expect(newRange).deep.equal([5, 11]);
         });
-        it('rangeToBackwardUpList: (c•#f•(|#b •[:f :b :z])•#z•1) => (c•|#f•(#b •[:f :b :z])•#z•1)', () => {
-            doc.selection = new ModelEditSelection(7, 7);
+        it('rangeToBackwardUpList: (a(b(c•#f•(|#b •[:f :b :z])•#z•1))) => (a(b(c•|#f•(#b •[:f :b :z])•#z•1)))', () => {
+            doc.selection = new ModelEditSelection(11, 11);
             const newRange = paredit.rangeToBackwardUpList(doc);
-            expect(newRange).deep.equal([3, 7]);
+            expect(newRange).deep.equal([7, 11]);
         });
-        it('dragSexprBackward: (c•#f•|(#b •[:f :b :z])•#z•1) => (#f•(#b •[:f :b :z])•c•#z•1)', () => {
-            doc.selection = new ModelEditSelection(6, 6);
+        it.skip('rangeToBackwardUpList: (a(b(c•#f•(#b •|[:f :b :z])•#z•1))) => (a(b(c•<•#f•(#b •<[:f :b :z])•#z•1)))', () => {
+            doc.selection = new ModelEditSelection(15, 15);
+            const newRange = paredit.rangeToBackwardUpList(doc);
+            expect(newRange).deep.equal([7, 15]);
+        });
+        it('dragSexprBackward: (a(b(c•#f•|(#b •[:f :b :z])•#z•1))) => (a(b(#f•(#b •[:f :b :z])•c•#z•1)))', () => {
+            doc.selection = new ModelEditSelection(10, 10);
             paredit.dragSexprBackward(doc);
-            expect(doc.model.getText(0, Infinity)).equal('(#f\n(#b \n[:f :b :z])\nc\n#z\n1)');
+            expect(doc.model.getText(0, Infinity)).equal('(a(b(#f\n(#b \n[:f :b :z])\nc\n#z\n1)))');
         });
-        it('dragSexprForward: (c•#f•|(#b •[:f :b :z])•#z•1) => (c•#z•1•#f•(#b •[:f :b :z]))', () => {
-            doc.selection = new ModelEditSelection(6, 6);
+        it('dragSexprForward: (a(b(c•#f•|(#b •[:f :b :z])•#z•1))) => (a(b(c•#z•1•#f•(#b •[:f :b :z]))))', () => {
+            doc.selection = new ModelEditSelection(10, 10);
             paredit.dragSexprForward(doc);
-            expect(doc.model.getText(0, Infinity)).equal('(c\n#z\n1\n#f\n(#b \n[:f :b :z]))');
+            expect(doc.model.getText(0, Infinity)).equal('(a(b(c\n#z\n1\n#f\n(#b \n[:f :b :z]))))');
         });
         describe('Stacked readers', () => {
             const docText = '(c\n#f\n(#b \n[:f :b :z])\n#x\n#y\n1)';

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -222,7 +222,7 @@ describe('paredit', () => {
                 doc = new mock.MockDocument();
                 doc.insertString(docText);
             });
-            it('dragSexprBackward: #f•(#b •[:f :b :z])•#x•#y•|1#å#ä#ö => #x•#y•1•#f•(#b •[:f :b :z])•#å#ä#ö', () => {
+            it('dragSexprBackward: #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö => #x•#y•1•#f•(#b •[:f :b :z])•#å#ä#ö', () => {
                 doc.selection = new ModelEditSelection(26, 26);
                 paredit.dragSexprBackward(doc);
                 expect(doc.model.getText(0, Infinity)).equal('#x\n#y\n1\n#f\n(#b \n[:f :b :z])\n#å#ä#ö');

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -180,10 +180,10 @@ describe('paredit', () => {
             const newRange = paredit.rangeToBackwardUpList(doc);
             expect(newRange).deep.equal([7, 11]);
         });
-        it.skip('rangeToBackwardUpList: (a(b(c•#f•(#b •|[:f :b :z])•#z•1))) => (a(b(c•<•#f•(#b •<[:f :b :z])•#z•1)))', () => {
+        it('rangeToBackwardUpList: (a(b(c•#f•(#b •|[:f :b :z])•#z•1))) => (a(b(c•<•#f•(#b •<[:f :b :z])•#z•1)))', () => {
             doc.selection = new ModelEditSelection(15, 15);
             const newRange = paredit.rangeToBackwardUpList(doc);
-            expect(newRange).deep.equal([7, 15]);
+            expect(newRange).deep.equal([4, 15]);
         });
         it('dragSexprBackward: (a(b(c•#f•|(#b •[:f :b :z])•#z•1))) => (a(b(#f•(#b •[:f :b :z])•c•#z•1)))', () => {
             doc.selection = new ModelEditSelection(10, 10);

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1,9 +1,7 @@
 import { expect } from 'chai';
 import * as paredit from '../../../cursor-doc/paredit';
-import { ReplReadline } from '../../../webview/readline';
 import * as mock from './mock';
 import { ModelEditSelection } from '../../../cursor-doc/model';
-import { integer } from 'fast-check/*';
 
 /**
  * Prose gets a bit clumsy when describing the expectations of many Paredit operations and functions.

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -52,4 +52,58 @@ describe('Token Cursor', () => {
         cursor.backwardUpList();
         expect(cursor.offsetStart).equal(7);
     });
+
+    describe('Current Form', () => {
+        const docText = '(aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)))'.replace(/•/g, '\n'),
+            doc: mock.MockDocument = new mock.MockDocument();
+
+        beforeEach(() => {
+            doc.insertString(docText);
+        });
+
+        it('0: selects from within non-list form', () => {
+            const cursor: LispTokenCursor = doc.getTokenCursor(1);
+            expect(cursor.rangeForCurrentForm(2)).deep.equal([1, 4]);
+        });
+        it('1: selects from adjanent after form', () => {
+            const cursor: LispTokenCursor = doc.getTokenCursor(54);
+            expect(cursor.rangeForCurrentForm(49)).deep.equal([46, 54]);
+        });
+        it('1: selects from adjanent after form, including readers', () => {
+            const cursor: LispTokenCursor = doc.getTokenCursor(43);
+            expect(cursor.rangeForCurrentForm(43)).deep.equal([22, 43]);
+        });
+        it('2: selects from adjanent before form', () => {
+            const cursor: LispTokenCursor = doc.getTokenCursor(46);
+            expect(cursor.rangeForCurrentForm(46)).deep.equal([46, 54]);
+        });
+        it('2: selects from adjanent before form, including readers', () => {
+            const cursor: LispTokenCursor = doc.getTokenCursor(22);
+            expect(cursor.rangeForCurrentForm(22)).deep.equal([22, 43]);
+        });
+        it('3: selects previous form, if on the same line', () => {
+            const cursor: LispTokenCursor = doc.getTokenCursor(76);
+            expect(cursor.rangeForCurrentForm(76)).deep.equal([72, 73]);
+        });
+        it('4: selects next form, if on the same line', () => {
+            const cursor: LispTokenCursor = doc.getTokenCursor(65);
+            expect(cursor.rangeForCurrentForm(65)).deep.equal([68, 69]);
+        });
+        it('5: selects previous form, if any', () => {
+            const cursor: LispTokenCursor = doc.getTokenCursor(84);
+            expect(cursor.rangeForCurrentForm(84)).deep.equal([77, 80]);
+        });
+        it('6: selects next form, if any', () => {
+            const doc: mock.MockDocument = new mock.MockDocument();
+            doc.insertString('  •  (foo {:a b})•(c)'.replace(/•/g, '\n'));
+            const cursor: LispTokenCursor = doc.getTokenCursor(1);
+            expect(cursor.rangeForCurrentForm(1)).deep.equal([5, 17]);
+        });
+        it('7: selects enclosing form, if any', () => {
+            const doc: mock.MockDocument = new mock.MockDocument();
+            doc.insertString('()  •  (foo {:a b})•(c)'.replace(/•/g, '\n'));
+            const cursor: LispTokenCursor = doc.getTokenCursor(1);
+            expect(cursor.rangeForCurrentForm(1)).deep.equal([0, 2]);
+        });
+    });
 });

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -81,6 +81,14 @@ describe('Token Cursor', () => {
             const cursor: LispTokenCursor = doc.getTokenCursor(22);
             expect(cursor.rangeForCurrentForm(22)).deep.equal([22, 43]);
         });
+        it('2: selects from adjanent before form, or in readers', () => {
+            const cursor: LispTokenCursor = doc.getTokenCursor(21);
+            expect(cursor.rangeForCurrentForm(21)).deep.equal([16, 55]);
+        });
+        it('2: selects from adjanent before a form tagged with readers', () => {
+            const cursor: LispTokenCursor = doc.getTokenCursor(27);
+            expect(cursor.rangeForCurrentForm(22)).deep.equal([22, 43]);
+        });
         it('3: selects previous form, if on the same line', () => {
             const cursor: LispTokenCursor = doc.getTokenCursor(76);
             expect(cursor.rangeForCurrentForm(76)).deep.equal([72, 73]);

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+import { LispTokenCursor } from '../../../cursor-doc/token-cursor';
+import * as mock from './mock';
+
+describe('Token Cursor', () => {
+    const docText = '(a(b(c\n#f\n(#b \n[:f :b :z])\n#z\n1)))',
+        doc: mock.MockDocument = new mock.MockDocument();
+
+    beforeEach(() => {
+        doc.insertString(docText);
+    });
+
+    it('forwardSexp x4: (a(b(|c•#f•(#b •[:f :b :z])•#z•1))) => (a(b(c•#f•(#b •[:f :b :z])•#z•1|)))', () => {
+        const cursor: LispTokenCursor = doc.getTokenCursor(5);
+        cursor.forwardSexp();
+        expect(cursor.offsetStart).equal(6);
+        cursor.forwardSexp();
+        expect(cursor.offsetStart).equal(26);
+        cursor.forwardSexp();
+        expect(cursor.offsetStart).equal(31);
+        cursor.forwardSexp();
+        expect(cursor.offsetStart).equal(31);
+    });
+    it('backwardSexp x4: (a(b(c•#f•(#b •[:f :b :z])•#z•1|))) => (a(b(|c•#f•(#b •[:f :b :z])•#z•1)))', () => {
+        const cursor: LispTokenCursor = doc.getTokenCursor(31);
+        cursor.backwardSexp();
+        expect(cursor.offsetStart).equal(27);
+        cursor.backwardSexp();
+        expect(cursor.offsetStart).equal(7);
+        cursor.backwardSexp();
+        expect(cursor.offsetStart).equal(5);
+        cursor.backwardSexp();
+        expect(cursor.offsetStart).equal(5);
+    });
+    it('forwardList: (a(b(c•#|f•(#b •[:f :b :z])•#z•1))) => (a(b(c•#f•(#b •[:f :b :z])•#z•1|)))', () => {
+        const cursor: LispTokenCursor = doc.getTokenCursor(8);
+        cursor.forwardList();
+        expect(cursor.offsetStart).equal(31);
+    });
+    it('upList: (a(b(c•#f•(#b •[:f :b :z])•#z•1|))) => (a(b(c•#f•(#b •[:f :b :z])•#z•1)|))', () => {
+        const cursor: LispTokenCursor = doc.getTokenCursor(31);
+        cursor.upList();
+        expect(cursor.offsetStart).equal(32);
+    });
+    it('backwardList: (a(b(c•#f•(#b •[:f :b :z])•#z•|1))) => (a(b(|c•#f•(#b •[:f :b :z])•#z•1)))', () => {
+        const cursor: LispTokenCursor = doc.getTokenCursor(30);
+        cursor.backwardList();
+        expect(cursor.offsetStart).equal(5);
+    });
+    it('backwardUpList: (a(b(c•#f•(#b •|[:f :b :z])•#z•1))) => (a(b(c•|#f•(#b •[:f :b :z])•#z•1)))', () => {
+        const cursor: LispTokenCursor = doc.getTokenCursor(15);
+        cursor.backwardUpList();
+        expect(cursor.offsetStart).equal(7);
+    });
+});

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -269,8 +269,10 @@ export function activate(context: vscode.ExtensionContext) {
             }
             stack.push({ char: char, start: pos, end: pos.translate(0, charLength), pair_idx: pair_idx });
             pairsBack.set(position_str(pos), [opening, closing]);
-            for (let i = 0; i < pair.char.length; ++i)
-              pairsForward.set(position_str(pair.start.translate(0, i)), [opening, closing]);
+            const startOffset = activeEditor.document.offsetAt(pair.start);
+            for (let i = 0; i < pair.char.length; ++i) {
+              pairsForward.set(position_str(activeEditor.document.positionAt(startOffset + i)), [opening, closing]);
+            }
             --stack_depth;
             if (colorsEnabled) {
               rainbow[colorIndex(stack_depth)].push(decoration);

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -6,6 +6,15 @@ import * as docMirror from '../../doc-mirror'
 import { Token, validPair } from '../../cursor-doc/clojure-lexer';
 import * as util from '../../utilities';
 import { LispTokenCursor } from '../../cursor-doc/token-cursor';
+import { read } from 'fs';
+
+type StackItem = {
+  char: string,
+  start: Position,
+  end: Position,
+  pair_idx: number,
+  opens_comment_form?: boolean
+}
 
 export function activate(context: vscode.ExtensionContext) {
   function position_str(pos: Position) { return "" + pos.line + ":" + pos.character; }
@@ -162,7 +171,7 @@ export function activate(context: vscode.ExtensionContext) {
       colorIndex = cycleBracketColors ? (i => i % len) : (i => Math.min(i, len - 1));
 
     let in_comment_form = false,
-      stack = [],
+      stack: StackItem[] = [],
       stack_depth = 0;
     pairsBack = new Map();
     pairsForward = new Map();
@@ -228,13 +237,18 @@ export function activate(context: vscode.ExtensionContext) {
         }
         // Rainbows! (And also highlight current parens.)
         if (token.type === 'open') {
-          const pos = activeEditor.document.positionAt(cursor.offsetStart);
+          const readerCursor = cursor.clone();
+          readerCursor.backwardThroughAnyReader();
+          const start = activeEditor.document.positionAt(readerCursor.offsetStart),
+            end = activeEditor.document.positionAt(cursor.offsetEnd),
+            openRange = new Range(start, end),
+            openString = activeEditor.document.getText(openRange);
           if (colorsEnabled) {
-            const decoration = { range: new Range(pos, pos.translate(0, charLength)) };
+            const decoration = { range: openRange };
             rainbow[colorIndex(stack_depth)].push(decoration);
           }
           ++stack_depth;
-          stack.push({ char: char, pos: pos, pair_idx: undefined, opens_comment_form: false });
+          stack.push({ char: openString, start: start, end: end, pair_idx: undefined, opens_comment_form: false });
           continue;
         } else if (token.type === 'close') {
           const pos = activeEditor.document.positionAt(cursor.offsetStart),
@@ -248,16 +262,15 @@ export function activate(context: vscode.ExtensionContext) {
           } else {
             let pair = stack[pair_idx],
               closing = new Range(pos, pos.translate(0, charLength)),
-              opening = new Range(pair.pos, pair.pos.translate(0, pair.char.length));
+              opening = new Range(pair.end.translate(0, -1), pair.end);
             if (in_comment_form && pair.opens_comment_form) {
-              comment_forms.push(new Range(pair.pos, pos.translate(0, charLength)));
+              comment_forms.push(new Range(pair.start, pos.translate(0, charLength)));
               in_comment_form = false;
             }
-            stack.push({ char: char, pos: pos, pair_idx: pair_idx });
-            for (let i = 0; i < charLength; ++i)
-              pairsBack.set(position_str(pos.translate(0, i)), [opening, closing]);
+            stack.push({ char: char, start: pos, end: pos.translate(0, charLength), pair_idx: pair_idx });
+            pairsBack.set(position_str(pos), [opening, closing]);
             for (let i = 0; i < pair.char.length; ++i)
-              pairsForward.set(position_str(pair.pos.translate(0, i)), [opening, closing]);
+              pairsForward.set(position_str(pair.start.translate(0, i)), [opening, closing]);
             --stack_depth;
             if (colorsEnabled) {
               rainbow[colorIndex(stack_depth)].push(decoration);

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -211,9 +211,9 @@ export function activate(context: vscode.ExtensionContext) {
             const ignoreCursor = cursor.clone();
             let ignore_counter = 0;
             const ignore_start = activeEditor.document.positionAt(ignoreCursor.offsetStart);
-            while (ignoreCursor.getToken().type == 'ignore') {
+            while (ignoreCursor.getToken().type === 'ignore') {
               ignore_counter++;
-              ignoreCursor.forwardSexp();
+              ignoreCursor.next();
               ignoreCursor.forwardWhitespace();
             }
             for (i = 0; i < ignore_counter; i++) {

--- a/test-data/test2.clj
+++ b/test-data/test2.clj
@@ -1,3 +1,10 @@
+(a(b
+   (c
+     #f
+      (#b
+        [:f :b :z])
+     #z
+      1)))
 (comment
   1
   #foo
@@ -9,8 +16,8 @@
   
   #foo :bar
   (foo #foo ('foo^' :bar))
-  #_#_
-  'abc #foo  @~#(foo :bar) \space
+  #_ 'abc 
+  #foo  @~#(foo :bar) \space
   \' {:foo (#foo '[1 2 3])} 'abc
   #_#_
   #foo

--- a/test-data/test2.clj
+++ b/test-data/test2.clj
@@ -1,4 +1,11 @@
 (comment
+  1
+  #foo
+   #bar
+    #baz
+     #{:foo (#foo '[1 2 3])})
+
+(comment
   
   #foo :bar
   (foo #foo ('foo^' :bar))
@@ -7,9 +14,11 @@
   \' {:foo (#foo '[1 2 3])} 'abc
   #_#_
   #foo
-   'bar
+   #bar
+    #baz
+     #{:foo (#foo '[1 2 3])}
   #foo
-   #{:foo (#foo '[1 2 3])}
+   'bar
   \a [] "a"
 
   )


### PR DESCRIPTION
## What has Changed?

Fixes #581 

- The token cursor has two new methods for moving forward and backwards through reader tokens, even when they are stacked.
- These are then used by some the primitive token cursor movement operations, forward/backward sexpr and up/down list.
- They are also used from some Paredit operations, because they had to.
- They are also used from Calva Highlight to get the rainbows right.

Here's a demo:

![stacked-readers-paredit](https://user-images.githubusercontent.com/30010/76167403-af126c00-6166-11ea-8e61-853e8384606a.gif)

A summary of what is going on in the GIF:

1. I am painting the reader tags with the same rainbow color as any list they are tagging. 
2. The session starts with expanding the selection a few times from the `nil` form.
3. Then I move past the `#foo-0` tagged list and back again.
4. Then I move down into to the` #foo-0` tagged list.
5. I drag the `1` forward through all its siblings in the list. And back again.
6. Then I drag the` #foo-3` quadruple tagged function call forward past its siblings, and back again.
7. Then I drag it down the `[1 2 3]` vector, and then out the end of it.
8. Then I drag it backward to its original place.
9. The last thing I do is to demonstrate that I don't need to place the cursor at the very start/end of a form for Calva Paredit to understand which form is the ”current” form.

Regarding what happens when something is dragged pass the ignore markers (`#_`). I have chosen to let those be ”forms”, so that things can be hidden from the reader by dragging things in front of them.


## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->