### PR TITLE
REPL window prompt string closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Fix: REPL Window Paredit does not close strings properly](https://github.com/BetterThanTomorrow/calva/issues/587)
 
 ## [2.0.85] - 2020-03-15
 - Fix: Make lein-shadow project type use lein injections

--- a/src/cursor-doc/clojure-lexer.ts
+++ b/src/cursor-doc/clojure-lexer.ts
@@ -90,7 +90,7 @@ let inString = new LexicalGrammar()
 // end a string
 inString.terminal(/"/, (l, m) => ({ type: "close" }))
 // still within a string
-inString.terminal(/(\\.|[^\\"\t\r\n ])+/, (l, m) => ({ type: "str-inside" }))
+inString.terminal(/(\\.|[^"\s])+/, (l, m) => ({ type: "str-inside" }))
 // whitespace, excluding newlines
 inString.terminal(/[\t ]+/, (l, m) => ({ type: "ws" }))
 // newlines, we want each one as a token of its own

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -579,7 +579,12 @@ export class LispTokenCursor extends TokenCursor {
      * Indicates if the current token is inside a string
      */
     withinString() {
-        return this.getToken().type == 'str-inside' || this.getPrevToken().type == 'str-inside';
+        const cursor = this.clone();
+        cursor.backwardList();
+        if (cursor.getPrevToken().type === 'open' && cursor.getPrevToken().raw === '"') {
+            return true;
+        };
+        return false;
     }
 
     /**

--- a/src/extension-test/unit/cursor-doc/clojure-lexer-test.ts
+++ b/src/extension-test/unit/cursor-doc/clojure-lexer-test.ts
@@ -246,6 +246,16 @@ describe('Scanner', () => {
             expect(tokens[4].type).equals('close');
             expect(tokens[4].raw).equals('"');
         });
+        it('tokenizes quoted quotes in strings', () => {
+            let tokens = scanner.processLine('"\\""');
+            expect(tokens[0].type).equals('open');
+            expect(tokens[0].raw).equals('"');
+            expect(tokens[1].type).equals('str-inside');
+            expect(tokens[1].raw).equals('\\"');
+            tokens = scanner.processLine('"foo\\"bar"');
+            expect(tokens[1].type).equals('str-inside');
+            expect(tokens[1].raw).equals('foo\\"bar');
+        });
     });
     describe('Reported issues', () => {
         it('too long lines - #566', () => {
@@ -283,5 +293,3 @@ describe('Scanner', () => {
         });
     });
 });
-
-

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -441,3 +441,26 @@ describe('paredit', () => {
 });
 
 
+
+    describe('edits', () => {
+        it('Closes list', () => {
+            const doc: mock.MockDocument = new mock.MockDocument(),
+                text = '(str "foo")',
+                caret = 10;
+            doc.insertString(text);
+            doc.selection = new ModelEditSelection(caret);
+            paredit.close(doc, ')');
+            expect(doc.model.getText(0, Infinity)).equal(text);
+            expect(doc.selection).deep.equal(new ModelEditSelection(caret + 1));
+        });
+        it('Closes quote at end of string', () => {
+            const doc: mock.MockDocument = new mock.MockDocument(),
+                text = '(str "foo")',
+                caret = 9;
+            doc.insertString(text);
+            doc.selection = new ModelEditSelection(caret);
+            paredit.stringQuote(doc);
+            expect(doc.model.getText(0, Infinity)).equal(text);
+            expect(doc.selection).deep.equal(new ModelEditSelection(caret + 1));
+        });
+    });

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -47,11 +47,37 @@ describe('Token Cursor', () => {
         cursor.backwardList();
         expect(cursor.offsetStart).equal(5);
     });
+
     it('backwardUpList: (a(b(c•#f•(#b •|[:f :b :z])•#z•1))) => (a(b(c•|#f•(#b •[:f :b :z])•#z•1)))', () => {
         const cursor: LispTokenCursor = doc.getTokenCursor(15);
         cursor.backwardUpList();
         expect(cursor.offsetStart).equal(7);
     });
+
+    // TODO: Figure out why adding these tests make other test break!
+    xdescribe('Navigation in and around strings', () => {
+        it('backwardList moves to start of string', () => {
+            const doc = new mock.MockDocument();
+            doc.insertString('(str [] "", "foo" "f   b  b"   "   f b b   " "\"" \")');
+            const cursor: LispTokenCursor = doc.getTokenCursor(21);
+            cursor.backwardList();
+            expect(cursor.offsetStart).equal(19);
+        });
+        it('forwardList moves to end of string', () => {
+            const doc = new mock.MockDocument();
+            doc.insertString('(str [] "", "foo" "f   b  b"   "   f b b   " "\"" \")');
+            const cursor: LispTokenCursor = doc.getTokenCursor(21);
+            cursor.forwardList();
+            expect(cursor.offsetStart).equal(27);
+        });
+        it('backwardSexpr inside string moves past quoted characters', () => {
+            const doc = new mock.MockDocument();
+            doc.insertString('(str [] "foo \" bar")');
+            const cursor: LispTokenCursor = doc.getTokenCursor(15);
+            cursor.backwardSexp();
+            expect(cursor.offsetStart).equal(13);
+        });
+    })
 
     describe('Current Form', () => {
         const docText = '(aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)))'.replace(/•/g, '\n'),
@@ -112,6 +138,44 @@ describe('Token Cursor', () => {
             doc.insertString('()  •  (foo {:a b})•(c)'.replace(/•/g, '\n'));
             const cursor: LispTokenCursor = doc.getTokenCursor(1);
             expect(cursor.rangeForCurrentForm(1)).deep.equal([0, 2]);
+        });
+    });
+    describe('Location State', () => {
+        it('Knows when inside string', () => {
+            const doc = new mock.MockDocument();
+            doc.insertString('(str [] "", "foo" "f   b  b"   "   f b b   " "\"" \")');
+            const withinEmpty = doc.getTokenCursor(9);
+            expect(withinEmpty.withinString()).equal(true);
+            const adjacentOutsideLeft = doc.getTokenCursor(8);
+            expect(adjacentOutsideLeft.withinString()).equal(false);
+            const adjacentOutsideRight = doc.getTokenCursor(10);
+            expect(adjacentOutsideRight.withinString()).equal(false);
+            const noStringWS = doc.getTokenCursor(11);
+            expect(noStringWS.withinString()).equal(false);
+            const leftOfFirstWord = doc.getTokenCursor(13);
+            expect(leftOfFirstWord.withinString()).equal(true);
+            const rightOfLastWord = doc.getTokenCursor(16);
+            expect(rightOfLastWord.withinString()).equal(true);
+            const inWord = doc.getTokenCursor(14);
+            expect(inWord.withinString()).equal(true);
+            const spaceBetweenWords = doc.getTokenCursor(21);
+            expect(spaceBetweenWords.withinString()).equal(true);
+            const spaceBeforeFirstWord = doc.getTokenCursor(33);
+            expect(spaceBeforeFirstWord.withinString()).equal(true);
+            const spaceAfterLastWord = doc.getTokenCursor(41);
+            expect(spaceAfterLastWord.withinString()).equal(true);
+            const beforeQuotedStringQuote = doc.getTokenCursor(46);
+            expect(beforeQuotedStringQuote.withinString()).equal(true);
+            // const inQuotedStringQuote = doc.getTokenCursor(47);
+            // expect(inQuotedStringQuote.withinString()).equal(true);
+            // const afterQuotedStringQuote = doc.getTokenCursor(48);
+            // expect(afterQuotedStringQuote.withinString()).equal(true);
+            // const beforeLiteralQuote = doc.getTokenCursor(50);
+            // expect(beforeLiteralQuote.withinString()).equal(false);
+            // const inLiteralQuote = doc.getTokenCursor(51);
+            // expect(inLiteralQuote.withinString()).equal(false);
+            // const afterLiteralQuote = doc.getTokenCursor(52);
+            // expect(afterLiteralQuote.withinString()).equal(false);
         });
     });
 });

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -55,24 +55,24 @@ describe('Token Cursor', () => {
     });
 
     // TODO: Figure out why adding these tests make other test break!
-    xdescribe('Navigation in and around strings', () => {
+    describe('Navigation in and around strings', () => {
         it('backwardList moves to start of string', () => {
             const doc = new mock.MockDocument();
-            doc.insertString('(str [] "", "foo" "f   b  b"   "   f b b   " "\"" \")');
+            doc.insertString('(str [] "", "foo" "f   b  b"   "   f b b   " "\\"" \\")');
             const cursor: LispTokenCursor = doc.getTokenCursor(21);
             cursor.backwardList();
             expect(cursor.offsetStart).equal(19);
         });
         it('forwardList moves to end of string', () => {
             const doc = new mock.MockDocument();
-            doc.insertString('(str [] "", "foo" "f   b  b"   "   f b b   " "\"" \")');
+            doc.insertString('(str [] "", "foo" "f   b  b"   "   f b b   " "\\"" \\")');
             const cursor: LispTokenCursor = doc.getTokenCursor(21);
             cursor.forwardList();
             expect(cursor.offsetStart).equal(27);
         });
         it('backwardSexpr inside string moves past quoted characters', () => {
             const doc = new mock.MockDocument();
-            doc.insertString('(str [] "foo \" bar")');
+            doc.insertString('(str [] "foo \\" bar")');
             const cursor: LispTokenCursor = doc.getTokenCursor(15);
             cursor.backwardSexp();
             expect(cursor.offsetStart).equal(13);
@@ -143,7 +143,7 @@ describe('Token Cursor', () => {
     describe('Location State', () => {
         it('Knows when inside string', () => {
             const doc = new mock.MockDocument();
-            doc.insertString('(str [] "", "foo" "f   b  b"   "   f b b   " "\"" \")');
+            doc.insertString('(str [] "", "foo" "f   b  b"   "   f b b   " "\\"" \\")');
             const withinEmpty = doc.getTokenCursor(9);
             expect(withinEmpty.withinString()).equal(true);
             const adjacentOutsideLeft = doc.getTokenCursor(8);
@@ -166,16 +166,16 @@ describe('Token Cursor', () => {
             expect(spaceAfterLastWord.withinString()).equal(true);
             const beforeQuotedStringQuote = doc.getTokenCursor(46);
             expect(beforeQuotedStringQuote.withinString()).equal(true);
-            // const inQuotedStringQuote = doc.getTokenCursor(47);
-            // expect(inQuotedStringQuote.withinString()).equal(true);
-            // const afterQuotedStringQuote = doc.getTokenCursor(48);
-            // expect(afterQuotedStringQuote.withinString()).equal(true);
-            // const beforeLiteralQuote = doc.getTokenCursor(50);
-            // expect(beforeLiteralQuote.withinString()).equal(false);
-            // const inLiteralQuote = doc.getTokenCursor(51);
-            // expect(inLiteralQuote.withinString()).equal(false);
-            // const afterLiteralQuote = doc.getTokenCursor(52);
-            // expect(afterLiteralQuote.withinString()).equal(false);
+            const inQuotedStringQuote = doc.getTokenCursor(47);
+            expect(inQuotedStringQuote.withinString()).equal(true);
+            const afterQuotedStringQuote = doc.getTokenCursor(48);
+            expect(afterQuotedStringQuote.withinString()).equal(true);
+            const beforeLiteralQuote = doc.getTokenCursor(50);
+            expect(beforeLiteralQuote.withinString()).equal(false);
+            const inLiteralQuote = doc.getTokenCursor(51);
+            expect(inLiteralQuote.withinString()).equal(false);
+            const afterLiteralQuote = doc.getTokenCursor(52);
+            expect(afterLiteralQuote.withinString()).equal(false);
         });
     });
 });


### PR DESCRIPTION
## What has Changed?

Right now strings are not closing when a double quote is entered at the end of the string. And this also is sometimes happening for lists/vectors/etcetera. Both problems [are mentioned on ClojueVerse](https://clojureverse.org/t/it-is-super-easy-to-hack-on-calva-why-dont-you-try-it-out/4953/3?u=pez). It turns out that the functionality for determining if we are in a string is quite broken, and the methods for closing lists too. This PR fixes both, and in addition to that improves the handling of quoted quotes inside strings.

Fixes #587

## My Calva PR Checklist
- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->