### PR TITLE
[WIP] Add support for connecting to generic project types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Add support for connecting to generic project types](https://github.com/BetterThanTomorrow/calva/issues/595)
 
 ## [2.0.88] - 2020-03-21
 - [Change all references to `#calva-dev` so that they now point to the `#calva` Slack channel](https://clojurians.slack.com/messages/calva/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "calva",
-    "version": "2.0.88",
+    "version": "2.0.89",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Calva: Clojure & ClojureScript Interactive Programming",
     "description": "Integrated REPL, formatter, Paredit, and more. Powered by nREPL.",
     "icon": "assets/calva.png",
-    "version": "2.0.88",
+    "version": "2.0.89",
     "publisher": "betterthantomorrow",
     "author": {
         "name": "Better Than Tomorrow",

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -8,7 +8,8 @@ enum ProjectTypes {
     "Leiningen" = "Leiningen",
     "Clojure CLI" = "Clojure CLI",
     "shadow-cljs" = "shadow-cljs",
-    "lein-shadow" = "lein-shadow"
+    "lein-shadow" = "lein-shadow",
+    'generic' = 'generic'
 }
 
 enum CljsTypes {
@@ -120,11 +121,19 @@ const leinShadowDefaults: ReplConnectSequence[] = [{
     nReplPortFile: [".shadow-cljs", "nrepl.port"]
 }];
 
+const genericDefaults: ReplConnectSequence[] = [{
+    name: "Generic",
+    projectType: ProjectTypes['generic'],
+    cljsType: CljsTypes.none,
+    nReplPortFile: ["nrepl.port"]
+}];
+
 const defaultSequences = {
     "lein": leiningenDefaults,
     "clj": cljDefaults,
     "shadow-cljs": shadowCljsDefaults,
-    "lein-shadow": leinShadowDefaults
+    "lein-shadow": leinShadowDefaults,
+    'generic': genericDefaults
 };
 
 const defaultCljsTypes: { [id: string]: CljsTypeConfig } = {
@@ -219,13 +228,7 @@ function getDefaultCljsType(cljsType: string): CljsTypeConfig {
 
 async function askForConnectSequence(cljTypes: string[], saveAs: string, logLabel: string): Promise<ReplConnectSequence> {
     // figure out what possible kinds of project we're in
-    if (cljTypes.length == 0) {
-        vscode.window.showErrorMessage("Cannot find project, no project.clj, deps.edn or shadow-cljs.edn.");
-        state.analytics().logEvent("REPL", logLabel, "FailedFindingProjectType").send();
-        return;
-    }
-
-    const sequences = getConnectSequences(cljTypes);
+    const sequences: ReplConnectSequence[] = getConnectSequences(cljTypes);
     if (sequences.length > 1) {
         const projectConnectSequenceName = await utilities.quickPickSingle({
             values: sequences.map(s => { return s.name }),

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -26,7 +26,7 @@ vscode.tasks.onDidEndTask(((e) => {
     if(e.execution.task.name == TASK_NAME) {
        JackinExecution = undefined;
        connector.default.disconnect();
-       // make sure everything is set back 
+       // make sure everything is set back
        // even if the task failed to connect
        // to the repl server.
        utilities.setLaunchingState(null);
@@ -36,7 +36,7 @@ vscode.tasks.onDidEndTask(((e) => {
 
 function cancelJackInTask() {
     setTimeout(() => {
-        calvaJackout(); 
+        calvaJackout();
     }, 1000);
 }
 
@@ -76,7 +76,7 @@ async function executeJackInTask(projectType: projectTypes.ProjectType, projectT
         }
 
         if(!fs.existsSync(portFileDir)) {
-            // try to make the directory to allow the 
+            // try to make the directory to allow the
             // started process to catch up.
             fs.mkdirSync(portFileDir);
         }
@@ -118,12 +118,12 @@ async function executeJackInTask(projectType: projectTypes.ProjectType, projectT
 export function calvaJackout() {
     if (JackinExecution != undefined) {
         if (projectTypes.isWin) {
-            // this is a hack under Windows to terminate the 
-            // repl process from the repl client because the 
-            // ShellExecution under Windows will not terminate 
+            // this is a hack under Windows to terminate the
+            // repl process from the repl client because the
+            // ShellExecution under Windows will not terminate
             // all child processes.
             //
-            // the clojure code to terminate the repl process 
+            // the clojure code to terminate the repl process
             // was taken from this comment on github:
             //
             // https://github.com/clojure-emacs/cider/issues/390#issuecomment-317791387
@@ -145,33 +145,42 @@ export async function calvaJackIn() {
     }
     state.analytics().logEvent("REPL", "JackInInitiated").send();
 
-    const cljTypes = await projectTypes.detectProjectTypes();
-    const projectConnectSequence: ReplConnectSequence = await askForConnectSequence(cljTypes, 'jack-in-type', "JackInInterrupted");
-    
-    if (!projectConnectSequence) {
-        state.analytics().logEvent("REPL", "JackInInterrupted", "NoProjectTypeForBuildName").send();
-        outputChannel.appendLine("Aborting Jack-in, since no project typee was selected.");
-        return;
+    const cljTypes: string[] = await projectTypes.detectProjectTypes();
+    if (cljTypes.length > 1) {
+        const projectConnectSequence: ReplConnectSequence = await askForConnectSequence(cljTypes.filter(t => t !== 'generic'), 'jack-in-type', "JackInInterrupted");
+
+        if (!projectConnectSequence) {
+            state.analytics().logEvent("REPL", "JackInInterrupted", "NoProjectTypeForBuildName").send();
+            outputChannel.appendLine("Aborting Jack-in, since no project typee was selected.");
+            return;
+        }
+        if (projectConnectSequence.projectType !== 'generic') {
+            outputChannel.appendLine("Jacking in...");
+
+            const projectTypeName: string = projectConnectSequence.projectType;
+            let selectedCljsType: CljsTypes;
+
+            if (typeof projectConnectSequence.cljsType == "string" && projectConnectSequence.cljsType != CljsTypes.none) {
+                selectedCljsType = projectConnectSequence.cljsType;
+            } else if (projectConnectSequence.cljsType && typeof projectConnectSequence.cljsType == "object") {
+                selectedCljsType = projectConnectSequence.cljsType.dependsOn;
+            }
+
+            let projectType = projectTypes.getProjectTypeForName(projectTypeName);
+            let executable = projectTypes.isWin ? projectType.winCmd : projectType.cmd;
+            // Ask the project type to build up the command line. This may prompt for further information.
+            let args = await projectType.commandLine(projectConnectSequence, selectedCljsType);
+
+            executeJackInTask(projectType, projectConnectSequence.name, executable, args, cljTypes, outputChannel, projectConnectSequence)
+                .then(() => { }, () => { });
+        } else {
+            outputChannel.appendLine("There is no Jack-in possible for this project type.");
+        }
+    } else { // Only 'generic' type left
+        outputChannel.appendLine("No Jack-in possible.");
+        vscode.window.showInformationMessage('No supported Jack-in project types detected. Maybe try starting your project manually and use the Connect command?')
     }
-    
-    outputChannel.appendLine("Jacking in...");
 
-    const projectTypeName: string = projectConnectSequence.projectType;
-    let selectedCljsType: CljsTypes;
-
-    if (typeof projectConnectSequence.cljsType == "string" && projectConnectSequence.cljsType != CljsTypes.none) {
-        selectedCljsType = projectConnectSequence.cljsType;
-    } else if (projectConnectSequence.cljsType && typeof projectConnectSequence.cljsType == "object") {
-        selectedCljsType = projectConnectSequence.cljsType.dependsOn;
-    }
-
-    let projectType = projectTypes.getProjectTypeForName(projectTypeName);
-    let executable = projectTypes.isWin ? projectType.winCmd : projectType.cmd;
-    // Ask the project type to build up the command line. This may prompt for further information.
-    let args = await projectType.commandLine(projectConnectSequence, selectedCljsType);
-
-    executeJackInTask(projectType, projectConnectSequence.name, executable, args, cljTypes, outputChannel, projectConnectSequence)
-        .then(() => { }, () => { });
 }
 
 export async function calvaDisconnect() {
@@ -213,7 +222,7 @@ export async function calvaJackInOrConnect() {
         commands["Connect to a running REPL server in your project"] = "calva.connect";
         commands["Connect to a running REPL server, not in your project"] = "calva.connectNonProjectREPL";
     } else {
-        // if connected add the disconnect command and the 
+        // if connected add the disconnect command and the
         // REPL window open commands if needed.
         commands["Disconnect from the REPL server"] = "calva.disconnect";
         if(utilities.getSession("clj")) {
@@ -222,7 +231,7 @@ export async function calvaJackInOrConnect() {
             } else {
                 commands["Clear Clojure REPL Window + History"] = "calva.clearClojureREPLWindow";
             }
-            
+
         }
         if(utilities.getSession("cljs"))  {
             if (!isReplWindowOpen("cljs")) {

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -363,7 +363,19 @@ const projectTypes: { [id: string]: ProjectType } = {
                 throw "No shadow-cljs build selected"
             }
         }
-    }
+    },
+    'generic': {
+        // There is no Jack-in supported here
+        name: 'generic',
+        cljsTypes: [],
+        cmd: undefined,
+        winCmd: undefined,
+        useWhenExists: undefined,
+        nReplPortFile: [".nrepl-port"],
+        commandLine: async (connectSequence: ReplConnectSequence, cljsType: CljsTypes) => {
+            return undefined;
+        }
+    },
 }
 
 async function leinCommandLine(command: string[], cljsType: CljsTypes, connectSequence: ReplConnectSequence) {
@@ -410,13 +422,15 @@ export function getProjectTypeForName(name: string) {
 }
 
 export async function detectProjectTypes(): Promise<string[]> {
-    let rootDir = state.getProjectRoot(),
-        cljProjTypes = []
+    const rootDir = state.getProjectRoot(),
+        cljProjTypes = ['generic'];
     for (let clj in projectTypes) {
-        try {
-            fs.accessSync(rootDir + "/" + projectTypes[clj].useWhenExists);
-            cljProjTypes.push(clj);
-        } catch (_e) { }
+        if (projectTypes[clj].useWhenExists) {
+            try {
+                fs.accessSync(path.resolve(rootDir, projectTypes[clj].useWhenExists));
+                cljProjTypes.push(clj);
+            } catch (_e) { }
+        }
     }
     return cljProjTypes;
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -202,6 +202,7 @@ export async function initProjectDir(): Promise<void> {
         throw "There is no document opened in the workspace. Aborting.";
     } else {
         let rootPath: string = path.resolve(workspaceFolder.uri.fsPath);
+        cursor.set(PROJECT_DIR_KEY, rootPath);
         let d = null;
         let prev = null;
         if (doc) {
@@ -233,9 +234,7 @@ export async function initProjectDir(): Promise<void> {
                 return;
             }
         }
-        vscode.window.showErrorMessage("There was no valid project configuration found in the workspace. Please open a file in your Clojure project and try again. Aborting.");
-        analytics().logEvent("REPL", "JackinOrConnectInterrupted", "NoCurrentDocument").send();
-        throw "There was no valid project configuration found in the workspace. Aborting.";
+        return;
     }
 }
 


### PR DESCRIPTION
## What has Changed?
A `generic` project type is added. This project type is not selectable at jack-in, but always on connect. Running the connect command In a project that has no Calva-known project files will bring up the connect prompt asking for nREPL url (pre-filled with port, if there is an `.nrepl-port` file. If there are such files, the project type `Generic` is added to the list of selectable project types.

Currently if there are custom sequences configured and one of them is of type `generic`, it will show up for Jack-in scenarios, but will not result in a jack-in starting. (A message in **Calva says**, informs about it.)

Fixes #595 

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->