### PR TITLE
Always send along `ns` w/ nrepl eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- nREPL `eval` should always send along the `ns` parameter
 
 ## [2.0.89] - 2020-03-29
 - [Add support for connecting to generic project types](https://github.com/BetterThanTomorrow/calva/issues/595)

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -133,7 +133,7 @@ type connectFn = (session: NReplSession, name: string, checkSuccess: checkConnec
 
 async function evalConnectCode(newCljsSession: NReplSession, code: string, name: string, checkSuccess: checkConnectedFn, outputProcessors: processOutputFn[] = [], errorProcessors: processOutputFn[] = []): Promise<boolean> {
     let chan = state.connectionLogChannel();
-    let err = [], out = [], result = await newCljsSession.eval(code, {
+    let err = [], out = [], result = await newCljsSession.eval(code, "user", {
         stdout: x => {
             out.push(util.stripAnsi(x));
             chan.append(util.stripAnsi(x));

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -26,7 +26,7 @@ export class NReplClient {
     /** Tracks all sessions */
     sessions: { [id: string]: NReplSession } = {};
 
-    ns: string = "user";
+    ns: string = 'user';
 
     private constructor(socket: net.Socket) {
         this.socket = socket;
@@ -256,7 +256,7 @@ export class NReplSession {
         })
     }
 
-    eval(code: string, opts: { line?: number, column?: number, eval?: string, file?: string, stderr?: (x: string) => void, stdout?: (x: string) => void, stdin?: () => Promise<string>, pprintOptions: PrettyPrintingOptions } = { pprintOptions: disabledPrettyPrinter }) {
+    eval(code: string, ns: string, opts: { line?: number, column?: number, eval?: string, file?: string, stderr?: (x: string) => void, stdout?: (x: string) => void, stdin?: () => Promise<string>, pprintOptions: PrettyPrintingOptions } = { pprintOptions: disabledPrettyPrinter }) {
         const pprintOptions = opts.pprintOptions;
         opts["pprint"] = pprintOptions.enabled;
         delete opts.pprintOptions;
@@ -270,7 +270,7 @@ export class NReplSession {
                     return true;
                 }
             }
-            const opMsg = { op: "eval", session: this.sessionId, code, id, ...extraOpts, ...opts };
+            const opMsg = { op: "eval", session: this.sessionId, code, ns, id, ...extraOpts, ...opts };
             this.addRunningID(id);
             this.client.write(opMsg);
         }))

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -129,7 +129,7 @@ export function calvaJackout() {
             // https://github.com/clojure-emacs/cider/issues/390#issuecomment-317791387
             //
             if (nClient && nClient.session) {
-                nClient.session.eval("(do (.start (Thread. (fn [] (Thread/sleep 5000) (shutdown-agents) (System/exit 0)))) nil)");
+                nClient.session.eval("(do (.start (Thread. (fn [] (Thread/sleep 5000) (shutdown-agents) (System/exit 0)))) nil)", 'user');
             }
         }
         JackinExecution.terminate();

--- a/src/repl-window.ts
+++ b/src/repl-window.ts
@@ -185,7 +185,7 @@ class REPLWindow {
         // evaluate something that really test
         // the ability of the connected repl.
         try {
-            const res = await this.session.eval("(+ 1 1)").value;
+            const res = await this.session.eval("(+ 1 1)", this.session.client.ns).value;
 
             if (res.ns) {
                 this.ns = res.ns;
@@ -232,7 +232,7 @@ class REPLWindow {
 
         this.interrupt();
 
-        let evaluation = this.session.eval(line, {
+        let evaluation = this.session.eval(line, ns, {
             stderr: m => this.postMessage({ type: "stderr", value: m }),
             stdout: m => this.postMessage({ type: "stdout", value: m }),
             stdin: () => this.getUserInput(),
@@ -464,10 +464,10 @@ export async function sendTextToREPLWindow(sessionType: "clj" | "cljs", text: st
             if (wnd) {
                 let inNs = ns ? ns : wnd.ns;
                 if (inNs && inNs !== wnd.ns) {
-                    const requireEvaluation = wnd.session.eval(inNs !== 'user' ? `(require '${inNs})` : 'nil');
+                    const requireEvaluation = wnd.session.eval(inNs !== 'user' ? `(require '${inNs})` : 'nil', wnd.ns);
                     requireEvaluation.value
                         .then((v) => {
-                            const inNSEvaluation = wnd.session.eval(`(in-ns '${inNs})`)
+                            const inNSEvaluation = wnd.session.eval(`(in-ns '${inNs})`, wnd.ns)
                             inNSEvaluation.value
                                 .then((v) => {
                                     wnd.setNamespace(inNSEvaluation.ns).then((v) => {
@@ -500,7 +500,7 @@ export async function setREPLNamespace(ns: string, reload = false) {
     }
     let wnd = replWindows[util.getREPLSessionType()];
     if (wnd) {
-        await wnd.session.eval("(in-ns '" + ns + ")").value;
+        await wnd.session.eval("(in-ns '" + ns + ")", wnd.ns).value;
         wnd.setNamespace(ns).catch(() => { });
     }
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -201,7 +201,7 @@ async function createNamespaceFromDocumentIfNotExists(doc) {
                 if (nsList['ns-list'] && nsList['ns-list'].includes(ns)) {
                     return;
                 }
-                await client.eval("(ns " + ns + ")").value;
+                await client.eval("(ns " + ns + ")", client.client.ns).value;
             }
         }
     }


### PR DESCRIPTION
## What has Changed?

- All uses of the nrepl client `eval()` op now are required to pass `ns`.
- Many uses send along the current client `ns`, as that makes more sense than sending `user`.

## My Calva PR Checklist
I have:

- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.

Ping @pez, @kstehn, @cfehse, @bpringe
