### PR TITLE
Filter Calva commands from editor context menu when not in Clojure files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Unclutter editor context menu when not in clojure files](https://github.com/BetterThanTomorrow/calva/issues/615)
+
 ## [2.0.92] - 2020-04-15
 
 - [Changed all documentation links from https://calva.readthedocs.io/ to https://calva.io/](https://github.com/BetterThanTomorrow/calva/issues/604)

--- a/package.json
+++ b/package.json
@@ -1599,12 +1599,14 @@
             ],
             "editor/context": [
                 {
-                    "when": "editorLangId == clojure && !calva:connected",
+                    "when": "editorLangId == clojure",
+                    "enablement": "!calva:connected",
                     "command": "calva.jackInOrConnect",
                     "group": "calva/x-connect"
                 },
                 {
-                    "when": "editorLangId == clojure && calva:connected",
+                    "when": "editorLangId == clojure",
+                    "enablement": "calva:connected",
                     "command": "calva.disconnect",
                     "group": "calva/x-connect"
                 },
@@ -1614,37 +1616,44 @@
                     "group": "calva/a-eval"
                 },
                 {
-                    "enablement": "editorLangId == clojure  && calva:connected",
+                    "when": "editorLangId == clojure",
+                    "enablement": "calva:connected",
                     "command": "calva.loadFile",
                     "group": "calva/b-eval"
                 },
                 {
-                    "enablement": "editorLangId == clojure && calva:connected",
+                    "when": "editorLangId == clojure",
+                    "enablement": "calva:connected",
                     "command": "calva.loadNamespace",
                     "group": "calva/b-eval"
                 },
                 {
-                    "enablement": "editorLangId == clojure && calva:connected",
+                    "when": "editorLangId == clojure",
+                    "enablement": "calva:connected",
                     "command": "calva.evaluateSelection",
                     "group": "calva/b-eval"
                 },
                 {
-                    "enablement": "editorLangId == clojure && calva:connected",
+                    "when": "editorLangId == clojure",
+                    "enablement": "calva:connected",
                     "command": "calva.evaluateCurrentTopLevelForm",
                     "group": "calva/b-eval"
                 },
                 {
-                    "enablement": "editorLangId == clojure && calva:connected",
+                    "when": "editorLangId == clojure",
+                    "enablement": "calva:connected",
                     "command": "calva.evaluateSelectionAsComment",
                     "group": "calva/b-eval"
                 },
                 {
-                    "enablement": "editorLangId == clojure && calva:connected",
+                    "when": "editorLangId == clojure",
+                    "enablement": "calva:connected",
                     "command": "calva.evaluateTopLevelFormAsComment",
                     "group": "calva/b-eval"
                 },
                 {
-                    "enablement": "editorLangId == clojure && calva:connected",
+                    "when": "editorLangId == clojure",
+                    "enablement": "calva:connected",
                     "command": "calva.interruptAllEvaluations",
                     "group": "calva/b-eval"
                 },
@@ -1654,22 +1663,26 @@
                     "group": "calva/b-eval"
                 },
                 {
-                    "enablement": "editorLangId == clojure && calva:connected",
+                    "when": "editorLangId == clojure",
+                    "enablement": "calva:connected",
                     "command": "calva.runAllTests",
                     "group": "calva/d-test"
                 },
                 {
-                    "enablement": "editorLangId == clojure && calva:connected",
+                    "when": "editorLangId == clojure",
+                    "enablement": "calva:connected",
                     "command": "calva.runNamespaceTests",
                     "group": "calva/d-test"
                 },
                 {
-                    "enablement": "editorLangId == clojure && calva:connected",
+                    "when": "editorLangId == clojure",
+                    "enablement": "calva:connected",
                     "command": "calva.rerunTests",
                     "group": "calva/d-test"
                 },
                 {
-                    "enablement": "editorLangId == clojure && calva:connected",
+                    "when": "editorLangId == clojure",
+                    "enablement": "calva:connected",
                     "command": "calva.runTestUnderCursor",
                     "group": "calva/d-test"
                 }


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->
- Removes Calva-specific commands from editor context menus when not in a _clojure_ file (per `editorLangId`
- Disentangles filtering on the context menu (via `when`) from enablement when present (via `enablement`)

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Fixes #615 

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [x] Made sure the PR is directed at the `dev` branch (unless reasons).
- [x] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->