### PR TITLE
Remove unnecessary cursor position restore, that sometimes causes Calva to stop functioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix [Format Document sometimes causes Calva to stop working](https://github.com/BetterThanTomorrow/calva/issues/651)
 - Fix [repl hanging after disconnecting debugger while repl window focused](https://github.com/BetterThanTomorrow/calva/issues/647)
 
 ## [2.0.101] - 2020-05-11

--- a/src/cljs-lib/src/calva/fmt/formatter.cljs
+++ b/src/cljs-lib/src/calva/fmt/formatter.cljs
@@ -132,8 +132,7 @@
         tail (subs range-text range-index)
         formatted-m (format-text (assoc m :range-text padded-text))]
     (-> (assoc formatted-m :range-text (subs (:range-text formatted-m) indent-before))
-        (assoc :range-tail tail)
-        (index-for-tail-in-range))))
+        (assoc :range-tail tail))))
 
 (defn format-text-at-range-bridge
   [m]
@@ -182,6 +181,7 @@
       (add-indent-token-if-empty-current-line)
       #_(enclosing-range)
       (format-text-at-range)
+      (index-for-tail-in-range)
       (remove-indent-token-if-empty-current-line)))
 
 (defn format-text-at-idx-bridge

--- a/src/cljs-lib/test/calva/fmt/formatter_test.cljs
+++ b/src/cljs-lib/test/calva/fmt/formatter_test.cljs
@@ -5,16 +5,17 @@
 
 (deftest format-text-at-range
   (is (= "(foo)\n(defn bar\n  [x]\n  baz)"
-         (:range-text (sut/format-text-at-range {:eol "\n" :all-text "  (foo)\n(defn bar\n[x]\nbaz)" :range [2 26]})))))
+         (:range-text (sut/format-text-at-range {:eol "\n" :all-text "  (foo)\n(defn bar\n[x]\nbaz)" :range [2 26]}))))
+  (is (not (contains? (sut/format-text-at-range {:eol "\n" :all-text "  (foo)\n(defn bar\n[x]\nbaz)" :range [2 26]}) :new-index))))
 
-
+{:eol "\n", :all-text "  (foo)\n(defn bar\n[x]\nbaz)", :range [2 26], :range-text "(foo)\n(defn bar\n  [x]\n  baz)", :range-tail "(foo)\n(defn bar\n[x]\nbaz)"}
 (def all-text "  (foo)
   (defn bar
          [x]
 
 baz)")
 
-
+{:current-line "(defn ", :config {:remove-surrounding-whitespace? false, :remove-trailing-whitespace? false, :remove-consecutive-blank-lines? false}, :on-type true, :range-tail "\n)", :new-index 6, :head "(defn ", :tail "\n)", :eol "\n", :range-text "(defn \n  )", :idx 6, :all-text "(defn \n)", :range [0 8]}
 (deftest format-text-at-idx
   (is (= "(defn bar
     [x]


### PR DESCRIPTION
## What has Changed?

When formatting, Calva goes to considerable length to keep the cursor at the right place after reformatting. Currently we use a quite hackish regexp match of the tail of the document to achieve this. In rare occasions this regex match runs amok and never finishes. Causing Calva to stop working entirely. These rare occasions get more common when the whole document is formatted. But it was just a mistake that the position restore is applied in these cases, because VS Code takes excellent care of that. So this PR fixes that mistake. Which should make it much less common that users run into this problem.

Fixes #651 (Well, makes it less likely to happen at least)

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->