### PR TITLE
Give the inString lexer a junk terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix [File lexing fails on junk characters inside strings](https://github.com/BetterThanTomorrow/calva/issues/659)
 
 ## [2.0.103] - 2020-06-05
 - Fix [Stream output messages to Calva Says as they're received](https://github.com/BetterThanTomorrow/calva/issues/638)

--- a/src/cursor-doc/clojure-lexer.ts
+++ b/src/cursor-doc/clojure-lexer.ts
@@ -67,7 +67,7 @@ toplevel.terminal(/#_/, (l, m) => ({ type: "ignore" }))
 // literals
 toplevel.terminal(/(\\[^\(\)\[\]\{\}\s]+|\\[\(\)\[\]\{\}])/, (l, m) => ({ type: "lit" }))
 
-// This seems unecessary?
+// This seems unnecessary?
 //toplevel.terminal(/(['`~#]\s*)*\\\"/, (l, m) => ({ type: "lit" }))
 toplevel.terminal(/(['`~#]\s*)*(true|false|nil)/, (l, m) => ({ type: "lit" }))
 toplevel.terminal(/(['`~#]\s*)*([0-9]+[rR][0-9a-zA-Z]+)/, (l, m) => ({ type: "lit" }))
@@ -96,7 +96,7 @@ inString.terminal(/[\t ]+/, (l, m) => ({ type: "ws" }))
 // newlines, we want each one as a token of its own
 inString.terminal(/(\r?\n)/, (l, m) => ({ type: "ws" }))
 
-// Lexer croaks without this catch-all safe: see https://github.com/BetterThanTomorrow/calva/issues/659
+// Lexer can croak on funny data without this catch-all safe: see https://github.com/BetterThanTomorrow/calva/issues/659
 inString.terminal(/./, (l, m) => ({ type: "junk" }))
 
 

--- a/src/cursor-doc/clojure-lexer.ts
+++ b/src/cursor-doc/clojure-lexer.ts
@@ -81,7 +81,7 @@ toplevel.terminal(/#[^\(\)\[\]\{\}'"_@~\s,]+/, (_l, _m) => ({ type: "reader" }))
 // symbols, about anything goes!
 toplevel.terminal(/(['`~#^@]\s*)*([^_()[\]\{\}#,~@'`^\"\s:;][^()[\]\{\},~@`^\"\s;]*)/, (l, m) => ({ type: "id" }))
 
-
+// Lexer croaks without this catch-all safe
 toplevel.terminal(/./, (l, m) => ({ type: "junk" }))
 
 /** This is inside-string string grammar. It spits out 'close' once it is time to switch back to the 'toplevel' grammar,
@@ -95,6 +95,9 @@ inString.terminal(/(\\.|[^"\s])+/, (l, m) => ({ type: "str-inside" }))
 inString.terminal(/[\t ]+/, (l, m) => ({ type: "ws" }))
 // newlines, we want each one as a token of its own
 inString.terminal(/(\r?\n)/, (l, m) => ({ type: "ws" }))
+
+// Lexer croaks without this catch-all safe: see https://github.com/BetterThanTomorrow/calva/issues/659
+inString.terminal(/./, (l, m) => ({ type: "junk" }))
 
 
 /**

--- a/src/extension-test/unit/cursor-doc/clojure-lexer-test.ts
+++ b/src/extension-test/unit/cursor-doc/clojure-lexer-test.ts
@@ -302,5 +302,15 @@ describe('Scanner', () => {
             expect(tokens[0].type).equals('id');
             expect(tokens[0].raw).equals("#'foo");
         });
+        it('does not croak on funny data in strings - #659', () => {
+            // https://github.com/BetterThanTomorrow/calva/issues/659
+            const tokens = scanner.processLine('" "'); // <- That's not a regular space
+            expect(tokens[0].type).equals('open');
+            expect(tokens[0].raw).equals('"');
+            expect(tokens[1].type).equals('junk');
+            expect(tokens[1].raw).equals(' ');
+            expect(tokens[2].type).equals('close');
+            expect(tokens[2].raw).equals('"');
+        });
     });
 });


### PR DESCRIPTION
## What has Changed?

Fixes #659 by adding a junk terminal to the `inString` lexer.

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->