### PR TITLE
Defer bracket match a bit when selection changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix [Flicker matching brackets as code is typed](https://github.com/BetterThanTomorrow/calva/issues/673)
 
 ## [2.0.106] - 2020-06-16
 - Fix [Crash - Lexing fails on comment w/ a 20+ hashes](https://github.com/BetterThanTomorrow/calva/issues/667)

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -39,6 +39,7 @@ export function activate(context: vscode.ExtensionContext) {
     pairsForward: Map<string, [Range, Range]> = new Map(),
     placedGuidesColor: Map<string, number> = new Map(),
     rainbowTimer = undefined,
+    matchTimer = undefined,
     dirty = false;
 
   reloadConfig();
@@ -51,10 +52,15 @@ export function activate(context: vscode.ExtensionContext) {
 
   vscode.window.onDidChangeTextEditorSelection(event => {
     if (event.textEditor === vscode.window.activeTextEditor && is_clojure(event.textEditor)) {
-      matchPairs();
-      if (highlightActiveIndent && rainbowTypes.length) {
-        decorateActiveGuides();
-      }
+      if (matchTimer)
+      clearTimeout(matchTimer);
+    if (is_clojure(activeEditor))
+      matchTimer = setTimeout(() => {
+        matchPairs();
+        if (highlightActiveIndent && rainbowTypes.length) {
+          decorateActiveGuides();
+        }
+      }, 16);
     }
   }, null, context.subscriptions);
 

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -55,13 +55,14 @@ export function activate(context: vscode.ExtensionContext) {
       if (matchTimer) {
         clearTimeout(matchTimer);
       }
-      if (is_clojure(activeEditor))
+      if (is_clojure(activeEditor)) {
         matchTimer = setTimeout(() => {
           matchPairs();
           if (highlightActiveIndent && rainbowTypes.length) {
             decorateActiveGuides();
           }
         }, 16);
+      }
     }
   }, null, context.subscriptions);
 

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -52,15 +52,16 @@ export function activate(context: vscode.ExtensionContext) {
 
   vscode.window.onDidChangeTextEditorSelection(event => {
     if (event.textEditor === vscode.window.activeTextEditor && is_clojure(event.textEditor)) {
-      if (matchTimer)
-      clearTimeout(matchTimer);
-    if (is_clojure(activeEditor))
-      matchTimer = setTimeout(() => {
-        matchPairs();
-        if (highlightActiveIndent && rainbowTypes.length) {
-          decorateActiveGuides();
-        }
-      }, 16);
+      if (matchTimer) {
+        clearTimeout(matchTimer);
+      }
+      if (is_clojure(activeEditor))
+        matchTimer = setTimeout(() => {
+          matchPairs();
+          if (highlightActiveIndent && rainbowTypes.length) {
+            decorateActiveGuides();
+          }
+        }, 16);
     }
   }, null, context.subscriptions);
 


### PR DESCRIPTION
## What has Changed?

- Hold the match bracket highlighting 16ms at selection change
- Just as we de with the colorizing.

Fixes #673

(Well, I hope it does. It at least fixes the bracket matching flicker on my machine. Not sure about the other things mentioned, because I didn't see it on my machine (which is reasonably new and fast).

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

Ping @pez, @kstehn, @cfehse, @bpringe
