### PR TITLE
Fix Clojure CLI + shadow-cljs jack-in error and combine custom and default connect sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix [Jack-in error when choosing Clojure CLI + shadow-cljs project type](https://github.com/BetterThanTomorrow/calva/issues/675)
 
 ## [2.0.107] - 2020-06-16
 - Fix [Flicker matching brackets as code is typed](https://github.com/BetterThanTomorrow/calva/issues/673)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - Fix [Jack-in error when choosing Clojure CLI + shadow-cljs project type](https://github.com/BetterThanTomorrow/calva/issues/675)
+- Fix [Cannot use default connect sequences when custom connect sequences added](https://github.com/BetterThanTomorrow/calva/issues/685)
 
 ## [2.0.107] - 2020-06-16
 - Fix [Flicker matching brackets as code is typed](https://github.com/BetterThanTomorrow/calva/issues/673)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9704,7 +9704,7 @@
         },
         "strip-eof": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
         },

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -90,12 +90,6 @@ const cljDefaults: ReplConnectSequence[] =
         cljsType: CljsTypes["Figwheel Main"]
     },
     {
-        name: "Clojure CLI + shadow-cljs",
-        projectType: ProjectTypes["Clojure CLI"],
-        cljsType: CljsTypes["shadow-cljs"],
-        nReplPortFile: [".shadow-cljs", "nrepl.port"]
-    },
-    {
         name: "Clojure CLI + Legacy Figwheel",
         projectType: ProjectTypes["Clojure CLI"],
         cljsType: CljsTypes["lein-figwheel"]
@@ -196,22 +190,14 @@ function getCustomConnectSequences(): ReplConnectSequence[] {
 }
 
 /**
- * Retrieve the replConnectSequences and returns only that if only one was defined.
- * Otherwise the user defined will be combined with the defaults one to be returned.
- * @param projectType what default Sequences would be used (leiningen, clj, shadow-cljs)
+ * User defined sequences will be combined with the default sequences.
+ * @param projectType what default sequences would be used (leiningen, clj, shadow-cljs)
  */
 function getConnectSequences(projectTypes: string[]): ReplConnectSequence[] {
-    let customSequences = getCustomConnectSequences();
-
-    if (customSequences.length) {
-        return customSequences;
-    } else {
-        let result = [];
-        for (let pType of projectTypes) {
-            result = result.concat(defaultSequences[pType]);
-        }
-        return result;
-    }
+    const customSequences = getCustomConnectSequences();
+    const defSequences = projectTypes.reduce((seqs, projecType) => seqs.concat(defaultSequences[projecType]), []);
+    const sequences = customSequences.concat(defSequences);
+    return sequences;
 }
 
 /**
@@ -227,23 +213,19 @@ function getDefaultCljsType(cljsType: string): CljsTypeConfig {
 async function askForConnectSequence(cljTypes: string[], saveAs: string, logLabel: string): Promise<ReplConnectSequence> {
     // figure out what possible kinds of project we're in
     const sequences: ReplConnectSequence[] = getConnectSequences(cljTypes);
-    if (sequences.length > 1) {
-        const projectConnectSequenceName = await utilities.quickPickSingle({
-            values: sequences.map(s => { return s.name }),
-            placeHolder: "Please select a project type",
-            saveAs: `${state.getProjectRoot()}/${saveAs}`,
-            autoSelect: true
-        });
-        if (!projectConnectSequenceName || projectConnectSequenceName.length <= 0) {
-            state.analytics().logEvent("REPL", logLabel, "NoProjectTypePicked").send();
-            return;
-        }
-        const sequence = sequences.find(seq => seq.name === projectConnectSequenceName);
-        state.extensionContext.workspaceState.update('selectedCljTypeName', sequence.projectType);
-        return sequence;
-    } else {
-        return sequences[0];
+    const projectConnectSequenceName = await utilities.quickPickSingle({
+        values: sequences.map(s => { return s.name }),
+        placeHolder: "Please select a project type",
+        saveAs: `${state.getProjectRoot()}/${saveAs}`,
+        autoSelect: true
+    });
+    if (!projectConnectSequenceName || projectConnectSequenceName.length <= 0) {
+        state.analytics().logEvent("REPL", logLabel, "NoProjectTypePicked").send();
+        return;
     }
+    const sequence = sequences.find(seq => seq.name === projectConnectSequenceName);
+    state.extensionContext.workspaceState.update('selectedCljTypeName', sequence.projectType);
+    return sequence;
 }
 
 export {

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -202,7 +202,8 @@ function getCustomConnectSequences(): ReplConnectSequence[] {
 function getConnectSequences(projectTypes: string[]): ReplConnectSequence[] {
     const customSequences = getCustomConnectSequences();
     const defSequences = projectTypes.reduce((seqs, projecType) => seqs.concat(defaultSequences[projecType]), []);
-    const sequences = customSequences.filter(customSequence => projectTypes.includes(customSequence.projectType)).concat(defSequences);
+    const defSequenceProjectTypes = [...new Set(defSequences.map(s => s.projectType))];
+    const sequences = customSequences.filter(customSequence => defSequenceProjectTypes.includes(customSequence.projectType)).concat(defSequences);
     return sequences;
 }
 

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -196,7 +196,7 @@ function getCustomConnectSequences(): ReplConnectSequence[] {
 function getConnectSequences(projectTypes: string[]): ReplConnectSequence[] {
     const customSequences = getCustomConnectSequences();
     const defSequences = projectTypes.reduce((seqs, projecType) => seqs.concat(defaultSequences[projecType]), []);
-    const sequences = customSequences.concat(defSequences);
+    const sequences = customSequences.filter(customSequence => projectTypes.includes(customSequence.projectType)).concat(defSequences);
     return sequences;
 }
 

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -90,6 +90,12 @@ const cljDefaults: ReplConnectSequence[] =
         cljsType: CljsTypes["Figwheel Main"]
     },
     {
+        name: "Clojure CLI + shadow-cljs",
+        projectType: ProjectTypes["Clojure CLI"],
+        cljsType: CljsTypes["shadow-cljs"],
+        nReplPortFile: [".shadow-cljs", "nrepl.port"]
+    },
+    {
         name: "Clojure CLI + Legacy Figwheel",
         projectType: ProjectTypes["Clojure CLI"],
         cljsType: CljsTypes["lein-figwheel"]

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -192,13 +192,16 @@ const leinDependencies = {
     "clj-kondo": CLJ_KONDO_VERSION
 }
 const middleware = ["cider.nrepl/cider-middleware"];
+const cljsMiddlewareNames = {
+    wrapCljsRepl: "cider.piggieback/wrap-cljs-repl"
+};
 const cljsMiddleware: { [id: string]: string[] } = {
-    "lein-figwheel": ["cider.piggieback/wrap-cljs-repl"],
-    "Figwheel Main": ["cider.piggieback/wrap-cljs-repl"],
+    "lein-figwheel": [cljsMiddlewareNames.wrapCljsRepl],
+    "Figwheel Main": [cljsMiddlewareNames.wrapCljsRepl],
     "shadow-cljs": [],
-    "lein-shadow": ["cider.piggieback/wrap-cljs-repl"],
-    "Nashorn": ["cider.piggieback/wrap-cljs-repl"],
-    "User provided": ["cider.piggieback/wrap-cljs-repl"]
+    "lein-shadow": [cljsMiddlewareNames.wrapCljsRepl],
+    "Nashorn": [cljsMiddlewareNames.wrapCljsRepl],
+    "User provided": [cljsMiddlewareNames.wrapCljsRepl]
 };
 
 const serverPrinterDependencies = pprint.getServerSidePrinterDependencies();

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -192,7 +192,14 @@ const leinDependencies = {
     "clj-kondo": CLJ_KONDO_VERSION
 }
 const middleware = ["cider.nrepl/cider-middleware"];
-const cljsMiddleware = ["cider.piggieback/wrap-cljs-repl"];
+const cljsMiddleware: { [id: string]: string[] } = {
+    "lein-figwheel": ["cider.piggieback/wrap-cljs-repl"],
+    "Figwheel Main": ["cider.piggieback/wrap-cljs-repl"],
+    "shadow-cljs": [],
+    "lein-shadow": ["cider.piggieback/wrap-cljs-repl"],
+    "Nashorn": ["cider.piggieback/wrap-cljs-repl"],
+    "User provided": ["cider.piggieback/wrap-cljs-repl"]
+};
 
 const serverPrinterDependencies = pprint.getServerSidePrinterDependencies();
 
@@ -280,7 +287,7 @@ const projectTypes: { [id: string]: ProjectType } = {
                 ...(cljsType ? { ...cljsDependencies[cljsType] } : {}),
                 ...serverPrinterDependencies
             },
-                useMiddleware = [...middleware, ...((cljsType && cljsType !== "shadow-cljs") ? cljsMiddleware : [])];
+                useMiddleware = [...middleware, ...(cljsType ? cljsMiddleware[cljsType] : [])];
             const aliasesOption = aliases.length > 0 ? `-A${aliases.join("")}` : '';
             let aliasHasMain: boolean = false;
             for (let ali in aliases) {
@@ -405,7 +412,7 @@ async function leinCommandLine(command: string[], cljsType: CljsTypes, connectSe
         let dep = keys[i];
         out.push("update-in", ":plugins", "conj", `${q + "[" + dep + dQ + leinPluginDependencies[dep] + dQ + "]" + q}`, '--');
     }
-    const useMiddleware = [...middleware, ...(cljsType ? cljsMiddleware : [])];
+    const useMiddleware = [...middleware, ...(cljsType ? cljsMiddleware[cljsType] : [])];
     for (let mw of useMiddleware) {
         out.push("update-in", `${q + '[:repl-options' + s + ':nrepl-middleware]' + q}`, "conj", `'["${mw}"]'`, '--');
     }

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -280,7 +280,7 @@ const projectTypes: { [id: string]: ProjectType } = {
                 ...(cljsType ? { ...cljsDependencies[cljsType] } : {}),
                 ...serverPrinterDependencies
             },
-                useMiddleware = [...middleware, ...(cljsType ? cljsMiddleware : [])];
+                useMiddleware = [...middleware, ...((cljsType && cljsType !== "shadow-cljs") ? cljsMiddleware : [])];
             const aliasesOption = aliases.length > 0 ? `-A${aliases.join("")}` : '';
             let aliasHasMain: boolean = false;
             for (let ali in aliases) {


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->
- Remove piggieback middleware from shadow-cljs sequences
- Always combine custom connect sequences with default connect sequences

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Fixes #675
Fixes #685 

Note about #685, I think it makes sense to restrict user-defined custom connect sequences for shadow-cljs to have a string for connect code. The internal/default connection uses an object to handle whether the user chooses to connect to a build or start a browser/node repl. If the user defined a custom connect sequence then they should supply the connect code to start the build/repl of their choosing. 

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->