### PR TITLE
Fix usage of dynamic vars *1, *2, and *3 for accessing recent results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - Fix: [Format-on-paste should not operate inside string literals](https://github.com/BetterThanTomorrow/calva/issues/720)
+- Fix: [Accessing recent results (*1, *2, *3) does not work](https://github.com/BetterThanTomorrow/calva/issues/724)
 
 ## [2.0.115] - 2020-08-2
 - [Add hover to display results for eval as window into output file](https://github.com/BetterThanTomorrow/calva/issues/693)

--- a/src/debugger/decorations.ts
+++ b/src/debugger/decorations.ts
@@ -79,7 +79,6 @@ async function updateDecorations(decorationsSession: NReplSession) {
             const instrumentedDefsInEditor = instrumentedDefs.list.filter(alist => alist[0] === docNamespace)[0]?.slice(1) || [];
 
             // Get editor ranges of instrumented var definitions and usages
-            // TODO: Don't run getLintAnalysis if instrumentedDefsInEditor.length === 0
             const lintAnalysis = await getLintAnalysis(decorationsSession, document.getText());
             const instrumentedVarDefs = lintAnalysis['var-definitions'].filter(varInfo => instrumentedDefsInEditor.includes(varInfo.name));
             const instrumentedVarDefRanges = getVarDefinitionRanges(instrumentedVarDefs, document);

--- a/src/debugger/decorations.ts
+++ b/src/debugger/decorations.ts
@@ -6,6 +6,7 @@ const { parseEdn } = require('../../out/cljs-lib/cljs-lib');
 import * as state from '../state';
 
 let enabled = false;
+let decorationsSession: NReplSession = null;
 
 const instrumentedFunctionDecorationType = vscode.window.createTextEditorDecorationType({
     borderStyle: 'solid',
@@ -63,7 +64,7 @@ function getVarUsageRanges(usages: any[], document: vscode.TextDocument): [numbe
     });
 }
 
-async function updateDecorations() {
+async function updateDecorations(decorationsSession: NReplSession) {
     const activeEditor = vscode.window.activeTextEditor;
 
     if (activeEditor && /(\.clj)$/.test(activeEditor.document.fileName)) {
@@ -78,7 +79,8 @@ async function updateDecorations() {
             const instrumentedDefsInEditor = instrumentedDefs.list.filter(alist => alist[0] === docNamespace)[0]?.slice(1) || [];
 
             // Get editor ranges of instrumented var definitions and usages
-            const lintAnalysis = await getLintAnalysis(cljSession, document.getText());
+            // TODO: Don't run getLintAnalysis if instrumentedDefsInEditor.length === 0
+            const lintAnalysis = await getLintAnalysis(decorationsSession, document.getText());
             const instrumentedVarDefs = lintAnalysis['var-definitions'].filter(varInfo => instrumentedDefsInEditor.includes(varInfo.name));
             const instrumentedVarDefRanges = getVarDefinitionRanges(instrumentedVarDefs, document);
             const instrumentedVarUsages = lintAnalysis['var-usages'].filter(varInfo => {
@@ -108,19 +110,20 @@ function triggerUpdateDecorations() {
         timeout = undefined;
     }
     if (enabled) {
-        timeout = setTimeout(updateDecorations, 50);
+        timeout = setTimeout(() => updateDecorations(decorationsSession), 50);
     }
 }
 
 async function activate() {
     const cljSession = util.getSession('clj');
+    decorationsSession = await cljSession.clone();
 
     try {
         await cljSession.eval("(require 'clj-kondo.core)", 'user').value;
         enabled = true;
         triggerUpdateDecorations();
 
-        vscode.window.onDidChangeActiveTextEditor(editor => {
+        vscode.window.onDidChangeActiveTextEditor(_ => {
             triggerUpdateDecorations();
         });
 

--- a/src/debugger/util.ts
+++ b/src/debugger/util.ts
@@ -24,6 +24,7 @@ function moveTokenCursorToBreakpoint(tokenCursor: LispTokenCursor, debugResponse
     const [_, defunEnd] = tokenCursor.rangeForDefun(tokenCursor.offsetStart);
     let inSyntaxQuote = false;
 
+    // Remove first coor to account for surrounding code added to user code by Calva
     const coor = debugResponse.coor.slice(1);
 
     for (let i = 0; i < coor.length; i++) {

--- a/src/debugger/util.ts
+++ b/src/debugger/util.ts
@@ -24,7 +24,7 @@ function moveTokenCursorToBreakpoint(tokenCursor: LispTokenCursor, debugResponse
     const [_, defunEnd] = tokenCursor.rangeForDefun(tokenCursor.offsetStart);
     let inSyntaxQuote = false;
 
-    const coor = [...debugResponse.coor]; // Copy the array so we do not modify the one stored in state
+    const coor = debugResponse.coor.slice(1);
 
     for (let i = 0; i < coor.length; i++) {
         while (!tokenCursor.downList(true)) {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -56,6 +56,7 @@ async function evaluateCode(code: string, options, selection?: vscode.Selection)
     if (code.length > 0) {
         let err: string[] = [], out: string[] = [];
 
+        // If the added surrounding code here is changed, check that the debugger still finds breakpoints correctly
         const codeWithInNsCall = `(do (in-ns '${ns}) ${code})`;
 
         let context: NReplEvaluation = session.eval(codeWithInNsCall, ns, {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -56,9 +56,9 @@ async function evaluateCode(code: string, options, selection?: vscode.Selection)
     if (code.length > 0) {
         let err: string[] = [], out: string[] = [];
 
-        await session.eval("(in-ns '" + ns + ")", session.client.ns).value;
+        const codeWithInNsCall = `(do (in-ns '${ns}) ${code})`;
 
-        let context: NReplEvaluation = session.eval(code, ns, {
+        let context: NReplEvaluation = session.eval(codeWithInNsCall, ns, {
             file: filePath,
             line: line + 1,
             column: column + 1,

--- a/src/extension-test/unit/debugger/util-test.ts
+++ b/src/extension-test/unit/debugger/util-test.ts
@@ -36,7 +36,7 @@ describe('Debugger Util', async () => {
 
         function expectBreakpointToBeFound(fileName: string) {
             const docText = getTestFileText(fileName);
-            debugResponse.coor = getCoordinates(docText);
+            debugResponse.coor = [2, ...getCoordinates(docText)];
             doc.insertString(docText);
             const tokenCursor = doc.getTokenCursor(0);
             moveTokenCursorToBreakpoint(tokenCursor, debugResponse);

--- a/src/extension-test/unit/debugger/util-test.ts
+++ b/src/extension-test/unit/debugger/util-test.ts
@@ -36,6 +36,7 @@ describe('Debugger Util', async () => {
 
         function expectBreakpointToBeFound(fileName: string) {
             const docText = getTestFileText(fileName);
+            // Add extra coor to account for surrounding code added by Calva
             debugResponse.coor = [2, ...getCoordinates(docText)];
             doc.insertString(docText);
             const tokenCursor = doc.getTokenCursor(0);


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->
- A call to `in-ns` was previously a separate eval before evaluating the user's code. This change adds the call inside a `do` followed by the user's code.
- Update the debugger breakpoint finding logic and tests to account for the additional code, essentially ignoring it when finding breakpoints, since the added code is not actually in the file.
- Add comments explaining these changes where necessary to help prevent regressions, though the unit tests for the debugger should fail if a change breaks the breakpoint finding logic in the future.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Fixes #724 

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->