### PR TITLE
Fix getDocument to not return a Log document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - Re-fix: [Can't jack-in when no project file is open](https://github.com/BetterThanTomorrow/calva/issues/734)
+- [Fix getDocument function to not return a Log document](https://github.com/BetterThanTomorrow/calva/issues/771)
 
 ## [2.0.123] - 2020-08-26
 - [Change output/repl window extension to .calva-repl](https://github.com/BetterThanTomorrow/calva/issues/754)

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -14,7 +14,6 @@ import * as replHistory from './repl-history';
 const RESULTS_DOC_NAME = `output.${config.REPL_FILE_EXT}`;
 
 const START_GREETINGS = '; This is the Calva evaluation results output window.\n\
-; Leave it open, please. Because quirks.\n\
 ; TIPS: The keyboard shortcut `ctrl+alt+c o` shows and focuses this window\n\
 ;   when connected to a REPL session.\n\
 ; Please see https://calva.io/output/ for more info.\n\

--- a/src/state.ts
+++ b/src/state.ts
@@ -198,46 +198,40 @@ export async function initProjectDir(): Promise<void> {
             workspaceFolder = workspace ? vscode.workspace.getWorkspaceFolder(workspace.uri) : null;
         }
     }
-    if (!workspaceFolder) {
-        vscode.window.showErrorMessage("There is no document opened in the workspace. Please open a file in your Clojure project and try again. Aborting.");
-        analytics().logEvent("REPL", "JackinOrConnectInterrupted", "NoCurrentDocument").send();
-        throw "There is no document opened in the workspace. Aborting.";
+    let rootPath: string = path.resolve(workspaceFolder.uri.fsPath);
+    cursor.set(PROJECT_DIR_KEY, rootPath);
+    let d = null;
+    let prev = null;
+    if (doc && path.dirname(doc.uri.fsPath) !== '.') {
+        d = path.dirname(doc.uri.fsPath);
     } else {
-        let rootPath: string = path.resolve(workspaceFolder.uri.fsPath);
-        cursor.set(PROJECT_DIR_KEY, rootPath);
-        let d = null;
-        let prev = null;
-        if (doc && path.dirname(doc.uri.fsPath) !== '.') {
-            d = path.dirname(doc.uri.fsPath);
-        } else {
-            d = workspaceFolder.uri.fsPath;
-        }
-        while (d != prev) {
-            for (let projectFile in projectFileNames) {
-                const p = path.resolve(d, projectFileNames[projectFile]);
-                if (fs.existsSync(p)) {
-                    rootPath = d;
-                    break;
-                }
-            }
-            if (d == rootPath) {
+        d = workspaceFolder.uri.fsPath;
+    }
+    while (d != prev) {
+        for (let projectFile in projectFileNames) {
+            const p = path.resolve(d, projectFileNames[projectFile]);
+            if (fs.existsSync(p)) {
+                rootPath = d;
                 break;
             }
-            prev = d;
-            d = path.resolve(d, "..");
         }
-
-        // at least be sure the the root folder contains a
-        // supported project.
-        for (let projectFile in projectFileNames) {
-            const p = path.resolve(rootPath, projectFileNames[projectFile]);
-            if (fs.existsSync(p)) {
-                cursor.set(PROJECT_DIR_KEY, rootPath);
-                return;
-            }
+        if (d == rootPath) {
+            break;
         }
-        return;
+        prev = d;
+        d = path.resolve(d, "..");
     }
+
+    // at least be sure the the root folder contains a
+    // supported project.
+    for (let projectFile in projectFileNames) {
+        const p = path.resolve(rootPath, projectFileNames[projectFile]);
+        if (fs.existsSync(p)) {
+            cursor.set(PROJECT_DIR_KEY, rootPath);
+            return;
+        }
+    }
+    return;
 }
 
 /**

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -135,10 +135,13 @@ function getWordAtPosition(document, position) {
 function getDocument(document): vscode.TextDocument {
     if (document && document.hasOwnProperty('fileName')) {
         return document;
-    } else if (vscode.window.activeTextEditor) {
+    } else if (vscode.window.activeTextEditor && 
+        vscode.window.activeTextEditor.document && 
+        vscode.window.activeTextEditor.document.languageId !== 'Log') {
         return vscode.window.activeTextEditor.document;
     } else if (vscode.window.visibleTextEditors.length > 0) {
-        return vscode.window.visibleTextEditors[0].document;
+        const editor = vscode.window.visibleTextEditors.find(editor => editor.document && editor.document.languageId !== 'Log');
+        return editor ? editor.document : null;
     } else {
         return null;
     }


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->
- Make getDocument check for languageId and only return a document if the languageId is not `Log`. This prevents a Log document from the bottom output pane being returned as a document.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Fixes #771 

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->