### PR TITLE
Allow toggling keyboard shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 - [Fix: evals should be ignored during parsing](https://github.com/BetterThanTomorrow/calva/issues/763)
 - Fix: [Test runner can't find tests under cursor when using a custom test macro](https://github.com/BetterThanTomorrow/calva/issues/786)
+- [Allow toggling Paredit function independently of mode](https://github.com/BetterThanTomorrow/calva/issues/784)
 
 ## [2.0.124] - 2020-08-31
 - Re-fix: [Can't jack-in when no project file is open](https://github.com/BetterThanTomorrow/calva/issues/734)

--- a/package.json
+++ b/package.json
@@ -504,6 +504,12 @@
                             "none"
                         ],
                         "scope": "window"
+                    },
+                    "calva.paredit.keybindingsEnabled": {
+                        "type": "boolean",
+                        "description": "Activate Paredit keybindings.",
+                        "default": true,
+                        "scope": "window"
                     }
                 }
             },
@@ -753,6 +759,11 @@
                 "title": "Toggle Paredit Mode",
                 "when": "paredit:keyMap =~ /original|strict/",
                 "enablement": "paredit:keyMap =~ /original|strict/"
+            },
+            {
+                "category": "Calva Paredit",
+                "command": "paredit.toggleKeybindingsEnabled",
+                "title": "Toggle Paredit Keybindings Enabled"
             },
             {
                 "category": "Calva Paredit",
@@ -1199,269 +1210,273 @@
                 "when": "paredit:keyMap =~ /original|strict/"
             },
             {
+                "command": "paredit.toggleKeybindingsEnabled",
+                "key": "ctrl+alt+p ctrl+alt+e"
+            },
+            {
                 "command": "paredit.forwardSexp",
                 "key": "ctrl+alt+right",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.backwardSexp",
                 "key": "ctrl+alt+left",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.forwardDownSexp",
                 "key": "ctrl+down",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.backwardDownSexp",
                 "key": "ctrl+alt+up",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.forwardUpSexp",
                 "key": "ctrl+alt+down",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.backwardUpSexp",
                 "key": "ctrl+up",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.closeList",
                 "key": "ctrl+end",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.openList",
                 "key": "ctrl+home",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectForwardSexp",
                 "key": "ctrl+shift+alt+right",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectBackwardSexp",
                 "key": "ctrl+shift+alt+left",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectForwardDownSexp",
                 "key": "ctrl+shift+down",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectBackwardDownSexp",
                 "key": "ctrl+shift+alt+up",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectForwardUpSexp",
                 "key": "ctrl+shift+alt+down",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectBackwardUpSexp",
                 "key": "ctrl+shift+up",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectCloseList",
                 "key": "ctrl+shift+end",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectOpenList",
                 "key": "ctrl+shift+home",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.rangeForDefun",
                 "key": "ctrl+alt+w space",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.sexpRangeExpansion",
                 "key": "ctrl+w",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.sexpRangeContraction",
                 "key": "ctrl+shift+w",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.slurpSexpForward",
                 "key": "ctrl+right",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.slurpSexpBackward",
                 "key": "ctrl+shift+left",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.barfSexpForward",
                 "key": "ctrl+left",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.barfSexpBackward",
                 "key": "ctrl+shift+right",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.spliceSexp",
                 "key": "ctrl+alt+s",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.splitSexp",
                 "key": "ctrl+shift+s",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.joinSexp",
                 "key": "ctrl+shift+j",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.raiseSexp",
                 "key": "ctrl+alt+p ctrl+alt+r",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.transpose",
                 "key": "ctrl+alt+t",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.dragSexprBackward",
                 "key": "ctrl+shift+alt+b",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.dragSexprForward",
                 "key": "ctrl+shift+alt+f",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.dragSexprBackwardUp",
                 "key": "ctrl+shift+alt+u",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.dragSexprForwardDown",
                 "key": "ctrl+shift+alt+d",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.dragSexprForwardUp",
                 "key": "ctrl+shift+alt+k",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.dragSexprBackwardDown",
                 "key": "ctrl+shift+alt+j",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.convolute",
                 "key": "ctrl+shift+c",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.killSexpForward",
                 "key": "ctrl+shift+delete",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.killSexpBackward",
                 "key": "ctrl+alt+backspace",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.killListForward",
                 "key": "ctrl+delete",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.killListBackward",
                 "key": "ctrl+backspace",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.spliceSexpKillForward",
                 "key": "ctrl+alt+shift+delete",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.spliceSexpKillBackward",
                 "key": "ctrl+alt+shift+backspace",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.wrapAroundParens",
                 "key": "ctrl+alt+shift+p",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.wrapAroundSquare",
                 "key": "ctrl+alt+shift+s",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.wrapAroundCurly",
                 "key": "ctrl+alt+shift+c",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.wrapAroundQuote",
                 "key": "ctrl+alt+shift+q",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.rewrapParens",
                 "key": "ctrl+alt+r ctrl+alt+p",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.rewrapSquare",
                 "key": "ctrl+alt+r ctrl+alt+s",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.rewrapCurly",
                 "key": "ctrl+alt+r ctrl+alt+c",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.rewrapQuote",
                 "key": "ctrl+alt+r ctrl+alt+q",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.deleteForward",
                 "key": "delete",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
             },
             {
                 "command": "paredit.deleteBackward",
                 "key": "backspace",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
             },
             {
                 "command": "paredit.forceDeleteForward",
                 "key": "alt+delete",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
             },
             {
                 "command": "paredit.forceDeleteBackward",
                 "key": "alt+backspace",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
+                "when": "editorLangId == clojure && editorTextFocus && paredit:keybindingsEnabled && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
             },
             {
                 "command": "calva-fmt.formatCurrentForm",

--- a/src/paredit/statusbar.ts
+++ b/src/paredit/statusbar.ts
@@ -5,68 +5,63 @@ import * as paredit from './extension';
 
 export class StatusBar {
 
-    private _enabled: Boolean;
     private _visible: Boolean;
-    private _keyMap: String;
+    private _keyMapConfig: paredit.KeyMapConfig;
 
     private _toggleBarItem: StatusBarItem;
 
-    constructor(keymap: String) {
+    constructor(keyMapConfig: paredit.KeyMapConfig) {
         this._toggleBarItem = window.createStatusBarItem(StatusBarAlignment.Right);
         this._toggleBarItem.text = "(λ)";
         this._toggleBarItem.tooltip = "";
         this._toggleBarItem.command = 'paredit.togglemode';
-        this._enabled = false;
         this._visible = false;
-        this.keyMap = keymap;
+        this.keyMapConfig = keyMapConfig;
 
-        paredit.onPareditKeyMapChanged((keymap) => {
-            this.keyMap = keymap;
-        }) 
+        paredit.onPareditKeyMapChanged((keyMapConfig) => {
+            this.keyMapConfig = keyMapConfig;
+        })
     }
 
-    get keyMap() {
-        return this._keyMap;
-    }
+    updateUIState() {
+        let keyMap = this._keyMapConfig.keyMap.trim().toLowerCase();
+        let keybindingsEnabled = this._keyMapConfig.keybindingsEnabled;
 
-    set keyMap(keymap: String) {
-        
-        switch (keymap.trim().toLowerCase()) {
-            case 'original':
-                this._keyMap = 'original';
-                this.enabled = true;
-                this.visible = true;
-                this._toggleBarItem.text = "(λ)";
-                this._toggleBarItem.tooltip = "Toggle to strict Mode"
-                break;
-            case 'strict':
-                this._keyMap = 'strict';
-                this.enabled = true;
-                this.visible = true;
-                this._toggleBarItem.text = "[λ]";
-                this._toggleBarItem.tooltip = "Toggle to original Mode"
-                break;
-            default:
-                this._keyMap = 'none';
-                this.enabled = false;
-                this.visible = true;
-                this._toggleBarItem.text = "λ";
-                this._toggleBarItem.tooltip = "Calva Paredit Keymap is set to none, Toggle to Strict Mode is Disabled"
-        }
-    }
-
-    get enabled() {
-        return this._enabled;
-    }
-
-    set enabled(value: Boolean) {
-        this._enabled = value;
-
-        if (this._enabled) {
-            this._toggleBarItem.color = undefined;
+        if (keybindingsEnabled) {
+            switch (keyMap) {
+                case 'original':
+                    this.visible = true;
+                    this._toggleBarItem.text = "(λ)";
+                    this._toggleBarItem.tooltip = "Toggle to strict Mode";
+                    this._toggleBarItem.color = undefined;
+                    break;
+                case 'strict':
+                    this.visible = true;
+                    this._toggleBarItem.text = "[λ]";
+                    this._toggleBarItem.tooltip = "Toggle to original Mode";
+                    this._toggleBarItem.color = undefined;
+                    break;
+                default:
+                    this.visible = true;
+                    this._toggleBarItem.text = "λ";
+                    this._toggleBarItem.tooltip = "Calva Paredit Keymap is set to none, Toggle to Strict Mode is Disabled"
+                    this._toggleBarItem.color = statusbar.color.inactive;
+            }
         } else {
+            this.visible = true;
+            this._toggleBarItem.text = "λ";
+            this._toggleBarItem.tooltip = "Calva Paredit Keybindings Enabled is set to false"
             this._toggleBarItem.color = statusbar.color.inactive;
         }
+    }
+
+    get keyMapConfig() {
+        return this._keyMapConfig;
+    }
+
+    set keyMapConfig(keyMapConfig: paredit.KeyMapConfig) {
+        this._keyMapConfig = keyMapConfig;
+        this.updateUIState();
     }
 
     get visible(): Boolean {


### PR DESCRIPTION
## What has Changed?
Closes #784

We introduce a `calva.paredit.keybindingsEnabled` config option and a
`paredit.toggleKeybindingsEnabled` command which allows toggling Paredit
keybindings on and off while preserving the current mode. The Paredit
keybindings are updated to only activate when the
`paredit:keybindingsEnabled` context key is true, in addition to the
existing conditions on the keymap. Finally, the Paredit StatusBar
component is updated to receive a `KeyMapConfig` object containing
`keyMap` and the new `keybindingsEnabled` boolean, and a new path is
added in the UI state management to handle this case as distinct from the
'none' keyMap case.

Inside the Paredit `StatusBar` component, I factored out the code for setting properties on the `_toggleBarItem` into a `updateUIState` fn, to indicate a separation of concerns between the `keyMapConfig` setter and updating the UI: previously the statements in the switch cases were updating the internal `_keyMap` value and also updating the `_toggleBarItem`. I have not touched `visible` setter.

Tested in VSCode 1.48.1 on Arch Linux.

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->