### PR TITLE
Allow toggling keyboard shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changes to Calva.
 - [Fix: evals should be ignored during parsing](https://github.com/BetterThanTomorrow/calva/issues/763)
 - Fix: [Test runner can't find tests under cursor when using a custom test macro](https://github.com/BetterThanTomorrow/calva/issues/786)
 - Fix: [Test runner output only partially commented](https://github.com/BetterThanTomorrow/calva/issues/787)
+- [Allow toggling keyboard shortcuts](https://github.com/BetterThanTomorrow/calva/issues/784)
 
 ## [2.0.124] - 2020-08-31
 - Re-fix: [Can't jack-in when no project file is open](https://github.com/BetterThanTomorrow/calva/issues/734)

--- a/docs/site/finding-commands.md
+++ b/docs/site/finding-commands.md
@@ -5,7 +5,7 @@ Calva relies a lot on that VS Code makes it really easy to find commands by open
 To leverage this, all Calva commands are prefixed with `Calva`. As an example, say you want to evaluate a form and pretty print it. Then you can do this:
 
 1. Open the command palette
-2. Type `calevpr` 
+2. Type `calevpr`
 
 VS Code will match `cal` to ”**Cal**va”, `ev` to ”**Ev**aluate”, and `pr` to ”**pr**etty” in ”**pr**etty print”. It looks like so:
 
@@ -17,6 +17,10 @@ Now might be a good time to see [Calva Top 10 Commands](commands-top10.md)
 
 ## All the Settings and Commands
 
-Did you know? There is a complete list of Calva settings and commands in the *Contributions* tab of the Calva entry in the *Extensions* pane in VS Code. 
+Did you know? There is a complete list of Calva settings and commands in the *Contributions* tab of the Calva entry in the *Extensions* pane in VS Code.
 
 ![The Calva Contributions Tab](https://user-images.githubusercontent.com/30010/66733740-c754b800-ee60-11e9-877b-962f6b920cd7.png)
+
+## Toggling Keyboard Shortcuts On/Off
+
+The command `calva.toggleKeybindingsEnabled` can be used to quickly enable and disable (almost) all keyboard shortcuts. By default it is bound to `ctrl+alt+c ctrl+alt+k`, and this shortcut is the only one which will not be disabled. This allows you to quickly toggle between Calva keybindings and other keybindings which would otherwise not be available when Calva is enabled. This is particularly useful with the Paredit keyboard shortcuts, whose default shortcuts conflict with the default VS Code shortcuts for textual (non-structural) editing.

--- a/package.json
+++ b/package.json
@@ -487,6 +487,12 @@
                         "type": "boolean",
                         "markdownDescription": "By default, the **Calva says** window opens on startup.",
                         "default": true
+                    },
+                    "calva.keybindingsEnabled": {
+                        "type": "boolean",
+                        "description": "Activate keybindings.",
+                        "default": true,
+                        "scope": "window"
                     }
                 }
             },
@@ -746,6 +752,11 @@
                 "title": "Refresh All Namespaces",
                 "enablement": "calva:connected",
                 "category": "Calva"
+            },
+            {
+                "category": "Calva",
+                "command": "calva.toggleKeybindingsEnabled",
+                "title": "Toggle Keybindings Enabled"
             },
             {
                 "category": "Calva Paredit",
@@ -1086,438 +1097,463 @@
             {
                 "command": "calva.tellAboutNewChordingKey",
                 "key": "ctrl+alt+v",
-                "when": "editorLangId == clojure"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure"
             },
             {
                 "command": "calva.debug.instrument",
                 "key": "ctrl+alt+c i",
-                "when": "editorLangId == clojure && calva:connected"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && calva:connected"
             },
             {
                 "command": "calva.jackIn",
-                "key": "ctrl+alt+c ctrl+alt+j"
+                "key": "ctrl+alt+c ctrl+alt+j",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.connect",
-                "key": "ctrl+alt+c ctrl+alt+c"
+                "key": "ctrl+alt+c ctrl+alt+c",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.connectNonProjectREPL",
-                "key": "ctrl+alt+c alt+c"
+                "key": "ctrl+alt+c alt+c",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.toggleCLJCSession",
-                "key": "ctrl+alt+c ctrl+alt+s"
+                "key": "ctrl+alt+c ctrl+alt+s",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.switchCljsBuild",
-                "key": "ctrl+alt+c ctrl+alt+b"
+                "key": "ctrl+alt+c ctrl+alt+b",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.selectCurrentForm",
-                "key": "ctrl+alt+c ctrl+s"
+                "key": "ctrl+alt+c ctrl+s",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.clearInlineResults",
                 "key": "escape",
-                "when": "editorTextFocus && !editorHasMultipleSelections && !editorHasSelection && !editorReadOnly && !hasOtherSuggestions && !parameterHintsVisible && !selectionAnchorSet && !suggestWidgetVisible && editorLangId == 'clojure'"
+                "when": "calva:keybindingsEnabled && editorTextFocus && !editorHasMultipleSelections && !editorHasSelection && !editorReadOnly && !hasOtherSuggestions && !parameterHintsVisible && !selectionAnchorSet && !suggestWidgetVisible && editorLangId == 'clojure'"
             },
             {
                 "command": "calva.evaluateSelection",
                 "key": "ctrl+alt+c e",
-                "win": "ctrl+alt+c v"
+                "win": "ctrl+alt+c v",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.evaluateSelection",
                 "key": "ctrl+enter",
-                "when": "editorTextFocus"
+                "when": "calva:keybindingsEnabled && editorTextFocus"
             },
             {
                 "command": "calva.interruptAllEvaluations",
-                "key": "ctrl+alt+c ctrl+alt+d"
+                "key": "ctrl+alt+c ctrl+alt+d",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.evaluateCurrentTopLevelForm",
-                "key": "ctrl+alt+c space"
+                "key": "ctrl+alt+c space",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.evaluateCurrentTopLevelForm",
                 "key": "alt+enter",
-                "when": "editorTextFocus"
+                "when": "calva:keybindingsEnabled && editorTextFocus"
             },
             {
                 "command": "calva.evaluateSelectionReplace",
-                "key": "ctrl+alt+c r"
+                "key": "ctrl+alt+c r",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.evaluateSelectionAsComment",
-                "key": "ctrl+alt+c c"
+                "key": "ctrl+alt+c c",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.evaluateTopLevelFormAsComment",
-                "key": "ctrl+alt+c ctrl+space"
+                "key": "ctrl+alt+c ctrl+space",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.copyLastResults",
-                "key": "ctrl+alt+c ctrl+c"
+                "key": "ctrl+alt+c ctrl+c",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.loadFile",
-                "key": "ctrl+alt+c enter"
+                "key": "ctrl+alt+c enter",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.togglePrettyPrint",
-                "key": "ctrl+alt+c p"
+                "key": "ctrl+alt+c p",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.requireREPLUtilities",
-                "key": "ctrl+alt+c ctrl+u"
+                "key": "ctrl+alt+c ctrl+u",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runNamespaceTests",
-                "key": "ctrl+alt+c t"
+                "key": "ctrl+alt+c t",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runAllTests",
-                "key": "ctrl+alt+c shift+t"
+                "key": "ctrl+alt+c shift+t",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.rerunTests",
-                "key": "ctrl+alt+c ctrl+t"
+                "key": "ctrl+alt+c ctrl+t",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runTestUnderCursor",
-                "key": "ctrl+alt+c ctrl+alt+t"
+                "key": "ctrl+alt+c ctrl+alt+t",
+                "when": "calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
-                "key": "ctrl+alt+c ."
+                "key": "ctrl+alt+c .",
+                "when": "calva:keybindingsEnabled"
+            },
+            {
+                "command": "calva.toggleKeybindingsEnabled",
+                "key": "ctrl+alt+c ctrl+alt+k"
             },
             {
                 "command": "paredit.togglemode",
                 "key": "ctrl+alt+p ctrl+alt+m",
-                "when": "paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.forwardSexp",
                 "key": "ctrl+alt+right",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.backwardSexp",
                 "key": "ctrl+alt+left",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.forwardDownSexp",
                 "key": "ctrl+down",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.backwardDownSexp",
                 "key": "ctrl+alt+up",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.forwardUpSexp",
                 "key": "ctrl+alt+down",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.backwardUpSexp",
                 "key": "ctrl+up",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.closeList",
                 "key": "ctrl+end",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.openList",
                 "key": "ctrl+home",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectForwardSexp",
                 "key": "ctrl+shift+alt+right",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectBackwardSexp",
                 "key": "ctrl+shift+alt+left",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectForwardDownSexp",
                 "key": "ctrl+shift+down",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectBackwardDownSexp",
                 "key": "ctrl+shift+alt+up",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectForwardUpSexp",
                 "key": "ctrl+shift+alt+down",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectBackwardUpSexp",
                 "key": "ctrl+shift+up",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectCloseList",
                 "key": "ctrl+shift+end",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.selectOpenList",
                 "key": "ctrl+shift+home",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.rangeForDefun",
                 "key": "ctrl+alt+w space",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.sexpRangeExpansion",
                 "key": "ctrl+w",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.sexpRangeContraction",
                 "key": "ctrl+shift+w",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.slurpSexpForward",
                 "key": "ctrl+right",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.slurpSexpBackward",
                 "key": "ctrl+shift+left",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.barfSexpForward",
                 "key": "ctrl+left",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.barfSexpBackward",
                 "key": "ctrl+shift+right",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.spliceSexp",
                 "key": "ctrl+alt+s",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.splitSexp",
                 "key": "ctrl+shift+s",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.joinSexp",
                 "key": "ctrl+shift+j",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.raiseSexp",
                 "key": "ctrl+alt+p ctrl+alt+r",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.transpose",
                 "key": "ctrl+alt+t",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.dragSexprBackward",
                 "key": "ctrl+shift+alt+b",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.dragSexprForward",
                 "key": "ctrl+shift+alt+f",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.dragSexprBackwardUp",
                 "key": "ctrl+shift+alt+u",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.dragSexprForwardDown",
                 "key": "ctrl+shift+alt+d",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.dragSexprForwardUp",
                 "key": "ctrl+shift+alt+k",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.dragSexprBackwardDown",
                 "key": "ctrl+shift+alt+j",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.convolute",
                 "key": "ctrl+shift+c",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.killSexpForward",
                 "key": "ctrl+shift+delete",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.killSexpBackward",
                 "key": "ctrl+alt+backspace",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.killListForward",
                 "key": "ctrl+delete",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.killListBackward",
                 "key": "ctrl+backspace",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.spliceSexpKillForward",
                 "key": "ctrl+alt+shift+delete",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.spliceSexpKillBackward",
                 "key": "ctrl+alt+shift+backspace",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.wrapAroundParens",
                 "key": "ctrl+alt+shift+p",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.wrapAroundSquare",
                 "key": "ctrl+alt+shift+s",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.wrapAroundCurly",
                 "key": "ctrl+alt+shift+c",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.wrapAroundQuote",
                 "key": "ctrl+alt+shift+q",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.rewrapParens",
                 "key": "ctrl+alt+r ctrl+alt+p",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.rewrapSquare",
                 "key": "ctrl+alt+r ctrl+alt+s",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.rewrapCurly",
                 "key": "ctrl+alt+r ctrl+alt+c",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.rewrapQuote",
                 "key": "ctrl+alt+r ctrl+alt+q",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
             },
             {
                 "command": "paredit.deleteForward",
                 "key": "delete",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
             },
             {
                 "command": "paredit.deleteBackward",
                 "key": "backspace",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
             },
             {
                 "command": "paredit.forceDeleteForward",
                 "key": "alt+delete",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
             },
             {
                 "command": "paredit.forceDeleteBackward",
                 "key": "alt+backspace",
-                "when": "editorLangId == clojure && editorTextFocus && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap == strict && !editorReadOnly && !editorHasMultipleSelections"
             },
             {
                 "command": "calva-fmt.formatCurrentForm",
                 "key": "tab",
-                "when": "editorLangId == clojure && editorTextFocus && !editorReadOnly && !inSnippetMode && !suggestWidgetVisible && !hasOtherSuggestions"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && !editorReadOnly && !inSnippetMode && !suggestWidgetVisible && !hasOtherSuggestions"
             },
             {
                 "command": "calva-fmt.alignCurrentForm",
                 "key": "ctrl+alt+l",
-                "when": "editorLangId == clojure && editorTextFocus && !editorReadOnly && !suggestWidgetVisible && !hasOtherSuggestions"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && !editorReadOnly && !suggestWidgetVisible && !hasOtherSuggestions"
             },
             {
                 "command": "calva-fmt.inferParens",
                 "key": "ctrl+alt+f ctrl+alt+p",
-                "when": "editorLangId == clojure && editorTextFocus && !editorReadOnly && !suggestWidgetVisible && !hasOtherSuggestions"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && !editorReadOnly && !suggestWidgetVisible && !hasOtherSuggestions"
             },
             {
                 "command": "calva-fmt.tabIndent",
                 "key": "ctrl+i",
-                "when": "editorLangId == clojure && editorTextFocus && !editorReadOnly && !suggestWidgetVisible && !hasOtherSuggestions"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && !editorReadOnly && !suggestWidgetVisible && !hasOtherSuggestions"
             },
             {
                 "command": "calva-fmt.tabDedent",
                 "key": "shift+ctrl+i",
-                "when": "editorLangId == clojure && editorTextFocus && !editorReadOnly && !suggestWidgetVisible && !hasOtherSuggestions"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && !editorReadOnly && !suggestWidgetVisible && !hasOtherSuggestions"
             },
             {
                 "command": "calva.showOutputWindow",
                 "key": "ctrl+alt+c o",
-                "when": "calva:connected && !calva:outputWindowActive"
+                "when": "calva:keybindingsEnabled && calva:connected && !calva:outputWindowActive"
             },
             {
                 "command": "calva.setOutputWindowNamespace",
                 "key": "ctrl+alt+c alt+n",
-                "when": "editorLangId == clojure && calva:connected && !calva:outputWindowActive"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && calva:connected && !calva:outputWindowActive"
             },
             {
                 "command": "calva.sendCurrentFormToOutputWindow",
                 "key": "ctrl+alt+c ctrl+alt+e",
                 "win": "ctrl+alt+c ctrl+alt+v",
-                "when": "editorLangId == clojure && calva:connected && !calva:outputWindowActive"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && calva:connected && !calva:outputWindowActive"
             },
             {
                 "command": "calva.sendCurrentTopLevelFormToOutputWindow",
                 "key": "ctrl+alt+c ctrl+alt+space",
-                "when": "editorLangId == clojure && calva:connected && !calva:outputWindowActive"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && calva:connected && !calva:outputWindowActive"
             },
             {
                 "command": "calva.showPreviousReplHistoryEntry",
                 "key": "alt+up",
-                "when": "editorLangId == clojure && calva:connected && calva:outputWindowActive"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && calva:connected && calva:outputWindowActive"
             },
             {
                 "command": "calva.showNextReplHistoryEntry",
                 "key": "alt+down",
-                "when": "editorLangId == clojure && calva:connected && calva:outputWindowActive"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && calva:connected && calva:outputWindowActive"
             }
         ],
         "menus": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,7 @@
 const config = {
-    REPL_FILE_EXT: 'calva-repl'
+    REPL_FILE_EXT: 'calva-repl',
+    KEYBINDINGS_ENABLED_CONFIG_KEY: 'calva.keybindingsEnabled',
+    KEYBINDINGS_ENABLED_CONTEXT_KEY: 'calva:keybindingsEnabled'
 };
 
 type ReplSessionType = 'clj' | 'cljs';

--- a/src/paredit/statusbar.ts
+++ b/src/paredit/statusbar.ts
@@ -5,7 +5,6 @@ import * as paredit from './extension';
 
 export class StatusBar {
 
-    private _enabled: Boolean;
     private _visible: Boolean;
     private _keyMap: String;
 
@@ -16,13 +15,12 @@ export class StatusBar {
         this._toggleBarItem.text = "(λ)";
         this._toggleBarItem.tooltip = "";
         this._toggleBarItem.command = 'paredit.togglemode';
-        this._enabled = false;
         this._visible = false;
         this.keyMap = keymap;
 
         paredit.onPareditKeyMapChanged((keymap) => {
             this.keyMap = keymap;
-        }) 
+        })
     }
 
     get keyMap() {
@@ -30,42 +28,29 @@ export class StatusBar {
     }
 
     set keyMap(keymap: String) {
-        
-        switch (keymap.trim().toLowerCase()) {
+        this._keyMap = keymap;
+        this.updateUIState();
+    }
+
+    updateUIState() {
+        switch (this.keyMap.trim().toLowerCase()) {
             case 'original':
-                this._keyMap = 'original';
-                this.enabled = true;
                 this.visible = true;
                 this._toggleBarItem.text = "(λ)";
-                this._toggleBarItem.tooltip = "Toggle to strict Mode"
+                this._toggleBarItem.tooltip = "Toggle to Strict Mode";
+                this._toggleBarItem.color = undefined;
                 break;
             case 'strict':
-                this._keyMap = 'strict';
-                this.enabled = true;
                 this.visible = true;
                 this._toggleBarItem.text = "[λ]";
-                this._toggleBarItem.tooltip = "Toggle to original Mode"
+                this._toggleBarItem.tooltip = "Toggle to Original Mode";
+                this._toggleBarItem.color = undefined;
                 break;
             default:
-                this._keyMap = 'none';
-                this.enabled = false;
                 this.visible = true;
                 this._toggleBarItem.text = "λ";
                 this._toggleBarItem.tooltip = "Calva Paredit Keymap is set to none, Toggle to Strict Mode is Disabled"
-        }
-    }
-
-    get enabled() {
-        return this._enabled;
-    }
-
-    set enabled(value: Boolean) {
-        this._enabled = value;
-
-        if (this._enabled) {
-            this._toggleBarItem.color = undefined;
-        } else {
-            this._toggleBarItem.color = statusbar.color.inactive;
+                this._toggleBarItem.color = statusbar.color.inactive;
         }
     }
 


### PR DESCRIPTION
## What has Changed?

Closes #784

We introduce a `calva.keybindingsEnabled` config option and a
`calva.toggleKeybindingsEnabled` command which allows toggling
keybindings on and off. The keybindings are updated to only activate
when the `calva:keybindingsEnabled` context key is true, in addition to
the existing conditions on the keymap.

Also includes minor improvement to Paredit StatusBar code.

Tested in VSCode 1.48.1 on Arch Linux.

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [x] Made sure the PR is directed at the `dev` branch (unless reasons).
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [x] Read the source changes.
- [x] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [x] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->