### PR TITLE
Fix multi repo jack-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Jack-in is broken for multi-project workspaces](https://github.com/BetterThanTomorrow/calva/issues/821)
 
 ## [2.0.128] - 2020-10-17
-- Fix: [Jack-in is broken](https://github.com/BetterThanTomorrow/calva/issues/821)
+- Fix: [Jack-in is broken if live share extension is not installed](https://github.com/BetterThanTomorrow/calva/issues/821)
 
 ## [2.0.127] - 2020-10-17
 - [Live Share Support](https://github.com/BetterThanTomorrow/calva/issues/803)

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -461,12 +461,14 @@ export function getProjectTypeForName(name: string) {
 }
 
 export async function detectProjectTypes(): Promise<string[]> {
-    const rootUri = state.getProjectRootUri(),
-        cljProjTypes = ['generic'];
+    const rootUri = state.getProjectRootUri();
+    const cljProjTypes = ['generic'];
     for (let clj in projectTypes) {
         if (projectTypes[clj].useWhenExists) {
             try {
-                await vscode.workspace.fs.readFile(vscode.Uri.joinPath(rootUri, projectTypes[clj].useWhenExists));
+                const projectFileName = projectTypes[clj].useWhenExists;
+                const uri = vscode.Uri.joinPath(rootUri, projectFileName);
+                await vscode.workspace.fs.readFile(uri);
                 cljProjTypes.push(clj);
             } catch (_e) { }
         }

--- a/src/state.ts
+++ b/src/state.ts
@@ -215,7 +215,7 @@ export async function initProjectDir(): Promise<void> {
     } else {
         d = workspaceFolder.uri.fsPath;
     }
-    while (d != prev) {
+    while (d !== prev) {
         for (let projectFile in projectFileNames) {
             const p = path.resolve(d, projectFileNames[projectFile]);
             if (fs.existsSync(p)) {
@@ -223,7 +223,7 @@ export async function initProjectDir(): Promise<void> {
                 break;
             }
         }
-        if (d == rootPath) {
+        if (d === rootPath) {
             break;
         }
         prev = d;
@@ -236,6 +236,7 @@ export async function initProjectDir(): Promise<void> {
         const p = path.resolve(rootPath, projectFileNames[projectFile]);
         if (fs.existsSync(p)) {
             cursor.set(PROJECT_DIR_KEY, rootPath);
+            cursor.set(PROJECT_DIR_URI_KEY, vscode.Uri.parse(rootPath));
             return;
         }
     }


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->
- Set project root directory uri in all cases when initializing project directory, so that jack-in works in multi-project workspaces

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Fixes #821 

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [ ] Created the issue I am fixing/addressing, if it was not present.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->