### PR TITLE
Fix: Connect to REPL as live share guest in multi-project workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [[Live Share] connecting to REPL as guest doesn't work in multi-project workspace](https://github.com/BetterThanTomorrow/calva/issues/831)
 
 ## [2.0.131] - 2020-11-05
 - Fix: [Syntax highlighting error when repl prompt shows ns containing digits](https://github.com/BetterThanTomorrow/calva/issues/834)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "calva",
-    "version": "2.0.131",
+    "version": "2.0.132",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Calva: Clojure & ClojureScript Interactive Programming",
     "description": "Integrated REPL, formatter, Paredit, and more. Powered by nREPL.",
     "icon": "assets/calva.png",
-    "version": "2.0.131",
+    "version": "2.0.132",
     "publisher": "betterthantomorrow",
     "author": {
         "name": "Better Than Tomorrow",

--- a/src/state.ts
+++ b/src/state.ts
@@ -191,9 +191,13 @@ export function getProjectWsFolder(): vscode.WorkspaceFolder {
  * If there is no project file found, throw an exception.
  */
 export async function initProjectDir(): Promise<void> {
-    const projectFileNames: string[] = ["project.clj", "shadow-cljs.edn", "deps.edn"],
-        workspace = vscode.workspace.workspaceFolders![0],
-        doc = util.getDocument({});
+    const projectFileNames: string[] = ["project.clj", "shadow-cljs.edn", "deps.edn"];
+    await findLocalProjectRoot(projectFileNames);
+}
+
+async function findLocalProjectRoot(projectFileNames): Promise<void> {
+    const workspace = vscode.workspace.workspaceFolders![0];
+    const doc = util.getDocument({});
 
     // first try the workplace folder
     let workspaceFolder = doc ? vscode.workspace.getWorkspaceFolder(doc.uri) : null;


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->
- `PROJECT_DIR_URI_KEY` (aka `getProjectRootUri()`) is determined using a new algorithm. The old algorithm only worked locally, not for remote use cases e.g. live share.

Note: this affects all platforms. I could only test it with macOS. I also did a quick check with a colleague who is on Windows. Using a multi-project folder it worked correctly in both directions.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Fixes #831

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [X] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [X] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [X] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [X] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [X] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [X] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [X] Tested the particular change
     - [X] Figured if the change might have some side effects and tested those as well.
     - [X] Smoke tested the extension as such.
- [X] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [X] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [X] Created the issue I am fixing/addressing, if it was not present.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->