### PR TITLE
Fix REBL doc typo

### DIFF
--- a/docs/site/rebl.md
+++ b/docs/site/rebl.md
@@ -30,7 +30,7 @@ Add the following aliases to your deps.edn file. Use the deps.edn file in the `~
 
 ;; nREBL
 :nrebl {:extra-deps {rickmoynihan/nrebl.middleware {:mvn/version "0.2.0"}}
-            :main-opts ["-e" "((requiring-resolve,'cognitect.rebl/ui))" "-m""nrepl.    cmdline" "--middleware" "[nrebl.middleware/wrap-nrebl]" "-I"]}
+            :main-opts ["-e" "((requiring-resolve,'cognitect.rebl/ui))" "-m" "nrepl.cmdline" "--middleware" "[nrebl.middleware/wrap-nrebl]" "-I"]}
 ```
 
 Create a Calva custom connect sequence for your VSCode editor. (Read [Custom REPL Connect Sequences](connect-sequences.md) if you haven't.) Add the following to your vscode settings.json:


### PR DESCRIPTION
Removes the wrong space in the `nrepl.cmdline` from the `How to Use Calva and REBL Together` doc

## What has Changed?

The *How to Use Calva and REBL Together* doc page has a typo, some space characters in the `nrepl.cmdline` which makes the example alias to fail. This PR just removes that typo.

## My Calva PR Checklist

I have:

- [ x ] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [ x ] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [ x ] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)

## The Calva Team PR Checklist:

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe
