### PR TITLE
885 fstat await problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Jack-in/Connect prompts never showing on some Windows machines](https://github.com/BetterThanTomorrow/calva/issues/885)
 
 ## [2.0.135 - 2020-12-20]
 - [Binding keys to REPL functions, passing the namespace and cursor line (Notespace integration)](https://github.com/BetterThanTomorrow/calva/issues/863)

--- a/src/state.ts
+++ b/src/state.ts
@@ -264,7 +264,9 @@ async function findProjectRootUri(projectFileNames, doc, workspaceFolder): Promi
                 catch { }
             }
         }
-        catch (_) { }
+        catch (e) { 
+            console.error(`Problems in search for project root directory: ${e}`);
+        }
         prev = searchUri;
         searchUri = vscode.Uri.joinPath(searchUri, "..");
     }

--- a/src/state.ts
+++ b/src/state.ts
@@ -253,17 +253,18 @@ async function findProjectRootUri(projectFileNames, doc, workspaceFolder): Promi
     let searchUri = doc?.uri || workspaceFolder?.uri;
     let prev = null;
     while (searchUri != prev) {
-        for (let projectFile in projectFileNames) {
-            const u = vscode.Uri.joinPath(searchUri, projectFileNames[projectFile]);
-            try {
-                const stat = await vscode.workspace.fs.stat(u);
-                if (stat) {
+        try {
+            for (let projectFile in projectFileNames) {
+                const u = vscode.Uri.joinPath(searchUri, projectFileNames[projectFile]);
+                try {
+                    await vscode.workspace.fs.stat(u);
                     cursor.set(PROJECT_DIR_URI_KEY, searchUri);
                     return;
                 }
+                catch { }
             }
-            catch (_) { }
         }
+        catch (_) { }
         prev = searchUri;
         searchUri = vscode.Uri.joinPath(searchUri, "..");
     }


### PR DESCRIPTION
## What has Changed?
Fix jack-in prompt never appearing on Windows.

Doesn't seem to happen to users out there, but on my Windows machine jack-in doesn't work.

The fix is to wrap the `fs.stat()` call in a try/catch instead of using the return value. Quite strange, but it is how the [VS Code team is recommending it to be done](https://github.com/microsoft/vscode-extension-samples/blob/master/fsconsumer-sample/src/extension.ts). (And also, it does fix the problem.)

Fixes #885

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- ~[ ] Added to or updated docs in this branch, if appropriate~

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->