### PR TITLE
Fix lsp refactorings on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ Changes to Calva.
 - [Remove default key binding for toggling Calva key bindings](https://github.com/BetterThanTomorrow/calva/issues/815)
 
 ## [2.0.140 - 2020-12-28]
-- Make Jack-in dependency versions configurable (and bump 'em all with default settings)
+- [Make Jack-in dependency versions configurable (and bump 'em all with default settings)](https://github.com/BetterThanTomorrow/calva/pull/899)
 
 ## [2.0.139 - 2020-12-28]
-- Use Pseudo Terminal instead of Task for Jack-in
+- [Use Pseudo Terminal instead of Task for Jack-in](https://github.com/BetterThanTomorrow/calva/pull/654)
 - [Prefer cider-nrepl symbol definitions over clojure-lsp](https://github.com/BetterThanTomorrow/calva/issues/897)
-- Enable clojure-lsp completion items when no nrepl connection
+- [Enable clojure-lsp completion items when no nrepl connection](https://github.com/BetterThanTomorrow/calva/pull/898)
 
 ## [2.0.138 - 2020-12-27]
 - [Bring in refactorings we get access to via clojure-lsp](https://github.com/BetterThanTomorrow/calva/issues/890)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [clojure-lsp refactorings not working on Windows](https://github.com/BetterThanTomorrow/calva/issues/911)
 - [Remove default key binding for toggling Calva key bindings](https://github.com/BetterThanTomorrow/calva/issues/815)
 
 ## [2.0.140 - 2020-12-28]

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -63,11 +63,11 @@ function createClient(jarPath: string): LanguageClient {
                 }
             },
             provideCompletionItem(document, position, context, token, next) {
-                 if (util.getConnectedState()) {
-                     return null;
-                 } else {
-                     return next(document, position, context, token);
-                 }
+                if (util.getConnectedState()) {
+                    return null;
+                } else {
+                    return next(document, position, context, token);
+                }
             },
             provideSignatureHelp(document, position, context, token, next) {
                 if (util.getConnectedState()) {
@@ -161,7 +161,8 @@ function registerLspCommand(client: LanguageClient, command: ClojureLspCommand):
         if (document && document.languageId === 'clojure') {
             const line = editor.selection.active.line;
             const column = editor.selection.active.character;
-            const params = [document.uri.toString(), line, column];
+            const docUri = `${document.uri.scheme}://${document.uri.path}`;
+            const params = [docUri, line, column];
             const extraParam = command.extraParamFn ? await command.extraParamFn() : undefined;
             if (!command.extraParamFn || command.extraParamFn && extraParam) {
                 client.sendRequest('workspace/executeCommand', {


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->
- Send a non-encoded document uri to clojure-lsp for the refactoring commands. Previously the `:` after the Windows drive letter was being encoded to `%3A` by the `TextDocument.uri.toString()` function, but clojure-lsp indexes the files without this encoding (like `c:\`).

I tested this in Windows and Linux

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Fixes #911 

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - ~[ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [x] Created the issue I am fixing/addressing, if it was not present.
- ~[ ] Added to or updated docs in this branch, if appropriate~

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->