### PR TITLE
Fix getJarContents for windows

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -343,13 +343,8 @@ async function getFileContents(uri: string) {
 async function getJarContents(uri: vscode.Uri | string) {
     return new Promise<string>((resolve, reject) => {
         const rawPath = typeof(uri) === "string" ? uri : uri.path;
-        const pathToFileInJar = rawPath.slice(rawPath.search('!/') + 2);
-        let pathToJar = rawPath.slice('file:'.length);
-
-        pathToJar = pathToJar.slice(0, pathToJar.search('!'));
-        if (os.platform() === 'win32') {
-            pathToJar = pathToJar.replace(/\//g, '\\').slice(1);
-        }
+        const replaceRegex = os.platform() === 'win32' ? /file:\/*/ : /file:/;
+        const [pathToJar, pathToFileInJar] = rawPath.replace(replaceRegex, '').split('!/');
 
         fs.readFile(pathToJar, (err, data) => {
             let zip = new JSZip();


### PR DESCRIPTION
I tested this in Windows and Linux with and without a repl connection. It works even if the windows path contains `/` instead of `\` (no need to replace). The fix involves removing the extra `/`s in front of the drive letter for Windows, but leaving them for Unix based OS's.