### PR TITLE
Make dimming of ignores skip meta and ignores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Dimming ignored forms does not work correctly with metadata](https://github.com/BetterThanTomorrow/calva/issues/908)
 
 ## [2.0.145 - 2021-01-03]
 - [Add command for opening the file for the output/repl window namespace](https://github.com/BetterThanTomorrow/calva/issues/920)

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -253,7 +253,7 @@ function updateRainbowBrackets() {
             ignoreCursor.forwardWhitespace();
           }
           for (i = 0; i < ignore_counter; i++) {
-            ignoreCursor.forwardSexp();
+            ignoreCursor.forwardSexp(true, true, true);
           }
           const ignore_end = activeEditor.document.positionAt(ignoreCursor.offsetStart);
           ignores.push(new Range(ignore_start, ignore_end));


### PR DESCRIPTION
We were not allowing the `forwardSexpr` of the token cursor used for dimming ignores to skip past metadata.

Fixes #908

There are still issues with the stacking of ignores in the presence of metadata, but this at least takes care of the reported case.

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->