### PR TITLE
Fix load file for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Load file command not loading changes since last file save on Windows](https://github.com/BetterThanTomorrow/calva/issues/975)
 
 ## [2.0.157] - 2021-02-01
 - [Add command for copying jack-in command to clipboard](https://github.com/BetterThanTomorrow/calva/pull/995)

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -189,11 +189,8 @@ export function revealResultsDoc(preserveFocus: boolean = true) {
 
 export async function revealDocForCurrentNS(preserveFocus: boolean = true) {
     const uri = await getUriForCurrentNamespace();
-    // if (uri.path.match(/jar!\//)) {
-    //     uri = uri.with({ scheme: 'jar' });
-    // }
     vscode.workspace.openTextDocument(uri).then(doc => vscode.window.showTextDocument(doc, {
-        preserveFocus: false
+        preserveFocus
     }));
 }
 

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -188,11 +188,10 @@ export function revealResultsDoc(preserveFocus: boolean = true) {
 }
 
 export async function revealDocForCurrentNS(preserveFocus: boolean = true) {
-    const [_fileName, filePath] = await getFilePathForCurrentNameSpace();
-    let uri = vscode.Uri.parse(filePath);
-    if (filePath.match(/jar!\//)) {
-        uri = uri.with({ scheme: 'jar' });
-    }
+    const uri = await getUriForCurrentNamespace();
+    // if (uri.path.match(/jar!\//)) {
+    //     uri = uri.with({ scheme: 'jar' });
+    // }
     vscode.workspace.openTextDocument(uri).then(doc => vscode.window.showTextDocument(doc, {
         preserveFocus: false
     }));
@@ -362,9 +361,8 @@ export function appendPrompt(onAppended?: OnAppendedCallback) {
     append(getPrompt(), onAppended);
 }
 
-export async function getFilePathForCurrentNameSpace(): Promise<[string, string]> {
+export async function getUriForCurrentNamespace(): Promise<vscode.Uri> {
     const ns = getNs();
     const info = await getSession().info(ns, ns);
-    const fileName = info.file;
-    return [fileName, vscode.Uri.parse(fileName).path];
+    return vscode.Uri.parse(info.file, true);
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -329,15 +329,15 @@ function scrollToBottom(editor: vscode.TextEditor) {
     editor.revealRange(new vscode.Range(lastPos, lastPos));
 }
 
-async function getFileContents(uri: string) {
-    const doc = vscode.workspace.textDocuments.find(document => document.uri.path === uri);
+async function getFileContents(path: string) {
+    const doc = vscode.workspace.textDocuments.find(document => document.uri.path === path);
     if (doc) {
         return doc.getText();
     }
-    if (uri.match(/jar!\//)) {
-        return await getJarContents(uri);
+    if (path.match(/jar!\//)) {
+        return await getJarContents(path);
     }
-    return fs.readFileSync(uri).toString();
+    return fs.readFileSync(path).toString();
 }
 
 function jarFilePathComponents(uri: vscode.Uri | string) {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -162,10 +162,6 @@ function getFileType(document) {
     }
 }
 
-function getFileName(document) {
-    return path.basename(document.fileName);
-}
-
 function getLaunchingState() {
     return state.deref().get('launching');
 }
@@ -410,7 +406,6 @@ export {
     getWordAtPosition,
     getDocument,
     getFileType,
-    getFileName,
     getLaunchingState,
     setLaunchingState,
     getConnectedState,


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->
- Refactors load file to use a vscode.Uri instead of just string fileName and filePath

I tested these changes with all scenarios that I could tell might be effected, including loading current file with jar files and revealing the file for the current output window ns, including for jar files.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Fixes #975 

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Added to or updated docs in this branch, if appropriate

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->