### PR TITLE
Add setting to hide Calva's REPL UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Add setting to use only static parts of Calva](https://github.com/BetterThanTomorrow/calva/issues/1005)
 
 ## [2.0.157] - 2021-02-01
 - [Add command for copying jack-in command to clipboard](https://github.com/BetterThanTomorrow/calva/pull/995)

--- a/docs/site/parinfer.md
+++ b/docs/site/parinfer.md
@@ -1,0 +1,15 @@
+# Using Calva with Parinfer
+
+Yes, you can use Calva with with the Parinfer extension. The only conflict here is that Calva's auto-formatting (that which happens as you type) is going to risk clash with Parinfer's.
+
+However, Calva's [Paredit](paredit.md) is carefully crafted. We suggest you consider that Clojure is a LISP, and therefore structural. There is power in this structure that other languages can not let you wield. Take advantage of this and make Paredit your friend. It takes only some few minutes to learn two or three basic Paredit commands:
+
+* **Select form**
+* **Slurp**
+* **Barf**
+
+Besides letting you benefit from auto-formatting, working this way will quickly bring you in better contact with the structural nature of the Clojure code. You'll thank yourself later.
+
+Also, if you find yourself having deleted or added a bracket out of structure, despite Calva Paredit's **Strict mode** (which you are using, right?) there is a command that might help you heal the structure: **Infer Parens**. That command is actually implemented using the Parinfer library, so it will let you recover from quite many situations.
+
+All that said, what was said first is true: if you want to use the Parinfer extension, you can. You'll probably want to disable Calva's auto-formatting. The setting for controlling this is named `calva.fmt.formatAsYouType`.

--- a/docs/site/quirks.md
+++ b/docs/site/quirks.md
@@ -10,9 +10,7 @@ Currently [`cider-nrepl` does not provide its test functionality for ClojureScri
 
 ## Using with Parinfer
 
-Calva defaults to formatting as you type. If you use Parinfer this creates a conflict, since it auto-indents your code. If you want to use Parinfer you'll have to tell Calva not to do auto-formatting by disabling `calva.fmt.formatAsYouType`.
-
-However, with VS Code and Calva it is probably better to learn to use [Paredit](paredit.md)'s **slurp** and **barf** and generally use Calva's automatic formatting.
+See [Using with Parinfer](parinfer.md)
 
 ## Calva and the VIM Extension
 

--- a/docs/site/static-only.md
+++ b/docs/site/static-only.md
@@ -8,6 +8,17 @@ As it could be a bit confusing and cluttered to have several REPL UIs active at 
 
 If you have the Calva REPL UI disabled and still want to [connect or jack-in to a REPL using Calva](connect.md), just do it. Then Calva's REPL UI will wake up and be there for the duration of the session.
 
+## Consider uninstalling these extensions
+
+Without Calva, many users install other nifty extensions (some of which are old pieces of Calva) that help with this or that problem. It might sometimes work together with Calva, sometimes not. Here's a list of some common extensions you should consider to at least disable:
+
+* Strict Paredit - Calva Paredit has evolved a lot since that version
+* Calva-fmt/Calva Formatter - Same here, evolution
+* Clojure Warrior - Calva includes it, in a much evolved way
+* Parinfer - This one you _can_ actually keep, _at some cost_, see [Using Calva with Parinfer](parinfer.md).
+
+## There's only one Calva REPL, though
+
 Of course we encourage you to use Calva's REPL. It gives you easy ways to
 
 * [start a Clojure REPL](connect.md)

--- a/docs/site/static-only.md
+++ b/docs/site/static-only.md
@@ -1,0 +1,21 @@
+# Use Calva as w/o the REPL
+
+Why would anyone want to use a Clojure editor without a REPL? It could be because you prefer some other REPL client over [Calva's ditto](https://calva.io/try-first/), like [Clover](https://github.com/mauricioszabo/clover/), but would be lacking Calva's [clojure-lsp](https://clojure-lsp.github.io/clojure-lsp/) support, [formatter](formatting.md), [Paredit](paredit.md), [highlighter](highlight), etcetera.
+
+As it could be a bit confusing and cluttered to have several REPL UIs active at the same time, Calva supports this use with a setting to disable most of its REPL UI elements, like statusbar items, command palette entries and editor context menus.
+
+* Set `calva.hideREPLUi` to `true` and the only commands still visible should be those for Connect and Jack-in.
+
+If you have the Calva REPL UI disabled and still want to [connect or jack-in to a REPL using Calva](connect.md), just do it. Then Calva's REPL UI will wake up and be there for the duration of the session.
+
+Of course we encourage you to use Calva's REPL. It gives you easy ways to
+
+* [start a Clojure REPL](connect.md)
+* [connect to an running REPL](connect.md#connecting-wo-jack-in)
+* [super duper nice debugger](debugger.md)
+* [test runner](test-runner.md)
+* [custom REPL commands](custom-commands.md)
+* enhanced symbol lookup and code navigation (keep navigating into library and Clojure core code, as well as into Java code).
+* easy to use [output](output.md) with [pretty printing](pprint.md), on-demand [stack traces](output.md#stack-traces), and that awesome [debugger.md](debugger.md)
+
+Happy REPLing, whichever REPL client you choose. ❤️

--- a/docs/site/static-only.md
+++ b/docs/site/static-only.md
@@ -4,7 +4,7 @@ Why would anyone want to use a Clojure editor without a REPL? It could be becaus
 
 As it could be a bit confusing and cluttered to have several REPL UIs active at the same time, Calva supports this use with a setting to disable most of its REPL UI elements, like statusbar items, command palette entries and editor context menus.
 
-* Set `calva.hideREPLUi` to `true` and the only commands still visible should be those for Connect and Jack-in.
+* Set `calva.hideReplUi` to `true` and the only commands still visible should be those for Connect and Jack-in.
 
 If you have the Calva REPL UI disabled and still want to [connect or jack-in to a REPL using Calva](connect.md), just do it. Then Calva's REPL UI will wake up and be there for the duration of the session.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
     - live-share.md
     - luminus.md
     - re-frame-template.md
+    - static-only.md
   - Etcetera:
     - workspace-layouts.md
     - quirks.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
     - luminus.md
     - re-frame-template.md
     - static-only.md
+    - parinfer.md
   - Etcetera:
     - workspace-layouts.md
     - quirks.md

--- a/package.json
+++ b/package.json
@@ -1732,7 +1732,7 @@
                     "group": "calva/x-connect"
                 },
                 {
-                    "when": "editorLangId == clojure",
+                    "when": "editorLangId == clojure && calva:showREPLUi",
                     "enablement": "calva:connected",
                     "command": "calva.disconnect",
                     "group": "calva/x-connect"
@@ -1743,72 +1743,72 @@
                     "group": "calva/a-eval"
                 },
                 {
-                    "when": "editorLangId == clojure",
+                    "when": "editorLangId == clojure && calva:showREPLUi",
                     "enablement": "calva:connected",
                     "command": "calva.loadFile",
                     "group": "calva/b-eval"
                 },
                 {
-                    "when": "editorLangId == clojure",
+                    "when": "editorLangId == clojure && calva:showREPLUi",
                     "enablement": "calva:connected",
                     "command": "calva.evaluateSelection",
                     "group": "calva/b-eval"
                 },
                 {
-                    "when": "editorLangId == clojure",
+                    "when": "editorLangId == clojure && calva:showREPLUi",
                     "enablement": "calva:connected",
                     "command": "calva.evaluateCurrentTopLevelForm",
                     "group": "calva/b-eval"
                 },
                 {
-                    "when": "editorLangId == clojure",
+                    "when": "editorLangId == clojure && calva:showREPLUi",
                     "enablement": "calva:connected",
                     "command": "calva.evaluateSelectionAsComment",
                     "group": "calva/b-eval"
                 },
                 {
-                    "when": "editorLangId == clojure",
+                    "when": "editorLangId == clojure && calva:showREPLUi",
                     "enablement": "calva:connected",
                     "command": "calva.evaluateTopLevelFormAsComment",
                     "group": "calva/b-eval"
                 },
                 {
-                    "when": "editorLangId == clojure",
+                    "when": "editorLangId == clojure && calva:showREPLUi",
                     "enablement": "calva:connected",
                     "command": "calva.interruptAllEvaluations",
                     "group": "calva/b-eval"
                 },
                 {
-                    "when": "editorLangId == clojure",
+                    "when": "editorLangId == clojure && calva:showREPLUi",
                     "command": "calva.togglePrettyPrint",
                     "group": "calva/b-eval"
                 },
                 {
                     "command": "calva.debug.instrument",
                     "enablement": "editorLangId == clojure && calva:connected",
-                    "when": "editorLangId == clojure",
+                    "when": "editorLangId == clojure && calva:showREPLUi",
                     "group": "calva/b-eval"
                 },
                 {
-                    "when": "editorLangId == clojure",
+                    "when": "editorLangId == clojure && calva:showREPLUi",
                     "enablement": "calva:connected",
                     "command": "calva.runAllTests",
                     "group": "calva/d-test"
                 },
                 {
-                    "when": "editorLangId == clojure",
+                    "when": "editorLangId == clojure && calva:showREPLUi",
                     "enablement": "calva:connected",
                     "command": "calva.runNamespaceTests",
                     "group": "calva/d-test"
                 },
                 {
-                    "when": "editorLangId == clojure",
+                    "when": "editorLangId == clojure && calva:showREPLUi",
                     "enablement": "calva:connected",
                     "command": "calva.rerunTests",
                     "group": "calva/d-test"
                 },
                 {
-                    "when": "editorLangId == clojure",
+                    "when": "editorLangId == clojure && calva:showREPLUi",
                     "enablement": "calva:connected",
                     "command": "calva.runTestUnderCursor",
                     "group": "calva/d-test"

--- a/package.json
+++ b/package.json
@@ -501,6 +501,11 @@
                         "description": "Activate keybindings.",
                         "default": true,
                         "scope": "window"
+                    },
+                    "calva.hideREPLUi": {
+                        "type": "boolean",
+                        "markdownDescription": "Don't surface REPL UI elements when avoidable. (For when using another REPL extension together with Calva's static features).",
+                        "default": false
                     }
                 }
             },

--- a/package.json
+++ b/package.json
@@ -502,7 +502,7 @@
                         "default": true,
                         "scope": "window"
                     },
-                    "calva.hideREPLUi": {
+                    "calva.hideReplUi": {
                         "type": "boolean",
                         "markdownDescription": "Don't surface REPL UI elements when avoidable. (For when using another REPL extension together with Calva's static features.)",
                         "default": false
@@ -1732,7 +1732,7 @@
                     "group": "calva/x-connect"
                 },
                 {
-                    "when": "editorLangId == clojure && calva:showREPLUi",
+                    "when": "editorLangId == clojure && calva:showReplUi",
                     "enablement": "calva:connected",
                     "command": "calva.disconnect",
                     "group": "calva/x-connect"
@@ -1743,72 +1743,72 @@
                     "group": "calva/a-eval"
                 },
                 {
-                    "when": "editorLangId == clojure && calva:showREPLUi",
+                    "when": "editorLangId == clojure && calva:showReplUi",
                     "enablement": "calva:connected",
                     "command": "calva.loadFile",
                     "group": "calva/b-eval"
                 },
                 {
-                    "when": "editorLangId == clojure && calva:showREPLUi",
+                    "when": "editorLangId == clojure && calva:showReplUi",
                     "enablement": "calva:connected",
                     "command": "calva.evaluateSelection",
                     "group": "calva/b-eval"
                 },
                 {
-                    "when": "editorLangId == clojure && calva:showREPLUi",
+                    "when": "editorLangId == clojure && calva:showReplUi",
                     "enablement": "calva:connected",
                     "command": "calva.evaluateCurrentTopLevelForm",
                     "group": "calva/b-eval"
                 },
                 {
-                    "when": "editorLangId == clojure && calva:showREPLUi",
+                    "when": "editorLangId == clojure && calva:showReplUi",
                     "enablement": "calva:connected",
                     "command": "calva.evaluateSelectionAsComment",
                     "group": "calva/b-eval"
                 },
                 {
-                    "when": "editorLangId == clojure && calva:showREPLUi",
+                    "when": "editorLangId == clojure && calva:showReplUi",
                     "enablement": "calva:connected",
                     "command": "calva.evaluateTopLevelFormAsComment",
                     "group": "calva/b-eval"
                 },
                 {
-                    "when": "editorLangId == clojure && calva:showREPLUi",
+                    "when": "editorLangId == clojure && calva:showReplUi",
                     "enablement": "calva:connected",
                     "command": "calva.interruptAllEvaluations",
                     "group": "calva/b-eval"
                 },
                 {
-                    "when": "editorLangId == clojure && calva:showREPLUi",
+                    "when": "editorLangId == clojure && calva:showReplUi",
                     "command": "calva.togglePrettyPrint",
                     "group": "calva/b-eval"
                 },
                 {
                     "command": "calva.debug.instrument",
                     "enablement": "editorLangId == clojure && calva:connected",
-                    "when": "editorLangId == clojure && calva:showREPLUi",
+                    "when": "editorLangId == clojure && calva:showReplUi",
                     "group": "calva/b-eval"
                 },
                 {
-                    "when": "editorLangId == clojure && calva:showREPLUi",
+                    "when": "editorLangId == clojure && calva:showReplUi",
                     "enablement": "calva:connected",
                     "command": "calva.runAllTests",
                     "group": "calva/d-test"
                 },
                 {
-                    "when": "editorLangId == clojure && calva:showREPLUi",
+                    "when": "editorLangId == clojure && calva:showReplUi",
                     "enablement": "calva:connected",
                     "command": "calva.runNamespaceTests",
                     "group": "calva/d-test"
                 },
                 {
-                    "when": "editorLangId == clojure && calva:showREPLUi",
+                    "when": "editorLangId == clojure && calva:showReplUi",
                     "enablement": "calva:connected",
                     "command": "calva.rerunTests",
                     "group": "calva/d-test"
                 },
                 {
-                    "when": "editorLangId == clojure && calva:showREPLUi",
+                    "when": "editorLangId == clojure && calva:showReplUi",
                     "enablement": "calva:connected",
                     "command": "calva.runTestUnderCursor",
                     "group": "calva/d-test"

--- a/package.json
+++ b/package.json
@@ -504,7 +504,7 @@
                     },
                     "calva.hideREPLUi": {
                         "type": "boolean",
-                        "markdownDescription": "Don't surface REPL UI elements when avoidable. (For when using another REPL extension together with Calva's static features).",
+                        "markdownDescription": "Don't surface REPL UI elements when avoidable. (For when using another REPL extension together with Calva's static features.)",
                         "default": false
                     }
                 }

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -493,10 +493,12 @@ async function standaloneConnect(connectSequence: ReplConnectSequence) {
 
 export default {
     connectNonProjectREPLCommand: async () => {
+        state.extensionContext.workspaceState.update('needREPLUi', true);
         const connectSequence = await askForConnectSequence(projectTypes.getAllProjectTypes(), 'connect-type', "ConnectInterrupted");
         standaloneConnect(connectSequence);
     },
     connectCommand: async () => {
+        state.extensionContext.workspaceState.update('needREPLUi', true);
         // TODO: Figure out a better way to have an initialized project directory.
         try {
             await state.initProjectDir();

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -493,12 +493,12 @@ async function standaloneConnect(connectSequence: ReplConnectSequence) {
 
 export default {
     connectNonProjectREPLCommand: async () => {
-        util.updateNeedREPLUi(true);
+        status.updateNeedREPLUi(true);
         const connectSequence = await askForConnectSequence(projectTypes.getAllProjectTypes(), 'connect-type', "ConnectInterrupted");
         standaloneConnect(connectSequence);
     },
     connectCommand: async () => {
-        util.updateNeedREPLUi(true);
+        status.updateNeedREPLUi(true);
         // TODO: Figure out a better way to have an initialized project directory.
         try {
             await state.initProjectDir();
@@ -513,7 +513,7 @@ export default {
         standaloneConnect(connectSequence);
     },
     disconnect: (options = null, callback = () => { }) => {
-        util.updateNeedREPLUi(false);
+        status.updateNeedREPLUi(false);
         ['clj', 'cljs'].forEach(sessionType => {
             state.cursor.set(sessionType, null);
         });

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -493,12 +493,12 @@ async function standaloneConnect(connectSequence: ReplConnectSequence) {
 
 export default {
     connectNonProjectREPLCommand: async () => {
-        status.updateNeedREPLUi(true);
+        status.updateNeedReplUi(true);
         const connectSequence = await askForConnectSequence(projectTypes.getAllProjectTypes(), 'connect-type', "ConnectInterrupted");
         standaloneConnect(connectSequence);
     },
     connectCommand: async () => {
-        status.updateNeedREPLUi(true);
+        status.updateNeedReplUi(true);
         // TODO: Figure out a better way to have an initialized project directory.
         try {
             await state.initProjectDir();
@@ -513,7 +513,7 @@ export default {
         standaloneConnect(connectSequence);
     },
     disconnect: (options = null, callback = () => { }) => {
-        status.updateNeedREPLUi(false);
+        status.updateNeedReplUi(false);
         ['clj', 'cljs'].forEach(sessionType => {
             state.cursor.set(sessionType, null);
         });

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -493,12 +493,12 @@ async function standaloneConnect(connectSequence: ReplConnectSequence) {
 
 export default {
     connectNonProjectREPLCommand: async () => {
-        state.extensionContext.workspaceState.update('needREPLUi', true);
+        util.updateNeedREPLUi(true);
         const connectSequence = await askForConnectSequence(projectTypes.getAllProjectTypes(), 'connect-type', "ConnectInterrupted");
         standaloneConnect(connectSequence);
     },
     connectCommand: async () => {
-        state.extensionContext.workspaceState.update('needREPLUi', true);
+        util.updateNeedREPLUi(true);
         // TODO: Figure out a better way to have an initialized project directory.
         try {
             await state.initProjectDir();
@@ -513,6 +513,7 @@ export default {
         standaloneConnect(connectSequence);
     },
     disconnect: (options = null, callback = () => { }) => {
+        util.updateNeedREPLUi(false);
         ['clj', 'cljs'].forEach(sessionType => {
             state.cursor.set(sessionType, null);
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,7 +65,7 @@ function setKeybindingsEnabledContext() {
 }
 
 async function activate(context: vscode.ExtensionContext) {
-    context.workspaceState.update('needREPLUi', false);
+    status.updateNeedREPLUi(false, context);
     lsp.activate(context).then(debugDecorations.triggerUpdateAndRenderDecorations);
     state.cursor.set('analytics', new Analytics(context));
     state.analytics().logPath("/start").logEvent("LifeCycle", "Started").send();
@@ -130,7 +130,7 @@ async function activate(context: vscode.ExtensionContext) {
         vscode.window.showErrorMessage("Calva Paredit extension detected, which will cause problems. Please uninstall, or disable, it.", "I hear ya. Doing it!");
     }
 
-    status.update();
+    status.update(context);
 
     // COMMANDS
     context.subscriptions.push(vscode.commands.registerCommand('calva.jackInOrConnect', jackIn.calvaJackInOrConnect));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,7 +65,7 @@ function setKeybindingsEnabledContext() {
 }
 
 async function activate(context: vscode.ExtensionContext) {
-    status.updateNeedREPLUi(false, context);
+    status.updateNeedReplUi(false, context);
     lsp.activate(context).then(debugDecorations.triggerUpdateAndRenderDecorations);
     state.cursor.set('analytics', new Analytics(context));
     state.analytics().logPath("/start").logEvent("LifeCycle", "Started").send();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,6 +65,7 @@ function setKeybindingsEnabledContext() {
 }
 
 async function activate(context: vscode.ExtensionContext) {
+    context.workspaceState.update('needREPLUi', false);
     lsp.activate(context).then(debugDecorations.triggerUpdateAndRenderDecorations);
     state.cursor.set('analytics', new Analytics(context));
     state.analytics().logPath("/start").logEvent("LifeCycle", "Started").send();

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -45,7 +45,7 @@ async function executeJackInTask(terminalOptions: JackInTerminalOptions, connect
 
     // in case we have a running task present try to end it.
     calvaJackout();
-    status.updateNeedREPLUi(true);
+    status.updateNeedReplUi(true);
     if (jackInTerminal !== undefined) {
         jackInTerminal.dispose();
         jackInTerminal = undefined;
@@ -181,7 +181,7 @@ async function getProjectConnectSequence(): Promise<ReplConnectSequence> {
 }
 
 export async function calvaJackIn() {
-    status.updateNeedREPLUi(true);
+    status.updateNeedReplUi(true);
     try {
         await state.initProjectDir();
     } catch (e) {

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as utilities from "../utilities";
 import * as _ from "lodash";
 import * as state from "../state"
+import status from '../status';
 import * as connector from "../connector";
 import { nClient } from "../connector";
 import statusbar from "../statusbar";
@@ -44,7 +45,7 @@ async function executeJackInTask(terminalOptions: JackInTerminalOptions, connect
 
     // in case we have a running task present try to end it.
     calvaJackout();
-    utilities.updateNeedREPLUi(true);
+    status.updateNeedREPLUi(true);
     if (jackInTerminal !== undefined) {
         jackInTerminal.dispose();
         jackInTerminal = undefined;
@@ -180,7 +181,7 @@ async function getProjectConnectSequence(): Promise<ReplConnectSequence> {
 }
 
 export async function calvaJackIn() {
-    utilities.updateNeedREPLUi(true);
+    status.updateNeedREPLUi(true);
     try {
         await state.initProjectDir();
     } catch (e) {

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -44,6 +44,7 @@ async function executeJackInTask(terminalOptions: JackInTerminalOptions, connect
 
     // in case we have a running task present try to end it.
     calvaJackout();
+    utilities.updateNeedREPLUi(true);
     if (jackInTerminal !== undefined) {
         jackInTerminal.dispose();
         jackInTerminal = undefined;
@@ -179,7 +180,7 @@ async function getProjectConnectSequence(): Promise<ReplConnectSequence> {
 }
 
 export async function calvaJackIn() {
-    state.extensionContext.workspaceState.update('needREPLUi', true);
+    utilities.updateNeedREPLUi(true);
     try {
         await state.initProjectDir();
     } catch (e) {
@@ -226,8 +227,7 @@ export async function calvaDisconnect() {
     if (utilities.getConnectedState()) {
         connector.default.disconnect();
         return;
-    } else if (utilities.getConnectingState() ||
-        utilities.getLaunchingState()) {
+    } else if (utilities.getConnectingState() || utilities.getLaunchingState()) {
         vscode.window.showInformationMessage(
             "Do you want to interrupt the connection process?",
             { modal: true },

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -179,6 +179,7 @@ async function getProjectConnectSequence(): Promise<ReplConnectSequence> {
 }
 
 export async function calvaJackIn() {
+    state.extensionContext.workspaceState.update('needREPLUi', true);
     try {
         await state.initProjectDir();
     } catch (e) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -118,7 +118,7 @@ function config() {
         autoOpenREPLWindow: configOptions.get("autoOpenREPLWindow") as boolean,
         autoOpenJackInTerminal: configOptions.get("autoOpenJackInTerminal") as boolean,
         referencesCodeLensEnabled: configOptions.get('referencesCodeLens.enabled') as boolean,
-        hideREPLUi: configOptions.get('hideREPLUi') as boolean,
+        hideReplUi: configOptions.get('hideReplUi') as boolean,
     };
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -118,6 +118,7 @@ function config() {
         autoOpenREPLWindow: configOptions.get("autoOpenREPLWindow") as boolean,
         autoOpenJackInTerminal: configOptions.get("autoOpenJackInTerminal") as boolean,
         referencesCodeLensEnabled: configOptions.get('referencesCodeLens.enabled') as boolean,
+        hideREPLUi: configOptions.get('hideREPLUi') as boolean,
     };
 }
 

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,11 +1,25 @@
+import * as vscode from 'vscode';
 import * as namespace from './namespace';
 import statusbar from './statusbar';
+import * as state from './state';
 
-function update() {
+function updateNeedREPLUi(isNeeded: boolean, context = state.extensionContext) {
+    context.workspaceState.update('needREPLUi', isNeeded);
+    update(context);
+}
+
+function shouldShowREPLUi(context = state.extensionContext): boolean {
+    return context.workspaceState.get('needREPLUi') || !state.config().hideREPLUi;
+}
+
+function update(context = state.extensionContext) {
+    vscode.commands.executeCommand('setContext', 'calva:showREPLUi', shouldShowREPLUi(context));
     namespace.updateREPLSessionType();
-    statusbar.update();
+    statusbar.update(context);
 }
 
 export default {
-    update
+    update,
+    updateNeedREPLUi,
+    shouldShowREPLUi
 };

--- a/src/status.ts
+++ b/src/status.ts
@@ -3,23 +3,23 @@ import * as namespace from './namespace';
 import statusbar from './statusbar';
 import * as state from './state';
 
-function updateNeedREPLUi(isNeeded: boolean, context = state.extensionContext) {
-    context.workspaceState.update('needREPLUi', isNeeded);
+function updateNeedReplUi(isNeeded: boolean, context = state.extensionContext) {
+    context.workspaceState.update('needReplUi', isNeeded);
     update(context);
 }
 
-function shouldShowREPLUi(context = state.extensionContext): boolean {
-    return context.workspaceState.get('needREPLUi') || !state.config().hideREPLUi;
+function shouldshowReplUi(context = state.extensionContext): boolean {
+    return context.workspaceState.get('needReplUi') || !state.config().hideReplUi;
 }
 
 function update(context = state.extensionContext) {
-    vscode.commands.executeCommand('setContext', 'calva:showREPLUi', shouldShowREPLUi(context));
+    vscode.commands.executeCommand('setContext', 'calva:showReplUi', shouldshowReplUi(context));
     namespace.updateREPLSessionType();
     statusbar.update(context);
 }
 
 export default {
     update,
-    updateNeedREPLUi,
-    shouldShowREPLUi
+    updateNeedReplUi,
+    shouldshowReplUi
 };

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -93,7 +93,7 @@ function update(context = state.extensionContext) {
         connectionStatus.color = colorValue("disconnectedColor", currentConf);
         connectionStatus.command = "calva.jackInOrConnect";
     }
-    if (status.shouldShowREPLUi(context)) {
+    if (status.shouldshowReplUi(context)) {
         connectionStatus.show();
         typeStatus.show();
         if (cljsBuildStatus.text) {

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -14,7 +14,7 @@ const color = {
 };
 
 function colorValue(section: string, currentConf: vscode.WorkspaceConfiguration): string {
-    let { defaultValue, globalValue, workspaceFolderValue, workspaceValue} = currentConf.inspect(section);
+    let { defaultValue, globalValue, workspaceFolderValue, workspaceValue } = currentConf.inspect(section);
     return (workspaceFolderValue || workspaceValue || globalValue || defaultValue) as string;
 }
 
@@ -92,15 +92,21 @@ function update() {
         connectionStatus.color = colorValue("disconnectedColor", currentConf);
         connectionStatus.command = "calva.jackInOrConnect";
     }
-
-    connectionStatus.show();
-    typeStatus.show();
-    if (cljsBuildStatus.text) {
-        cljsBuildStatus.show();
+    if (util.showREPLUi()) {
+        connectionStatus.show();
+        typeStatus.show();
+        if (cljsBuildStatus.text) {
+            cljsBuildStatus.show();
+        } else {
+            cljsBuildStatus.hide();
+        }
+        prettyPrintToggle.show();
     } else {
+        connectionStatus.hide();
+        typeStatus.hide();
         cljsBuildStatus.hide();
+        prettyPrintToggle.hide();
     }
-    prettyPrintToggle.show();
 }
 
 export default {

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -3,6 +3,7 @@ import * as state from './state';
 import * as util from './utilities';
 import config from './config';
 import * as namespace from './namespace';
+import status from './status';
 
 const connectionStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
 const typeStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
@@ -18,7 +19,7 @@ function colorValue(section: string, currentConf: vscode.WorkspaceConfiguration)
     return (workspaceFolderValue || workspaceValue || globalValue || defaultValue) as string;
 }
 
-function update() {
+function update(context = state.extensionContext) {
 
     let currentConf = vscode.workspace.getConfiguration('calva.statusColor');
 
@@ -92,7 +93,7 @@ function update() {
         connectionStatus.color = colorValue("disconnectedColor", currentConf);
         connectionStatus.command = "calva.jackInOrConnect";
     }
-    if (util.showREPLUi()) {
+    if (status.shouldShowREPLUi(context)) {
         connectionStatus.show();
         typeStatus.show();
         if (cljsBuildStatus.text) {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -405,6 +405,11 @@ function currentTopLevelFunction(editor: vscode.TextEditor) {
     }
 }
 
+function showREPLUi(): boolean {
+    return state.extensionContext.workspaceState.get('needREPLUi') ||
+    !state.config().hideREPLUi;
+}
+
 export {
     getStartExpression,
     getWordAtPosition,
@@ -439,5 +444,6 @@ export {
     getJarContents,
     currentFormText,
     currentFunction,
-    currentTopLevelFunction
+    currentTopLevelFunction,
+    showREPLUi
 };

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -406,16 +406,6 @@ function currentTopLevelFunction(editor: vscode.TextEditor) {
     }
 }
 
-function updateNeedREPLUi(isNeeded: boolean) {
-    state.extensionContext.workspaceState.update('needREPLUi', isNeeded);
-    status.update();
-}
-
-function showREPLUi(): boolean {
-    return state.extensionContext.workspaceState.get('needREPLUi') ||
-    !state.config().hideREPLUi;
-}
-
 export {
     getStartExpression,
     getWordAtPosition,
@@ -450,7 +440,5 @@ export {
     getJarContents,
     currentFormText,
     currentFunction,
-    currentTopLevelFunction,
-    updateNeedREPLUi,
-    showREPLUi
+    currentTopLevelFunction
 };

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -8,6 +8,7 @@ import * as JSZip from 'jszip';
 import select from './select';
 import * as outputWindow from './results-output/results-doc';
 import * as docMirror from './doc-mirror';
+import status from './status';
 
 const specialWords = ['-', '+', '/', '*']; //TODO: Add more here
 const syntaxQuoteSymbol = "`";
@@ -405,6 +406,11 @@ function currentTopLevelFunction(editor: vscode.TextEditor) {
     }
 }
 
+function updateNeedREPLUi(isNeeded: boolean) {
+    state.extensionContext.workspaceState.update('needREPLUi', isNeeded);
+    status.update();
+}
+
 function showREPLUi(): boolean {
     return state.extensionContext.workspaceState.get('needREPLUi') ||
     !state.config().hideREPLUi;
@@ -445,5 +451,6 @@ export {
     currentFormText,
     currentFunction,
     currentTopLevelFunction,
+    updateNeedREPLUi,
     showREPLUi
 };


### PR DESCRIPTION
## What has Changed?

Following discussions in the `#lsp` and `#chlorine-clover` channels at Clojurians Slack, regarding how to give `clojure-lsp` and things like Calva's formatter, Paredit, code highlighting and such to Clover users, @ericdallo suggested a not-so-costly alternative: Since Calva brings all this. _Make it easier to use Calva only for its static services._

Which makes a lot of sense. I have spent a lot of time trying to  make Calva format etcetera available seperately, to pull apart what I once joined (for good reasons). I still think that is the real solution, but it is hard for me to motivate myself using time I can spend on serving Calva users, to make non-Calva-users happy. This is a good interim solution, until someone signs up for the real one. It also happens to possibly attract more Calva users. Haha. 😄 (Jokes, aside, it is good that more people have the Calva REPL a keystroke away, we do think it is quite awesome, right?.)

In this PR I have added a user setting, `calva.hideREPLUi` that affect how the status bar, command palette and editor context menus behave. When the settings is active, the status bar won't show Calva REPL items, the command palette won't show Calva REPL commands and the editor context menu won't either. The only commands still visible are for connecting or starting a REPL. And when the user does that, the REPL UI is enabled again, until Calva's REPL is disconnected.

Fixes #1005 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Added to or updated docs in this branch, if appropriate

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->