### PR TITLE
Fix completion info call to use the correct ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Completion not working with babashka](https://github.com/BetterThanTomorrow/calva/issues/1083)
 
 ## [2.0.182] - 2021-03-26
 - [Use graalvm-compiled native image for clojure-lsp instead of jar](https://github.com/BetterThanTomorrow/calva/issues/1017)

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -64,13 +64,13 @@ export default class CalvaCompletionItemProvider implements CompletionItemProvid
     }
 
     async resolveCompletionItem(item: CompletionItem, token: CancellationToken) {
-
         if (util.getConnectedState()) {
             let client = replSession.getSession(util.getFileType(window.activeTextEditor.document));
             if (client) {
                 await namespace.createNamespaceFromDocumentIfNotExists(window.activeTextEditor.document);
-                let result = await client.info(item.insertText["ns"], item.label)
-                let [doc, details] = infoparser.getCompletion(result);
+                const ns = namespace.getDocumentNamespace();
+                const result = await client.info(ns, item.label)
+                const [doc, details] = infoparser.getCompletion(result);
                 item.documentation = doc;
                 item.detail = details;
             }


### PR DESCRIPTION
## What has Changed?

For the documentation part of the completion handler we were sending along whatever was in the `"ns"` entry in the `item`'s `insertText` property. (In the case of symbols with aliased namespaces, this seems to have been the aliased namespace itself, how that could be I do not understand, but it is cool in a way.)

Now we send the document's namespace as any civilized nrepl client should be doing.

Fixes #1083

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

Ping @bpringe
