### PR TITLE
Add `clojure-lsp` version setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Make clojure-lsp version configurable](Make clojure-lsp version configurable by the user) and bump to `2021.03.30-20.42.34`
 
 ## [2.0.183] - 2021-03-30
 - [Stop printing to the output window when all evaluations are interrupted](https://github.com/BetterThanTomorrow/calva/issues/978)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
-- [Make clojure-lsp version configurable](Make clojure-lsp version configurable by the user) and bump to `2021.03.30-20.42.34`
+- [Make clojure-lsp version configurable by the user](https://github.com/BetterThanTomorrow/calva/issues/1088) and bump to `2021.03.30-20.42.34`
 
 ## [2.0.183] - 2021-03-30
 - [Stop printing to the output window when all evaluations are interrupted](https://github.com/BetterThanTomorrow/calva/issues/978)

--- a/package.json
+++ b/package.json
@@ -271,7 +271,7 @@
                     "calva.clojureLspVersion": {
                         "type": "string",
                         "default": "2021.03.30-20.42.34",
-                        "markdownDescription": "The version of `clojure-lsp` to download and use."
+                        "markdownDescription": "The version of `clojure-lsp` to download and use. (Will take effect after a reload of the project window.)"
                     },
                     "calva.openBrowserWhenFigwheelStarted": {
                         "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -268,6 +268,11 @@
                             "cider/piggieback": "0.5.2"
                         }
                     },
+                    "calva.clojureLspVersion": {
+                        "type": "string",
+                        "default": "2021.03.30-20.42.34",
+                        "markdownDescription": "The version of `clojure-lsp` to download and use."
+                    },
                     "calva.openBrowserWhenFigwheelStarted": {
                         "type": "boolean",
                         "default": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,6 @@ import { PrettyPrintingOptions } from './printer';
 const REPL_FILE_EXT = 'calva-repl';
 const KEYBINDINGS_ENABLED_CONFIG_KEY = 'calva.keybindingsEnabled';
 const KEYBINDINGS_ENABLED_CONTEXT_KEY = 'calva:keybindingsEnabled';
-const CLOJURE_LSP_VERSION = '2021.03.24-00.41.55';
 
 type ReplSessionType = 'clj' | 'cljs';
 
@@ -39,6 +38,7 @@ function getConfig() {
         showDocstringInParameterHelp: configOptions.get("showDocstringInParameterHelp") as boolean,
         jackInEnv: configOptions.get("jackInEnv"),
         jackInDependencyVersions: configOptions.get("jackInDependencyVersions") as { JackInDependency: string },
+        clojureLspVersion: configOptions.get("clojureLspVersion") as string,
         openBrowserWhenFigwheelStarted: configOptions.get("openBrowserWhenFigwheelStarted") as boolean,
         customCljsRepl: configOptions.get("customCljsRepl", null),
         replConnectSequences: configOptions.get("replConnectSequences") as ReplConnectSequence[],
@@ -63,7 +63,6 @@ export {
     REPL_FILE_EXT,
     KEYBINDINGS_ENABLED_CONFIG_KEY,
     KEYBINDINGS_ENABLED_CONTEXT_KEY,
-    CLOJURE_LSP_VERSION,
     documentSelector,
     ReplSessionType,
     getConfig

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -238,8 +238,9 @@ async function activate(context: vscode.ExtensionContext): Promise<void> {
     const extensionPath = context.extensionPath;
     const currentVersion = readVersionFile(extensionPath);
     let clojureLspPath = getClojureLspPath(extensionPath, util.isWindows);
-    if (currentVersion !== config.CLOJURE_LSP_VERSION) {
-        const downloadPromise = downloadClojureLsp(context.extensionPath, config.CLOJURE_LSP_VERSION);
+    const configuredVersion: string = config.getConfig().clojureLspVersion;
+    if (currentVersion !== configuredVersion) {
+        const downloadPromise = downloadClojureLsp(context.extensionPath, configuredVersion);
         vscode.window.setStatusBarMessage('$(sync~spin) Downloading clojure-lsp', downloadPromise);
         clojureLspPath = await downloadPromise;
     }


### PR DESCRIPTION
## What has Changed?

Add a setting `calva.clojureLspVersion` so that the user can control which version is used.

Also bumping the default version to `2021.03.30-20.42.34`.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Closes #1088 

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- ~[ ] Added to or updated docs in this branch, if appropriate~ (I think the settings pane in VS Code is documentation enough)


Ping @bpringe
