### PR TITLE
Improve our cursor-doc test utilities some

### DIFF
--- a/src/extension-test/unit/common/text-notation.ts
+++ b/src/extension-test/unit/common/text-notation.ts
@@ -14,7 +14,7 @@ import * as model from '../../../cursor-doc/model';
  *   * Selections with direction left->right are denoted with `|<|` at the range boundaries
  */
 
-function dotToNl(s: string): [string, model.ModelEditSelection] {
+function textNotationToTextAndSelection(s: string): [string, { anchor: number, active: number }] {
     const text = s.replace(/•/g, '\n').replace(/\|?[<>]?\|/g, '');
     let anchor = undefined;
     let active = undefined;
@@ -40,19 +40,18 @@ function dotToNl(s: string): [string, model.ModelEditSelection] {
     }
     return [
         text,
-        new model.ModelEditSelection(anchor, active)
+        { anchor, active }
     ];
 }
 
 /**
- * Utility function to create a doc from dot-notated strings
- * Only handles translation of `•` to newline and `|` to selection for now
+ * Utility function to create a doc from text-notated strings
  */
-export function docFromDot(s: string): mock.MockDocument {
-    const [text, selection] = dotToNl(s);
+export function docFromTextNotation(s: string): mock.MockDocument {
+    const [text, selection] = textNotationToTextAndSelection(s);
     const doc = new mock.MockDocument();
     doc.insertString(text);
-    doc.selection = selection;
+    doc.selection = new model.ModelEditSelection(selection.anchor, selection.active);
     return doc;
 }
 

--- a/src/extension-test/unit/common/text-notation.ts
+++ b/src/extension-test/unit/common/text-notation.ts
@@ -14,7 +14,7 @@ import * as model from '../../../cursor-doc/model';
  *   * Selections with direction left->right are denoted with `|<|` at the range boundaries
  */
 
-export function dotToNl(s: string): [string, model.ModelEditSelection] {
+function dotToNl(s: string): [string, model.ModelEditSelection] {
     const text = s.replace(/•/g, '\n').replace(/\|?[<>]?\|/g, '');
     let anchor = undefined;
     let active = undefined;

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1,7 +1,7 @@
 import * as expect from 'expect';
 import * as paredit from '../../../cursor-doc/paredit';
 import * as mock from '../common/mock';
-import { docFromDot, textAndSelection, dotToNl } from '../common/text-notation';
+import { docFromDot, textAndSelection } from '../common/text-notation';
 import { ModelEditSelection } from '../../../cursor-doc/model';
 
 /**
@@ -322,77 +322,61 @@ describe('paredit', () => {
             });
 
             it('drags forward in regular lists', () => {
-                const doc = docFromDot(`(c• [:|f '(0 "t")•   "b" :s]•)`);
-                const [afterText, afterCursor] = dotToNl(`(c• ['(0 "t") :|f•   "b" :s]•)`);
-                paredit.dragSexprForward(doc);
-                expect(doc.model.getText(0, Infinity)).toBe(afterText);
-                expect(doc.selection).toEqual(afterCursor);
+                const a = docFromDot(`(c• [:|f '(0 "t")•   "b" :s]•)`);
+                const b = docFromDot(`(c• ['(0 "t") :|f•   "b" :s]•)`);
+                paredit.dragSexprForward(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('drags backward in regular lists', () => {
-                const doc = docFromDot(`(c• [:f '(0 "t")•   "b"| :s]•)`);
-                const [afterText, afterCursor] = dotToNl(`(c• [:f "b"|•   '(0 "t") :s]•)`);
-                paredit.dragSexprBackward(doc);
-                expect(doc.model.getText(0, Infinity)).toBe(afterText);
-                expect(doc.selection).toEqual(afterCursor);
+                const a = docFromDot(`(c• [:f '(0 "t")•   "b"| :s]•)`);
+                const b = docFromDot(`(c• [:f "b"|•   '(0 "t") :s]•)`);
+                paredit.dragSexprBackward(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('does not drag forward when sexpr is last in regular lists', () => {
                 const dotText = `(c• [:f '(0 "t")•   "b" |:s ]•)`;
-                const doc = docFromDot(dotText);
-                const [afterText, afterCursor] = dotToNl(dotText);
-                paredit.dragSexprForward(doc);
-                expect(doc.model.getText(0, Infinity)).toBe(afterText);
-                expect(doc.selection).toEqual(afterCursor);
+                const a = docFromDot(dotText);
+                const b = docFromDot(dotText);
+                paredit.dragSexprForward(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('does not drag backward when sexpr is last in regular lists', () => {
                 const dotText = `(c• [ :|f '(0 "t")•   "b" :s ]•)`;
-                const doc = docFromDot(dotText);
-                const [afterText, afterCursor] = dotToNl(dotText);
-                paredit.dragSexprBackward(doc);
-                expect(doc.model.getText(0, Infinity)).toBe(afterText);
-                expect(doc.selection).toEqual(afterCursor);
+                const a = docFromDot(dotText);
+                const b = docFromDot(dotText);
+                paredit.dragSexprBackward(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('drags pair forward in maps', () => {
-                const bDot = `(c• {:|e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`;
-                const aDot = `(c• {3 {:w? 'w}•   :|e '(e o ea)•   :t '(t i o im)•   :b 'b}•)`;
-                const doc = docFromDot(bDot);
-                const [afterText, afterCursor] = dotToNl(aDot);
-                paredit.dragSexprForward(doc);
-                expect(doc.model.getText(0, Infinity)).toBe(afterText);
-                expect(doc.selection).toEqual(afterCursor);
+                const a = docFromDot(`(c• {:|e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`);
+                const b = docFromDot(`(c• {3 {:w? 'w}•   :|e '(e o ea)•   :t '(t i o im)•   :b 'b}•)`);
+                paredit.dragSexprForward(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('drags pair backwards in maps', () => {
-                const bDot = `(c• {:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)|•   :b 'b}•)`;
-                const aDot = `(c• {:e '(e o ea)•   :t '(t i o im)|•   3 {:w? 'w}•   :b 'b}•)`;
-                const doc = docFromDot(bDot);
-                const [afterText, afterCursor] = dotToNl(aDot);
-                paredit.dragSexprBackward(doc);
-                expect(doc.model.getText(0, Infinity)).toBe(afterText);
-                expect(doc.selection).toEqual(afterCursor);
+                const a = docFromDot(`(c• {:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)|•   :b 'b}•)`);
+                const b = docFromDot(`(c• {:e '(e o ea)•   :t '(t i o im)|•   3 {:w? 'w}•   :b 'b}•)`);
+                paredit.dragSexprBackward(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('drags pair backwards in meta-data maps', () => {
-                const bDot = `(c• ^{:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)|•   :b 'b}•)`;
-                const aDot = `(c• ^{:e '(e o ea)•   :t '(t i o im)|•   3 {:w? 'w}•   :b 'b}•)`;
-                const doc = docFromDot(bDot);
-                const [afterText, afterCursor] = dotToNl(aDot);
-                paredit.dragSexprBackward(doc);
-                expect(doc.model.getText(0, Infinity)).toBe(afterText);
-                expect(doc.selection).toEqual(afterCursor);
+                const a = docFromDot(`(c• ^{:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)|•   :b 'b}•)`);
+                const b = docFromDot(`(c• ^{:e '(e o ea)•   :t '(t i o im)|•   3 {:w? 'w}•   :b 'b}•)`);
+                paredit.dragSexprBackward(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('drags single sexpr forward in sets', () => {
-                const bDot = `(c• #{:|e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`;
-                const aDot = `(c• #{'(e o ea) :|e•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`;
-                const doc = docFromDot(bDot);
-                const [afterText, afterCursor] = dotToNl(aDot);
-                paredit.dragSexprForward(doc);
-                expect(doc.model.getText(0, Infinity)).toBe(afterText);
-                expect(doc.selection).toEqual(afterCursor);
+                const a = docFromDot(`(c• #{:|e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`);
+                const b = docFromDot(`(c• #{'(e o ea) :|e•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`);
+                paredit.dragSexprForward(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('drags pair in binding box', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1,7 +1,7 @@
 import * as expect from 'expect';
 import * as paredit from '../../../cursor-doc/paredit';
 import * as mock from '../common/mock';
-import { docFromDot, textAndSelection } from '../common/text-notation';
+import { docFromTextNotation, textAndSelection } from '../common/text-notation';
 import { ModelEditSelection } from '../../../cursor-doc/model';
 
 /**
@@ -236,16 +236,16 @@ describe('paredit', () => {
         describe('selectRangeBackward', () => {
             // TODO: Fix #498
             it('Extends backward selections backwards', () => {
-                const a = docFromDot('(def foo [:foo :bar |<|:baz|<|])');
-                const selDoc = docFromDot('(def foo [:foo |:bar| :baz])');
-                const b = docFromDot('(def foo [:foo |<|:bar :baz|<|])');
+                const a = docFromTextNotation('(def foo [:foo :bar |<|:baz|<|])');
+                const selDoc = docFromTextNotation('(def foo [:foo |:bar| :baz])');
+                const b = docFromTextNotation('(def foo [:foo |<|:bar :baz|<|])');
                 paredit.selectRangeBackward(a, [selDoc.selection.anchor, selDoc.selection.active]);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Contracts forward selection and extends backwards', () => {
-                const a = docFromDot('(def foo [:foo :bar |>|:baz|>|])');
-                const selDoc = docFromDot('(def foo [:foo |:bar| :baz])');
-                const b = docFromDot('(def foo [:foo |<|:bar |<|:baz])');
+                const a = docFromTextNotation('(def foo [:foo :bar |>|:baz|>|])');
+                const selDoc = docFromTextNotation('(def foo [:foo |:bar| :baz])');
+                const b = docFromTextNotation('(def foo [:foo |<|:bar |<|:baz])');
                 paredit.selectRangeBackward(a, [selDoc.selection.anchor, selDoc.selection.active]);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
@@ -322,66 +322,66 @@ describe('paredit', () => {
             });
 
             it('drags forward in regular lists', () => {
-                const a = docFromDot(`(c• [:|f '(0 "t")•   "b" :s]•)`);
-                const b = docFromDot(`(c• ['(0 "t") :|f•   "b" :s]•)`);
+                const a = docFromTextNotation(`(c• [:|f '(0 "t")•   "b" :s]•)`);
+                const b = docFromTextNotation(`(c• ['(0 "t") :|f•   "b" :s]•)`);
                 paredit.dragSexprForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('drags backward in regular lists', () => {
-                const a = docFromDot(`(c• [:f '(0 "t")•   "b"| :s]•)`);
-                const b = docFromDot(`(c• [:f "b"|•   '(0 "t") :s]•)`);
+                const a = docFromTextNotation(`(c• [:f '(0 "t")•   "b"| :s]•)`);
+                const b = docFromTextNotation(`(c• [:f "b"|•   '(0 "t") :s]•)`);
                 paredit.dragSexprBackward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('does not drag forward when sexpr is last in regular lists', () => {
                 const dotText = `(c• [:f '(0 "t")•   "b" |:s ]•)`;
-                const a = docFromDot(dotText);
-                const b = docFromDot(dotText);
+                const a = docFromTextNotation(dotText);
+                const b = docFromTextNotation(dotText);
                 paredit.dragSexprForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('does not drag backward when sexpr is last in regular lists', () => {
                 const dotText = `(c• [ :|f '(0 "t")•   "b" :s ]•)`;
-                const a = docFromDot(dotText);
-                const b = docFromDot(dotText);
+                const a = docFromTextNotation(dotText);
+                const b = docFromTextNotation(dotText);
                 paredit.dragSexprBackward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('drags pair forward in maps', () => {
-                const a = docFromDot(`(c• {:|e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`);
-                const b = docFromDot(`(c• {3 {:w? 'w}•   :|e '(e o ea)•   :t '(t i o im)•   :b 'b}•)`);
+                const a = docFromTextNotation(`(c• {:|e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`);
+                const b = docFromTextNotation(`(c• {3 {:w? 'w}•   :|e '(e o ea)•   :t '(t i o im)•   :b 'b}•)`);
                 paredit.dragSexprForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('drags pair backwards in maps', () => {
-                const a = docFromDot(`(c• {:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)|•   :b 'b}•)`);
-                const b = docFromDot(`(c• {:e '(e o ea)•   :t '(t i o im)|•   3 {:w? 'w}•   :b 'b}•)`);
+                const a = docFromTextNotation(`(c• {:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)|•   :b 'b}•)`);
+                const b = docFromTextNotation(`(c• {:e '(e o ea)•   :t '(t i o im)|•   3 {:w? 'w}•   :b 'b}•)`);
                 paredit.dragSexprBackward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('drags pair backwards in meta-data maps', () => {
-                const a = docFromDot(`(c• ^{:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)|•   :b 'b}•)`);
-                const b = docFromDot(`(c• ^{:e '(e o ea)•   :t '(t i o im)|•   3 {:w? 'w}•   :b 'b}•)`);
+                const a = docFromTextNotation(`(c• ^{:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)|•   :b 'b}•)`);
+                const b = docFromTextNotation(`(c• ^{:e '(e o ea)•   :t '(t i o im)|•   3 {:w? 'w}•   :b 'b}•)`);
                 paredit.dragSexprBackward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('drags single sexpr forward in sets', () => {
-                const a = docFromDot(`(c• #{:|e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`);
-                const b = docFromDot(`(c• #{'(e o ea) :|e•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`);
+                const a = docFromTextNotation(`(c• #{:|e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`);
+                const b = docFromTextNotation(`(c• #{'(e o ea) :|e•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`);
                 paredit.dragSexprForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
 
             it('drags pair in binding box', () => {
-                const b = docFromDot(`(c• [:e '(e o ea)•   3 {:w? 'w}•   :t |'(t i o im)•   :b 'b]•)`);
-                const a = docFromDot(`(c• [:e '(e o ea)•   3 {:w? 'w}•   :b 'b•   :t |'(t i o im)]•)`);
+                const b = docFromTextNotation(`(c• [:e '(e o ea)•   3 {:w? 'w}•   :t |'(t i o im)•   :b 'b]•)`);
+                const a = docFromTextNotation(`(c• [:e '(e o ea)•   3 {:w? 'w}•   :b 'b•   :t |'(t i o im)]•)`);
                 paredit.dragSexprForward(b, ['c']);
                 expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
             });

--- a/src/extension-test/unit/util/get-text-test.ts
+++ b/src/extension-test/unit/util/get-text-test.ts
@@ -1,7 +1,6 @@
 import * as expect from 'expect';
-import { LispTokenCursor } from '../../../cursor-doc/token-cursor';
 import * as mock from '../common/mock';
-import { docFromDot, textAndSelection, dotToNl } from '../common/text-notation';
+import { docFromDot } from '../common/text-notation';
 import * as getText from '../../../util/cursor-get-text';
 
 describe('getTopLevelFunction', () => {

--- a/src/extension-test/unit/util/get-text-test.ts
+++ b/src/extension-test/unit/util/get-text-test.ts
@@ -1,25 +1,25 @@
 import * as expect from 'expect';
 import * as mock from '../common/mock';
-import { docFromDot } from '../common/text-notation';
+import { docFromTextNotation } from '../common/text-notation';
 import * as getText from '../../../util/cursor-get-text';
 
 describe('getTopLevelFunction', () => {
     it('Finds top level function at top', () => {
-        const doc: mock.MockDocument = docFromDot('(foo bar)•(deftest a-test•  (baz |gaz))');
-        const selDoc: mock.MockDocument = docFromDot('(foo bar)•(deftest |a-test|•  (baz gaz))');
+        const doc: mock.MockDocument = docFromTextNotation('(foo bar)•(deftest a-test•  (baz |gaz))');
+        const selDoc: mock.MockDocument = docFromTextNotation('(foo bar)•(deftest |a-test|•  (baz gaz))');
         expect(getText.currentTopLevelFunction(doc)).toEqual([[selDoc.selectionLeft, selDoc.selectionRight], 'a-test']);
     });
     
     it('Finds top level function when nested', () => {
-        const doc: mock.MockDocument = docFromDot('(foo bar)•(with-test•  (deftest a-test•    (baz |gaz)))');
-        const selDoc: mock.MockDocument = docFromDot('(foo bar)•(with-test•  (deftest |a-test|•    (baz gaz)))');
+        const doc: mock.MockDocument = docFromTextNotation('(foo bar)•(with-test•  (deftest a-test•    (baz |gaz)))');
+        const selDoc: mock.MockDocument = docFromTextNotation('(foo bar)•(with-test•  (deftest |a-test|•    (baz gaz)))');
         expect(getText.currentTopLevelFunction(doc)).toEqual([[selDoc.selectionLeft, selDoc.selectionRight], 'a-test']);
     });
 
     it('Finds top level function when namespaced def-macro', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1086
-        const doc: mock.MockDocument = docFromDot('(foo bar)•(with-test•  (t/deftest a-test•    (baz |gaz)))');
-        const selDoc: mock.MockDocument = docFromDot('(foo bar)•(with-test•  (t/deftest |a-test|•    (baz gaz)))');
+        const doc: mock.MockDocument = docFromTextNotation('(foo bar)•(with-test•  (t/deftest a-test•    (baz |gaz)))');
+        const selDoc: mock.MockDocument = docFromTextNotation('(foo bar)•(with-test•  (t/deftest |a-test|•    (baz gaz)))');
         expect(getText.currentTopLevelFunction(doc)).toEqual([[selDoc.selectionLeft, selDoc.selectionRight], 'a-test']);
     });
 


### PR DESCRIPTION
In preparation for fixing some paredit issues I have made the test-text notation a bit more formal and also implemented support for the ”language”:

```typescript
/**
 * Text Notation for expressing states of a document, including
 * current text and selection. 
 * * Since JavasScript makes it clumsy with multiline strings,
 *   newlines are denoted with a middle dot character: `•`
 * * Selections are denoted like so
 *   * Single position selections are denoted with a single `|`.
 *   * Selections w/o direction are denoted with `|` at the range's boundaries.
 *   * Selections with direction left->right are denoted with `|>|` at the range boundaries
 *   * Selections with direction left->right are denoted with `|<|` at the range boundaries
 */
````

So that now we can express tests like so:

```typescript
            it('drags forward in regular lists', () => {
                const a = docFromTextNotation(`(c• [:|f '(0 "t")•   "b" :s]•)`);
                const b = docFromTextNotation(`(c• ['(0 "t") :|f•   "b" :s]•)`);
                paredit.dragSexprForward(a);
                expect(textAndSelection(a)).toEqual(textAndSelection(b));
            });
```

Like so:

```typescript
            it('Extends backward selections backwards', () => {
                const a = docFromTextNotation('(def foo [:foo :bar |<|:baz|<|])');
                const selDoc = docFromTextNotation('(def foo [:foo |:bar| :baz])');
                const b = docFromTextNotation('(def foo [:foo |<|:bar :baz|<|])');
                paredit.selectRangeBackward(a, [selDoc.selection.anchor, selDoc.selection.active]);
                expect(textAndSelection(a)).toEqual(textAndSelection(b));
            });
```

Like so: 

```typescript
    it('Finds top level function when nested', () => {
        const doc: mock.MockDocument = docFromTextNotation('(foo bar)•(with-test•  (deftest a-test•    (baz |gaz)))');
        const selDoc: mock.MockDocument = docFromTextNotation('(foo bar)•(with-test•  (deftest |a-test|•    (baz gaz)))');
        expect(getText.currentTopLevelFunction(doc)).toEqual([[selDoc.selectionLeft, selDoc.selectionRight], 'a-test']);
    });
```

I also refactored the code around this a bit.

There are some new and old tests using this now as a proof of concept. As a somewhat huge TODO we should replace all cursor-doc-involving tests to use this. But we can take that piece by piece as we go.

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- ~[ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.~
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *There is a CircleCI bug that makes the Artifacts hard to find. Please see [this issue](https://discuss.circleci.com/t/artifacts-tab-not-showing-unless-logged-in/32433) for workarounds.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- ~[ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.~
- ~[ ] Added to or updated docs in this branch, if appropriate~

Ping @bpringe