### PR TITLE
1122 paredit backspace in open token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Paredit backspace should delete non-bracket parts of the opening token](https://github.com/BetterThanTomorrow/calva/issues/1122)
 
 ## [2.0.188] - 2021-04-16
 - Fix: [Getting Started REPL failing on Windows when username has spaces (on some machines)](https://github.com/BetterThanTomorrow/calva/issues/1085)

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -470,7 +470,7 @@ export function backspace(doc: EditableDocument, start: number = doc.selection.a
     } else {
         const nextToken = cursor.getToken();
         const p = start;
-        const prevToken = p > cursor.offsetStart ? nextToken : cursor.getPrevToken();
+        const prevToken = p > cursor.offsetStart && !['open', 'close'].includes(nextToken.type) ? nextToken : cursor.getPrevToken();
         if (prevToken.type == 'prompt') {
             return new Promise<boolean>(resolve => resolve(true));
         } else if (nextToken.type == 'prompt') {

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -463,7 +463,7 @@ export function close(doc: EditableDocument, close: string, start: number = doc.
     }
 }
 
-export function backspace(doc: EditableDocument, start: number = doc.selectionLeft, end: number = doc.selectionRight): Thenable<boolean> {
+export function backspace(doc: EditableDocument, start: number = doc.selection.anchor, end: number = doc.selection.active): Thenable<boolean> {
     const cursor = doc.getTokenCursor(start);
     if (start != end) {
         return doc.backspace();
@@ -485,7 +485,7 @@ export function backspace(doc: EditableDocument, start: number = doc.selectionLe
             ], { selection: new ModelEditSelection(p - prevToken.raw.length) });
         } else {
             if (['open', 'close'].includes(prevToken.type) && docIsBalanced(doc)) {
-                doc.selection = new ModelEditSelection(p - 1);
+                doc.selection = new ModelEditSelection(p - prevToken.raw.length);
                 return new Promise<boolean>(resolve => resolve(true));
             } else {
                 return doc.backspace();

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -670,6 +670,32 @@ describe('paredit', () => {
                 paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
+            it('Deletes open paren prefix characters', () => {
+                // https://github.com/BetterThanTomorrow/calva/issues/1122
+                const a = docFromTextNotation('#|(foo)');
+                const b = docFromTextNotation('|(foo)');
+                paredit.backspace(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
+            });
+            it('Deletes open map curly prefix/ns characters', () => {
+                const a = docFromTextNotation('#:same|{:thing :here}');
+                const b = docFromTextNotation('#:sam|{:thing :here}');
+                paredit.backspace(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
+            });
+            it('Deletes open set hash characters', () => {
+                // https://github.com/BetterThanTomorrow/calva/issues/1122
+                const a = docFromTextNotation('#|{:thing :here}');
+                const b = docFromTextNotation('|{:thing :here}');
+                paredit.backspace(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
+            });
+            it('Moves cursor past entire open paren, including prefix characters', () => {
+                const a = docFromTextNotation('#(|foo)');
+                const b = docFromTextNotation('|#(foo)');
+                paredit.backspace(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
+            });
         });
 
         describe('Kill character forwards (delete)', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -633,6 +633,12 @@ describe('paredit', () => {
                 paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
+            it('Deletes contents in strings 3', () => {
+                const a = docFromTextNotation('{::foo "aa|"• ::bar :foo}');
+                const b = docFromTextNotation('{::foo "a|"• ::bar :foo}');
+                paredit.backspace(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
+            });
             it('Deletes quoted quote', () => {
                 const a = docFromTextNotation('{::foo \\"|• ::bar :foo}');
                 const b = docFromTextNotation('{::foo |• ::bar :foo}');
@@ -693,6 +699,13 @@ describe('paredit', () => {
             it('Moves cursor past entire open paren, including prefix characters', () => {
                 const a = docFromTextNotation('#(|foo)');
                 const b = docFromTextNotation('|#(foo)');
+                paredit.backspace(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
+            });
+            it('Moves cursor only past the open curly for namespaced maps', () => {
+                // Could be argued it should move past the entire reader tag, but anyway
+                const a = docFromTextNotation('#:same{|:thing :here}');
+                const b = docFromTextNotation('#:same|{:thing :here}');
                 paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });


### PR DESCRIPTION
## What has Changed?

Paredit strict backspace now deletes the non-bracket parts of the opening token:

`#|(foo)` <kbd>backspace</kbd> => `|(foo)`

 And from inside a list, when protecting from deleting the open token the cursor jumps past the whole opening token:

`#(|foo)` <kbd>backspace</kbd> => `|#(foo)`

Fixes #1122

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

## The Calva Team PR Checklist:

Ping @pez, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->