### PR TITLE
Fix Inline result displaying in wrong editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 - [Paredit backspace should delete non-bracket parts of the opening token](https://github.com/BetterThanTomorrow/calva/issues/1122)
 - [Use `shift+tab` for the ”Infer parens from indentation” command](https://github.com/BetterThanTomorrow/calva/issues/1126)
+- Fix: [Inline evaluation results can show up in the wrong editor](https://github.com/BetterThanTomorrow/calva/issues/1120)
 
 ## [2.0.188] - 2021-04-16
 - Fix: [Getting Started REPL failing on Windows when username has spaces (on some machines)](https://github.com/BetterThanTomorrow/calva/issues/1085)

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -54,6 +54,7 @@ async function evaluateCode(code: string, options, selection?: vscode.Selection)
     const filePath = options.filePath;
     const session: NReplSession = options.session;
     const ns = options.ns;
+    const editor = vscode.window.activeTextEditor;
 
     if (code.length > 0) {
         let err: string[] = [];
@@ -79,7 +80,6 @@ async function evaluateCode(code: string, options, selection?: vscode.Selection)
             outputWindow.append(value, (resultLocation) => {
                 if (selection) {
                     const c = selection.start.character;
-                    const editor = vscode.window.activeTextEditor;
                     if (options.replace) {
                         const indent = `${' '.repeat(c)}`,
                             edit = vscode.TextEdit.replace(selection, value.replace(/\n/gm, "\n" + indent)),
@@ -112,7 +112,6 @@ async function evaluateCode(code: string, options, selection?: vscode.Selection)
             const outputWindowError = err.length ? `; ${normalizeNewLinesAndJoin(err, true)}` : formatAsLineComments(e);
             outputWindow.append(outputWindowError, async (resultLocation, afterResultLocation) => {
                 if (selection) {
-                    const editor = vscode.window.activeTextEditor;
                     const editorError = util.stripAnsi(err.length ? err.join("\n") : e);
                     const currentCursorPos = editor.selection.active;
                     if (!outputWindow.isResultsDoc(editor.document)) {
@@ -142,7 +141,6 @@ async function evaluateSelection(document: {}, options) {
 
     if (getStateValue('connected')) {
         const editor = vscode.window.activeTextEditor;
-        const selection = editor.selection;
         let code = "";
         let codeSelection: vscode.Selection;
         state.analytics().logEvent("Evaluation", "selectionFn").send();


### PR DESCRIPTION
## What has Changed?

Figure out which editor to show the results in at evaluation time, rather than at annotation time.

Fixes #1120

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

Ping @pez, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->