### PR TITLE
Reinstall result hovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 - [Paredit backspace should delete non-bracket parts of the opening token](https://github.com/BetterThanTomorrow/calva/issues/1122)
 - [Use `shift+tab` for the ”Infer parens from indentation” command](https://github.com/BetterThanTomorrow/calva/issues/1126)
 - Fix: [Inline evaluation results can show up in the wrong editor](https://github.com/BetterThanTomorrow/calva/issues/1120)
+- [Bring back results in hovers](https://github.com/BetterThanTomorrow/calva/issues/736)
 
 ## [2.0.188] - 2021-04-16
 - Fix: [Getting Started REPL failing on Windows when username has spaces (on some machines)](https://github.com/BetterThanTomorrow/calva/issues/1085)

--- a/docs/site/output.md
+++ b/docs/site/output.md
@@ -63,21 +63,6 @@ If you have typed some text after the prompt before you start traversing up the 
 
 You can clear the repl history by running the command "Clear REPL History" from the command palette.
 
-## Peek at Results
-
-On smaller screens (or just depending on your taste) you might not have the output window visible side-by-side with your code, but rather in a tab in the same editor group.
-
-Then your immediate feedback will be the inline display, which is limited to the first line of the results. All is not lost, however, you can peek at the full results using VS Code's command **Peek Definition**. Calva adds a definition pointer ”in” to the evaluated code in the output window.
-
-![Peek at results](images/howto/output/peek-last-result.gif)
-
-(On Mac the default keyboard shortcut for the peek command is `alt+f12`.)
-
-In the demo gif we utilize two things about this peek widget:
-
-1. It stays open until you close it. So you can keep evaluating different versions of your form and see the results get printed.
-2. The widget displays a ”full” Calva editor, so you can use Paredit to conveniently select forms.
-
 ## Stack Traces
 
 When an evaluation produces an error, the output window will automatically print the the error message. If there is a stack trace associated with the error, this can now be printed on demand using the **Calva: Print Last Stacktrace to the Output Window** command. The output window will also have a Codelense button below the error message that will print the stack trace..

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,6 +178,7 @@ async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('calva.runAllTests', testRunner.runAllTestsCommand));
     context.subscriptions.push(vscode.commands.registerCommand('calva.rerunTests', testRunner.rerunTestsCommand));
     context.subscriptions.push(vscode.commands.registerCommand('calva.clearInlineResults', annotations.clearEvaluationDecorations));
+    context.subscriptions.push(vscode.commands.registerCommand('calva.copyAnnotationHoverText', annotations.copyHoverTextCommand));
     context.subscriptions.push(vscode.commands.registerCommand('calva.copyLastResults', eval.copyLastResultCommand));
     context.subscriptions.push(vscode.commands.registerCommand('calva.requireREPLUtilities', eval.requireREPLUtilitiesCommand));
     context.subscriptions.push(vscode.commands.registerCommand('calva.refresh', refresh.refresh));
@@ -222,7 +223,6 @@ async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.languages.registerHoverProvider(config.documentSelector, new HoverProvider()));
     context.subscriptions.push(vscode.languages.registerDefinitionProvider(config.documentSelector, new definition.ClojureDefinitionProvider()));
     context.subscriptions.push(vscode.languages.registerDefinitionProvider(config.documentSelector, new definition.StackTraceDefinitionProvider()));
-    context.subscriptions.push(vscode.languages.registerDefinitionProvider(config.documentSelector, new definition.ResultsDefinitionProvider()));
     context.subscriptions.push(vscode.languages.registerSignatureHelpProvider(config.documentSelector, new CalvaSignatureHelpProvider(), ' ', ' '));
 
 

--- a/src/providers/annotations.ts
+++ b/src/providers/annotations.ts
@@ -139,9 +139,11 @@ function decorateSelection(resultString: string, codeSelection: vscode.Selection
     decorationRanges = _.filter(decorationRanges, (o) => { return !o.range.intersection(codeSelection) });
     decoration["range"] = codeSelection;
     if (status != AnnotationStatus.PENDING && status != AnnotationStatus.REPL_WINDOW) {
-        const commandUri = `command:calva.showOutputWindow`,
-            commandMd = `[Open Results Window](${commandUri} "Open the results window")`;
-        let hoverMessage = new vscode.MarkdownString(commandMd);
+        const copyCommandUri = `command:calva.copyAnnotationHoverText?${encodeURIComponent(JSON.stringify([{ text: resultString }]))}`,
+        copyCommandMd = `[Copy](${copyCommandUri} "Copy results to the clipboard")`;
+        const openWindowCommandUri = `command:calva.showOutputWindow`,
+        openWindowCommandMd = `[Open Output Window](${openWindowCommandUri} "Open the output window")`;
+        const hoverMessage = new vscode.MarkdownString(`${copyCommandMd} | ${openWindowCommandMd}\n` + '```clojure\n' + resultString + '\n```');
         hoverMessage.isTrusted = true;
         decoration["hoverMessage"] = status == AnnotationStatus.ERROR ? resultString : hoverMessage;
     }
@@ -169,10 +171,14 @@ function onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent) {
     }
 }
 
+function copyHoverTextCommand(args: { [x: string]: string; }) {
+    vscode.env.clipboard.writeText(args["text"]);
+}
 export default {
     AnnotationStatus,
     clearEvaluationDecorations,
     clearAllEvaluationDecorations,
+    copyHoverTextCommand,
     decorateResults,
     decorateSelection,
     onDidChangeTextDocument,

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -51,13 +51,3 @@ export class StackTraceDefinitionProvider implements vscode.DefinitionProvider {
     }
   }
 }
-
-export class ResultsDefinitionProvider implements vscode.DefinitionProvider {
-  state: any;
-  constructor() {
-    this.state = state;
-  }
-  async provideDefinition(document, position, token) {
-    return annotations.getResultsLocation(position);
-  }
-}


### PR DESCRIPTION
## What has Changed?

I've resurrected the code for displaying the results and a way to copy them in the hover of the inline evaluation.

Also removed the peek, as it mostly is annoyance now when the results can be seen in the hover.

Fixes #736

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

Ping @pez, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->