### PR TITLE
Restore the right selection after eval to comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Wrong selection restored after eval-to-comment](https://github.com/BetterThanTomorrow/calva/issues/1131)
 
 ## [2.0.189] - 2021-04-18
 - [Paredit backspace should delete non-bracket parts of the opening token](https://github.com/BetterThanTomorrow/calva/issues/1122)

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -42,9 +42,8 @@ function interruptAllEvaluations() {
 async function addAsComment(c: number, result: string, codeSelection: vscode.Selection, editor: vscode.TextEditor, selection: vscode.Selection) {
     const indent = `${' '.repeat(c)}`, output = result.replace(/\n\r?$/, "").split(/\n\r?/).join(`\n${indent};;    `), edit = vscode.TextEdit.insert(codeSelection.end, `\n${indent};; => ${output}\n`), wsEdit = new vscode.WorkspaceEdit();
     wsEdit.set(editor.document.uri, [edit]);
-    await vscode.workspace.applyEdit(wsEdit).then(_v => {
-        editor.selection = selection;
-    });
+    await vscode.workspace.applyEdit(wsEdit);
+    editor.selection = selection;
 }
 
 async function evaluateCode(code: string, options, selection?: vscode.Selection): Promise<void> {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -39,10 +39,10 @@ function interruptAllEvaluations() {
     vscode.window.showInformationMessage("Not connected to a REPL server");
 }
 
-function addAsComment(c: number, result: string, codeSelection: vscode.Selection, editor: vscode.TextEditor, selection: vscode.Selection) {
+async function addAsComment(c: number, result: string, codeSelection: vscode.Selection, editor: vscode.TextEditor, selection: vscode.Selection) {
     const indent = `${' '.repeat(c)}`, output = result.replace(/\n\r?$/, "").split(/\n\r?/).join(`\n${indent};;    `), edit = vscode.TextEdit.insert(codeSelection.end, `\n${indent};; => ${output}\n`), wsEdit = new vscode.WorkspaceEdit();
     wsEdit.set(editor.document.uri, [edit]);
-    vscode.workspace.applyEdit(wsEdit).then((_v) => {
+    await vscode.workspace.applyEdit(wsEdit).then(_v => {
         editor.selection = selection;
     });
 }
@@ -77,7 +77,7 @@ async function evaluateCode(code: string, options, selection?: vscode.Selection)
         try {
             let value = await context.value;
             value = util.stripAnsi(context.pprintOut || value);
-            outputWindow.append(value, (resultLocation) => {
+            outputWindow.append(value, async (resultLocation) => {
                 if (selection) {
                     const c = selection.start.character;
                     if (options.replace) {
@@ -86,12 +86,15 @@ async function evaluateCode(code: string, options, selection?: vscode.Selection)
                             wsEdit = new vscode.WorkspaceEdit();
                         wsEdit.set(editor.document.uri, [edit]);
                         vscode.workspace.applyEdit(wsEdit);
-                    } else if (options.comment) {
-                        addAsComment(c, value, selection, editor, selection);
                     } else {
+                        if (options.comment) {
+                            await addAsComment(c, value, selection, editor, editor.selection);
+                        }
                         if (!outputWindow.isResultsDoc(editor.document)) {
                             annotations.decorateSelection(value, selection, editor, editor.selection.active, resultLocation, annotations.AnnotationStatus.SUCCESS);
-                            annotations.decorateResults(value, false, selection, editor);
+                            if (!options.comment) {
+                                annotations.decorateResults(value, false, selection, editor);
+                            }
                         }
                     }
                 }
@@ -114,12 +117,14 @@ async function evaluateCode(code: string, options, selection?: vscode.Selection)
                 if (selection) {
                     const editorError = util.stripAnsi(err.length ? err.join("\n") : e);
                     const currentCursorPos = editor.selection.active;
+                    if (options.comment) {
+                        await addAsComment(selection.start.character, editorError, selection, editor, editor.selection);
+                    }
                     if (!outputWindow.isResultsDoc(editor.document)) {
                         annotations.decorateSelection(editorError, selection, editor, currentCursorPos, resultLocation, annotations.AnnotationStatus.ERROR);
-                        annotations.decorateResults(editorError, true, selection, editor);
-                    }
-                    if (options.asComment) {
-                        addAsComment(selection.start.character, editorError, selection, editor, selection);
+                        if (!options.comment) {
+                            annotations.decorateResults(editorError, true, selection, editor);
+                        }
                     }
                 }
                 if (context.stacktrace && context.stacktrace.stacktrace) {


### PR DESCRIPTION
## What has Changed?

Seems we had a regression in the code for evaluating to comment. I've restored the previous behaviour of restoring the previous editor selection after having inserted the comment.

While at it I also made it decorate the evaluated form, just as with ”normal” evaluation. It is a bit erratic, but still good to see what it was that was evaluated, I think.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Fixes #1131 

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

Ping @pez, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->