### PR TITLE
Make continue comment a command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Replace automatic comment continuation with an on-demand one](https://github.com/BetterThanTomorrow/calva/issues/644)
 
 ## [2.0.189] - 2021-04-18
 - [Paredit backspace should delete non-bracket parts of the opening token](https://github.com/BetterThanTomorrow/calva/issues/1122)

--- a/package.json
+++ b/package.json
@@ -823,6 +823,11 @@
                 "enablement": "calva:connected"
             },
             {
+                "command": "calva.continueComment",
+                "title": "Continue Comment (add a commented line below).",
+                "category": "Calva"
+            },
+            {
                 "command": "calva.switchCljsBuild",
                 "title": "Select CLJS Build Connection",
                 "enablement": "calva:connected",
@@ -1488,6 +1493,11 @@
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space",
                 "when": "calva:connected && calva:keybindingsEnabled"
+            },
+            {
+                "command": "calva.continueComment",
+                "key": "alt+enter",
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && calva:cursorInComment"
             },
             {
                 "command": "paredit.togglemode",

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -19,9 +19,11 @@ export function continueCommentCommand() {
         const commentOffset = cursor.rowCol[1];
         const commentText = cursor.getToken().raw;
         const [_1, startText, bullet, num] =
-            commentText.match(/^([;\s]+)([*-] +|(\d+)\. )?/);
+            commentText.match(/^([;\s]+)([*-] +|(\d+)\. +)?/);
+        const newNum = num ? parseInt(num) + 1 : undefined;
+        const bulletText = newNum ? bullet.replace(/\d+/, '' + newNum) : bullet;
         const pad = ' '.repeat(commentOffset);
-        const newText = `${pad}${startText}${num ? (parseInt(num) + 1) + '. ' : bullet ? bullet : ''}`;
+        const newText = `${pad}${startText}${bullet ? bulletText : ''}`;
         editor.edit(edits => edits.insert(eolPosition, `\n${newText}`), { undoStopAfter: false, undoStopBefore: true }).then(fulfilled => {
             if (fulfilled) {
                 const newEolPosition = eolPosition.with(eolPosition.line + 1, newText.length);

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as util from './utilities';
+import * as docMirror from './doc-mirror/index';
 
 export function continueCommentCommand() {
     const document = util.getDocument({});
@@ -7,21 +8,25 @@ export function continueCommentCommand() {
         const editor = vscode.window.activeTextEditor;
         const position = editor.selection.active;
         const eolPosition = position.with(position.line, Infinity);
-        const lineRange = new vscode.Range(position.with(position.line, 0), eolPosition);
-        const lineText: string = document.getText(lineRange),
-            match = lineText.match(/^[ \t]*;+[ \t]*/);
-        if (match) {
-            const [commentStart] = match;
-            //const edit = vscode.TextEdit.insert(eolPosition, `\n${commentStart}`);
-            //const wsEdit = new vscode.WorkspaceEdit();
-            //wsEdit.set(editor.document.uri, [edit]);
-            //vscode.workspace.applyEdit(wsEdit);
-            editor.edit(edits => edits.insert(eolPosition, `\n${commentStart}`), { undoStopAfter: false, undoStopBefore: true }).then(fulfilled => {
-                if (fulfilled) {
-                    const newEolPosition = eolPosition.with(eolPosition.line + 1, commentStart.length);
-                    editor.selection = new vscode.Selection(newEolPosition, newEolPosition);
-                }
-            });
+        const cursor = docMirror.getDocument(document).getTokenCursor();
+        if (!(cursor.getToken().type === 'comment')) {
+            if (cursor.getPrevToken().type === 'comment') {
+                cursor.previous();
+            } else {
+                cursor.next();
+            }
         }
+        const commentOffset = cursor.rowCol[1];
+        const commentText = cursor.getToken().raw;
+        const [_1, startText, bullet, num] =
+            commentText.match(/^([;\s]+)([*-] +|(\d+)\. )?/);
+        const pad = ' '.repeat(commentOffset);
+        const newText = `${pad}${startText}${num ? (parseInt(num) + 1) + '. ' : bullet ? bullet : ''}`;
+        editor.edit(edits => edits.insert(eolPosition, `\n${newText}`), { undoStopAfter: false, undoStopBefore: true }).then(fulfilled => {
+            if (fulfilled) {
+                const newEolPosition = eolPosition.with(eolPosition.line + 1, newText.length);
+                editor.selection = new vscode.Selection(newEolPosition, newEolPosition);
+            }
+        });
     }
 }

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+import * as util from './utilities';
+
+export function continueCommentCommand() {
+    const document = util.getDocument({});
+    if (document && document.languageId === 'clojure') {
+        const editor = vscode.window.activeTextEditor;
+        const position = editor.selection.active;
+        const eolPosition = position.with(position.line, Infinity);
+        const lineRange = new vscode.Range(position.with(position.line, 0), eolPosition);
+        const lineText: string = document.getText(lineRange),
+            match = lineText.match(/^[ \t]*;+[ \t]*/);
+        if (match) {
+            const [commentStart] = match;
+            //const edit = vscode.TextEdit.insert(eolPosition, `\n${commentStart}`);
+            //const wsEdit = new vscode.WorkspaceEdit();
+            //wsEdit.set(editor.document.uri, [edit]);
+            //vscode.workspace.applyEdit(wsEdit);
+            editor.edit(edits => edits.insert(eolPosition, `\n${commentStart}`), { undoStopAfter: false, undoStopBefore: true }).then(fulfilled => {
+                if (fulfilled) {
+                    const newEolPosition = eolPosition.with(eolPosition.line + 1, commentStart.length);
+                    editor.selection = new vscode.Selection(newEolPosition, newEolPosition);
+                }
+            });
+        }
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ import * as snippets from './custom-snippets';
 import setCursorContextIfChanged from './when-contexts'
 import lsp from './lsp/main';
 import { setStateValue } from '../out/cljs-lib/cljs-lib';
-
+import * as edit from './edit';
 async function onDidSave(document) {
     let {
         evaluate,
@@ -210,6 +210,7 @@ async function activate(context: vscode.ExtensionContext) {
                 console.error(`Problems visiting calva docs: ${e}`);
             });
     }))
+    context.subscriptions.push(vscode.commands.registerCommand('calva.continueComment', edit.continueCommentCommand));
 
     // Initial set of the provided contexts
     outputWindow.setContextForOutputWindowActive(false);


### PR DESCRIPTION
## What has Changed?

Instead of continue comment happening automatically (and instead of making it an opt-in setting) I've here made it a command, default bound to `alt+enter`.

I think that strikes the right balance between being really accessible, but also out of the way.

Fixes #644

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate (Don't know where to add this...)
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

Ping @pez, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->