### PR TITLE
Warn at deps.edn jack in if main opts aliases are detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Give the user some help to choose the right deps.edn jack-in alias when there are aliases with :main-opts](https://github.com/BetterThanTomorrow/calva/issues/1140)
 
 ## [2.0.192] - 2021-04-21
 - Fix: [Evaluating top level form sometimes does nothing](https://github.com/BetterThanTomorrow/calva/issues/1136)


### PR DESCRIPTION
## What has Changed?

* If we at jack-in to a deps.edn project see that there are aliases that specify `:main-opts` we will show an information message warning about selecting them.
* The message box has a button to disable the warning. 
   * If clicked, the warning will not show again for this project.

Fixes #1140

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.


Ping @pez, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->