### PR TITLE
No shell quoting whatsoever for deps.edn projects on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - Update cider-nrepl to [0.26.0](https://github.com/clojure-emacs/cider-nrepl/releases/tag/v0.26.0)
+- Fix [Getting Started Repl not working on some Windows machines](https://github.com/BetterThanTomorrow/calva/issues/1162)
 
 ## [2.0.194] - 2021-04-26
 - [Make Clojure-lsp Server Info command always enabled](https://github.com/BetterThanTomorrow/calva/issues/1143)

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -162,13 +162,6 @@ async function getJackInTerminalOptions(projectConnectSequence: ReplConnectSeque
     }
     executable = cmd[0];
     args = [...cmd.slice(1), ...args];
-    if (projectTypes.isWin && projectType.resolveBundledPathWin) {
-        const cmdFile = path.join('.calva', 'jack-in.cmd');
-        const cmdFileUri = vscode.Uri.file(path.join(state.getProjectRootLocal(), '.calva', 'jack-in.cmd'))
-        await utilities.writeTextToFile(cmdFileUri, createCommandLine(executable, args))
-        executable = cmdFile;
-        args = [];
-    }
 
     const terminalOptions: JackInTerminalOptions = {
         name: `Calva Jack-in: ${projectConnectSequence.name}`,

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -162,6 +162,13 @@ async function getJackInTerminalOptions(projectConnectSequence: ReplConnectSeque
     }
     executable = cmd[0];
     args = [...cmd.slice(1), ...args];
+    if (projectTypes.isWin && projectType.resolveBundledPathWin) {
+        const cmdFile = path.join('.calva', 'start.cmd');
+        const cmdFileUri = vscode.Uri.file(path.join(state.getProjectRootLocal(), '.calva', 'start.cmd'))
+        utilities.writeTextToFile(cmdFileUri, createCommandLine(executable, args))
+        executable = cmdFile;
+        args = [];
+    }
 
     const terminalOptions: JackInTerminalOptions = {
         name: `Calva Jack-in: ${projectConnectSequence.name}`,

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -165,7 +165,7 @@ async function getJackInTerminalOptions(projectConnectSequence: ReplConnectSeque
     if (projectTypes.isWin && projectType.resolveBundledPathWin) {
         const cmdFile = path.join('.calva', 'jack-in.cmd');
         const cmdFileUri = vscode.Uri.file(path.join(state.getProjectRootLocal(), '.calva', 'jack-in.cmd'))
-        utilities.writeTextToFile(cmdFileUri, createCommandLine(executable, args))
+        await utilities.writeTextToFile(cmdFileUri, createCommandLine(executable, args))
         executable = cmdFile;
         args = [];
     }

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -163,8 +163,8 @@ async function getJackInTerminalOptions(projectConnectSequence: ReplConnectSeque
     executable = cmd[0];
     args = [...cmd.slice(1), ...args];
     if (projectTypes.isWin && projectType.resolveBundledPathWin) {
-        const cmdFile = path.join('.calva', 'start.cmd');
-        const cmdFileUri = vscode.Uri.file(path.join(state.getProjectRootLocal(), '.calva', 'start.cmd'))
+        const cmdFile = path.join('.calva', 'jack-in.cmd');
+        const cmdFileUri = vscode.Uri.file(path.join(state.getProjectRootLocal(), '.calva', 'jack-in.cmd'))
         utilities.writeTextToFile(cmdFileUri, createCommandLine(executable, args))
         executable = cmdFile;
         args = [];

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -251,7 +251,7 @@ const cljsMiddleware: { [id: string]: string[] } = {
 const serverPrinterDependencies = pprint.getServerSidePrinterDependencies();
 
 function depsCljWindowsPath() {
-    return `"${path.join('.', '.calva', 'deps.clj.jar')}"`;
+    return `${path.join('.', '.calva', 'deps.clj.jar')}`;
 }
 
 const projectTypes: { [id: string]: ProjectType } = {
@@ -368,7 +368,7 @@ const projectTypes: { [id: string]: ProjectType } = {
         resolveBundledPathWin: depsCljWindowsPath,
         resolveBundledPathUnix: () => `'${path.join(state.extensionContext.extensionPath, 'deps.clj.jar')}'`,
         processShellUnix: true,
-        processShellWin: true,
+        processShellWin: false,
         useWhenExists: undefined,
         nReplPortFile: [".nrepl-port"],
         commandLine: async (connectSequence: ReplConnectSequence, cljsType: CljsTypes) => {
@@ -458,7 +458,7 @@ async function cljCommandLine(connectSequence: ReplConnectSequence, cljsType: Cl
     if (selectedAliasesHasMain) {
         args.push(aliasesOption);
     } else {
-        args.push(aliasesOption, "-m", "nrepl.cmdline", "--middleware", `"[${useMiddleware.join(' ')}]"`);
+        args.push(aliasesOption, "-m", "nrepl.cmdline", "--middleware", `${q}[${useMiddleware.join(' ')}]${q}`);
     }
 
     return args;

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -448,8 +448,8 @@ async function cljCommandLine(connectSequence: ReplConnectSequence, cljsType: Cl
     };
     const useMiddleware = [...middleware, ...(cljsType ? cljsMiddleware[cljsType] : [])];
     const aliasesOption = aliases.length > 0 ? `-A${aliases.join("")}` : '';
-    const q = isWin ? '"' : "'";
-    const dQ = isWin ? '""' : '"';
+    const q = isWin ? '' : "'";
+    const dQ = '"';
     for (let dep in dependencies)
         out.push(dep + ` {:mvn/version,${dQ}${dependencies[dep]}${dQ}}`)
 


### PR DESCRIPTION
Avoiding quoting hell on Windows by not using the `child_process` `shell` option and then not quoting at all.

Famous last words, but this time I think we've nailed it.

Fixes #1162

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

Ping @pez, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->