### PR TITLE
Add batching to output window printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Improvement: [REPL is Slow and Performance Degrades as the Output Grows](https://github.com/BetterThanTomorrow/calva/issues/942)
 
 ## [2.0.200] - 2021-06-06
 - Update clojure-lsp to version `2021.06.01-16.19.44`

--- a/package-lock.json
+++ b/package-lock.json
@@ -12202,11 +12202,6 @@
                 "safer-buffer": "^2.0.2",
                 "tweetnacl": "~0.14.0"
             },
-            "bin": {
-                "sshpk-conv": "bin/sshpk-conv",
-                "sshpk-sign": "bin/sshpk-sign",
-                "sshpk-verify": "bin/sshpk-verify"
-            },
             "engines": {
                 "node": ">=0.10.0"
             }

--- a/src/extension-test/unit/results-output/util-test.ts
+++ b/src/extension-test/unit/results-output/util-test.ts
@@ -1,4 +1,5 @@
 import * as expect from 'expect';
+import { OnAppendedCallback } from '../../../results-output/results-doc';
 import * as util from '../../../results-output/util';
 
 
@@ -41,4 +42,53 @@ describe('formatAsLineComments', () => {
         const formattedError = util.formatAsLineComments(error);
         expect(formattedError).toBe('; hello\n; world');
     });
+});
+
+describe('splitEditQueueForTextBatching', () => {
+    it('handles empty queue correctly', () => {
+        const queue = [];
+        const [textBatch, remainingEditQueue] = util.splitEditQueueForTextBatching(queue);
+        expect(textBatch).toHaveLength(0);
+        expect(remainingEditQueue).toHaveLength(0);
+    });   
+    it('doesn\'t perform batching if first item has callback', () => {
+        const queue : [string, OnAppendedCallback][] = [
+            ["item-with-callback", () => {}],
+            ["item2", null],
+            ["item3", null]
+        ];
+        const [textBatch, remainingEditQueue] = util.splitEditQueueForTextBatching(queue);
+        expect(textBatch).toHaveLength(0);
+        expect(remainingEditQueue.map(([s]) => s)).toEqual(expect.arrayContaining(["item-with-callback", "item2", "item3"]));
+    });
+    it('batches only leading items with no callback', () => {
+        const queue : [string, OnAppendedCallback][] = [
+            ["item1", null],
+            ["item2", null],
+            ["item3-with-callback", () => {}],
+            ["item4", null]
+        ];
+        const [textBatch, remainingEditQueue] = util.splitEditQueueForTextBatching(queue);
+        expect(textBatch).toEqual(expect.arrayContaining(["item1", "item2"]));
+        expect(remainingEditQueue.map(([s]) => s)).toEqual(expect.arrayContaining(["item3-with-callback", "item4"]));
+    });
+    it('correctly handles queue containing just items without callbacks', () => {
+        const queue : [string, OnAppendedCallback][] = [
+            ["item1", null],
+            ["item2", null]
+        ];
+        const [textBatch, remainingEditQueue] = util.splitEditQueueForTextBatching(queue);
+        expect(textBatch).toEqual(expect.arrayContaining(["item1", "item2"]));
+        expect(remainingEditQueue).toHaveLength(0);
+    });
+    it('respects maxBatchSize', () => {
+        const queue : [string, OnAppendedCallback][] = [
+            ["item1", null],
+            ["item2", null],
+            ["item3", null]
+        ];
+        const [textBatch, remainingEditQueue] = util.splitEditQueueForTextBatching(queue, 2);
+        expect(textBatch).toEqual(expect.arrayContaining(["item1", "item2"]));
+        expect(remainingEditQueue.map(([s]) => s)).toEqual(expect.arrayContaining(["item3"]));
+    })
 });

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -294,8 +294,17 @@ export function append(text: string, onAppended?: OnAppendedCallback): void {
                         onAppended(new vscode.Location(DOC_URI(), insertPosition),
                             new vscode.Location(DOC_URI(), doc.positionAt(Infinity)));
                     }
-                    if (editQueue.length > 0) {
-                        return append.apply(null, editQueue.shift());
+                    
+                    const queueLength = editQueue.length
+                    if (queueLength > 0) {                    
+                        var allTexts = [];
+                        var lastOnAppendCallback: OnAppendedCallback;
+                        for (var i=0; i<queueLength; i++) {                            
+                            var [text, onAppendCallback] = editQueue.shift();                            
+                            allTexts.push(text);                            
+                            lastOnAppendCallback = onAppendCallback;
+                        }                                                 
+                        return append(allTexts.join('\n'), lastOnAppendCallback)
                     }
                 });
             }

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -13,7 +13,6 @@ import * as replHistory from './repl-history';
 import * as docMirror from '../doc-mirror/index'
 import { PrintStackTraceCodelensProvider } from '../providers/codelense';
 import * as replSession from '../nrepl/repl-session';
-import { max, takeWhile } from 'lodash';
 import { splitEditQueueForTextBatching } from './util';
 
 const RESULTS_DOC_NAME = `output.${config.REPL_FILE_EXT}`;

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -13,7 +13,7 @@ import * as replHistory from './repl-history';
 import * as docMirror from '../doc-mirror/index'
 import { PrintStackTraceCodelensProvider } from '../providers/codelense';
 import * as replSession from '../nrepl/repl-session';
-import { max } from 'lodash';
+import { max, takeWhile } from 'lodash';
 
 const RESULTS_DOC_NAME = `output.${config.REPL_FILE_EXT}`;
 

--- a/src/results-output/util.ts
+++ b/src/results-output/util.ts
@@ -1,3 +1,6 @@
+import { takeWhile } from "lodash";
+import { OnAppendedCallback } from "./results-doc";
+
 function addToHistory(history: string[], content: string): string[] {
     if (content) {
         const entry = content.trim();
@@ -14,7 +17,16 @@ function formatAsLineComments(error: string): string {
     return `; ${error.trim().replace(/\n\r?/, '\n; ')}`;
 }
 
+function splitEditQueueForTextBatching(editQueue: [string, OnAppendedCallback][], maxBatchSize: number = 1000): [String[], [string, OnAppendedCallback][]]  {
+    const textBatch = takeWhile(editQueue, (value, index) => {
+        return index < maxBatchSize && !value[1];
+    }).map(value => value[0]);
+    const remainingEditQueue = [...editQueue].slice(textBatch.length);
+    return [textBatch, remainingEditQueue]
+}
+
 export {
     addToHistory,
-    formatAsLineComments
+    formatAsLineComments,
+    splitEditQueueForTextBatching
 };


### PR DESCRIPTION

<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?

When `editQueue` is filled rapidly by many one-line `println` outputs, `append` function in `results-doc.ts` actually processed that queue one-by-one, always appending a single line to document (`output.calva-repl`) and scrolling to the bottom of the document. This was very slow. (even 25 seconds for 500 outputted lines)

This change basically does what klauswuestefeld suggested here:

https://github.com/BetterThanTomorrow/calva/issues/942#issuecomment-759049579

> If there is a queue, can't we read all pending output events from the
> queue, concat them and apply them as a single batch to the output file?
> That would maybe make the console jumpy but at least it would not be
> absurdly slow.

Even after the change it's likely that first few executions might end up appending just a few lines, as the queue is not filled much. This could definitely be improved somehow (probably by some waiting a few hundred ms), but it would introduce much more complexity. And it's likely that this whole output processing/redirection to `output.calva-repl` might deserve a bigger refactoring/rewrite.

I tried to make this change as little and as simple as possible.

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Fixes #942 (I'd say drastically improves, not completely fixes. After 30k of lines in `output.calva-repl` it takes let's say 5 seconds to append 500 lines. It's not super quick, but it's bearable. Without the change, it's not bearable, as it takes minutes.)

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] ~Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).~
- [x] ~Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)~
- [x] ~Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)~
- [x] ~Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.~
- [x] ~Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- [x] ~Added to or updated docs in this branch, if appropriate~
- [x] ~Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*~
     - [x] ~Tested the particular change~
     - [x] ~Figured if the change might have some side effects and tested those as well.~
     - [x] ~Smoke tested the extension as such.~
- [x] ~Referenced the issue I am fixing/addressing _in a commit message for the pull request_.~
     - [x] ~If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)~
     - [x] ~If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [x] ~Created the issue I am fixing/addressing, if it was not present.~

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->