### PR TITLE
Workaround issue with command palette showing wrong fwd/back sexp bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - [Add nrepl and clojure-lsp versions to Calva says greetings](https://github.com/BetterThanTomorrow/calva/issues/1199)
+- Workaround: [Command Palette shows wrong keyboard shortcuts for Paredit Forward/Backward Sexp](https://github.com/BetterThanTomorrow/calva/issues/1161)
 
 ## [2.0.200] - 2021-06-06
 - Update clojure-lsp to version `2021.06.01-16.19.44`

--- a/package.json
+++ b/package.json
@@ -1549,11 +1549,11 @@
                 "when": "editorLangId == clojure calva:keybindingsEnabled && paredit:keyMap =~ /original|strict/"
             },
             {
-                "command": "paredit.forwardSexp",
-                "mac": "alt+right",
-                "win": "ctrl+right",
-                "linux": "ctrl+right",
-                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/ && config.calva.paredit.hijackVSCodeDefaults && !calva:cursorInComment || calva:cursorAfterComment"
+                "command": "paredit.backwardSexp",
+                "mac": "ctrl+left",
+                "win": "alt+left",
+                "linux": "alt+left",
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/ && !config.calva.paredit.hijackVSCodeDefaults && !calva:cursorInComment || calva:cursorBeforeComment"
             },
             {
                 "command": "paredit.backwardSexp",
@@ -1570,11 +1570,11 @@
                 "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/ && !config.calva.paredit.hijackVSCodeDefaults && !calva:cursorInComment || calva:cursorAfterComment"
             },
             {
-                "command": "paredit.backwardSexp",
-                "mac": "ctrl+left",
-                "win": "alt+left",
-                "linux": "alt+left",
-                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/ && !config.calva.paredit.hijackVSCodeDefaults && !calva:cursorInComment || calva:cursorBeforeComment"
+                "command": "paredit.forwardSexp",
+                "mac": "alt+right",
+                "win": "ctrl+right",
+                "linux": "ctrl+right",
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/ && config.calva.paredit.hijackVSCodeDefaults && !calva:cursorInComment || calva:cursorAfterComment"
             },
             {
                 "command": "paredit.forwardDownSexp",


### PR DESCRIPTION
## What has Changed?

Place primary bindings last in package.json

Due to https://github.com/microsoft/vscode/issues/126306 we can't make the bindings for fwd/back sexp display correctly in the command palette. But by placing the default binding last we mitigate the issue for new users and for the majority of users.

Fixes: #1161

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

Ping @pez, @bpringe
