### PR TITLE
Fix clojure-lsp statusbar messages moving the nREPL button around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [clojure-lsp statusbar messages move the nREPL button around](https://github.com/BetterThanTomorrow/calva/issues/1205)
 
 ## [2.0.201] - 2021-06-24
 - [Add nrepl and clojure-lsp versions to Calva says greetings](https://github.com/BetterThanTomorrow/calva/issues/1199)

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -12,6 +12,7 @@ import * as fs from 'fs';
 
 const LSP_CLIENT_KEY = 'lspClient';
 const RESOLVE_MACRO_AS_COMMAND = 'resolve-macro-as';
+const lspStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -1);
 
 function createClient(clojureLspPath: string): LanguageClient {
     const serverOptions: ServerOptions = {
@@ -272,9 +273,11 @@ async function startClient(clojureLspPath: string, context: vscode.ExtensionCont
     const client = createClient(clojureLspPath);
     console.log('Starting clojure-lsp at', clojureLspPath);
     const onReadyPromise = client.onReady();
-    vscode.window.setStatusBarMessage('$(sync~spin) Initializing Clojure language features via clojure-lsp', onReadyPromise);
+    lspStatus.text = '$(sync~spin) Initializing Clojure language features via clojure-lsp';
+    lspStatus.show();
     client.start();
     await onReadyPromise;
+    lspStatus.hide();
     setStateValue(LSP_CLIENT_KEY, client);
     registerCommands(context, client);
     registerEventHandlers(context, client);
@@ -304,8 +307,10 @@ async function activate(context: vscode.ExtensionContext): Promise<void> {
         }
         if (currentVersion !== configuredVersion) {
             const downloadPromise = downloadClojureLsp(context.extensionPath, configuredVersion);
-            vscode.window.setStatusBarMessage('$(sync~spin) Downloading clojure-lsp', downloadPromise);
+            lspStatus.text = '$(sync~spin) Downloading clojure-lsp';
+            lspStatus.show();
             clojureLspPath = await downloadPromise;
+            lspStatus.hide();
         }
     }
     await startClient(clojureLspPath, context);


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->
Using a `StatusBarItem` instead of `setStatusBarMessage` to be able to control the placement of the clojure-lsp "Initializing" / "Downloading" messages.
Placing the messages on the right of other StatusBarItems (priority = -1) to avoid moving the `nREPL ⚡` button.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Fixes #1205

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- ~[ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - ~[ ] Figured if the change might have some side effects and tested those as well.~
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->