### PR TITLE
Custom REPL commands enablement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Custom repl commands show error if run from non-clojure file](https://github.com/BetterThanTomorrow/calva/issues/1203)
 
 ## [2.0.202] - 2021-06-29
 - Fix: [Custom repl commands are not evaluated in specified ns if different than current ns](https://github.com/BetterThanTomorrow/calva/issues/1196)

--- a/package.json
+++ b/package.json
@@ -877,7 +877,7 @@
                 "command": "calva.runCustomREPLCommand",
                 "title": "Run Custom REPL Command",
                 "category": "Calva",
-                "enablement": "calva:connected"
+                "enablement": "calva:connected && editorLangId == clojure"
             },
             {
                 "command": "calva.continueComment",
@@ -1941,284 +1941,284 @@
             },
             {
                 "command": "calva.runCustomREPLCommand",
-                "key": "ctrl+alt+space space",
-                "when": "calva:connected && calva:keybindingsEnabled"
-            },
-            {
-                "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space enter",
                 "args": "enter",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space ,",
                 "args": ",",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space .",
                 "args": ".",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space -",
                 "args": "-",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space backspace",
                 "args": "backspace",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space left",
                 "args": "left",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space right",
                 "args": "right",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space up",
                 "args": "up",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space down",
                 "args": "down",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space tab",
                 "args": "tab",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space 0",
                 "args": "0",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space 1",
                 "args": "1",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space 2",
                 "args": "2",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space 3",
                 "args": "3",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space 4",
                 "args": "4",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space 5",
                 "args": "5",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space 6",
                 "args": "6",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space 7",
                 "args": "7",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space 8",
                 "args": "8",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space 9",
                 "args": "9",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space a",
                 "args": "a",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space b",
                 "args": "b",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space c",
                 "args": "c",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space d",
                 "args": "d",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space e",
                 "args": "e",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space f",
                 "args": "f",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space g",
                 "args": "g",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space h",
                 "args": "h",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space i",
                 "args": "i",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space j",
                 "args": "j",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space k",
                 "args": "k",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space l",
                 "args": "l",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space m",
                 "args": "m",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space n",
                 "args": "n",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space o",
                 "args": "o",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space p",
                 "args": "p",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space q",
                 "args": "q",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space r",
                 "args": "r",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space s",
                 "args": "s",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space t",
                 "args": "t",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space u",
                 "args": "u",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space v",
                 "args": "v",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space w",
                 "args": "w",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space x",
                 "args": "x",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space y",
                 "args": "y",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.runCustomREPLCommand",
                 "key": "ctrl+alt+space z",
                 "args": "z",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
+            },
+            {
+                "command": "calva.runCustomREPLCommand",
+                "key": "ctrl+alt+space space",
+                "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
             },
             {
                 "command": "calva.toggleBetweenImplAndTest",


### PR DESCRIPTION
## What has Changed?

1. Only enable the commands in Clojure files
2. Only bind keyboard shortcuts in Clojure files
3. Move ”bring up custom commands menu” shortcut last in the definitions to make it be displayed in the Command Palette, see: https://github.com/microsoft/vscode/issues/126306

Fixes #1203

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - ~[ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)~
     - ~[ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~

Ping @bpringe
