### PR TITLE
improve performance of rangeForDefun (cause of repl slowness) #942

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Performance improvement [REPL is Slow and Performance Degrades as the Output Grows](https://github.com/BetterThanTomorrow/calva/issues/942) 
 
 ## [2.0.205] - 2021-07-14
 - [Use new custom LSP method for server info command and print info in "Calva says" output channel ](https://github.com/BetterThanTomorrow/calva/issues/1211)

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -92,7 +92,7 @@ export function selectOpenList(doc: EditableDocument) {
  */
 export function rangeForDefun(doc: EditableDocument, offset: number = doc.selection.active): [number, number] {
     const cursor = doc.getTokenCursor(offset);
-    return cursor.rangeForDefun2(offset);
+    return cursor.rangeForDefun(offset);
 }
 
 export function forwardSexpRange(doc: EditableDocument, offset = Math.max(doc.selection.anchor, doc.selection.active), goPastWhitespace = false): [number, number] {

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -90,9 +90,9 @@ export function selectOpenList(doc: EditableDocument) {
  * Gets the range for the ”current” top level form
  * @see ListTokenCursor.rangeForDefun
  */
-export function rangeForDefun(doc: EditableDocument, offset: number = doc.selectionLeft, start: number = 0): [number, number] {
-    const cursor = doc.getTokenCursor(start);
-    return cursor.rangeForDefun(offset);
+export function rangeForDefun(doc: EditableDocument, offset: number = doc.selection.active): [number, number] {
+    const cursor = doc.getTokenCursor(offset);
+    return cursor.rangeForDefun2(offset);
 }
 
 export function forwardSexpRange(doc: EditableDocument, offset = Math.max(doc.selection.anchor, doc.selection.active), goPastWhitespace = false): [number, number] {

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -635,7 +635,7 @@ export class LispTokenCursor extends TokenCursor {
     }
 
     rangeForDefun2(offset: number, commentCreatesTopLevel = true): [number, number] {
-        const cursor = this.clone();
+        const cursor = this.doc.getTokenCursor(offset);
         let lastCandidateRange: [number, number] = cursor.rangeForCurrentForm(offset);
         while (cursor.forwardList() && cursor.upList()) {
             const commentCursor = cursor.clone();

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -613,6 +613,7 @@ export class LispTokenCursor extends TokenCursor {
      */
     rangeForDefun(offset: number, depth = 0, commentCreatesTopLevel = true): [number, number] {
         const cursor = this.clone();
+
         while (cursor.forwardSexp()) {
             if (cursor.offsetEnd >= offset) {
                 if (depth < 1 && cursor.getPrevToken().raw === ')') {
@@ -631,6 +632,19 @@ export class LispTokenCursor extends TokenCursor {
             }
         }
         return [offset, offset]
+    }
+
+    rangeForDefun2(offset: number, commentCreatesTopLevel = true): [number, number] {
+        const cursor = this.clone();
+        let lastCandidateRange: [number, number] = cursor.rangeForCurrentForm(offset);
+        while (cursor.forwardList() && cursor.upList()) {
+            const commentCursor = cursor.clone();
+            commentCursor.backwardDownList();
+            if (!commentCreatesTopLevel || commentCursor.getToken().raw !== ')' || commentCursor.getFunctionName() !== 'comment') {
+                lastCandidateRange = cursor.rangeForCurrentForm(cursor.offsetStart);
+            }
+        }
+        return lastCandidateRange;
     }
 
     rangesForTopLevelForms(): [number, number][] {

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -602,39 +602,9 @@ export class LispTokenCursor extends TokenCursor {
             }
         }
         return undefined; // 8.
-    }
+    }  
 
-    /**
-     * Gets the range for the ”current” top level form, visiting forms from the cursor towards `offset`
-     * With `commentCreatesTopLevel` as true (default): If the current top level form is a `(comment ...)`, consider it creating a new top level and continue the search.
-     * @param offset The ”current” position
-     * @param depth Controls if the cursor should consider `comment` top level (if > 0, it will not)
-     * @param commentIsTopLevel? Controls
-     */
-    rangeForDefun(offset: number, depth = 0, commentCreatesTopLevel = true): [number, number] {
-        const cursor = this.clone();
-
-        while (cursor.forwardSexp()) {
-            if (cursor.offsetEnd >= offset) {
-                if (depth < 1 && cursor.getPrevToken().raw === ')') {
-                    const commentCursor = cursor.clone();
-                    commentCursor.previous();
-                    if (commentCursor.getFunctionName() === 'comment' && commentCreatesTopLevel) {
-                        commentCursor.backwardList();
-                        commentCursor.forwardWhitespace();
-                        commentCursor.forwardSexp();
-                        return commentCursor.rangeForDefun(offset, depth + 1);
-                    }
-                }
-                const end = cursor.offsetStart;
-                cursor.backwardSexp();
-                return [cursor.offsetStart, end];
-            }
-        }
-        return [offset, offset]
-    }
-
-    rangeForDefun2(offset: number, commentCreatesTopLevel = true): [number, number] {
+    rangeForDefun(offset: number, commentCreatesTopLevel = true): [number, number] {
         const cursor = this.doc.getTokenCursor(offset);
         let lastCandidateRange: [number, number] = cursor.rangeForCurrentForm(offset);
         while (cursor.forwardList() && cursor.upList()) {

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -388,8 +388,11 @@ export class LispTokenCursor extends TokenCursor {
         let cursor = this.clone();
         while (cursor.forwardSexp()) { }
         if (cursor.getToken().type === "close") {
-            this.set(cursor);
-            return true;
+            const backCursor = cursor.clone();
+            if (backCursor.backwardList()) {
+                this.set(cursor);
+                return true;
+            }
         }
         return false;
     }

--- a/src/debugger/util.ts
+++ b/src/debugger/util.ts
@@ -21,7 +21,7 @@ function moveCursorPastStringInList(tokenCursor: LispTokenCursor, s: string): vo
 function moveTokenCursorToBreakpoint(tokenCursor: LispTokenCursor, debugResponse: any): LispTokenCursor {
 
     const errorMessage = "Error finding position of breakpoint";
-    const [_, defunEnd] = tokenCursor.rangeForDefun2(tokenCursor.offsetStart);
+    const [_, defunEnd] = tokenCursor.rangeForDefun(tokenCursor.offsetStart);
     let inSyntaxQuote = false;
 
     const coor = [...debugResponse.coor]; // Copy the array so we do not modify the one stored in state

--- a/src/debugger/util.ts
+++ b/src/debugger/util.ts
@@ -21,7 +21,7 @@ function moveCursorPastStringInList(tokenCursor: LispTokenCursor, s: string): vo
 function moveTokenCursorToBreakpoint(tokenCursor: LispTokenCursor, debugResponse: any): LispTokenCursor {
 
     const errorMessage = "Error finding position of breakpoint";
-    const [_, defunEnd] = tokenCursor.rangeForDefun(tokenCursor.offsetStart);
+    const [_, defunEnd] = tokenCursor.rangeForDefun2(tokenCursor.offsetStart);
     let inSyntaxQuote = false;
 
     const coor = [...debugResponse.coor]; // Copy the array so we do not modify the one stored in state

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -438,7 +438,7 @@ describe('Token Cursor', () => {
             const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
             expect(cursor.rangeForDefun2(a.selection.active)).toEqual(textAndSelection(b)[1]);
         });
-        it('Can find the comment range for a top level form inside a comment', () => {
+        it('Finds top level comment range if comment special treatment is disabled', () => {
             const a = docFromTextNotation('aaa (comment (ccc •#foo•(#bar •#baz•[:a :b| :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) (ddd eee)');
             const b = docFromTextNotation('aaa |(comment (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar))| (ddd eee)');
             const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
@@ -477,6 +477,13 @@ describe('Token Cursor', () => {
         it('Finds the succeeding range when cursor is at the start of the line', () => {
             const a = docFromTextNotation('aaa (comment [bbb ccc]• | ddd)');
             const b = docFromTextNotation('aaa (comment [bbb ccc]•  |ddd|)');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+            expect(cursor.rangeForDefun2(a.selection.active)).toEqual(textAndSelection(b)[1]);
+        });
+        it('Finds the preceding comment symbol range when cursor is between that and something else on the same line', () => {
+            // This is a bit funny, but is not an important use case
+            const a = docFromTextNotation('aaa (comment  | [bbb ccc]  ddd)');
+            const b = docFromTextNotation('aaa (|comment|   [bbb ccc]  ddd)');
             const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
             expect(cursor.rangeForDefun2(a.selection.active)).toEqual(textAndSelection(b)[1]);
         });

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -203,12 +203,35 @@ describe('Token Cursor', () => {
         });
     });
 
-    it('forwardList', () => {
-        const a = docFromTextNotation('(a(b(c•|#f•(#b •[:f :b :z])•#z•1)))');
-        const b = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1|)))');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-        cursor.forwardList();
-        expect(cursor.offsetStart).toBe(b.selectionLeft);
+    describe('forwardList', () => {
+        it('Moves to closing end of list', () => {
+            const a = docFromTextNotation('(a(b(c•|#f•(#b •[:f :b :z])•#z•1)))');
+            const b = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1|)))');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            cursor.forwardList();
+            expect(cursor.offsetStart).toBe(b.selectionLeft);
+        });
+        it('Does not move at top level', () => {
+            const a = docFromTextNotation('|foo (bar baz)');
+            const b = docFromTextNotation('|foo (bar baz)');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            cursor.forwardList();
+            expect(cursor.offsetStart).toBe(b.selectionLeft);
+        });
+        it('Does not move at top level when unbalanced document from extra closings', () => {
+            const a = docFromTextNotation('|foo (bar baz))');
+            const b = docFromTextNotation('|foo (bar baz))');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            cursor.forwardList();
+            expect(cursor.offsetStart).toBe(b.selectionLeft);
+        });
+        it('Does not move at top level when unbalanced document from extra opens', () => {
+            const a = docFromTextNotation('|foo ((bar baz)');
+            const b = docFromTextNotation('|foo ((bar baz)');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            cursor.forwardList();
+            expect(cursor.offsetStart).toBe(b.selectionLeft);
+        });
     });
     it('upList', () => {
         const a = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1|)))');
@@ -217,12 +240,35 @@ describe('Token Cursor', () => {
         cursor.upList();
         expect(cursor.offsetStart).toBe(b.selectionLeft);
     });
-    it('backwardList', () => {
-        const a = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•|1)))');
-        const b = docFromTextNotation('(a(b(|c•#f•(#b •[:f :b :z])•#z•1)))');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-        cursor.backwardList();
-        expect(cursor.offsetStart).toBe(b.selectionLeft);
+    describe('backwardList', () => {
+        it('backwardList', () => {
+            const a = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•|1)))');
+            const b = docFromTextNotation('(a(b(|c•#f•(#b •[:f :b :z])•#z•1)))');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            cursor.backwardList();
+            expect(cursor.offsetStart).toBe(b.selectionLeft);
+        });
+            it('Does not move at top level', () => {
+            const a = docFromTextNotation('foo (bar baz)|');
+            const b = docFromTextNotation('foo (bar baz)|');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            cursor.forwardList();
+            expect(cursor.offsetStart).toBe(b.selectionLeft);
+        });
+        it('Does not move at top level when unbalanced document from extra closings', () => {
+            const a = docFromTextNotation('foo (bar baz))|');
+            const b = docFromTextNotation('foo (bar baz))|');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            cursor.forwardList();
+            expect(cursor.offsetStart).toBe(b.selectionLeft);
+        });
+        it('Does not move at top level when unbalanced document from extra opens', () => {
+            const a = docFromTextNotation('foo ((bar baz)|');
+            const b = docFromTextNotation('foo ((bar baz)|');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            cursor.forwardList();
+            expect(cursor.offsetStart).toBe(b.selectionLeft);
+        });
     });
 
     it('backwardUpList', () => {
@@ -455,7 +501,7 @@ describe('Token Cursor', () => {
             expect(cursor.rangeForDefun(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
         });
     });
-    
+
     describe('Location State', () => {
         it('Knows when inside string', () => {
             const doc = docFromTextNotation('(str [] "", "foo" "f   b  b"   "   f b b   " "\\"" \\")');

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -358,6 +358,12 @@ describe('Token Cursor', () => {
             const cursor: LispTokenCursor = a.getTokenCursor(0);
             expect(cursor.rangeForDefun(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
         });
+        it('Can find the comment range for a top level form inside a comment', () => {
+            const a = docFromTextNotation('aaa (comment (ccc •#foo•(#bar •#baz•[:a :b| :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) (ddd eee)');
+            const b = docFromTextNotation('aaa |(comment (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar))| (ddd eee)');
+            const cursor: LispTokenCursor = a.getTokenCursor(0);
+            expect(cursor.rangeForDefun(a.selectionLeft, 0, false)).toEqual(textAndSelection(b)[1]);
+        });
         it('Finds comment range when comments are nested', () => { // TODO: Consider changing this behavior
             const a = docFromTextNotation('aaa (comment (comment [bbb ccc] | ddd))');
             const b = docFromTextNotation('aaa (comment |(comment [bbb ccc]  ddd)|)');
@@ -383,6 +389,50 @@ describe('Token Cursor', () => {
             expect(cursor.rangeForDefun(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
         });
 
+    });
+    describe('Top Level Form 2', () => {
+        it('Finds range for a regular top level form', () => {
+            const a = docFromTextNotation('aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b| :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) (ddd eee)');
+            const b = docFromTextNotation('aaa |(bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar))| (ddd eee)');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+            expect(cursor.rangeForDefun2(a.selection.active)).toEqual(textAndSelection(b)[1]);
+        });
+        it('Finds range for a top level form inside a comment', () => {
+            const a = docFromTextNotation('aaa (comment (comment [bbb cc|c]  ddd))');
+            const b = docFromTextNotation('aaa (comment (comment |[bbb ccc]|  ddd))');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+            expect(cursor.rangeForDefun2(a.selection.active)).toEqual(textAndSelection(b)[1]);
+        });
+        it('Can find the comment range for a top level form inside a comment', () => {
+            const a = docFromTextNotation('aaa (comment (ccc •#foo•(#bar •#baz•[:a :b| :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) (ddd eee)');
+            const b = docFromTextNotation('aaa |(comment (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar))| (ddd eee)');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+            expect(cursor.rangeForDefun2(a.selection.active, false)).toEqual(textAndSelection(b)[1]);
+        });
+        it('Finds comment range when comments are nested', () => { // TODO: Consider changing this behavior
+            const a = docFromTextNotation('aaa (comment (comment [bbb ccc] | ddd))');
+            const b = docFromTextNotation('aaa (comment (comment |[bbb ccc]|  ddd))');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+            expect(cursor.rangeForDefun2(a.selection.active)).toEqual(textAndSelection(b)[1]);
+        });
+        it('Includes reader tag', () => {
+            const a = docFromTextNotation('aaa (comment #r [bbb ccc|]  ddd)');
+            const b = docFromTextNotation('aaa (comment |#r [bbb ccc]|  ddd)');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+            expect(cursor.rangeForDefun2(a.selection.active)).toEqual(textAndSelection(b)[1]);
+        });
+        it('Finds the preceding range when cursor is between to forms on the same line', () => {
+            const a = docFromTextNotation('aaa (comment [bbb ccc] | ddd)');
+            const b = docFromTextNotation('aaa (comment |[bbb ccc]|  ddd)');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+            expect(cursor.rangeForDefun2(a.selection.active)).toEqual(textAndSelection(b)[1]);
+        });
+        it('Finds the succeeding range when cursor is at the start of the line', () => {
+            const a = docFromTextNotation('aaa (comment [bbb ccc]• | ddd)');
+            const b = docFromTextNotation('aaa (comment [bbb ccc]•  |ddd|)');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+            expect(cursor.rangeForDefun2(a.selection.active)).toEqual(textAndSelection(b)[1]);
+        });
     });
     describe('Location State', () => {
         it('Knows when inside string', () => {

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -256,7 +256,24 @@ describe('Token Cursor', () => {
             cursor.backwardSexp();
             expect(cursor.offsetStart).toEqual(b.selectionLeft);
         });
-    })
+    });
+
+    describe('The REPL prompt', () => {
+        it('Backward sexp bypasses prompt', () => {
+            const a = docFromTextNotation('foo•clj꞉foo꞉> |');
+            const b = docFromTextNotation('|foo•clj꞉foo꞉> ');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            cursor.backwardSexp();
+            expect(cursor.offsetStart).toEqual(b.selection.active);
+        });
+        it('Backward sexp not skipping comments bypasses prompt finding its start', () => {
+            const a = docFromTextNotation('foo•clj꞉foo꞉> |');
+            const b = docFromTextNotation('foo•|clj꞉foo꞉> ');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            cursor.backwardSexp(false);
+            expect(cursor.offsetStart).toEqual(b.selection.active);
+        });
+    });
 
     describe('Current Form', () => {
         it('0: selects from within non-list form', () => {

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -219,8 +219,8 @@ function updateRainbowBrackets() {
       startRange = startCursor.rangeForDefun(startOffset, false),
       endCursor: LispTokenCursor = mirrorDoc.getTokenCursor(endOffset),
       endRange = endCursor.rangeForDefun(endOffset, false),
-      rangeStart = startRange[0],
-      rangeEnd = endRange[1];
+      rangeStart = startRange ? startRange[0] : startOffset,
+      rangeEnd = endRange ? endRange[1] : endOffset;
     // Look for top level ignores, and adjust starting point if found
     const topLevelSentinelCursor = mirrorDoc.getTokenCursor(rangeStart);
     let startPaintingFrom = rangeStart;

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -216,9 +216,9 @@ function updateRainbowBrackets() {
     const startOffset = doc.offsetAt(range.start),
       endOffset = doc.offsetAt(range.end),
       startCursor: LispTokenCursor = mirrorDoc.getTokenCursor(0),
-      startRange = startCursor.rangeForDefun2(startOffset, false),
+      startRange = startCursor.rangeForDefun(startOffset, false),
       endCursor: LispTokenCursor = mirrorDoc.getTokenCursor(endOffset),
-      endRange = endCursor.rangeForDefun2(endOffset, false),
+      endRange = endCursor.rangeForDefun(endOffset, false),
       rangeStart = startRange[0],
       rangeEnd = endRange[1];
     // Look for top level ignores, and adjust starting point if found

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -216,9 +216,9 @@ function updateRainbowBrackets() {
     const startOffset = doc.offsetAt(range.start),
       endOffset = doc.offsetAt(range.end),
       startCursor: LispTokenCursor = mirrorDoc.getTokenCursor(0),
-      startRange = startCursor.rangeForDefun(startOffset, 1),
-      endCursor: LispTokenCursor = mirrorDoc.getTokenCursor(startRange[1]),
-      endRange = endCursor.rangeForDefun(endOffset, 1),
+      startRange = startCursor.rangeForDefun2(startOffset, false),
+      endCursor: LispTokenCursor = mirrorDoc.getTokenCursor(endOffset),
+      endRange = endCursor.rangeForDefun2(endOffset, false),
       rangeStart = startRange[0],
       rangeEnd = endRange[1];
     // Look for top level ignores, and adjust starting point if found

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -154,11 +154,13 @@ export async function initResultsDoc(): Promise<vscode.TextDocument> {
                 const selectionCursor = mirrorDoc.getTokenCursor(idx);
                 selectionCursor.forwardWhitespace();
                 if (selectionCursor.atEnd()) {
-                    const tlCursor = mirrorDoc.getTokenCursor(idx);
-                    const topLevelFormRange = tlCursor.rangeForDefun2(idx);
-                    submitOnEnter = topLevelFormRange &&
-                        topLevelFormRange[0] !== topLevelFormRange[1] &&
-                        idx >= topLevelFormRange[1];
+                    const promptCursor = mirrorDoc.getTokenCursor(idx);
+                    do {
+                        promptCursor.previous();
+                    } while (promptCursor.getPrevToken().type !== 'prompt' && !promptCursor.atStart());
+                    const submitRange = selectionCursor.rangeForCurrentForm(idx);
+                    submitOnEnter = submitRange &&
+                        submitRange[1] > promptCursor.offsetStart;
                 }
             }
         }

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -154,8 +154,8 @@ export async function initResultsDoc(): Promise<vscode.TextDocument> {
                 const selectionCursor = mirrorDoc.getTokenCursor(idx);
                 selectionCursor.forwardWhitespace();
                 if (selectionCursor.atEnd()) {
-                    const tlCursor = mirrorDoc.getTokenCursor(0);
-                    const topLevelFormRange = tlCursor.rangeForDefun(idx);
+                    const tlCursor = mirrorDoc.getTokenCursor(idx);
+                    const topLevelFormRange = tlCursor.rangeForDefun2(idx);
                     submitOnEnter = topLevelFormRange &&
                         topLevelFormRange[0] !== topLevelFormRange[1] &&
                         idx >= topLevelFormRange[1];

--- a/src/select.ts
+++ b/src/select.ts
@@ -8,8 +8,8 @@ function selectionFromOffsetRange(doc: vscode.TextDocument, range: [number, numb
 
 function getFormSelection(doc: vscode.TextDocument, pos: vscode.Position, topLevel): vscode.Selection {
     const idx = doc.offsetAt(pos);
-    const cursor = docMirror.getDocument(doc).getTokenCursor(topLevel ? 0 : idx);
-    const range = topLevel ? cursor.rangeForDefun(idx) : cursor.rangeForCurrentForm(idx);
+    const cursor = docMirror.getDocument(doc).getTokenCursor(idx);
+    const range = topLevel ? cursor.rangeForDefun2(idx) : cursor.rangeForCurrentForm(idx);
     if (range) {
         return selectionFromOffsetRange(doc, range);
     }

--- a/src/select.ts
+++ b/src/select.ts
@@ -9,7 +9,7 @@ function selectionFromOffsetRange(doc: vscode.TextDocument, range: [number, numb
 function getFormSelection(doc: vscode.TextDocument, pos: vscode.Position, topLevel): vscode.Selection {
     const idx = doc.offsetAt(pos);
     const cursor = docMirror.getDocument(doc).getTokenCursor(idx);
-    const range = topLevel ? cursor.rangeForDefun2(idx) : cursor.rangeForCurrentForm(idx);
+    const range = topLevel ? cursor.rangeForDefun(idx) : cursor.rangeForCurrentForm(idx);
     if (range) {
         return selectionFromOffsetRange(doc, range);
     }

--- a/src/util/cursor-get-text.ts
+++ b/src/util/cursor-get-text.ts
@@ -7,8 +7,8 @@ import { EditableDocument } from "../cursor-doc/model";
 export type RangeAndText = [[number, number], string];
 
 export function currentTopLevelFunction(doc: EditableDocument): RangeAndText {
-    const defunCursor = doc.getTokenCursor(0);
-    const defunStart = defunCursor.rangeForDefun(doc.selection.active)[0];
+    const defunCursor = doc.getTokenCursor(doc.selection.active);
+    const defunStart = defunCursor.rangeForDefun2(doc.selection.active)[0];
     const cursor = doc.getTokenCursor(defunStart);
     while (cursor.downList()) {
         cursor.forwardWhitespace();
@@ -26,8 +26,8 @@ export function currentTopLevelFunction(doc: EditableDocument): RangeAndText {
 }
 
 export function currentTopLevelForm(doc: EditableDocument): RangeAndText {
-    const defunCursor = doc.getTokenCursor(0);
-    const defunRange = defunCursor.rangeForDefun(doc.selection.active);
+    const defunCursor = doc.getTokenCursor(doc.selection.active);
+    const defunRange = defunCursor.rangeForDefun2(doc.selection.active);
     return defunRange ? [defunRange, doc.model.getText(...defunRange)] : [undefined, ''];
 }
 
@@ -53,13 +53,13 @@ export function currentEnclosingFormToCursor(doc: EditableDocument): RangeAndTex
 }
 
 export function currentTopLevelFormToCursor(doc: EditableDocument): RangeAndText {
-    const cursor = doc.getTokenCursor(0);
-    const defunRange = cursor.rangeForDefun(doc.selection.active, 0);
+    const cursor = doc.getTokenCursor(doc.selection.active);
+    const defunRange = cursor.rangeForDefun2(doc.selection.active);
     return rangeOrStartOfFileToCursor(doc, defunRange, defunRange[0]);
 }
 
 export function startOfFileToCursor(doc: EditableDocument): RangeAndText {
-    const cursor = doc.getTokenCursor(0);
-    const defunRange = cursor.rangeForDefun(doc.selection.active, 0, false);
+    const cursor = doc.getTokenCursor(doc.selection.active);
+    const defunRange = cursor.rangeForDefun2(doc.selection.active, false);
     return rangeOrStartOfFileToCursor(doc, defunRange, 0);
 }

--- a/src/util/cursor-get-text.ts
+++ b/src/util/cursor-get-text.ts
@@ -8,7 +8,7 @@ export type RangeAndText = [[number, number], string];
 
 export function currentTopLevelFunction(doc: EditableDocument): RangeAndText {
     const defunCursor = doc.getTokenCursor(doc.selection.active);
-    const defunStart = defunCursor.rangeForDefun2(doc.selection.active)[0];
+    const defunStart = defunCursor.rangeForDefun(doc.selection.active)[0];
     const cursor = doc.getTokenCursor(defunStart);
     while (cursor.downList()) {
         cursor.forwardWhitespace();
@@ -27,7 +27,7 @@ export function currentTopLevelFunction(doc: EditableDocument): RangeAndText {
 
 export function currentTopLevelForm(doc: EditableDocument): RangeAndText {
     const defunCursor = doc.getTokenCursor(doc.selection.active);
-    const defunRange = defunCursor.rangeForDefun2(doc.selection.active);
+    const defunRange = defunCursor.rangeForDefun(doc.selection.active);
     return defunRange ? [defunRange, doc.model.getText(...defunRange)] : [undefined, ''];
 }
 
@@ -54,12 +54,12 @@ export function currentEnclosingFormToCursor(doc: EditableDocument): RangeAndTex
 
 export function currentTopLevelFormToCursor(doc: EditableDocument): RangeAndText {
     const cursor = doc.getTokenCursor(doc.selection.active);
-    const defunRange = cursor.rangeForDefun2(doc.selection.active);
+    const defunRange = cursor.rangeForDefun(doc.selection.active);
     return rangeOrStartOfFileToCursor(doc, defunRange, defunRange[0]);
 }
 
 export function startOfFileToCursor(doc: EditableDocument): RangeAndText {
     const cursor = doc.getTokenCursor(doc.selection.active);
-    const defunRange = cursor.rangeForDefun2(doc.selection.active, false);
+    const defunRange = cursor.rangeForDefun(doc.selection.active, false);
     return rangeOrStartOfFileToCursor(doc, defunRange, 0);
 }

--- a/test-data/unbalance.clj
+++ b/test-data/unbalance.clj
@@ -1,0 +1,5 @@
+(ns unbalance)
+
+(def foo))
+
+:foo


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?
- `rangeForDefun` got rewritten so that it no longer needs to navigate from the very beginning of the document (which caused slowness when appending to repl window)
- added way more tests for `rangeForDefun` (as there weren't any :-))

Greatly improves #942. Before the fix, outputting become sluggish at 6k lines and was nearly unusable at just 10k (freezes for 30-60s). Now even 100k lines is bearable : execution of repl expression takes about 5 seconds.

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - ~[ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)~
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- ~[ ] Created the issue I am fixing/addressing, if it was not present.~

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it there if so.
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->