### PR TITLE
Add functionality to use  latest clojure lsp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Default to using the latest release of clojure](https://github.com/BetterThanTomorrow/calva/issues/1248)
 
 ## [2.0.205] - 2021-07-14
 - [Use new custom LSP method for server info command and print info in "Calva says" output channel ](https://github.com/BetterThanTomorrow/calva/issues/1211)

--- a/docs/site/clojure-lsp.md
+++ b/docs/site/clojure-lsp.md
@@ -3,7 +3,7 @@
 Calva uses a mix of static and dynamic analysis to power the experience. A lot of the static abilities come from [clojure-lsp](https://github.com/snoe/clojure-lsp). This enables you to check something up in a project, with a lot of navigational and contextual support, without starting a REPL for it. (And once you do start a REPL you'll get even more capabilities, enabled by the dynamic analysis.)
 
 !!! Note
-    Calva determines the version of clojure-lsp it uses by default. This means it may not be using the latest version of clojure-lsp. You can see what version is being used by running the `Clojure-lsp Server Info` command, which will also show the version of clj-kondo that's being used as well as other info. To use a different version of clojure-lsp, see the [configuration](#configuration) section. **Calva does not use the clojure-lsp installed on your system, unless you [set the path for clojure-lsp](#using-a-custom-clojure-lsp-native-binary) to the installed binary in your settings**.
+    By default, Calva determines the version of clojure-lsp it uses, and it defaults to `latest`. To use a different version of clojure-lsp, see the [configuration](#configuration) section. **Calva does not use the clojure-lsp installed on your system, unless you [set the path for clojure-lsp](#using-a-custom-clojure-lsp-native-binary) to the installed binary in your settings**. You can see what version is being used by running the `Clojure-lsp Server Info` command, which will also show the version of clj-kondo that's being used as well as other info. 
 
 ## Starting the LSP server
 

--- a/docs/site/clojure-lsp.md
+++ b/docs/site/clojure-lsp.md
@@ -29,13 +29,15 @@ For information about how to configure clojure-lsp, see the [settings](https://c
 
 ### Changing the Version of Clojure-lsp Used by Calva
 
-You can change the version of clojure-lsp used by Calva by setting the `calva.clojureLspVersion` property to a version of clojure-lsp found in its GitHub [releases](https://github.com/clojure-lsp/clojure-lsp/releases). This can be helpful if you're debugging an issue with clojure-lsp or you want to try out a feature of a new release that Calva does not yet use. However, you must remember to reset this setting in order for Calva to automatically use newer versions of clojure-lsp that are released with new versions of Calva.
+By default, Calva will use the latest released **clojure-lsp**. You can change the version of clojure-lsp used by Calva by setting the `calva.clojureLspVersion` property to a version of clojure-lsp found in its GitHub [releases](https://github.com/clojure-lsp/clojure-lsp/releases). This can be helpful if you're debugging an issue with clojure-lsp or you want to try out a feature of a new release that Calva does not yet use. However, you must remember to reset this setting in order for Calva to automatically use newer versions of clojure-lsp that are released with new versions of Calva.
 
 Example:
 
 ```json
 "calva.clojureLspVersion": "2021.04.07-16.34.10"
 ```
+
+If you have specified a version and want to use the latest release, either remove the setting, or set it to `latest`.
 
 ### Using a Custom Clojure-lsp Native Binary
 

--- a/package.json
+++ b/package.json
@@ -278,8 +278,8 @@
                     },
                     "calva.clojureLspVersion": {
                         "type": "string",
-                        "default": "2021.07.12-12.30.59",
-                        "markdownDescription": "The version of `clojure-lsp` to download and use. (Will take effect after a reload of the project window.) Remove this setting to switch back to using the current Calva default."
+                        "default": "latest",
+                        "markdownDescription": "The version of `clojure-lsp` to download and use. A release tag-name or `latest`. (Will take effect after a reload of the project window.) Remove this setting to switch back to using the current Calva default (`latest`)."
                     },
                     "calva.clojureLspPath": {
                         "type": "string",

--- a/src/lsp/download.ts
+++ b/src/lsp/download.ts
@@ -6,6 +6,12 @@ import * as fs from 'fs';
 import { https } from 'follow-redirects';
 import * as extractZip from 'extract-zip';
 
+async function getLatestVersion(): Promise<string> {
+    const releasesJSON = await util.fetchFromUrl('https://api.github.com/repos/clojure-lsp/clojure-lsp/releases');
+    const releases = JSON.parse(releasesJSON);
+    return releases[0].tag_name;
+}
+
 function getZipFileName(platform: string): string {
     return {
         'darwin': 'clojure-lsp-native-macos-amd64.zip',
@@ -87,5 +93,6 @@ async function downloadClojureLsp(extensionPath: string, version: string): Promi
 }
 
 export {
-    downloadClojureLsp
+    downloadClojureLsp,
+    getLatestVersion
 }

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -4,7 +4,7 @@ import * as util from '../utilities'
 import * as config from '../config';
 import { provideClojureDefinition } from '../providers/definition';
 import { setStateValue, getStateValue } from '../../out/cljs-lib/cljs-lib';
-import { downloadClojureLsp } from './download';
+import { downloadClojureLsp, getLatestVersion } from './download';
 import { readVersionFile, getClojureLspPath } from './utilities';
 import * as os from 'os';
 import * as path from 'path';
@@ -310,8 +310,9 @@ async function activate(context: vscode.ExtensionContext): Promise<void> {
             vscode.window.showWarningMessage('The calva.clojureLspVersion setting is blank and calva.clojureLspPath is also blank, so clojure-lsp will not be started. Please reset the calva.clojureLspVersion setting to use the default version of clojure-lsp, or set it to a clojure-lsp version you want to use. Alternatively, you can set the calva.clojureLspPath to use a downloaded binary of clojure-lsp.');
             return;
         }
-        if (currentVersion !== configuredVersion) {
-            const downloadPromise = downloadClojureLsp(context.extensionPath, configuredVersion);
+        const downloadVersion = configuredVersion === 'latest' ? await getLatestVersion() : configuredVersion;
+        if (currentVersion !== downloadVersion) {
+            const downloadPromise = downloadClojureLsp(context.extensionPath, downloadVersion);
             lspStatus.text = '$(sync~spin) Downloading clojure-lsp';
             lspStatus.show();
             clojureLspPath = await downloadPromise;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import * as JSZip from 'jszip';
 import * as outputWindow from './results-output/results-doc';
 import * as cljsLib from '../out/cljs-lib/cljs-lib';
+import * as url from 'url';
 
 const specialWords = ['-', '+', '/', '*']; //TODO: Add more here
 const syntaxQuoteSymbol = "`";
@@ -372,9 +373,15 @@ async function downloadFromUrl(url: string, savePath: string) {
     });
 }
 
-async function fetchFromUrl(url: string): Promise<string> {
+async function fetchFromUrl(fullUrl: string): Promise<string> {
+    const q = url.parse(fullUrl);
     return new Promise((resolve, reject) => {
-        https.get(url, (res) => {
+        https.get({
+            host: q.hostname,
+            path: q.pathname,
+            port: q.port,
+            headers: {'user-agent': 'node.js'}
+        }, (res) => {
             let data = '';
             res.on('data', (chunk: any) => {
                 data += chunk;


### PR DESCRIPTION
## What has Changed?

- Make it such that if the  `clojureLspVersion` is set to `latest`, then the latest clojure-lsp is used.
- Make `latest` the default.

Fixes #1248

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.

Ping @bpringe
