### PR TITLE
Handle blank clojure-lsp version setting gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Support a blank `clojureLspVersion` setting](https://github.com/BetterThanTomorrow/calva/issues/1251)
 
 ## [2.0.206] - 2021-08-05
 - [Default to using the latest release of clojure-lsp](https://github.com/BetterThanTomorrow/calva/issues/1248)

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -305,12 +305,7 @@ async function activate(context: vscode.ExtensionContext): Promise<void> {
     let clojureLspPath = userConfiguredClojureLspPath === '' ? getClojureLspPath(extensionPath, util.isWindows) : userConfiguredClojureLspPath;
     if (userConfiguredClojureLspPath === '') {
         const configuredVersion: string = config.getConfig().clojureLspVersion;
-        if (configuredVersion === '') {
-            // This should never be an empty string and can cause issues with clojure-lsp starting, particularly if there is no version file yet from a previous download and no custom clojure-lsp path set. Inform the user.
-            vscode.window.showWarningMessage('The calva.clojureLspVersion setting is blank and calva.clojureLspPath is also blank, so clojure-lsp will not be started. Please reset the calva.clojureLspVersion setting to use the default version of clojure-lsp, or set it to a clojure-lsp version you want to use. Alternatively, you can set the calva.clojureLspPath to use a downloaded binary of clojure-lsp.');
-            return;
-        }
-        const downloadVersion = configuredVersion === 'latest' ? await getLatestVersion() : configuredVersion;
+        const downloadVersion = ['', 'latest'].includes(configuredVersion) ? await getLatestVersion() : configuredVersion;
         if (currentVersion !== downloadVersion) {
             const downloadPromise = downloadClojureLsp(context.extensionPath, downloadVersion);
             lspStatus.text = '$(sync~spin) Downloading clojure-lsp';

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -281,6 +281,17 @@ async function startClient(clojureLspPath: string, context: vscode.ExtensionCont
     setStateValue(LSP_CLIENT_KEY, client);
     registerCommands(context, client);
     registerEventHandlers(context, client);
+    sayClientVersionInfo(client);
+}
+
+async function sayClientVersionInfo(client: LanguageClient) {
+    const serverInfo = await getServerInfo(client);
+    const clojureLspVersion = serverInfo['server-version'];
+    const cljKondoVersion = serverInfo['clj-kondo-version'];
+    const calvaSaysChannel = state.outputChannel();
+    calvaSaysChannel.appendLine('');
+    calvaSaysChannel.appendLine(`clojure-lsp version used: ${clojureLspVersion}`);
+    calvaSaysChannel.appendLine(`clj-kondo version used: ${cljKondoVersion}`);
 }
 
 async function serverInfoCommandHandler(): Promise<void> {


### PR DESCRIPTION
## What has Changed?

- A blank `clojureLspVersion` setting is now interpreted as `latest`
- The clojure-lsp and clj-kondo versions used are now logged to **Calva says** when the server has started

Fixes #1251

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.


Ping  @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->