### PR TITLE
Remove default project type configurations for deps.edn and Leiningen + shadow-cljs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix [Project configuration shadow-cljs + deps.edn doesn't work](https://github.com/BetterThanTomorrow/calva/issues/1253)
 
 ## [2.0.207] - 2021-08-07
 - [Support a blank `clojureLspVersion` setting](https://github.com/BetterThanTomorrow/calva/issues/1251)

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -65,12 +65,6 @@ const leiningenDefaults: ReplConnectSequence[] =
         cljsType: CljsTypes["Figwheel Main"]
     },
     {
-        name: "Leiningen + shadow-cljs",
-        projectType: ProjectTypes.Leiningen,
-        cljsType: CljsTypes["shadow-cljs"],
-        nReplPortFile: [".shadow-cljs", "nrepl.port"]
-    },
-    {
         name: "Leiningen + ClojureScript built-in for browser",
         projectType: ProjectTypes.Leiningen,
         cljsType: CljsTypes["ClojureScript built-in for browser"]
@@ -96,12 +90,6 @@ const cljDefaults: ReplConnectSequence[] =
         name: "deps.edn + Figwheel Main",
         projectType: ProjectTypes["deps.edn"],
         cljsType: CljsTypes["Figwheel Main"]
-    },
-    {
-        name: "deps.edn + shadow-cljs",
-        projectType: ProjectTypes["deps.edn"],
-        cljsType: CljsTypes["shadow-cljs"],
-        nReplPortFile: [".shadow-cljs", "nrepl.port"]
     },
     {
         name: "deps.edn + ClojureScript built-in for browser",


### PR DESCRIPTION
## What has Changed?

The default connect/jack-in configurations for **deps.edn + shadow-cljs** and **Leiningen + shadow-cljs** are removed, since they don't work and don't really make sense. The user should in these cases use the **shadow-cljs** configuration.

Fixes #1253

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

## The Calva Team PR Checklist:

Ping @pez, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->