### PR TITLE
Theme type aware statusbar REPL button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix [Statusbar buttons hard to see with light themes](https://github.com/BetterThanTomorrow/calva/issues/1264)
 
 ## [2.0.208] - 2021-08-09
 - Fix [Project configuration shadow-cljs + deps.edn doesn't work](https://github.com/BetterThanTomorrow/calva/issues/1253)

--- a/package.json
+++ b/package.json
@@ -213,36 +213,72 @@
                         "type": "object",
                         "description": "Configuration for custom coloring of the statusbar.",
                         "properties": {
-                            "disconnectedColor": {
-                                "type": "string",
-                                "default": "#c0c0c0",
-                                "pattern": "#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})",
-                                "description": "Foreground color for the disconnected status"
+                            "light": {
+                                "type": "object",
+                                "description": "Light theme colors",
+                                "properties": {
+                                    "disconnectedColor": {
+                                        "type": "string",
+                                        "pattern": "#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})",
+                                        "description": "Foreground color for the disconnected status"
+                                    },
+                                    "launchingColor": {
+                                        "type": "string",
+                                        "pattern": "#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})",
+                                        "description": "Foreground color for the launching status"
+                                    },
+                                    "connectedStatusColor": {
+                                        "type": "string",
+                                        "pattern": "#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})",
+                                        "description": "Foreground color for the connected status"
+                                    },
+                                    "typeStatusColor": {
+                                        "type": "string",
+                                        "pattern": "#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})",
+                                        "description": "Foreground color for the type status"
+                                    }
+                                }
                             },
-                            "launchingColor": {
-                                "type": "string",
-                                "default": "#fdd023",
-                                "pattern": "#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})",
-                                "description": "Foreground color for the launching status"
-                            },
-                            "connectedStatusColor": {
-                                "type": "string",
-                                "default": "#fdd023",
-                                "pattern": "#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})",
-                                "description": "Foreground color for the connected status"
-                            },
-                            "typeStatusColor": {
-                                "type": "string",
-                                "default": "#91dc47",
-                                "pattern": "#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})",
-                                "description": "Foreground color for the type status"
+                            "dark": {
+                                "type": "object",
+                                "description": "Dark theme colors",
+                                "properties": {
+                                    "disconnectedColor": {
+                                        "type": "string",
+                                        "pattern": "#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})",
+                                        "description": "Foreground color for the disconnected status"
+                                    },
+                                    "launchingColor": {
+                                        "type": "string",
+                                        "pattern": "#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})",
+                                        "description": "Foreground color for the launching status"
+                                    },
+                                    "connectedStatusColor": {
+                                        "type": "string",
+                                        "pattern": "#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})",
+                                        "description": "Foreground color for the connected status"
+                                    },
+                                    "typeStatusColor": {
+                                        "type": "string",
+                                        "pattern": "#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})",
+                                        "description": "Foreground color for the type status"
+                                    }
+                                }
                             }
                         },
                         "default": {
-                            "disconnectedColor": "#c0c0c0",
-                            "launchingColor": "#fdd023",
-                            "connectedStatusColor": "#fdd023",
-                            "typeStatusColor": "#91dc47"
+                            "light": {
+                                "disconnectedColor": "#777777",
+                                "launchingColor": "#000000",
+                                "connectedStatusColor": "#DB9550",
+                                "typeStatusColor": "#91dc47"
+                            },
+                            "dark": {
+                                "disconnectedColor": "#aaaaaa",
+                                "launchingColor": "#ffffff",
+                                "connectedStatusColor": "#DB9550",
+                                "typeStatusColor": "#91dc47"
+                            }
                         }
                     },
                     "calva.customCljsRepl": {

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -146,21 +146,21 @@ export async function startStandaloneRepl(context: vscode.ExtensionContext, dram
 }
 
 export async function startOrConnectRepl() {
-    const JACK_IN_OPTION = "Start your project with a REPL server and connect (a.k.a. Jack-in)";
+    const JACK_IN_OPTION = "Start your project with a REPL and connect (a.k.a. Jack-in)";
     const JACK_IN_COMMAND = "calva.jackIn";
-    const START_REPL_OPTION = "Start a standalone REPL server";
+    const START_REPL_OPTION = "Start a standalone REPL";
     const START_REPL_COMMAND = "calva.startStandaloneRepl";
-    const START_HELLO_REPL_OPTION = "Fire up the ”Getting Started” REPL server";
+    const START_HELLO_REPL_OPTION = "Fire up the ”Getting Started” REPL";
     const START_HELLO_REPL_COMMAND = "calva.startStandaloneHelloRepl";
     const START_HELLO_CLJS_BROWSER_OPTION = "Fire up the ”ClojureScript Quick Start” Browser REPL";
     const START_HELLO_CLJS_BROWSER_COMMAND = "calva.startStandaloneCljsBrowserRepl";
     const START_HELLO_CLJS_NODE_OPTION = "Fire up the ”ClojureScript Quick Start” Node REPL";
     const START_HELLO_CLJS_NODE_COMMAND = "calva.startStandaloneCljsNodeRepl";
-    const CONNECT_PROJECT_OPTION = "Connect to a running REPL server in your project";
+    const CONNECT_PROJECT_OPTION = "Connect to a running REPL in your project";
     const CONNECT_PROJECT_COMMAND = "calva.connect";
-    const CONNECT_STANDALONE_OPTION = "Connect to a running REPL server, not in your project";
+    const CONNECT_STANDALONE_OPTION = "Connect to a running REPL, not in your project";
     const CONNECT_STANDALONE_COMMAND = "calva.connectNonProjectREPL";
-    const DISCONNECT_OPTION = "Disconnect from the REPL server";
+    const DISCONNECT_OPTION = "Disconnect from the REPL";
     const DISCONNECT_COMMAND = "calva.disconnect";
     const OPEN_WINDOW_OPTION = "Open the Output Window";
     const OPEN_WINDOW_COMMAND = "calva.showOutputWindow";

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -15,6 +15,12 @@ const color = {
     inactive: "#b3b3b3"
 };
 
+// get theme kind once
+//console.log(vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Light ? 'light' : 'dark/hc');
+// event
+//vscode.window.onDidChangeActiveColorTheme(e => {
+//	console.log(e.kind === ColorThemeKind.Light ? 'light' : 'dark/hc');
+//});
 function colorValue(section: string, currentConf: vscode.WorkspaceConfiguration): string {
     let { defaultValue, globalValue, workspaceFolderValue, workspaceValue } = currentConf.inspect(section);
     return (workspaceFolderValue || workspaceValue || globalValue || defaultValue) as string;
@@ -22,7 +28,9 @@ function colorValue(section: string, currentConf: vscode.WorkspaceConfiguration)
 
 function update(context = state.extensionContext) {
 
-    let currentConf = vscode.workspace.getConfiguration('calva.statusColor');
+    let currentConf = vscode.workspace.getConfiguration(`calva.statusColor.${
+        vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Light ? 'light' : 'dark'
+    }`);
 
     let doc = util.getDocument({}),
         fileType = util.getFileType(doc),
@@ -54,7 +62,7 @@ function update(context = state.extensionContext) {
     cljsBuildStatus.tooltip = null;
 
     if (getStateValue('connected')) {
-        connectionStatus.text = "nREPL $(zap)";
+        connectionStatus.text = "REPL $(zap)";
         connectionStatus.color = colorValue("connectedStatusColor", currentConf);
         connectionStatus.tooltip = `nrepl://${getStateValue('hostname')}:${getStateValue('port')} (Click to reset connection)`;
         connectionStatus.command = "calva.startOrConnectRepl";
@@ -84,11 +92,11 @@ function update(context = state.extensionContext) {
         connectionStatus.tooltip = "Click to interrupt jack-in or Connect to REPL Server";
         connectionStatus.command = "calva.disconnect";
     } else if (util.getConnectingState()) {
-        connectionStatus.text = "nREPL - trying to connect";
+        connectionStatus.text = "REPL - trying to connect";
         connectionStatus.tooltip = "Click to interrupt jack-in or Connect to REPL Server";
         connectionStatus.command = "calva.disconnect";
     } else {
-        connectionStatus.text = "nREPL $(zap)";
+        connectionStatus.text = "REPL $(zap)";
         connectionStatus.tooltip = "Click to jack-in or Connect to REPL Server";
         connectionStatus.color = colorValue("disconnectedColor", currentConf);
         connectionStatus.command = "calva.startOrConnectRepl";


### PR DESCRIPTION
## What has Changed?

I've made the statusbarColor setting aware about the theme type (light/dark). With these defaults.

```json
        "light": {
            "disconnectedColor": "#777777",
            "launchingColor": "#000000",
            "connectedStatusColor": "#DB9550",
            "typeStatusColor": "#91dc47"
        },
        "dark": {
            "disconnectedColor": "#aaaaaa",
            "launchingColor": "#ffffff",
            "connectedStatusColor": "#DB9550",
            "typeStatusColor": "#91dc47"
        }
```

Users who have set the old `statusbarColor` setting will have to update the setting. I have made no upgrading/backward compatibility effort, because I don't think the colors here are important enough.

Fixes #1264

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.

Ping  @bpringe
