### PR TITLE
1301 snippet replace g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - Fix [The schema for the setting `calva.highlight.bracketColors` is broken](https://github.com/BetterThanTomorrow/calva/issues/1290)
+- Fix [Can't use $current-form more than once in a custom repl command snippet](https://github.com/BetterThanTomorrow/calva/issues/1301)
 
 ## [2.0.211] - 2021-09-01
 - [Add setting for letting Paredit Kill commands copy the deleted code to the clipboard](https://github.com/BetterThanTomorrow/calva/issues/1283)

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -86,18 +86,18 @@ async function evaluateCustomCodeSnippet(codeOrKey?: string): Promise<void> {
     const ns = pick !== undefined ? snippetsDict[pick].ns : editorNS;
     const repl = pick !== undefined ? snippetsDict[pick].repl : editorRepl;
     const interpolatedCode = code.
-        replace("$line", currentLine).
-        replace("$column", currentColumn).
-        replace("$file", currentFilename).
-        replace("$ns", ns).
-        replace("$selection", editor.document.getText(editor.selection)).
-        replace("$current-form", getText.currentFormText(editor)[1]).
-        replace("$enclosing-form", getText.currentEnclosingFormText(editor)[1]).
-        replace("$top-level-form", getText.currentTopLevelFormText(editor)[1]).
-        replace("$current-fn", getText.currentFunction(editor)[1]).
-        replace("$top-level-defined-symbol", getText.currentTopLevelFunction(editor)[1]).
-        replace("$head", getText.toStartOfList(editor)[1]).
-        replace("$tail", getText.toEndOfList(editor)[1]);
+        replaceAll("$line", currentLine).
+        replaceAll("$column", currentColumn).
+        replaceAll("$file", currentFilename).
+        replaceAll("$ns", ns).
+        replaceAll("$selection", editor.document.getText(editor.selection)).
+        replaceAll("$current-form", getText.currentFormText(editor)[1]).
+        replaceAll("$enclosing-form", getText.currentEnclosingFormText(editor)[1]).
+        replaceAll("$top-level-form", getText.currentTopLevelFormText(editor)[1]).
+        replaceAll("$current-fn", getText.currentFunction(editor)[1]).
+        replaceAll("$top-level-defined-symbol", getText.currentTopLevelFunction(editor)[1]).
+        replaceAll("$head", getText.toStartOfList(editor)[1]).
+        replaceAll("$tail", getText.toEndOfList(editor)[1]);
     await evaluate.evaluateInOutputWindow(interpolatedCode, repl, ns);
     outputWindow.appendPrompt();
 }

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "calva.customREPLCommandSnippets": [
+    {
+      "name": "Double current",
+      "snippet": "(tap> [$current-form $current-form])"
+    }
+  ]
+}


### PR DESCRIPTION
## What has Changed?

- When substituting snippet variables/placeholders we were using `String.replace()` so only replacing the first occurrence. Now we use `replaceAll()`
-
-

Fixes #1301

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

## The Calva Team PR Checklist:

Ping @bpringe
