### PR TITLE
Add nbb workaround connect sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Workaround [nbb nrepl-server: can only eval from file with extension .clj](https://github.com/BetterThanTomorrow/calva/issues/1308)
 
 ## [2.0.212] - 2021-09-26
 - Fix [The schema for the setting `calva.highlight.bracketColors` is broken](https://github.com/BetterThanTomorrow/calva/issues/1290)

--- a/docs/site/connect-sequences.md
+++ b/docs/site/connect-sequences.md
@@ -36,6 +36,9 @@ A connect sequence configures the following:
 
 The [Calva built-in sequences](https://github.com/BetterThanTomorrow/calva/blob/published/src/nrepl/connectSequence.ts) also use this format, check them out to get a clearer picture of how these settings work.
 
+!!! Note "Apropos the **ClojureScript nREPL Server** built-in sequence"
+    Because of ancient decisions in the design of Calva session managament, the current implementation of the ClojureScript nREPL Server connect sequence is a workaround. Calva will still indicate that it has a Clojure session available, which is nonsense in a pure ClojureScript nREPL environment. This session is also a ClojureScript session.
+
 ## Example Sequences
 
 Setting for a full-stack application. It starts the backend server when the CLJ REPL has started. Then proceeds to create a custom CLJS REPL (calling in to the application code for this). And then connects to it.

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -8,7 +8,8 @@ enum ProjectTypes {
     "deps.edn" = "deps.edn",
     "shadow-cljs" = "shadow-cljs",
     "lein-shadow" = "lein-shadow",
-    'generic' = 'generic'
+    'generic' = 'generic',
+    'cljs-only' = 'cljs-only'
 }
 
 enum CljsTypes {
@@ -17,6 +18,7 @@ enum CljsTypes {
     "shadow-cljs" = "shadow-cljs",
     "ClojureScript built-in for browser" = "ClojureScript built-in for browser",
     "ClojureScript built-in for node" = "ClojureScript built-in for node",
+    "ClojureScript nREPL" = "ClojureScript nREPL",
     "User provided" = "User provided",
     "none" = "none"
 }
@@ -139,12 +141,21 @@ const genericDefaults: ReplConnectSequence[] = [{
     nReplPortFile: ["nrepl.port"]
 }];
 
+const cljsOnlyDefaults: ReplConnectSequence[] = [{
+    name: "ClojureScript nREPL Server",
+    projectType: ProjectTypes['cljs-only'],
+    cljsType: CljsTypes["ClojureScript nREPL"],
+    nReplPortFile: ["nrepl.port"]
+}];
+
+
 const defaultSequences = {
     "lein": leiningenDefaults,
     "clj": cljDefaults,
     "shadow-cljs": shadowCljsDefaults,
     "lein-shadow": leinShadowDefaults,
-    'generic': genericDefaults
+    'generic': genericDefaults,
+    'cljs-only': cljsOnlyDefaults
 };
 
 const defaultCljsTypes: { [id: string]: CljsTypeConfig } = {
@@ -195,6 +206,13 @@ const defaultCljsTypes: { [id: string]: CljsTypeConfig } = {
         isStarted: true,
         connectCode: "(do (require 'cljs.repl.node) (cider.piggieback/cljs-repl (cljs.repl.node/repl-env)))",
         isConnectedRegExp: "To quit, type: :cljs/quit"
+    },
+    "ClojureScript nREPL": {
+        name: "ClojureScript nREPL",
+        buildsRequired: false,
+        isStarted: true,
+        connectCode: ":fake-it",
+        isConnectedRegExp: ":fake-it"
     }
 };
 
@@ -268,5 +286,6 @@ export {
     ReplConnectSequence,
     CljsTypeConfig,
     genericDefaults,
+    cljsOnlyDefaults,
     cljDefaults
 }

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -506,7 +506,7 @@ export function getProjectTypeForName(name: string) {
 
 export async function detectProjectTypes(): Promise<string[]> {
     const rootUri = state.getProjectRootUri();
-    const cljProjTypes = ['generic'];
+    const cljProjTypes = ['generic', 'cljs-only'];
     for (let clj in projectTypes) {
         if (projectTypes[clj].useWhenExists) {
             try {
@@ -521,7 +521,7 @@ export async function detectProjectTypes(): Promise<string[]> {
 }
 
 export function getAllProjectTypes(): string[] {
-    return ['generic', ...Object.keys(projectTypes).filter(pt => pt !== 'generic')];
+    return ['generic', 'cljs-only', ...Object.keys(projectTypes).filter(pt => !['generic', 'cljs-only'].includes(pt))];
 }
 
 export function getCljsTypeName(connectSequence: ReplConnectSequence) {


### PR DESCRIPTION
## What has Changed?

With `nbb` the assumption that an nREPL server is always running on a Clojure host broke. It will take quite some effort to remove this assumption from Calva. Therefore I am adding this workaround built-in sequence: **ClojureScript nREPL Server**.  Hopefully we will be able to keep it and just change it's implementation when we fix this issue properly.

Fixes #1308

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)


Ping @pez, @bpringe

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->