### PR TITLE
Add command for quickly adding a rich comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Add command for inserting a Rich Comment](https://github.com/BetterThanTomorrow/calva/issues/1324)
 
 ## [2.0.214] - 2021-10-06
 - [Add Babashka Jack-in option](https://github.com/BetterThanTomorrow/calva/issues/1001)

--- a/docs/site/rich-comments.md
+++ b/docs/site/rich-comments.md
@@ -36,7 +36,7 @@ To develop or refine a function you might:
 
 Calva has several features to facilitate the Rich comments workflow, e.g.
 
-1. A command that helps you crate a new Rich comment form quickly: **Calva: Add Rich Comment**, <kbd>ctrl+alt+r c</kbd>
+1. A command that helps you create a new Rich comment form quickly: **Calva: Add Rich Comment**, <kbd>ctrl+alt+r c</kbd>
 1. Special [Syntax highlight](customizing.md#calva-highlight). By default `comment` forms are rendered in _italics_
 1. Special [top-level form](evaluation.md#current-top-level-form) context
 1. Special formatting

--- a/docs/site/rich-comments.md
+++ b/docs/site/rich-comments.md
@@ -36,6 +36,7 @@ To develop or refine a function you might:
 
 Calva has several features to facilitate the Rich comments workflow, e.g.
 
+1. A command that helps you crate a new Rich comment form quickly: **Calva: Add Rich Comment**, <kbd>ctrl+alt+r c</kbd>
 1. Special [Syntax highlight](customizing.md#calva-highlight). By default `comment` forms are rendered in _italics_
 1. Special [top-level form](evaluation.md#current-top-level-form) context
 1. Special formatting

--- a/package.json
+++ b/package.json
@@ -1471,6 +1471,12 @@
                 "category": "Calva",
                 "command": "calva.toggleBetweenImplAndTest",
                 "title": "Toggle between implementation and test"
+            },
+            {
+                "category": "Calva",
+                "command": "paredit.addRichComment",
+                "title": "Add Rich Comment",
+                "enablement": "editorLangId == clojure"
             }
         ],
         "keybindings": [
@@ -2297,6 +2303,11 @@
             {
                 "command": "calva.toggleBetweenImplAndTest",
                 "when": "calva:keybindingsEnabled"
+            },
+            {
+                "command": "paredit.addRichComment",
+                "key": "ctrl+alt+r c",
+                "when": "editorLangId == clojure && calva:keybindingsEnabled"
             }
         ],
         "menus": {

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -88,6 +88,8 @@ export type ModelEditOptions = {
 };
 
 export interface EditableModel {
+    readonly lineEndingLength: number,
+
     /**
      * Performs a model edit batch.
      * For some EditableModel's these are performed as one atomic set of edits.
@@ -117,7 +119,7 @@ export interface EditableDocument {
 /** The underlying model for the REPL readline. */
 export class LineInputModel implements EditableModel {
     /** How many characters in the line endings of the text of this model? */
-    constructor(private lineEndingLength: number = 1, private document?: EditableDocument) { }
+    constructor(readonly lineEndingLength: number = 1, private document?: EditableDocument) { }
 
     /** The input lines. */
     lines: TextLine[] = [new TextLine("", this.getStateForLine(0))];

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -8,9 +8,15 @@ import { ModelEdit, EditableDocument, EditableModel, ModelEditOptions, LineInput
 let documents = new Map<vscode.TextDocument, MirroredDocument>();
 
 export class DocumentModel implements EditableModel {
-    constructor(private document: MirroredDocument) { }
+    readonly lineEndingLength: number;
+    lineInputModel: LineInputModel;
 
-    lineInputModel = new LineInputModel(this.document.document.eol == vscode.EndOfLine.CRLF ? 2 : 1);
+    constructor(private document: MirroredDocument) {
+        this.lineEndingLength = document.document.eol == vscode.EndOfLine.CRLF ? 2 : 1;
+        this.lineInputModel = new LineInputModel(this.lineEndingLength);
+     }
+
+
 
     edit(modelEdits: ModelEdit[], options: ModelEditOptions): Thenable<boolean> {
         const editor = vscode.window.activeTextEditor,

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -828,7 +828,7 @@ describe('paredit', () => {
             });
             it('Inserts Rich Comment between Top Levels, in comment', () => {
                 const a = docFromTextNotation('(foo)•;foo| bar•(bar)');
-                const b = docFromTextNotation('(foo)•;foo bar•(comment•  |•  )••(bar)');
+                const b = docFromTextNotation('(foo)•;foo bar••(comment•  |•  )••(bar)');
                 paredit.addRichComment(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -801,5 +801,37 @@ describe('paredit', () => {
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
         });
+        describe('addRichComment', () => {
+            it('Adds Rich Comment after Top Level form', () => {
+                const a = docFromTextNotation('(fo|o)••(bar)');
+                const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
+                paredit.addRichComment(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
+            });
+            it('Inserts Rich Comment between Top Levels', () => {
+                const a = docFromTextNotation('(foo)•|•(bar)');
+                const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
+                paredit.addRichComment(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
+            });
+            it('Inserts Rich Comment between Top Levels, before Top Level form', () => {
+                const a = docFromTextNotation('(foo)••|(bar)');
+                const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
+                paredit.addRichComment(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
+            });
+            it('Inserts Rich Comment between Top Levels, after Top Level form', () => {
+                const a = docFromTextNotation('(foo)|••(bar)');
+                const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
+                paredit.addRichComment(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
+            });
+            it('Inserts Rich Comment between Top Levels, in comment', () => {
+                const a = docFromTextNotation('(foo)•;foo| bar•(bar)');
+                const b = docFromTextNotation('(foo)•;foo bar•(comment•  |•  )••(bar)');
+                paredit.addRichComment(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
+            });
+        }) 
     });
 });

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -295,6 +295,10 @@ const pareditCommands: PareditCommand[] = [
     {
         command: 'paredit.forceDeleteBackward',
         handler: () => { vscode.commands.executeCommand('deleteLeft') }
+    },
+    {
+        command: 'paredit.addRichComment',
+        handler: paredit.addRichComment
     }
 ];
 


### PR DESCRIPTION
## What has Changed?

- Adding a rich comment is now only this keystroke away: `ctrl+alt+r c`

I added it in the paredit module, because it is about structural editing. But to the user it is not necessarily Paredit so the command is added in the general Calva category.

Fixes #1324

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.

Ping @pez, @bpringe