### PR TITLE
Inline display with :after + non-breaking spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Inline results display pushes the cursor away when evaluation at the end of the line](https://github.com/BetterThanTomorrow/calva/issues/1329)
 
 ## [2.0.215] - 2021-10-10
 - [Add command for inserting a Rich Comment](https://github.com/BetterThanTomorrow/calva/issues/1324)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - Fix: [Inline results display pushes the cursor away when evaluation at the end of the line](https://github.com/BetterThanTomorrow/calva/issues/1329)
+- Fix: [Inline evaluation display renders differently than the REPL display for empty spaces](https://github.com/BetterThanTomorrow/calva/issues/872)
 
 ## [2.0.215] - 2021-10-10
 - [Add command for inserting a Rich Comment](https://github.com/BetterThanTomorrow/calva/issues/1324)

--- a/src/providers/annotations.ts
+++ b/src/providers/annotations.ts
@@ -24,7 +24,7 @@ const selectionRulerColors = [
 ]
 
 const evalResultsDecorationType = vscode.window.createTextEditorDecorationType({
-    before: {
+    after: {
         textDecoration: 'none',
         fontWeight: 'normal',
         fontStyle: 'normal',
@@ -53,17 +53,17 @@ function getEvaluationPosition(pos: vscode.Position): vscode.Position {
 function evaluated(contentText, hoverText, hasError) {
     return {
         renderOptions: {
-            before: {
+            after: {
                 contentText: contentText,
                 overflow: "hidden"
             },
             light: {
-                before: {
+                after: {
                     color: hasError ? 'rgb(255, 127, 127)' : 'black',
                 },
             },
             dark: {
-                before: {
+                after: {
                     color: hasError ? 'rgb(255, 175, 175)' : 'white',
                 }
             },

--- a/src/providers/annotations.ts
+++ b/src/providers/annotations.ts
@@ -54,7 +54,7 @@ function evaluated(contentText, hoverText, hasError) {
     return {
         renderOptions: {
             after: {
-                contentText: contentText,
+                contentText: contentText.replaceAll(/ /g, "\u00a0"),
                 overflow: "hidden"
             },
             light: {


### PR DESCRIPTION
## What has Changed?

Inline results displays now:

- Use `:after`, in order not to push the cursor away
- Uses non-breaking spaces instead of spaces, so that strings of spaces display correctly

The `:after` is a bit of a bet. It used to be a problem, but now I can't see that it is, even with GitLense line blames on. Let's hope it stays non-problematic.

Fixes #1329 

Fixes #872 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.

Ping @bpringe