### PR TITLE
Jump to any existing Rich comment where we would insert one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Make Add Rich Comment command go to any existing Rich comment right below](https://github.com/BetterThanTomorrow/calva/issues/1333)
 
 ## [2.0.216] - 2021-10-10
 - Fix: [Inline results display pushes the cursor away when evaluation at the end of the line](https://github.com/BetterThanTomorrow/calva/issues/1329)

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -981,15 +981,19 @@ export function addRichComment(doc: EditableDocument, p = doc.selection.active) 
     const richComment = '(comment\n  \n  )';
     let cursor = doc.getTokenCursor(p);
     const topLevelRange = rangeForDefun(doc, p, false);
-    const isTopLevel = (p <= topLevelRange[0] || p >= topLevelRange[1]);
-    if (!isTopLevel) {
+    const isInsideForm = !(p <= topLevelRange[0] || p >= topLevelRange[1]);
+    const checkIfAtStartCursor = doc.getTokenCursor(p);
+    checkIfAtStartCursor.backwardWhitespace(true);
+    const isAtStart = checkIfAtStartCursor.atStart();
+    if (isInsideForm || isAtStart) {
         cursor = doc.getTokenCursor(topLevelRange[1]);
     }
-    const inComment = cursor.getPrevToken().type === 'comment' || cursor.getToken().type === 'comment';
-    if (inComment) {
+    const inLineComment = cursor.getPrevToken().type === 'comment' || cursor.getToken().type === 'comment';
+    if (inLineComment) {
         cursor.forwardWhitespace(true);
         cursor.backwardWhitespace(false);
     }
+    
     const insertStart = cursor.offsetStart;
     cursor.backwardWhitespace(false);
     const leftWs = doc.model.getText(cursor.offsetStart, insertStart);

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -832,6 +832,18 @@ describe('paredit', () => {
                 paredit.addRichComment(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
+            it('Moves to Rich Comment below, if any', () => {
+                const a = docFromTextNotation('(foo|)••(comment••bar••baz)');
+                const b = docFromTextNotation('(foo)••(comment••|bar••baz)');
+                paredit.addRichComment(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
+            });
+            it('Moves to Rich Comment below, if any, looking behind line comments', () => {
+                const a = docFromTextNotation('(foo|)••;;line comment••(comment••bar••baz)');
+                const b = docFromTextNotation('(foo)••;;line comment••(comment••|bar••baz)');
+                paredit.addRichComment(a);
+                expect(textAndSelection(a)).toEqual(textAndSelection(b));
+            });
         }) 
     });
 });


### PR DESCRIPTION
## What has Changed?

- If there is a Rich comment where the Add Rich Comment command would add one, we jump there instead.
- If the cursor is at the start of the file, add the comment below the first form (typically the `ns` form).

Fixes #1333

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.

Ping @pez, @bpringe