### PR TITLE
Fix inline evaluation result not displaying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
+## [2.0.217] - 2021-10-14
+- Fix: [Inline evaluation results no longer display in 2.0.216](https://github.com/BetterThanTomorrow/calva/issues/1332)
+
 ## [2.0.216] - 2021-10-10
 - Fix: [Inline results display pushes the cursor away when evaluation at the end of the line](https://github.com/BetterThanTomorrow/calva/issues/1329)
 - Fix: [Inline evaluation display renders differently than the REPL display for empty spaces](https://github.com/BetterThanTomorrow/calva/issues/872)

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -86,18 +86,18 @@ async function evaluateCustomCodeSnippet(codeOrKey?: string): Promise<void> {
     const ns = pick !== undefined ? snippetsDict[pick].ns : editorNS;
     const repl = pick !== undefined ? snippetsDict[pick].repl : editorRepl;
     const interpolatedCode = code.
-        replace("$line", currentLine).
-        replace("$column", currentColumn).
-        replace("$file", currentFilename).
-        replace("$ns", ns).
-        replace("$selection", editor.document.getText(editor.selection)).
-        replace("$current-form", getText.currentFormText(editor)[1]).
-        replace("$enclosing-form", getText.currentEnclosingFormText(editor)[1]).
-        replace("$top-level-form", getText.currentTopLevelFormText(editor)[1]).
-        replace("$current-fn", getText.currentFunction(editor)[1]).
-        replace("$top-level-defined-symbol", getText.currentTopLevelFunction(editor)[1]).
-        replace("$head", getText.toStartOfList(editor)[1]).
-        replace("$tail", getText.toEndOfList(editor)[1]);
+        replace(/\$line/g, currentLine).
+        replace(/\$column/g, currentColumn).
+        replace(/\$file/g, currentFilename).
+        replace(/\$ns/g, ns).
+        replace(/\$selection/g, editor.document.getText(editor.selection)).
+        replace(/\$current-form/g, getText.currentFormText(editor)[1]).
+        replace(/\$enclosing-form/g, getText.currentEnclosingFormText(editor)[1]).
+        replace(/\$top-level-form/g, getText.currentTopLevelFormText(editor)[1]).
+        replace(/\$current-fn/g, getText.currentFunction(editor)[1]).
+        replace(/\$top-level-defined-symbol/g, getText.currentTopLevelFunction(editor)[1]).
+        replace(/\$head/g, getText.toStartOfList(editor)[1]).
+        replace(/\$tail/g, getText.toEndOfList(editor)[1]);
     await evaluate.evaluateInOutputWindow(interpolatedCode, repl, ns);
     outputWindow.appendPrompt();
 }

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -86,18 +86,18 @@ async function evaluateCustomCodeSnippet(codeOrKey?: string): Promise<void> {
     const ns = pick !== undefined ? snippetsDict[pick].ns : editorNS;
     const repl = pick !== undefined ? snippetsDict[pick].repl : editorRepl;
     const interpolatedCode = code.
-        replaceAll("$line", currentLine).
-        replaceAll("$column", currentColumn).
-        replaceAll("$file", currentFilename).
-        replaceAll("$ns", ns).
-        replaceAll("$selection", editor.document.getText(editor.selection)).
-        replaceAll("$current-form", getText.currentFormText(editor)[1]).
-        replaceAll("$enclosing-form", getText.currentEnclosingFormText(editor)[1]).
-        replaceAll("$top-level-form", getText.currentTopLevelFormText(editor)[1]).
-        replaceAll("$current-fn", getText.currentFunction(editor)[1]).
-        replaceAll("$top-level-defined-symbol", getText.currentTopLevelFunction(editor)[1]).
-        replaceAll("$head", getText.toStartOfList(editor)[1]).
-        replaceAll("$tail", getText.toEndOfList(editor)[1]);
+        replace("$line", currentLine).
+        replace("$column", currentColumn).
+        replace("$file", currentFilename).
+        replace("$ns", ns).
+        replace("$selection", editor.document.getText(editor.selection)).
+        replace("$current-form", getText.currentFormText(editor)[1]).
+        replace("$enclosing-form", getText.currentEnclosingFormText(editor)[1]).
+        replace("$top-level-form", getText.currentTopLevelFormText(editor)[1]).
+        replace("$current-fn", getText.currentFunction(editor)[1]).
+        replace("$top-level-defined-symbol", getText.currentTopLevelFunction(editor)[1]).
+        replace("$head", getText.toStartOfList(editor)[1]).
+        replace("$tail", getText.toEndOfList(editor)[1]);
     await evaluate.evaluateInOutputWindow(interpolatedCode, repl, ns);
     outputWindow.appendPrompt();
 }

--- a/src/providers/annotations.ts
+++ b/src/providers/annotations.ts
@@ -54,7 +54,7 @@ function evaluated(contentText, hoverText, hasError) {
     return {
         renderOptions: {
             after: {
-                contentText: contentText.replaceAll(/ /g, "\u00a0"),
+                contentText: contentText.replace(/ /g, "\u00a0"),
                 overflow: "hidden"
             },
             light: {


### PR DESCRIPTION
## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Replace usage of `replaceAll` with `replace`

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1332 
Workaround for #1339 

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x]  Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe