### PR TITLE
Add support for custom pprint printfn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Support setting the cider-nrepl print-fn to whatever](https://github.com/BetterThanTomorrow/calva/issues/1340)
 
 ## [2.0.216] - 2021-10-10
 - Fix: [Inline results display pushes the cursor away when evaluation at the end of the line](https://github.com/BetterThanTomorrow/calva/issues/1329)

--- a/docs/site/pprint.md
+++ b/docs/site/pprint.md
@@ -16,6 +16,7 @@ Setting          | Type    | Effect
 -------          | ----    | ------
 `enabled`        | boolean | So this is a third way you can change this mode 😄
 `printEngine`    | enum    | Which printer function that will be used. Default is `pprint`, more about this setting below
+`printFn`        | object  | You can configure Calva to use a custom `nREPL` compatible `print` function, more below.
 `width`          | number  | The maximum line length of printed output (or at least the printers will try)
 `maxLength`      | number  | The maximum number of elements printed in nested nodes, [good for evaluating something like `(iterate inc 0)`](https://clojuredocs.org/clojure.core/*print-length*#example-542692cac026201cdc326b12), which you shouldn't do without setting `maxLength`. Most printers will indicate truncated lists with `...` at the end.
 `maxDepth`       | number  | The maximum number of levels deep that will get printed. Different printers mark a stop different ways. `puget` doesn't support it at all.
@@ -42,6 +43,10 @@ Print Engine | Client or Server Side | Comments
 [`zprint`](https://github.com/kkinnear/zprint) | server | Recommended. Will need to be configured before [Jack-in](connect.md) if you want Calva's help to inject its dependencies
 
 These particular server side functions were chosen because they have pre-configured print-functions in [`cider-nrepl`](https://docs.cider.mx/cider-nrepl/).
+
+#### Or configure `printFn`
+
+If the selection of built-in `printEngine` support doesn't cut it, you can configure a custom function. This function will need to conform to the requirements of nREPL print functions. The VS Code settings editor will help you configure this one.
 
 ### Why does Server or Client Side Matter?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "calva",
-    "version": "2.0.217",
+    "version": "2.0.217-fooo",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Calva: Clojure & ClojureScript Interactive Programming",
     "description": "Integrated REPL, formatter, Paredit, and more. Powered by cider-nrepl and clojure-lsp.",
     "icon": "assets/calva.png",
-    "version": "2.0.217",
+    "version": "2.0.217-fooo",
     "publisher": "betterthantomorrow",
     "author": {
         "name": "Better Than Tomorrow",
@@ -116,7 +116,7 @@
                 "editor.formatOnPaste": true,
                 "files.trimTrailingWhitespace": false,
                 "editor.matchBrackets": "never",
-                "editor.renderIndentGuides": false,
+                "editor.guides.indentation": false,
                 "editor.parameterHints.enabled": false
             }
         },
@@ -135,13 +135,38 @@
                             },
                             "printEngine": {
                                 "type": "string",
-                                "description": "The print engine to use. 'calva' means that the nREPL server will first plain print it and then Calva will prettify. The other options will make the server use the chosen printer-function to print the result, and Calva will not reformat it.",
+                                "description": "The print engine to use. 'calva' means that the nREPL server will first plain print it and then Calva will prettify. The other options will make the server use the chosen printer-function to print the result, and Calva will not reformat it. To use some other function (on the server), configure `printFn` instead. To use the `nREPL` default (the equivalent of `clojure.core/pr`), set neither this nore `printFn`.",
                                 "enum": [
                                     "calva",
                                     "pprint",
                                     "fipp",
                                     "puget",
                                     "zprint"
+                                ]
+                            },
+                            "printFn": {
+                                "type": "object",
+                                "markdownDescription": "A custom `nREPL` compatible `print-fn`. See https://nrepl.org/nrepl/usage/misc.html#pretty-printing",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "markdownDescription": "A symbol referencing a Clojure function to use for printing result values. E.g. `pr`. Or `foo.bar/baz`."
+                                    },
+                                    "maxWidthArgument": {
+                                        "type": "string",
+                                        "markdownDescription": "Argument that the function uses for setting the max-width of the lines printed. E.g. `width`."
+                                    },
+                                    "seqLimitArgument": {
+                                        "type": "string",
+                                        "markdownDescription": "Argument that the function uses for truncating the number of elements to print  for sequences. E.g. `length`."
+                                    },
+                                    "maxDepthArgument": {
+                                        "type": "string",
+                                        "markdownDescription": "Argument that the function uses for limiting the depth that collections are traversed. E.g. `levels`."
+                                    }
+                                },
+                                "required": [
+                                    "name"
                                 ]
                             },
                             "width": {
@@ -164,12 +189,10 @@
                             }
                         },
                         "required": [
-                            "enabled",
-                            "printEngine"
+                            "enabled"
                         ],
                         "default": {
                             "enabled": true,
-                            "printEngine": "pprint",
                             "width": 120,
                             "maxLength": 50
                         }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Calva: Clojure & ClojureScript Interactive Programming",
     "description": "Integrated REPL, formatter, Paredit, and more. Powered by cider-nrepl and clojure-lsp.",
     "icon": "assets/calva.png",
-    "version": "2.0.217-fooo",
+    "version": "2.0.217",
     "publisher": "betterthantomorrow",
     "author": {
         "name": "Better Than Tomorrow",

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -366,7 +366,7 @@ async function togglePrettyPrint() {
         pprintConfigKey = 'prettyPrintingOptions',
         pprintOptions = config.get(pprintConfigKey) as PrettyPrintingOptions;
     pprintOptions.enabled = !pprintOptions.enabled;
-    if (pprintOptions.enabled && !(pprintOptions.printEngine || pprintOptions.printFn) {
+    if (pprintOptions.enabled && !(pprintOptions.printEngine || pprintOptions.printFn)) {
         pprintOptions.printEngine = 'pprint';
     }
     await config.update(pprintConfigKey, pprintOptions, vscode.ConfigurationTarget.Global);

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -366,6 +366,9 @@ async function togglePrettyPrint() {
         pprintConfigKey = 'prettyPrintingOptions',
         pprintOptions = config.get(pprintConfigKey) as PrettyPrintingOptions;
     pprintOptions.enabled = !pprintOptions.enabled;
+    if (pprintOptions.enabled && !(pprintOptions.printEngine || pprintOptions.printFn) {
+        pprintOptions.printEngine = 'pprint';
+    }
     await config.update(pprintConfigKey, pprintOptions, vscode.ConfigurationTarget.Global);
     statusbar.update();
 };

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1,8 +1,17 @@
 import { getConfig } from './config';
 
+export type PrintFnOptions = {
+    name: string,
+    maxWidthArgument?: string,
+    seqLimitArgument?: string,
+    maxDepthArgument: string
+};
+
+
 export type PrettyPrintingOptions = {
     enabled: boolean,
-    printEngine?: 'calva' | 'pprint' | 'fipp' | 'puget' | 'zprint',
+    printFn?: PrintFnOptions,
+    printEngine?: 'calva' | 'pprint' | 'fipp' | 'puget' | 'zprint' | 'custom',
     width: number,
     maxLength?: number,
     maxDepth?: number
@@ -22,7 +31,9 @@ function getPrinter(pprintOptions: PrettyPrintingOptions, printerFn: string, wid
     let printer = {};
     printer[OPTIONS] = moreOptions;
     printer[PRINTER_FN] = printerFn;
-    printer[OPTIONS][widthSlug] = pprintOptions.width;
+    if (widthSlug !== undefined) {
+        printer[OPTIONS][widthSlug] = pprintOptions.width;
+    }
     if (pprintOptions.maxLength && lengthSlug !== undefined) {
         printer[OPTIONS][lengthSlug] = pprintOptions.maxLength;
     }
@@ -53,8 +64,10 @@ export function getServerSidePrinter(pprintOptions: PrettyPrintingOptions) {
             default:
                 return undefined;
         }
+    } else if (pprintOptions.printFn) {
+        const printerFn = pprintOptions.printFn;
+        return getPrinter(pprintOptions, printerFn.name, printerFn?.maxWidthArgument, printerFn?.seqLimitArgument, printerFn?.maxDepthArgument);
     }
-    return undefined;
 }
 
 export function prettyPrintingOptions(): PrettyPrintingOptions {


### PR DESCRIPTION
## What has Changed?

New configuration options for providing a custom nREPL print-fn.

Also stops using `pprint` as default print engine in the setting schema. We are setting this from code when pprint is enable instead. This is to prevent it being added when pprint is disabled.

Fixes #1340

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe