### PR TITLE
Fix select top level deref in comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Select top level form fails for top level derefs in comment forms](https://github.com/BetterThanTomorrow/calva/issues/1345)
 
 ## [2.0.217] - 2021-10-17
 - [Support setting the cider-nrepl print-fn to whatever](https://github.com/BetterThanTomorrow/calva/issues/1340)

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -432,7 +432,7 @@ export class LispTokenCursor extends TokenCursor {
     backwardListOfType(openingBracket: string): boolean {
         let cursor = this.clone();
         while (cursor.backwardList()) {
-            if (cursor.getPrevToken().raw === openingBracket) {
+            if (cursor.getPrevToken().raw.endsWith(openingBracket)) {
                 this.set(cursor);
                 return true;
             }
@@ -610,6 +610,7 @@ export class LispTokenCursor extends TokenCursor {
     rangeForDefun(offset: number, commentCreatesTopLevel = true): [number, number] {
         const cursor = this.doc.getTokenCursor(offset);
         let lastCandidateRange: [number, number] = cursor.rangeForCurrentForm(offset);
+        console.log(lastCandidateRange);
         while (cursor.forwardList() && cursor.upList()) {
             const commentCursor = cursor.clone();
             commentCursor.backwardDownList();

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -500,6 +500,12 @@ describe('Token Cursor', () => {
             const cursor: LispTokenCursor = a.getTokenCursor(0);
             expect(cursor.rangeForDefun(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
         });
+        it('Finds top level form when deref in comment', () => {
+            const a = docFromTextNotation('(comment @(foo [bar|]))');
+            const b = docFromTextNotation('(comment |@(foo [bar])|)');
+            const cursor: LispTokenCursor = a.getTokenCursor(0);
+            expect(cursor.rangeForDefun(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+        })
     });
 
     describe('Location State', () => {

--- a/test-data/select.clj
+++ b/test-data/select.clj
@@ -1,0 +1,3 @@
+(comment
+  @(rf/subscribe [:foo])
+  )


### PR DESCRIPTION
## What has Changed?

`cursor.backwardListOfType()` now matches `type` towards the end of the opening bracket. Making a search for function name in a deref shorthand list `@(function-name ...)` work.

It might not be the right behaviour for when go backwards in a map from within a set, but I don't see when we would be doing that....

Fixes #1345

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.

Ping @pez, @bpringe