### PR TITLE
Provide token scope map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Provide semantic token fallback map for Calva's TM grammar](https://github.com/BetterThanTomorrow/calva/issues/1348)
 
 ## [2.0.218] - 2021-10-18
 - [npm audit fixes](https://github.com/BetterThanTomorrow/calva/issues/1346)

--- a/package.json
+++ b/package.json
@@ -120,6 +120,20 @@
                 "editor.parameterHints.enabled": false
             }
         },
+        "semanticTokenScopes": [
+            {
+                "language": "clojure",
+                "scopes": {
+                    "macro": [
+                        "storage.control.clojure",
+                        "keyword.control.clojure"
+                    ],
+                    "keyword": [
+                        "variable.other.constant.clojure"
+                    ]
+                }
+            }
+        ],
         "configuration": [
             {
                 "type": "object",

--- a/src/calva-fmt/atom-language-clojure/grammars/clojure.cson
+++ b/src/calva-fmt/atom-language-clojure/grammars/clojure.cson
@@ -166,12 +166,12 @@
       }
       {
         'match': '(?<=^|\\s|\\(|\\[|\\{)(declare-?|(in-)?ns|import|use|require|load|compile|(def(?!ault)[\\p{Ll}\\-]*))(?=(\\s|\\)|\\]|\\}))'
-        'name': 'keyword.control.clojure'
+        'name': 'storage.control.clojure'
       }
     ]
   'dynamic-variables':
     'match': '\\*[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\d]+\\*'
-    'name': 'meta.symbol.dynamic.clojure'
+    'name': 'entity.name.variable.dynamic.clojure'
   'map':
     'begin': '(\\{)'
     'beginCaptures':
@@ -297,7 +297,7 @@
         'begin': '(?<=\\()(ns|declare|def(?!ault)[\\w\\d._:+=><!?*-]*|[\\w._:+=><!?*-][\\w\\d._:+=><!?*-]*/def(?!ault)[\\w\\d._:+=><!?*-]*)\\s+'
         'beginCaptures':
           '1':
-            'name': 'keyword.control.clojure'
+            'name': 'storage.control.clojure'
         'end': '(?=\\))'
         'name': 'meta.definition.global.clojure'
         'patterns': [
@@ -336,6 +336,14 @@
       }
       {
         'include': '#sexp'
+      }
+      {
+        'match': '(?<=\\()([\\p{L}\\.\\-\\_\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*)/([^"]+?)(?=\\s|\\))'
+        'captures':
+          '1':
+            'name': 'entity.name.namespace.clojure'
+          '2':
+            'name': 'entity.name.function.clojure'
       }
       {
         'match': '(?<=\\()([^"]+?)(?=\\s|\\))'
@@ -383,14 +391,14 @@
         'match': '([\\p{L}\\.\\-\\_\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*)/'
         'captures':
           '1':
-            'name': 'meta.symbol.namespace.clojure'
+            'name': 'entity.name.namespace.clojure'
       }
     ]
   'symbol':
     'patterns': [
       {
         'match': '([\\p{L}\\.\\-\\_\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*)'
-        'name': 'meta.symbol.clojure'
+        'name': 'entity.name.variable.clojure'
       }
     ]
   'var':
@@ -423,7 +431,7 @@
           '2':
             'name': 'keyword.control.prompt.clojure'
           '3':
-            'name': 'meta.symbol.namespace.prompt.clojure'
+            'name': 'entity.name.namespace.prompt.clojure'
           '4':
             'name': 'keyword.control.prompt.clojure'
       }


### PR DESCRIPTION
## What has Changed?

Provide scope mapping to the TM grammar tokens so that most coloring stays the same when clojure-lsp provides semantic tokens to the Clojure documents.

Fixes #1348

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~ (Probably should...)
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.


Ping @pez, @bpringe