### PR TITLE
Consistently let lsp provide when nrepl doesn't

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - [Clean away legacy evaluation keyboard shortcuts](https://github.com/BetterThanTomorrow/calva/issues/1353)
+- [Don't wait for clojure-lsp to initialize before activating nREPL lookup and navigation](https://github.com/BetterThanTomorrow/calva/issues/1341)
 
 ## [2.0.220] - 2021-10-20
 - [Add Paredit select/kill right functionality](https://github.com/BetterThanTomorrow/calva/issues/1024)

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -3,12 +3,15 @@ import { LanguageClient, ServerOptions, LanguageClientOptions, DocumentSymbol, P
 import * as util from '../utilities'
 import * as config from '../config';
 import { provideClojureDefinition } from '../providers/definition';
+import { provideCompletionItems } from '../providers/completion';
 import { setStateValue, getStateValue } from '../../out/cljs-lib/cljs-lib';
 import { downloadClojureLsp, getLatestVersion } from './download';
 import { readVersionFile, getClojureLspPath } from './utilities';
 import * as os from 'os';
 import * as path from 'path';
 import * as state from '../state';
+import { provideHover } from '../providers/hover';
+import { provideSignatureHelp } from '../providers/signature';
 
 const LSP_CLIENT_KEY = 'lspClient';
 const RESOLVE_MACRO_AS_COMMAND = 'resolve-macro-as';
@@ -54,30 +57,33 @@ function createClient(clojureLspPath: string): LanguageClient {
                 }
                 return null;
             },
-            provideHover(document, position, token, next) {
-                if (util.getConnectedState()) {
+            async provideHover(document, position, token, next) {
+                const hover: vscode.Hover = await provideHover(document, position);
+                if (hover) {
                     return null;
                 } else {
                     return next(document, position, token);
                 }
             },
             async provideDefinition(document, position, token, next) {
-                const nReplDefinition = await provideClojureDefinition(document, position, token);
-                if (nReplDefinition) {
+                const definition = await provideClojureDefinition(document, position, token);
+                if (definition) {
                     return null;
                 } else {
                     return next(document, position, token);
                 }
             },
-            provideCompletionItem(document, position, context, token, next) {
-                if (util.getConnectedState()) {
+            async provideCompletionItem(document, position, context, token, next) {
+                const items = await provideCompletionItems(document, position, token, context);
+                if (items) {
                     return null;
                 } else {
                     return next(document, position, context, token);
                 }
             },
-            provideSignatureHelp(document, position, context, token, next) {
-                if (util.getConnectedState()) {
+            async provideSignatureHelp(document, position, context, token, next) {
+                const help = await provideSignatureHelp(document, position, context, token);
+                if (help) {
                     return null;
                 } else {
                     return next(document, position, context, token);

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -82,7 +82,7 @@ function createClient(clojureLspPath: string): LanguageClient {
                 }
             },
             async provideSignatureHelp(document, position, context, token, next) {
-                const help = await provideSignatureHelp(document, position, context, token);
+                const help = await provideSignatureHelp(document, position, token);
                 if (help) {
                     return null;
                 } else {

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -60,7 +60,7 @@ export async function provideCompletionItems(document: TextDocument, position: P
 
 
 export default class CalvaCompletionItemProvider implements CompletionItemProvider {
-    async provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext): ProviderResult<CompletionItem[] | CompletionList<CompletionItem>> {
+    async provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext) {
         return provideCompletionItems(document, position, token, context);
     }
 

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -1,4 +1,4 @@
-import { TextDocument, Position, CancellationToken, CompletionContext, Hover, CompletionItemKind, window, CompletionList, CompletionItemProvider, CompletionItem, CompletionItemLabel } from 'vscode';
+import { TextDocument, Position, CancellationToken, CompletionContext, Hover, CompletionItemKind, window, CompletionList, CompletionItemProvider, CompletionItem, CompletionItemLabel, ProviderResult } from 'vscode';
 import * as state from '../state';
 import * as util from '../utilities';
 import select from '../select';
@@ -7,60 +7,61 @@ import * as infoparser from './infoparser';
 import * as namespace from '../namespace';
 import * as replSession from '../nrepl/repl-session';
 
-export default class CalvaCompletionItemProvider implements CompletionItemProvider {
-    state: any;
-    mappings: any;
-    constructor() {
-        this.state = state;
-        this.mappings = {
-            'nil': CompletionItemKind.Value,
-            'macro': CompletionItemKind.Value,
-            'class': CompletionItemKind.Class,
-            'keyword': CompletionItemKind.Keyword,
-            'namespace': CompletionItemKind.Module,
-            'function': CompletionItemKind.Function,
-            'special-form': CompletionItemKind.Keyword,
-            'var': CompletionItemKind.Variable,
-            'method': CompletionItemKind.Method
-        };
-    }
+const mappings = {
+    'nil': CompletionItemKind.Value,
+    'macro': CompletionItemKind.Value,
+    'class': CompletionItemKind.Class,
+    'keyword': CompletionItemKind.Keyword,
+    'namespace': CompletionItemKind.Module,
+    'function': CompletionItemKind.Function,
+    'special-form': CompletionItemKind.Keyword,
+    'var': CompletionItemKind.Variable,
+    'method': CompletionItemKind.Method
+};
 
-    async provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext) {
-        let text = util.getWordAtPosition(document, position);
+export async function provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext) {
+    let text = util.getWordAtPosition(document, position);
 
-        if (util.getConnectedState()) {
-            const toplevelSelection = select.getFormSelection(document, position, true),
-                toplevel = document.getText(toplevelSelection),
-                toplevelStartOffset = document.offsetAt(toplevelSelection.start),
-                toplevelStartCursor = docMirror.getDocument(document).getTokenCursor(toplevelStartOffset + 1),
-                wordRange = document.getWordRangeAtPosition(position),
-                wordStartLocalOffset = document.offsetAt(wordRange.start) - toplevelStartOffset,
-                wordEndLocalOffset = document.offsetAt(wordRange.end) - toplevelStartOffset,
-                contextStart = toplevel.substring(0, wordStartLocalOffset),
-                contextEnd = toplevel.substring(wordEndLocalOffset),
-                context = `${contextStart}__prefix__${contextEnd}`,
-                toplevelIsValidForm = toplevelStartCursor.withinValidList() && context != '__prefix__',
-                ns = namespace.getNamespace(document),
-                client = replSession.getSession(util.getFileType(document)),
-                res = await client.complete(ns, text, toplevelIsValidForm ? context : null),
-                results = res.completions || [];
-                if(results) {
-                    results.forEach(element => {
-                        if(!element['ns']) {
-                            // make sure every entry has a namespace
-                            // for the 'info' call.
-                            element['ns'] = ns;
-                        }
-                    });
+    if (util.getConnectedState()) {
+        const toplevelSelection = select.getFormSelection(document, position, true),
+            toplevel = document.getText(toplevelSelection),
+            toplevelStartOffset = document.offsetAt(toplevelSelection.start),
+            toplevelStartCursor = docMirror.getDocument(document).getTokenCursor(toplevelStartOffset + 1),
+            wordRange = document.getWordRangeAtPosition(position),
+            wordStartLocalOffset = document.offsetAt(wordRange.start) - toplevelStartOffset,
+            wordEndLocalOffset = document.offsetAt(wordRange.end) - toplevelStartOffset,
+            contextStart = toplevel.substring(0, wordStartLocalOffset),
+            contextEnd = toplevel.substring(wordEndLocalOffset),
+            context = `${contextStart}__prefix__${contextEnd}`,
+            toplevelIsValidForm = toplevelStartCursor.withinValidList() && context != '__prefix__',
+            ns = namespace.getNamespace(document),
+            client = replSession.getSession(util.getFileType(document)),
+            res = await client.complete(ns, text, toplevelIsValidForm ? context : null),
+            results = res.completions || [];
+
+        if (results?.length > 0) {
+            results.forEach(element => {
+                if (!element['ns']) {
+                    // make sure every entry has a namespace
+                    // for the 'info' call.
+                    element['ns'] = ns;
                 }
+            });
             return new CompletionList(
                 results.map(item => ({
                     label: item.candidate,
-                    kind: this.mappings[item.type] || CompletionItemKind.Text,
+                    kind: mappings[item.type] || CompletionItemKind.Text,
                     insertText: item[0] === '.' ? item.slice(1) : item
                 })), true);
         }
-        return [];
+    }
+    return null;
+}
+
+
+export default class CalvaCompletionItemProvider implements CompletionItemProvider {
+    async provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext): ProviderResult<CompletionItem[] | CompletionList<CompletionItem>> {
+        return provideCompletionItems(document, position, token, context);
     }
 
     async resolveCompletionItem(item: CompletionItem, token: CancellationToken) {

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -7,7 +7,7 @@ import * as outputWindow from '../results-output/results-doc';
 import * as replSession from '../nrepl/repl-session';
 
 // Used by out LSP middleware
-export async function provideClojureDefinition(document, position: vscode.Position, token) {
+export async function provideClojureDefinition(document, position: vscode.Position, _token) {
   const evalPos = annotations.getEvaluationPosition(position);
   const posIsEvalPos = evalPos && position.isEqual(evalPos);
   if (util.getConnectedState() && !posIsEvalPos) {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -5,25 +5,25 @@ import * as infoparser from './infoparser';
 import * as namespace from '../namespace';
 import * as replSession from '../nrepl/repl-session';
 
-export default class HoverProvider implements vscode.HoverProvider {
-    state: any;
-
-    constructor() {
-        this.state = state;
-    }
-
-    async provideHover(document, position, _) {
-
-        if (util.getConnectedState()) {
-            let text = util.getWordAtPosition(document, position);
-            let ns = namespace.getNamespace(document);
-            let client = replSession.getSession(util.getFileType(document));
-            if(client) {
-                await namespace.createNamespaceFromDocumentIfNotExists(document);
-                let res = await client.info(ns, text);
+export async function provideHover(document, position) {
+    if (util.getConnectedState()) {
+        let text = util.getWordAtPosition(document, position);
+        let ns = namespace.getNamespace(document);
+        let client = replSession.getSession(util.getFileType(document));
+        if(client) {
+            await namespace.createNamespaceFromDocumentIfNotExists(document);
+            let res = await client.info(ns, text);
+            if (!res.status.includes('error')) {
                 return new vscode.Hover(infoparser.getHover(res));
             }
-            return new vscode.Hover(infoparser.getHoverNotAvailable(text));
         }
+        return null; //new vscode.Hover(infoparser.getHoverNotAvailable(text));
+    }
+}
+
+
+export default class HoverProvider implements vscode.HoverProvider {
+    async provideHover(document, position, _) {
+        return provideHover(document, position);
     }
 };

--- a/src/providers/signature.ts
+++ b/src/providers/signature.ts
@@ -7,73 +7,78 @@ import * as namespace from '../namespace';
 import * as replSession from '../nrepl/repl-session';
 
 export class CalvaSignatureHelpProvider implements SignatureHelpProvider {
-    async provideSignatureHelp(document: TextDocument, position: Position, _token: CancellationToken): Promise<SignatureHelp> {
-        if (util.getConnectedState()) {
-            const ns = namespace.getNamespace(document),
-                idx = document.offsetAt(position),
-                symbol = this.getSymbol(document, idx);
-            if (symbol) {
-                const client = replSession.getSession(util.getFileType(document));
-                if (client) {
-                    await namespace.createNamespaceFromDocumentIfNotExists(document);
-                    const res = await client.info(ns, symbol),
-                        signatures = infoparser.getSignatures(res, symbol);
-                    if (signatures) {
-                        const help = new SignatureHelp(),
-                            currentArgsRanges = this.getCurrentArgsRanges(document, idx);
-                        help.signatures = signatures;
-                        help.activeSignature = this.getActiveSignatureIdx(signatures, currentArgsRanges.length);
-                        if (signatures[help.activeSignature].parameters !== undefined) {
-                            const currentArgIdx = currentArgsRanges.findIndex(range => range.contains(position)),
-                                activeSignature = signatures[help.activeSignature];
-                            help.activeParameter = activeSignature.label.match(/&/) !== null ?
-                                Math.min(currentArgIdx, activeSignature.parameters.length - 1) :
-                                currentArgIdx;
-                        }
-                        return (help);
+    async provideSignatureHelp(document: TextDocument, position: Position, token: CancellationToken): Promise<SignatureHelp> {
+        return provideSignatureHelp(document, position, token);
+    }
+}
+
+export async function provideSignatureHelp(document: TextDocument, position: Position, _token: CancellationToken): Promise<SignatureHelp> {
+    if (util.getConnectedState()) {
+        const ns = namespace.getNamespace(document),
+            idx = document.offsetAt(position),
+            symbol = getSymbol(document, idx);
+        if (symbol) {
+            const client = replSession.getSession(util.getFileType(document));
+            if (client) {
+                await namespace.createNamespaceFromDocumentIfNotExists(document);
+                const res = await client.info(ns, symbol),
+                    signatures = infoparser.getSignatures(res, symbol);
+                if (signatures) {
+                    const help = new SignatureHelp(),
+                        currentArgsRanges = getCurrentArgsRanges(document, idx);
+                    help.signatures = signatures;
+                    help.activeSignature = getActiveSignatureIdx(signatures, currentArgsRanges.length);
+                    if (signatures[help.activeSignature].parameters !== undefined) {
+                        const currentArgIdx = currentArgsRanges.findIndex(range => range.contains(position)),
+                            activeSignature = signatures[help.activeSignature];
+                        help.activeParameter = activeSignature.label.match(/&/) !== null ?
+                            Math.min(currentArgIdx, activeSignature.parameters.length - 1) :
+                            currentArgIdx;
                     }
+                    return (help);
                 }
             }
         }
     }
+    return null;
+}
 
-    private getActiveSignatureIdx(signatures: SignatureInformation[], currentArgsCount): number {
-        const activeSignatureIdx = signatures.findIndex(signature => signature.parameters && signature.parameters.length >= currentArgsCount);
-        return activeSignatureIdx !== -1 ? activeSignatureIdx : signatures.length - 1;
+function getCurrentArgsRanges(document: TextDocument, idx: number): Range[] {
+    const cursor: LispTokenCursor = docMirror.getDocument(document).getTokenCursor(idx),
+        allRanges = cursor.rowColRangesForSexpsInList('(');
+
+    // Are we in a function that gets a threaded first parameter?
+    const { previousRangeIndex, previousFunction } = getPreviousRangeIndexAndFunction(document, idx);
+    const isInThreadFirst: boolean =
+        previousRangeIndex > 1 && ['->', 'some->'].includes(previousFunction) ||
+        previousRangeIndex > 1 && previousRangeIndex % 2 && previousFunction === 'cond->';
+
+    if (allRanges !== undefined) {
+        return allRanges
+            .slice(1 - (isInThreadFirst ? 1 : 0))
+            .map(coordsToRange)
     }
+}
 
-    private getSymbol(document: TextDocument, idx: number): string {
-        const cursor: LispTokenCursor = docMirror.getDocument(document).getTokenCursor(idx);
-        return cursor.getFunctionName();
-    }
+function getActiveSignatureIdx(signatures: SignatureInformation[], currentArgsCount): number {
+    const activeSignatureIdx = signatures.findIndex(signature => signature.parameters && signature.parameters.length >= currentArgsCount);
+    return activeSignatureIdx !== -1 ? activeSignatureIdx : signatures.length - 1;
+}
 
-    private coordsToRange(coords: [[number, number], [number, number]]): Range {
-        return new Range(new Position(...coords[0]), new Position(...coords[1]));
-    }
+function getSymbol(document: TextDocument, idx: number): string {
+    const cursor: LispTokenCursor = docMirror.getDocument(document).getTokenCursor(idx);
+    return cursor.getFunctionName();
+}
 
-    private getPreviousRangeIndexAndFunction(document: TextDocument, idx: number) {
-        const peekBehindCursor: LispTokenCursor = docMirror.getDocument(document).getTokenCursor(idx);
-        peekBehindCursor.backwardFunction(1);
-        const previousFunction = peekBehindCursor.getFunctionName(0),
-            previousRanges = peekBehindCursor.rowColRangesForSexpsInList('(').map(this.coordsToRange),
-            previousRangeIndex = previousRanges.findIndex(range => range.contains(document.positionAt(idx)));
-        return { previousRangeIndex, previousFunction };
-    }
+function coordsToRange(coords: [[number, number], [number, number]]): Range {
+    return new Range(new Position(...coords[0]), new Position(...coords[1]));
+}
 
-    private getCurrentArgsRanges(document: TextDocument, idx: number): Range[] {
-        const cursor: LispTokenCursor = docMirror.getDocument(document).getTokenCursor(idx),
-            allRanges = cursor.rowColRangesForSexpsInList('(');
-
-        // Are we in a function that gets a threaded first parameter?
-        const { previousRangeIndex, previousFunction } = this.getPreviousRangeIndexAndFunction(document, idx);
-        const isInThreadFirst: boolean =
-            previousRangeIndex > 1 && ['->', 'some->'].includes(previousFunction) ||
-            previousRangeIndex > 1 && previousRangeIndex % 2 && previousFunction === 'cond->';
-
-        if (allRanges !== undefined) {
-            return allRanges
-                .slice(1 - (isInThreadFirst ? 1 : 0))
-                .map(this.coordsToRange)
-        }
-    }
+function getPreviousRangeIndexAndFunction(document: TextDocument, idx: number) {
+    const peekBehindCursor: LispTokenCursor = docMirror.getDocument(document).getTokenCursor(idx);
+    peekBehindCursor.backwardFunction(1);
+    const previousFunction = peekBehindCursor.getFunctionName(0),
+        previousRanges = peekBehindCursor.rowColRangesForSexpsInList('(').map(coordsToRange),
+        previousRangeIndex = previousRanges.findIndex(range => range.contains(document.positionAt(idx)));
+    return { previousRangeIndex, previousFunction };
 }


### PR DESCRIPTION
## What has Changed?

Calva currently assumes that if we have an nrepl connection, it is also a cider-nrepl connection. With babashka's and nbb's nREPL implementations that is not (yet) the case.

This gets important in the clojure-lsp middleware where we check if have an nrepl connection and if we don't we let clojure-lsp handle it.

This change instead checks if we get a valid response from the nrepl connection, and if we don't, we let clojure-lsp hava a go instead.

Fixes #1341

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.

Ping @pez, @bpringe