### PR TITLE
Add command to open clojure lsp log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Add command to open the clojure-lsp log file](https://github.com/BetterThanTomorrow/calva/issues/1362)
 
 ## [2.0.221] - 2021-10-23
 - [Clean away legacy evaluation keyboard shortcuts](https://github.com/BetterThanTomorrow/calva/issues/1353)

--- a/docs/site/clojure-lsp.md
+++ b/docs/site/clojure-lsp.md
@@ -63,6 +63,10 @@ It may be helpful to clear the output channel, then perform the action with whic
 
 You can run the `Clojure-lsp Server Info` command to get information about the running clojure-lsp server, such as the version the server being used, the version of clj-kondo it's using, and more. This info is printed to the "Calva says" output channel.
 
+### Opening the Server Log File
+
+You can open the clojure-lsp log file by running the command `Calva Diagnostics: Open Clojure-lsp Log File`. The log file will only be opened with this command if the clojure-lsp server is running and has finished initializing. If you need to open the file when the server is failing to run or initialize, see the [clojure-lsp docs](https://clojure-lsp.io/troubleshooting/#server-log) for information on the file location.
+
 ## Related
 
 See also:

--- a/package.json
+++ b/package.json
@@ -770,7 +770,7 @@
         ],
         "commands": [
             {
-                "command": "calva.openClojureLspLogFile",
+                "command": "calva.diagnostics.openClojureLspLogFile",
                 "title": "Open Clojure-lsp Log File",
                 "category": "Calva Diagnostics"
             },

--- a/package.json
+++ b/package.json
@@ -770,6 +770,11 @@
         ],
         "commands": [
             {
+                "command": "calva.openClojureLspLogFile",
+                "title": "Open Clojure-lsp Log File",
+                "category": "Calva Diagnostics"
+            },
+            {
                 "command": "calva.linting.resolveMacroAs",
                 "title": "Resolve Macro As",
                 "category": "Calva Linting",

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -368,6 +368,11 @@ async function getServerInfo(lspClient: LanguageClient): Promise<any> {
     return lspClient.sendRequest('clojure/serverInfo/raw');
 }
 
+async function openLogFile(lspClient: LanguageClient): Promise<void> {
+    const serverInfo = await getServerInfo(lspClient);
+    console.log(serverInfo);
+}
+
 export default {
     activate,
     deactivate,

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -239,6 +239,10 @@ function resolveMacroAsCommandHandler(): void {
     }
 }
 
+const generalCommands = {
+    
+}
+
 function registerCommands(context: vscode.ExtensionContext, client: LanguageClient) {
     // The title of this command is dictated by clojure-lsp and is executed when the user clicks the references code lens for a symbol
     context.subscriptions.push(vscode.commands.registerCommand('code-lens-references', codeLensReferencesHandler));
@@ -247,6 +251,8 @@ function registerCommands(context: vscode.ExtensionContext, client: LanguageClie
     context.subscriptions.push(vscode.commands.registerCommand(RESOLVE_MACRO_AS_COMMAND, resolveMacroAsCodeActionCommandHandler));
 
     context.subscriptions.push(vscode.commands.registerCommand('calva.linting.resolveMacroAs', resolveMacroAsCommandHandler));
+
+    context.subscriptions.push(vscode.commands.registerCommand('calva.diagnostics.openClojureLspLogFile', openLogFile));
 
     context.subscriptions.push(
         ...clojureLspCommands.map(command => registerLspCommand(client, command))
@@ -315,7 +321,7 @@ async function serverInfoCommandHandler(): Promise<void> {
 }
 
 async function activate(context: vscode.ExtensionContext): Promise<void> {
-    vscode.commands.registerCommand('calva.diagnostics.clojureLspServerInfo', serverInfoCommandHandler);
+    context.subscriptions.push(vscode.commands.registerCommand('calva.diagnostics.clojureLspServerInfo', serverInfoCommandHandler));
     const extensionPath = context.extensionPath;
     const currentVersion = readVersionFile(extensionPath);
     const userConfiguredClojureLspPath = config.getConfig().clojureLspPath;


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Added a command to open the clojure-lsp log file - `Calva Diagnostics: Open Clojure-lsp Log File`
- This is implemented by getting the log file name from clojure-lsp's server-info command, so if clojure-lsp is failing to start, this command will not work.

TODO:
- Test on:
  - [ ] Windows
  - [x] Linux
  - [x] MacOS
- [x] Make the command show a message that the server isn't started if it's not, like the server info command does. We could also make it not show in the menu when the server isn't started, but I like the former approach since this is a diagnostic tool, and no one will wonder why the command isn't showing up when the server is failing to start.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Closes #1362 

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe