### PR TITLE
Fixes #823, keyboard shortcuts check language id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - Fix: [Not able to escape read-line in the output window](https://github.com/BetterThanTomorrow/calva/issues/783)
+- Fix: [Some keyboard shortcuts missing the languageID check](https://github.com/BetterThanTomorrow/calva/issues/823)
 
 ## [2.0.222] - 2021-10-27
 - [Add command to open the clojure-lsp log file](https://github.com/BetterThanTomorrow/calva/issues/1362)

--- a/package.json
+++ b/package.json
@@ -1576,7 +1576,7 @@
             {
                 "command": "calva.selectCurrentForm",
                 "key": "ctrl+alt+c ctrl+s",
-                "when": "calva:keybindingsEnabled"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
             },
             {
                 "command": "calva.clearInlineResults",
@@ -1586,47 +1586,47 @@
             {
                 "command": "calva.evaluateSelection",
                 "key": "ctrl+enter",
-                "when": "calva:keybindingsEnabled && editorTextFocus"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
             },
             {
                 "command": "calva.evaluateEnclosingForm",
                 "key": "ctrl+shift+enter",
-                "when": "calva:keybindingsEnabled && editorTextFocus"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
             },
             {
                 "command": "calva.evaluateToCursor",
                 "key": "ctrl+alt+enter",
-                "when": "calva:keybindingsEnabled && editorTextFocus"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
             },
             {
                 "command": "calva.evaluateTopLevelFormToCursor",
                 "key": "shift+alt+enter",
-                "when": "calva:keybindingsEnabled && editorTextFocus"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
             },
             {
                 "command": "calva.evaluateStartOfFileToCursor",
                 "key": "ctrl+shift+alt+enter",
-                "when": "calva:keybindingsEnabled && editorTextFocus"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
             },
             {
                 "command": "calva.tapSelection",
                 "key": "ctrl+shift+t t",
-                "when": "calva:keybindingsEnabled && editorTextFocus"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
             },
             {
                 "command": "calva.tapCurrentTopLevelForm",
                 "key": "ctrl+shift+t space",
-                "when": "calva:keybindingsEnabled && editorTextFocus"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
             },
             {
                 "command": "calva.interruptAllEvaluations",
                 "key": "ctrl+alt+c ctrl+alt+d",
-                "when": "calva:keybindingsEnabled"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
             },
             {
                 "command": "calva.evaluateCurrentTopLevelForm",
                 "key": "alt+enter",
-                "when": "calva:keybindingsEnabled && editorTextFocus"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
             },
             {
                 "command": "calva.evaluateCurrentTopLevelForm",
@@ -1636,27 +1636,27 @@
             {
                 "command": "calva.evaluateSelectionReplace",
                 "key": "ctrl+alt+c r",
-                "when": "calva:keybindingsEnabled"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
             },
             {
                 "command": "calva.evaluateSelectionAsComment",
                 "key": "ctrl+alt+c c",
-                "when": "calva:keybindingsEnabled"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
             },
             {
                 "command": "calva.evaluateTopLevelFormAsComment",
                 "key": "ctrl+alt+c ctrl+space",
-                "when": "calva:keybindingsEnabled"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
             },
             {
                 "command": "calva.printLastStacktrace",
                 "key": "ctrl+alt+c ctrl+alt+p",
-                "when": "calva:keybindingsEnabled"
+                "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
             },
             {
                 "command": "calva.copyLastResults",
                 "key": "ctrl+alt+c ctrl+c",
-                "when": "calva:connected && calva:keybindingsEnabled"
+                "when": "calva:connected && calva:keybindingsEnabled && editorLangId == clojure"
             },
             {
                 "command": "calva.loadFile",


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Adds `editorLangId == clojure` checks for calva keyboard shortcuts


<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #823 

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - ~[ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [x] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe