### PR TITLE
Treat comma as whitespace throughout the formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 - Fix: [Not able to escape read-line in the output window](https://github.com/BetterThanTomorrow/calva/issues/783)
 - Fix: [Some keyboard shortcuts missing the languageID check](https://github.com/BetterThanTomorrow/calva/issues/823)
+- Fix: [Formatting form with comma whitespace inserts 0 and places the cursor wrong](https://github.com/BetterThanTomorrow/calva/issues/1370)
 
 ## [2.0.222] - 2021-10-27
 - [Add command to open the clojure-lsp log file](https://github.com/BetterThanTomorrow/calva/issues/1362)

--- a/src/cljs-lib/test/calva/fmt/formatter_test.cljs
+++ b/src/cljs-lib/test/calva/fmt/formatter_test.cljs
@@ -8,14 +8,12 @@
          (:range-text (sut/format-text-at-range {:eol "\n" :all-text "  (foo)\n(defn bar\n[x]\nbaz)" :range [2 26]}))))
   (is (not (contains? (sut/format-text-at-range {:eol "\n" :all-text "  (foo)\n(defn bar\n[x]\nbaz)" :range [2 26]}) :new-index))))
 
-{:eol "\n", :all-text "  (foo)\n(defn bar\n[x]\nbaz)", :range [2 26], :range-text "(foo)\n(defn bar\n  [x]\n  baz)", :range-tail "(foo)\n(defn bar\n[x]\nbaz)"}
 (def all-text "  (foo)
   (defn bar
          [x]
 
 baz)")
 
-{:current-line "(defn ", :config {:remove-surrounding-whitespace? false, :remove-trailing-whitespace? false, :remove-consecutive-blank-lines? false}, :on-type true, :range-tail "\n)", :new-index 6, :head "(defn ", :tail "\n)", :eol "\n", :range-text "(defn \n  )", :idx 6, :all-text "(defn \n)", :range [0 8]}
 (deftest format-text-at-idx
   (is (= "(defn bar
     [x]
@@ -25,7 +23,11 @@ baz)")
   (is (= 1
          (:new-index (sut/format-text-at-idx {:eol "\n" :all-text all-text :range [10 38] :idx 11}))))
   (is (= [10 38]
-         (:range (sut/format-text-at-idx {:eol "\n" :all-text all-text :range [10 38] :idx 11})))))
+         (:range (sut/format-text-at-idx {:eol "\n" :all-text all-text :range [10 38] :idx 11}))))
+  (is (= [0 5]
+         (:range (sut/format-text-at-idx {:eol "\n" :all-text "(\n\n,)" :range [0 5] :idx 2}))))
+  (is (= "()"
+         (:range-text (sut/format-text-at-idx {:eol "\n" :all-text "(\n\n,)" :range [0 5] :idx 2})))))
 
 (def a-comment
   {:eol "\n"
@@ -50,7 +52,7 @@ baz))"
          (select-keys (sut/format-text-at-idx
                        (assoc-in a-comment [:config :comment-form?] false))
                       [:range-text :new-index])))
-  
+
   (is (= {:new-index 41
           :range-text "(comment
   (defn bar
@@ -58,7 +60,7 @@ baz))"
 
     baz)
   )"}
-         (select-keys (sut/format-text-at-idx 
+         (select-keys (sut/format-text-at-idx
                        (assoc a-comment :idx 47))
                       [:range-text :new-index]))))
 
@@ -76,7 +78,9 @@ baz))"
   (is (= 5
          (:new-index (sut/format-text-at-idx {:eol "\n" :all-text "(defn \n  \nfoo)" :range [0 14] :idx 6}))))
   (is (= 11
-         (:new-index (sut/format-text-at-idx {:eol "\n" :all-text "(foo\n (bar)\n )" :range [0 14] :idx 11})))))
+         (:new-index (sut/format-text-at-idx {:eol "\n" :all-text "(foo\n (bar)\n )" :range [0 14] :idx 11}))))
+  (is (= 1
+         (:new-index (sut/format-text-at-idx {:eol "\n" :all-text "(\n\n,)" :range [0 14] :idx 2})))))
 
 
 (def head-and-tail-text "(def a 1)


### PR DESCRIPTION
## What has Changed?

cljfmt treats comma the same as `tab` and `space`. Our formatter glue code now also does this at all places it deals with these whitespace characters.

fixes #1370 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

Ping @pez, @bpringe