### PR TITLE
Remove inaccurate anti-parinfer propaganda ;)

### DIFF
--- a/docs/site/parinfer.md
+++ b/docs/site/parinfer.md
@@ -7,13 +7,11 @@ description: Yes, you can use Calva with with the Parinfer extension
 
 Yes, you can use Calva with with the Parinfer extension. The only conflict here is that Calva's auto-formatting (that which happens as you type) is going to risk clash with Parinfer's.
 
-However, Calva's [Paredit](paredit.md) is carefully crafted. We suggest you consider that Clojure is a LISP, and therefore structural. There is power in this structure that other languages can not let you wield. Take advantage of this and make Paredit your friend. It takes only some few minutes to learn two or three basic Paredit commands:
+However, Calva's [Paredit](paredit.md) is carefully crafted. If you don't already have an established preference for parinfer, we suggest you give it a try. Even parinfer veterans may find they prefer the explicit nature of paredit. It takes only some few minutes to learn two or three basic Paredit commands:
 
 * **Select form**
 * **Slurp**
 * **Barf**
-
-Besides letting you benefit from auto-formatting, working this way will quickly bring you in better contact with the structural nature of the Clojure code. You'll thank yourself later.
 
 Also, if you find yourself having deleted or added a bracket out of structure, despite Calva Paredit's **Strict mode** (which you are using, right?) there is a command that might help you heal the structure: **Infer Parens from Indentation**. That command is actually implemented using the Parinfer library, so it will let you recover from quite many situations. This command is bound to `shift+tab` by default, making it a good companion to `tab` which indents based on bracket structure. 
 


### PR DESCRIPTION
In all seriousness, the statements about paredit in here that I removed / edited apply equally well to parinfer. It isn't non-structural editing, it's just more implicit by letting indentation specify structure rather than requiring explicit editor commands. I think your points in here are stronger when they aren't needlessly vilifying a straw-man parinfer. I think this is important for especially newcomers to Clojure / Lisps where there is already so much to learn and parinfer can be a really friendly way to get started without having to manually balance parens nor learn paredit. Thanks for considering!