### PR TITLE
Fixes: #1395 paredit.spliceSexp works with set literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 - Re-enable, Experimental: [Add Parinfer Options](https://github.com/BetterThanTomorrow/calva/issues/253)
 - Internal: [Handle the unknown-op status from test commands](https://github.com/BetterThanTomorrow/calva/pull/1365)
 - Fix: [textDocument/linkedEditingRange failed when opening files or moving cursor](https://github.com/BetterThanTomorrow/calva/issues/1374)
+- Fix: [paredit.spliceSexp doesn't work with set literals](https://github.com/BetterThanTomorrow/calva/issues/1395)
 
 ## [2.0.225] - 2021-11-10
 - Revert 224 changes: [Version v2.0.224 causes problems on some machines (possibly Windows related)](https://github.com/BetterThanTomorrow/calva/issues/1379)

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -201,8 +201,8 @@ export function forwardHybridSexpRange(doc: EditableDocument, offset = Math.max(
         // Work backwards to find the smallest open token offset
         // greater than the document's cursor location if any
         cursor = doc.getTokenCursor(currentLineNewlineOffset);
-        while(cursor.offsetStart > offset) {
-            while(cursor.backwardSexp()) {}
+        while (cursor.offsetStart > offset) {
+            while (cursor.backwardSexp()) { }
             if (cursor.offsetStart > offset) {
                 nearestOpenTokenOffset = cursor.offsetStart;
                 cursor = doc.getTokenCursor(cursor.offsetStart - 1);
@@ -401,20 +401,20 @@ export function spliceSexp(doc: EditableDocument, start: number = doc.selectionR
         let end = cursor.offsetStart;
         if (close.type == "close" && validPair(open.raw, close.raw)) {
             return doc.model.edit([
-                new ModelEdit('changeRange', [end, end + 1, ""]),
-                new ModelEdit('changeRange', [beginning - 1, beginning, ""])
+                new ModelEdit('changeRange', [end, end + close.raw.length, ""]),
+                new ModelEdit('changeRange', [beginning - open.raw.length, beginning, ""])
             ], { undoStopBefore, selection: new ModelEditSelection(start - 1) });
         }
     }
 }
 
-export function killBackwardList(doc: EditableDocument, [start,end]: [number, number]): Thenable<boolean> {
+export function killBackwardList(doc: EditableDocument, [start, end]: [number, number]): Thenable<boolean> {
     return doc.model.edit([
         new ModelEdit('changeRange', [start, end, "", [end, end], [start, start]])
     ], { selection: new ModelEditSelection(start) });
 }
 
-export function killForwardList(doc: EditableDocument, [start,end]: [number, number]): Thenable<boolean> {
+export function killForwardList(doc: EditableDocument, [start, end]: [number, number]): Thenable<boolean> {
     let cursor = doc.getTokenCursor(start);
     let inComment = (cursor.getToken().type == "comment" && start > cursor.offsetStart) || cursor.getPrevToken().type == "comment";
     return doc.model.edit([
@@ -422,7 +422,7 @@ export function killForwardList(doc: EditableDocument, [start,end]: [number, num
     ], { selection: new ModelEditSelection(start) });
 }
 
-export function forwardSlurpSexp(doc: EditableDocument, start: number = doc.selectionRight, extraOpts = {"formatDepth": 1}) {
+export function forwardSlurpSexp(doc: EditableDocument, start: number = doc.selectionRight, extraOpts = { "formatDepth": 1 }) {
     const cursor = doc.getTokenCursor(start);
     cursor.forwardList();
     if (cursor.getToken().type == "close") {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1093,13 +1093,14 @@ describe('paredit', () => {
             });
 
             // TODO: enable after fixing spliceSexp
-            xit('splice set', () => {
+            it('splice set', () => {
                 const a = docFromTextNotation('#{a| b}');
                 paredit.spliceSexp(a);
                 expect(text(a)).toEqual('a b');
             });
 
-            // TODO: enabling this breaks bunch of other tests. Not sure why
+            // NB: enabling this breaks bunch of other tests.
+            //     Not sure why, but it can be run successfully by itself.
             xit('splice string', () => {
                 const a = docFromTextNotation('"h|ello"');
                 paredit.spliceSexp(a);


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- paredit.spliceSexp works with set literals now
- enabled the corresponding test for set literals
- few unrelated lines were auto formatted

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1395 

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - ~[ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [x] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe