### PR TITLE
Enable experimental support for the Test Explorer

### DIFF
--- a/docs/site/test-runner.md
+++ b/docs/site/test-runner.md
@@ -24,6 +24,14 @@ Toggle between implementation and test | - | Switches the file between implement
 
 You can enable the Calva setting "Test on Save" to have tests for the current namespace run on file save.
 
+## Test Explorer
+
+Calva has experimental support for showing test results in the VSCode Test Explorer UI. You can enable this support by setting `calva.useTestExplorer` to `true`. When you enable this setting, the Testing icon will appear in the VSCode Activilty Bar.
+
+With this feature you will be able to browse and run tests directly from the Testing tab.
+
+Please join the [#calva channel](https://clojurians.slack.com/messages/calva) on the Clojurians Slack if you have any feedback on this new feature.
+
 ## Troubleshooting
 
 ### Tests Are Not Found

--- a/docs/site/test-runner.md
+++ b/docs/site/test-runner.md
@@ -26,9 +26,9 @@ You can enable the Calva setting "Test on Save" to have tests for the current na
 
 ## Test Explorer
 
-Calva has experimental support for showing test results in the VSCode Test Explorer UI. You can enable this support by setting `calva.useTestExplorer` to `true`. When you enable this setting, the Testing icon will appear in the VSCode Activilty Bar.
+Calva has experimental support for showing test results in the [VSCode Test Explorer UI](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer). You can enable this support by setting `calva.useTestExplorer` to `true`. When you enable this setting, the Testing icon will appear in the VSCode Activilty Bar.
 
-With this feature you will be able to browse and run tests directly from the Testing tab.
+With this feature (and the TestExplorer UI extension installed) you will be able to browse and run tests directly from the Testing tab.
 
 Please join the [#calva channel](https://clojurians.slack.com/messages/calva) on the Clojurians Slack if you have any feedback on this new feature.
 

--- a/package.json
+++ b/package.json
@@ -139,6 +139,11 @@
                 "type": "object",
                 "title": "Calva",
                 "properties": {
+                    "calva.useTestExplorer": {
+                        "type": "boolean",
+                        "description": "Enable experimental support for the VSCode Test Explorer",
+                        "default": false
+                    },
                     "calva.prettyPrintingOptions": {
                         "type": "object",
                         "description": "Settings for Calva's pretty printing",

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -271,7 +271,7 @@ async function loadFile(document, pprintOptions: PrettyPrintingOptions) {
     if (doc && doc.languageId == "clojure" && fileType != "edn" && getStateValue('connected')) {
         state.analytics().logEvent("Evaluation", "LoadFile").send();
         const docUri = outputWindow.isResultsDoc(doc) ?
-            await outputWindow.getUriForCurrentNamespace() :
+            await namespace.getUriForNamespace(session, ns) :
             doc.uri;
         const fileName = path.basename(docUri.path);
         const fileContents = await util.getFileContents(docUri.path);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,7 @@ import * as edit from './edit';
 import * as nreplLogging from './nrepl/logging';
 
 import * as clojureDocs from './clojuredocs';
-async function onDidSave(document) {
+async function onDidSave(testController: vscode.TestController, document: vscode.TextDocument) {
     let {
         evaluate,
         test,
@@ -47,7 +47,7 @@ async function onDidSave(document) {
     }
 
     if (test && util.getConnectedState()) {
-        testRunner.runNamespaceTests(document);
+        testRunner.runNamespaceTests(testController, document);
         state.analytics().logEvent("Calva", "OnSaveTest").send();
     } else if (evaluate) {
         if (!outputWindow.isResultsDoc(document)) {
@@ -86,14 +86,19 @@ async function activate(context: vscode.ExtensionContext) {
     initializeState();
 
     status.updateNeedReplUi(false, context);
-    lsp.activate(context);
+
+
+    const controller = vscode.tests.createTestController('calvaTestController', 'Clojure Cider')
+    context.subscriptions.push(controller);
+
+    lsp.activate(context, testTree => { testRunner.onTestTree(controller, testTree) });
+
     setStateValue('analytics', new Analytics(context));
     state.analytics().logPath("/start").logEvent("LifeCycle", "Started").send();
 
     model.initScanner(vscode.workspace.getConfiguration('editor').get('maxTokenizationLineLength'));
 
     const chan = state.outputChannel();
-
     const legacyExtension = vscode.extensions.getExtension('cospaia.clojure4vscode');
     const fmtExtension = vscode.extensions.getExtension('cospaia.calva-fmt');
     const pareEditExtension = vscode.extensions.getExtension('cospaia.paredit-revived');
@@ -119,6 +124,8 @@ async function activate(context: vscode.ExtensionContext) {
                 }
             })
     }
+
+    testRunner.initialize(controller);
 
     if (legacyExtension) {
         vscode.window.showErrorMessage("Calva Legacy extension detected. Things will break. Please uninstall, or disable, the old Calva extension.", "Roger that. Right away!")
@@ -187,10 +194,10 @@ async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateSelectionAsComment', eval.evaluateSelectionAsComment));
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateTopLevelFormAsComment', eval.evaluateTopLevelFormAsComment));
     context.subscriptions.push(vscode.commands.registerCommand('calva.togglePrettyPrint', eval.togglePrettyPrint));
-    context.subscriptions.push(vscode.commands.registerCommand('calva.runTestUnderCursor', testRunner.runTestUnderCursorCommand));
-    context.subscriptions.push(vscode.commands.registerCommand('calva.runNamespaceTests', testRunner.runNamespaceTestsCommand));
-    context.subscriptions.push(vscode.commands.registerCommand('calva.runAllTests', testRunner.runAllTestsCommand));
-    context.subscriptions.push(vscode.commands.registerCommand('calva.rerunTests', testRunner.rerunTestsCommand));
+    context.subscriptions.push(vscode.commands.registerCommand('calva.runTestUnderCursor', () => { testRunner.runTestUnderCursorCommand(controller) }));
+    context.subscriptions.push(vscode.commands.registerCommand('calva.runNamespaceTests', () => { testRunner.runNamespaceTestsCommand(controller) }));
+    context.subscriptions.push(vscode.commands.registerCommand('calva.runAllTests', () => { testRunner.runAllTestsCommand(controller) }));
+    context.subscriptions.push(vscode.commands.registerCommand('calva.rerunTests', () => { testRunner.rerunTestsCommand(controller) }));
     context.subscriptions.push(vscode.commands.registerCommand('calva.clearInlineResults', annotations.clearEvaluationDecorations));
     context.subscriptions.push(vscode.commands.registerCommand('calva.copyAnnotationHoverText', annotations.copyHoverTextCommand));
     context.subscriptions.push(vscode.commands.registerCommand('calva.copyLastResults', eval.copyLastResultCommand));
@@ -254,7 +261,7 @@ async function activate(context: vscode.ExtensionContext) {
         onDidOpen(document);
     }));
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((document) => {
-        onDidSave(document);
+        onDidSave(controller, document);
     }));
     context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor((editor) => {
         status.update();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,7 +88,7 @@ async function activate(context: vscode.ExtensionContext) {
     status.updateNeedReplUi(false, context);
 
 
-    const controller = vscode.tests.createTestController('calvaTestController', 'Clojure Cider')
+    const controller = vscode.tests.createTestController('calvaTestController', 'Calva')
     context.subscriptions.push(controller);
     testRunner.initialize(controller);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,6 +90,7 @@ async function activate(context: vscode.ExtensionContext) {
 
     const controller = vscode.tests.createTestController('calvaTestController', 'Clojure Cider')
     context.subscriptions.push(controller);
+    testRunner.initialize(controller);
 
     lsp.activate(context, testTree => { testRunner.onTestTree(controller, testTree) });
 
@@ -126,7 +127,7 @@ async function activate(context: vscode.ExtensionContext) {
             })
     }
 
-    testRunner.initialize(controller);
+
 
     if (legacyExtension) {
         vscode.window.showErrorMessage("Calva Legacy extension detected. Things will break. Please uninstall, or disable, the old Calva extension.", "Roger that. Right away!")

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -325,7 +325,7 @@ async function startClient(clojureLspPath: string, context: vscode.ExtensionCont
     const client = createClient(clojureLspPath);
     console.log('Starting clojure-lsp at', clojureLspPath);
 
-    const testTree : StaticFeature =new TestTreeFeature();
+    const testTree : StaticFeature = new TestTreeFeature();
     client.registerFeature(testTree);
 
     const onReadyPromise = client.onReady();

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -21,10 +21,12 @@ const SERVER_NOT_RUNNING_OR_INITIALIZED_MESSAGE = 'The clojure-lsp server is not
 const lspStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -1);
 let serverVersion: string;
 
+// The Node LSP client requires the client code to jump through a few hoops in
+// order to enable an experimental feature. This class exists solely to set
+// enable the `experimental.testTree` feature.
 class TestTreeFeature implements StaticFeature {
 
     initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector | undefined): void {
-        capabilities.experimental = {testTree: true };
     }
 
     fillClientCapabilities(capabilities: ClientCapabilities): void {
@@ -90,7 +92,7 @@ function createClient(clojureLspPath: string): LanguageClient {
                 try {
                     hover = await provideHover(document, position);
                 } catch (e) {}
-                
+
                 if (hover) {
                     return null;
                 } else {

--- a/src/lsp/types.ts
+++ b/src/lsp/types.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode';
+
+export enum TestTreeKind {
+    DEFTEST = 0,
+    TESTING = 1
+}
+
+export interface TestTreeNode {
+    name: string,
+    'name-range': vscode.Range
+    range: vscode.Range,
+    kind: TestTreeKind
+    children: TestTreeNode[]
+}
+
+export interface TestTreeParams {
+    uri: string
+    tree: TestTreeNode
+}
+
+export type TestTreeHandler = (tree: TestTreeParams) => void;

--- a/src/lsp/types.ts
+++ b/src/lsp/types.ts
@@ -1,4 +1,14 @@
-import * as vscode from 'vscode';
+// This file contains type definitions for LSP message payloads.
+
+interface Position {
+    line: number
+    character: number
+}
+interface Range {
+    start: Position
+    end: Position
+}
+
 
 export enum TestTreeKind {
     DEFTEST = 0,
@@ -7,15 +17,21 @@ export enum TestTreeKind {
 
 export interface TestTreeNode {
     name: string,
-    'name-range': vscode.Range
-    range: vscode.Range,
+    'name-range': Range
+    range: Range,
     kind: TestTreeKind
     children: TestTreeNode[]
 }
 
+// See https://clojure-lsp.io/capabilities/#test-tree
 export interface TestTreeParams {
     uri: string
     tree: TestTreeNode
 }
 
+// The Clojure LSP client will call this handler function any time a test is
+// detected. This allows Calva to populate the Test Explorer from the data provided
+// by Clojure LSP. This indirection allows us to write testRunner.ts without
+// specific knowledge of LSP, and also write the LSP client without any specific
+// knowledge of the testRunner code.
 export type TestTreeHandler = (tree: TestTreeParams) => void;

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -6,6 +6,7 @@ import { Token } from './cursor-doc/clojure-lexer';
 import * as outputWindow from './results-output/results-doc'
 import * as utilities from './utilities';
 import * as replSession from './nrepl/repl-session';
+import { NReplSession } from './nrepl';
 
 export function getNamespace(doc: vscode.TextDocument) {
     if (outputWindow.isResultsDoc(doc)) {
@@ -84,4 +85,9 @@ export function getDocumentNamespace(document = {}) {
     let doc = utilities.getDocument(document);
 
     return getNamespace(doc);
+}
+
+export async function getUriForNamespace(session: NReplSession, ns: string): Promise<vscode.Uri> {
+    const info = await session.info(ns, ns);
+    return vscode.Uri.parse(info.file, true);
 }

--- a/src/nrepl/cider.ts
+++ b/src/nrepl/cider.ts
@@ -135,7 +135,7 @@ export function shortMessage(result: TestResult): string {
             return 'Error running test: ' + result.message + ' ' + result.error;
         case 'fail':
             if (result.message) {
-                return 'Expected ' + result.expected + ' actual' + result.actual
+                return 'Expected ' + result.expected + ' actual ' + result.actual
             } else {
                 return result.message + ' expected ' + result.expected + ' actual' + result.actual;
             }

--- a/src/nrepl/cider.ts
+++ b/src/nrepl/cider.ts
@@ -14,7 +14,7 @@ export interface TestResult {
     index: number;
     message: string;
     ns: string;
-    type: string;
+    type: 'pass' | 'fail' | 'error';
     var: string;
     expected?: string;
     'gen-input'?: string;
@@ -125,4 +125,19 @@ export function detailedMessage(result: TestResult): string {
 // Return a short message that can be shown to user as a Diagnostic.
 export function diagnosticMessage(result: TestResult): string {
     return `failure in test: ${result.var} context: ${result.context}, expected ${result.expected}, got: ${result.actual}`
+}
+
+export function shortMessage(result: TestResult): string {
+    switch (result.type) {
+        case 'pass':
+            return '';
+        case 'error':
+            return 'Error running test: ' + result.message + ' ' + result.error;
+        case 'fail':
+            if (result.message) {
+                return 'Expected ' + result.expected + ' actual' + result.actual
+            } else {
+                return result.message + ' expected ' + result.expected + ' actual' + result.actual;
+            }
+    }
 }

--- a/src/nrepl/cider.ts
+++ b/src/nrepl/cider.ts
@@ -14,7 +14,7 @@ export interface TestResult {
     index: number;
     message: string;
     ns: string;
-    type: string;
+    type: 'pass' | 'fail' | 'error';
     var: string;
     expected?: string;
     'gen-input'?: string;
@@ -125,4 +125,19 @@ export function detailedMessage(result: TestResult): string {
 // Return a short message that can be shown to user as a Diagnostic.
 export function diagnosticMessage(result: TestResult): string {
     return `failure in test: ${result.var} context: ${result.context}, expected ${result.expected}, got: ${result.actual}`
+}
+
+export function shortMessage(result: TestResult): string {
+    switch (result.type) {
+        case 'pass':
+            return '';
+        case 'error':
+            return 'Error running test: ' + result.message + ' ' + result.error;
+        case 'fail':
+            if (result.message) {
+                return 'Expected ' + result.expected + ' actual ' + result.actual
+            } else {
+                return result.message + ' expected ' + result.expected + ' actual ' + result.actual;
+            }
+    }
 }

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -297,9 +297,9 @@ export function append(text: string, onAppended?: OnAppendedCallback): void {
                         onAppended(new vscode.Location(DOC_URI(), insertPosition),
                             new vscode.Location(DOC_URI(), doc.positionAt(Infinity)));
                     }
-                    
+
                     if (editQueue.length > 0) {
-                        const [textBatch, remainingEditQueue] = splitEditQueueForTextBatching(editQueue, 1000);                    
+                        const [textBatch, remainingEditQueue] = splitEditQueueForTextBatching(editQueue, 1000);
                         if (textBatch.length > 0) {
                             editQueue = remainingEditQueue;
                             return append(textBatch.join('\n'));
@@ -372,8 +372,6 @@ export function appendPrompt(onAppended?: OnAppendedCallback) {
     append(getPrompt(), onAppended);
 }
 
-export async function getUriForCurrentNamespace(): Promise<vscode.Uri> {
-    const ns = getNs();
-    const info = await getSession().info(ns, ns);
-    return vscode.Uri.parse(info.file, true);
+function getUriForCurrentNamespace(): Promise<vscode.Uri> {
+    return namespace.getUriForNamespace(getSession(), getNs());
 }

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -330,26 +330,21 @@ function initialize(context: vscode.ExtensionContext): vscode.TestController {
                 return;
             }
 
-            if (request.include.length > 1) {
+            const runItems = request.include.map(req => {
+                // Split into [namespace, var]
+                return req.id.split('/', 2);
+            });
 
-                const runItems = request.include.map(req => {
-                    return req.id.split('/').slice(0, 2);
-                })
-
-                const namespaces = runItems.filter(ri => ri.length === 1).map( ri => ri[0]);
-                const namespaceAndVars = runItems.filter(ri => ri.length === 2);
-
-                const doc = vscode.window.activeTextEditor.document
-                runNamespaceTestsImpl(controller, doc, namespaces).catch((msg) => {
-                    vscode.window.showWarningMessage(msg)
-                });
-
-
-            }
+            // TODO.marc: We don't support running specific vars right now.
+            // We run the entire namespace for any tests selected.
+            const namespaces = util.distinct(runItems.map(ri => ri[0]));
+            const doc = vscode.window.activeTextEditor.document
+            runNamespaceTestsImpl(controller, doc, namespaces).catch((msg) => {
+                vscode.window.showWarningMessage(msg)
+            });
 
         },
         true);
-
 
     controller.resolveHandler = (item: vscode.TestItem | undefined) => {
         // Currently unused

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -414,7 +414,14 @@ export async function isDocumentWritable(document: vscode.TextDocument): Promise
     return (fileStat.permissions & vscode.FilePermission.Readonly) !== 1;
 }
 
+// Returns the elements of coll with duplicates removed
+// (See clojure.core/distinct).
+function distinct<T>(coll: T[]): T[] {
+    return [... new Set(coll)];
+}
+
 export {
+    distinct,
     getWordAtPosition,
     getDocument,
     getFileType,

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -21,6 +21,10 @@ export function escapeStringRegexp(s: string): string {
     return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+export function isNonEmptyString(value: any): boolean {
+    return typeof (value) == 'string' && value.length > 0
+}
+
 async function quickPickSingle(opts: { values: string[], saveAs?: string, placeHolder: string, autoSelect?: boolean }) {
     if (opts.values.length == 0)
         return;
@@ -414,7 +418,14 @@ export async function isDocumentWritable(document: vscode.TextDocument): Promise
     return (fileStat.permissions & vscode.FilePermission.Readonly) !== 1;
 }
 
+// Returns the elements of coll with duplicates removed
+// (See clojure.core/distinct).
+function distinct<T>(coll: T[]): T[] {
+    return [... new Set(coll)];
+}
+
 export {
+    distinct,
     getWordAtPosition,
     getDocument,
     getFileType,


### PR DESCRIPTION
This is currently disabled behind the `calva.useTestExplorer` flag while
we test it.

Enable the Test Explorer view. This is a first pass and there are
missing features:

- [x] Re-run support
- [x] The UI that pops up is jarring - can we collapse it?
- [x] Test discovery using clojure-lsp
- [x] Assertions have the name '0'

Fixes #953
Fixes #1438
Fixes #1163

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe