### PR TITLE
Extract error message handling into functions

### DIFF
--- a/src/extension-test/unit/test-runner-test.ts
+++ b/src/extension-test/unit/test-runner-test.ts
@@ -1,0 +1,43 @@
+import * as expect from 'expect';
+import * as cider from '../../nrepl/cider';
+
+describe('test result processing', () => {
+    it('shows a summary', () => {
+
+        expect(cider.summaryMessage({
+            ns: 0, var: 0, test: 0, pass: 0, fail: 0, error: 0
+        })).toBe("No tests found. 😱, ns: 0, vars: 0");
+
+        expect(cider.summaryMessage({
+            ns: 1, var: 1, test: 1, pass: 1, fail: 0, error: 0
+        })).toBe("1 tests finished, all passing 👍, ns: 1, vars: 1");
+
+        expect(cider.summaryMessage({
+            ns: 1, var: 2, test: 3, pass: 4, fail: 5, error: 6
+        })).toBe("3 tests finished, problems found. 😭 errors: 6, failures: 5, ns: 1, vars: 2");
+
+    });
+
+    it('can merge results', () => {
+
+        expect(cider.totalSummary([])).toMatchObject({
+            test: 0, error: 0, ns: 0, var: 0, fail: 0, pass: 0
+        });
+
+        expect(cider.totalSummary([
+            { test: 0, error: 0, ns: 0, var: 0, fail: 0, pass: 0 },
+            { test: 0, error: 0, ns: 0, var: 0, fail: 0, pass: 0 }
+        ])).toMatchObject({
+            test: 0, error: 0, ns: 0, var: 0, fail: 0, pass: 0
+        });
+
+        expect(cider.totalSummary([
+            { test: 1, error: 2, ns: 3, var: 5, fail: 7, pass: 11 },
+            { test: 13, error: 17, ns: 19, var: 23, fail: 29, pass: 31 }
+        ])).toMatchObject({
+            test: 14, error: 19, ns: 22, var: 28, fail: 36, pass: 42
+        });
+
+    });
+
+});

--- a/src/nrepl/cider.ts
+++ b/src/nrepl/cider.ts
@@ -37,3 +37,51 @@ export interface TestResults {
     'testing-ns'?: string
     'gen-input': unknown
 }
+
+
+export function resultMessage(resultItem: Readonly<TestResult>): string {
+    let msg = [];
+    if (resultItem.context && resultItem.context !== "false")
+        msg.push(resultItem.context);
+    if (resultItem.message)
+        msg.push(resultItem.message);
+    return `${msg.length > 0 ? msg.join(": ").replace(/\r?\n$/, "") : ''}`;
+}
+
+// Given a summary, return a message suitable for printing in the REPL to show
+// the user a quick summary of the test run.
+// Examples:
+// ; No tests found. 😱, ns: 0, vars: 0
+// ; 6 tests finished, all passing 👍, ns: 1, vars: 2
+// ; 6 tests finished, problems found. 😭 errors: 0, failures: 1, ns: 1, vars: 2
+export function summaryMessage(summary: Readonly<TestSummary>): string {
+    let msg = [];
+    if (summary.test > 0) {
+        msg.push(summary.test + " tests finished");
+
+        const hasProblems = summary.error + summary.fail > 0;
+        if (!hasProblems) {
+            msg.push("all passing 👍");
+        } else {
+            msg.push("problems found. 😭 errors: " + summary.error + ", failures: " + summary.fail);
+        }
+
+    } else {
+        msg.push("No tests found. 😱");
+    }
+
+    msg.push("ns: " + summary.ns + ", vars: " + summary.var);
+    return msg.join(", ");
+}
+
+// Given a list of summaries, sum them to compute the total number of tests,
+// errors and vars, etc.
+export function totalSummary(summaries: TestSummary[]): TestSummary {
+    let result = { test: 0, error: 0, ns: 0, var: 0, fail: 0, pass: 0 };
+    for (let summary of summaries) {
+        for (const k in result) {
+            result[k] = result[k] + summary[k];
+        }
+    }
+    return result;
+}


### PR DESCRIPTION
I want to re-use some of this infrastructure when adding Test Explorer
support, so I'd like to extract this code out into smaller, composable
functions. This will allow me to re-use them (and test them).

Changes:

- Extract the code for adding summaries together into `totalSummary`.
- Extract the summary message generation into `summaryMessage.
- Replace uses of _ with native TypeScript looping constructs.

Ping @pez, @bpringe