### PR TITLE
Improve leiningen project search

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import Analytics from './analytics';
 import * as util from './utilities';
+import * as filesCache from './files-cache'
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
@@ -140,14 +141,20 @@ export async function initProjectDir(uri?: vscode.Uri): Promise<void> {
     }
 }
 
-async function findLocalProjectRoot(projectFileNames, doc, workspaceFolder): Promise<void> {
+function isNamespace(path: string): boolean {
+    const content = filesCache.content(path);
+    const hasNsDecl = /^\(ns /.test(content);
+    return hasNsDecl;
+}
+
+async function findLocalProjectRoot(projectFileNames: string[], doc: vscode.TextDocument, workspaceFolder: vscode.WorkspaceFolder): Promise<void> {
     if (workspaceFolder) {
         let rootPath: string = path.resolve(workspaceFolder.uri.fsPath);
         setStateValue(PROJECT_DIR_KEY, rootPath);
         setStateValue(PROJECT_DIR_URI_KEY, workspaceFolder.uri);
 
-        let d = null;
-        let prev = null;
+        let d: string = null;
+        let prev: string = null;
         if (doc && path.dirname(doc.uri.fsPath) !== '.') {
             d = path.dirname(doc.uri.fsPath);
         } else {
@@ -156,7 +163,7 @@ async function findLocalProjectRoot(projectFileNames, doc, workspaceFolder): Pro
         while (d !== prev) {
             for (let projectFile in projectFileNames) {
                 const p = path.resolve(d, projectFileNames[projectFile]);
-                if (fs.existsSync(p)) {
+                if (fs.existsSync(p) && !isNamespace(p)) {
                     rootPath = d;
                     break;
                 }
@@ -192,8 +199,10 @@ async function findProjectRootUri(projectFileNames, doc, workspaceFolder): Promi
                     const u = vscode.Uri.joinPath(searchUri, projectFileNames[projectFile]);
                     try {
                         await vscode.workspace.fs.stat(u);
-                        setStateValue(PROJECT_DIR_URI_KEY, searchUri);
-                        return;
+                        if (!isNamespace(u.fsPath)) {
+                            setStateValue(PROJECT_DIR_URI_KEY, searchUri);
+                            return;
+                        }
                     }
                     catch { }
                 }


### PR DESCRIPTION
## What has Changed?

I have a problem when I use Calva's Jack In command - I have to run to
open my project.clj file in the root of the repo before I Jack In. If
I run the command when I have any source files open in the editor, the
Jack In fails.

The reason for this is that Calva will search from the directory
containing the current file down to the workspace root.

There are many projects named `project.clj` in the main CircleCI repo,
since a project one of our core domain objects:

```
marc@blaster ~/dev/circleci/circle $ find . -name project.clj
./project.clj
./src/circle/project.clj
./src/circle/http/api/v1/v1_0/project.clj
./src/circle/http/api/v1/v1_1/project.clj
./src/circle/http/api/v1/shared/project.clj
./src/circle/http/api/v2/insights/project.clj
./src/circle/http/api/v2/project.clj
./src/circle/http/api/v2/entities/insights/project.clj
./src/circle/http/api/v2/entities/project.clj
./src/circle/model/project.clj
./src/circle/model/api/project.clj
```

If I have any file open in `src/circle`, (which is the location of all
source files), Calva will find `src/circle/project.clj` before it
considers the project.clj in the root. As far as I understand, this is a
desirable search behaviour, since it allows folks to use Calva in
projects that contain multiple leiningen projects.

This change alters the search behaviour to only consider files that
don't begin with the string `(ns ` when attempting the determine the
project path.

Fixes #871

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe