### PR TITLE
Extract error messages

### DIFF
--- a/src/extension-test/unit/test-runner-test.ts
+++ b/src/extension-test/unit/test-runner-test.ts
@@ -40,4 +40,57 @@ describe('test result processing', () => {
 
     });
 
+    it('can produce detailed messages', () => {
+
+        expect(cider.detailedMessage({
+            type: 'pass',
+            ns: 'core',
+            context: 'ctx',
+            index: 0,
+            var: 'test',
+            message: ''
+        })).toBe('');
+
+        expect(cider.detailedMessage({
+            type: 'fail',
+            ns: 'core',
+            context: 'ctx',
+            index: 1,
+            expected: 'apple',
+            actual: 'orange',
+            var: 'test',
+            file: 'core.clj',
+            line: 7,
+            message: 'an extra message'
+        })).toBe(
+            `; FAIL in core/test (core.clj:7):
+; ctx: an extra message
+; expected:
+apple
+; actual:
+orange`);
+
+
+        expect(cider.detailedMessage({
+            type: 'error',
+            ns: 'core',
+            context: 'ctx',
+            index: 1,
+            expected: 'apple',
+            actual: 'orange',
+            var: 'test',
+            error: 'shoes fell off',
+            file: 'impl.clj',
+            line: 9,
+            message: 'an extra message'
+        })).toBe(
+            `; ERROR in core/test (line 9):
+; ctx: an extra message
+; error: shoes fell off (impl.clj)
+; expected:
+apple`);
+
+
+    });
+
 });


### PR DESCRIPTION
## What has Changed?
Extract error message generation.

This refactor makes it easier to use the Test Explorer. Here we
complete the separation between generating messages about why tests
failed from how we render them to the output window and diagnostic
system. This allows for easier testing.

Changes:

- extract whitespace cleaning function into cider namespace
- add tests for failure messages
- extract failure message generation into cider namespace
- extract diagnostic message generation into cider namespaceFixes #

## My Calva PR Checklist

<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe