### PR TITLE
Handle missing stacktrace middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [ Babashka Jack-In REPL doesn't show eval errors](https://github.com/BetterThanTomorrow/calva/issues/1413)
 
 ## [2.0.228] - 2021-12-02
 - Revert: Parinfer Experimental

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -829,7 +829,14 @@ export class NReplEvaluation {
                     this.session.stacktrace().then((stacktrace) => {
                         this._stacktrace = stacktrace;
                         this.doReject(this.exception);
-                    }).catch(() => { });
+                    }).catch((e) => {
+                        // This failure occurs  when the `stacktrace` cider-nrepl
+                        // middleware is not available. In this case we can still
+                        // display the error message, but we won't have a stacktrace
+                        // to show.
+                        // https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#stacktrace
+                        this.doReject(this.exception);
+                    });
                 } else if (this.pprintOut) {
                     this.doResolve(this.pprintOut)
                 } else if (this.stacktrace) {


### PR DESCRIPTION
## What has Changed?

When the user is using a NREPL connection that doesn't have the
cider-nrepl middleware loaded, we cannot reply on the `stacktrace`
middleware being present. Handle the missing middleware gracefully.

Fixes: #1413

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe