### PR TITLE
Clojure extension dragons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 Changes to Calva.
 
 ## [Unreleased]
-- Fix: [ Babashka Jack-In REPL doesn't show eval errors](https://github.com/BetterThanTomorrow/calva/issues/1413)
+- Fix: [Babashka Jack-In REPL doesn't show eval errors](https://github.com/BetterThanTomorrow/calva/issues/1413)
+- [Inform about conflict with the Clojure extension](https://github.com/BetterThanTomorrow/calva/issues/1427)
+
 
 ## [2.0.228] - 2021-12-02
 - Revert: Parinfer Experimental

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,13 +99,14 @@ async function activate(context: vscode.ExtensionContext) {
     const pareEditExtension = vscode.extensions.getExtension('cospaia.paredit-revived');
     const cwExtension = vscode.extensions.getExtension('tonsky.clojure-warrior');
     const vimExtension = vscode.extensions.getExtension('vscodevim.vim');
-    const cwConfig = vscode.workspace.getConfiguration('clojureWarrior');
+    const clojureExtension = vscode.extensions.getExtension('avli.clojure');
     const customCljsRepl = config.getConfig().customCljsRepl;
     const replConnectSequences = config.getConfig().replConnectSequences;
     const BUTTON_GOTO_DOC = "Open the docs";
     const BUTTON_OK = "Got it";
     const VIM_DOC_URL = "https://calva.io/vim/";
     const VIEWED_VIM_DOCS = "viewedVimDocs";
+    const DONT_SHOW_CLOJURE_EXT_NAG = "dontShowClojureExtNag";
     const CONNECT_SEQUENCES_DOC_URL = "https://calva.io/connect-sequences/";
     const CALVA_DOCS_URL = "https://calva.io/";
     const VIEWED_CALVA_DOCS = "viewedCalvaDocs";
@@ -308,6 +309,18 @@ async function activate(context: vscode.ExtensionContext) {
                     if (v == BUTTON_GOTO_DOC) {
                         context.globalState.update(VIEWED_VIM_DOCS, true);
                         open(VIM_DOC_URL).catch(() => { });
+                    }
+                })
+        }
+    }
+
+    if (clojureExtension) {
+        chan.appendLine(`The Clojure Extension is installed.\n`);
+        if (!context.globalState.get(DONT_SHOW_CLOJURE_EXT_NAG)) {
+            vscode.window.showWarningMessage("You have the Clojure extension installed. Please note that it will conflict with Calva.", "Don't show again", 'OK')
+                .then(v => {
+                    if (v == "Don't show again") {
+                        context.globalState.update(DONT_SHOW_CLOJURE_EXT_NAG, true);
                     }
                 })
         }


### PR DESCRIPTION
## What has Changed?

- When the Clojure extension is detected, Calva shows a warning message. The user can choose for the message to not be shown again.

Fixes #1427 
Fixes #1426

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. NB: *You need to sign in/up at Circle CI to find the _Artifacts_ tab.*
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.

Ping @pez, @bpringe