### PR TITLE
Add better number matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - Fix: [Hover broken when repl is connected but cider-nrelp is not present](https://github.com/BetterThanTomorrow/calva/issues/1432)
+- Fix: [Some valid floats are highlighted incorrectly](https://github.com/BetterThanTomorrow/calva/issues/1378)
 
 ## [2.0.229] - 2021-12-12
 - Fix: [Babashka Jack-In REPL doesn't show eval errors](https://github.com/BetterThanTomorrow/calva/issues/1413)

--- a/src/calva-fmt/atom-language-clojure/grammars/clojure.cson
+++ b/src/calva-fmt/atom-language-clojure/grammars/clojure.cson
@@ -108,11 +108,16 @@
         'name': 'constant.language.boolean.clojure'
       }
       {
+        'match': '(##(?:Inf|-Inf|NaN))'
+        'name': 'constant.numeric.symbol.clojure'
+      }
+      {
         'match': '([-+]?\\d+/\\d+)'
         'name': 'constant.numeric.ratio.clojure'
       }
       {
-        'match': '([-+]?\\d+[rR]\\w+)'
+        # Only Radixes between 2 and 36 are allowed
+        'match': '([-+]?(?:(?:3[0-6])|(?:[12]\\d)|[2-9])[rR][0-9A-Za-z]+N?)'
         'name': 'constant.numeric.arbitrary-radix.clojure'
       }
       {
@@ -120,35 +125,16 @@
         'name': 'constant.numeric.hexadecimal.clojure'
       }
       {
-        'match': '([-+]?0[xX][g-zG-Z]+)'
-        'name': 'constant.numeric.invalid.clojure'
-      }
-      {
-        'match': '([-+]?\\d+M)'
-        'name': 'constant.numeric.bigdecimal.clojure'
-      }
-      {
         'match': '([-+]?0[0-7]+N?)'
         'name': 'constant.numeric.octal.clojure'
       }
       {
-        'match': '([-+]?0[89]+)'
-        'name': 'constant.numeric.invalid.clojure'
-      }
-      {
-        'match': '([-+]?\\d+\\.\\d+([eE][+-]?\\d+)?M)'
-        'name': 'constant.numeric.bigdecimal.clojure'
-      }
-      {
-        'match': '([-+]?\\d+\\.\\d+([eE][+-]?\\d+)?)'
+        # The decimal separator is optional only when followed by e, E or M! 
+        'match': '([-+]?[0-9]+(?:(\\.|(?=[eEM]))[0-9]*([eE][-+]?[0-9]+)?)M?)'
         'name': 'constant.numeric.double.clojure'
       }
       {
-        'match': '([-+]?\\d+N)'
-        'name': 'constant.numeric.bigint.clojure'
-      }
-      {
-        'match': '([-+]?\\d+)'
+        'match': '([-+]?\\d+N?)'
         'name': 'constant.numeric.long.clojure'
       }
       { # separating the pattern for reuse

--- a/src/calva-fmt/atom-language-clojure/spec/clojure-spec.coffee
+++ b/src/calva-fmt/atom-language-clojure/spec/clojure-spec.coffee
@@ -62,16 +62,13 @@ describe "Clojure grammar", ->
 
   it "tokenizes numerics", ->
     numbers =
-      "constant.numeric.ratio.clojure": ["1/2", "123/456"]
-      "constant.numeric.arbitrary-radix.clojure": ["2R1011", "16rDEADBEEF", "56råäöÅÄÖπ"]
-      "constant.numeric.hexadecimal.clojure": ["0xDEADBEEF", "0XDEADBEEF", "0xCafeBabeN", "-0xCafeBabeN"]
-      "constant.numeric.octal.clojure": ["0123", "0123N", "+0123", "-0123N"]
-      "constant.numeric.bigdecimal.clojure": ["123.456M", "123M", "0123M", "-0123M"]
-      "constant.numeric.double.clojure": ["123.45", "123.45e6", "123.45E6"]
-      "constant.numeric.bigint.clojure": ["123N"]
-      "constant.numeric.long.clojure": ["123", "12321"]
-      "constant.numeric.invalid.clojure": ["0xg", "0Xg", "0XG", "0Xg"]
-      "constant.numeric.invalid.clojure": ["08", "09"]
+      "constant.numeric.ratio.clojure": ["1/2", "123/456", "+0/2", "-23/1"]
+      "constant.numeric.arbitrary-radix.clojure": ["2R1011", "16rDEADBEEF", "16rDEADBEEFN", "36rZebra"]
+      "constant.numeric.hexadecimal.clojure": ["0xDEADBEEF", "0XDEADBEEF", "0xDEADBEEFN", "0x0"]
+      "constant.numeric.octal.clojure": ["0123", "0123N", "00"]
+      "constant.numeric.double.clojure": ["123.45", "123.45e6", "123.45E6", "123.456M", "42.", "42.M", "42E+9M", "42E-0", "0M", "+0M", "42.E-23M"]
+      "constant.numeric.long.clojure": ["123", "12321", "123N", "+123N", "-123", "0"]
+      "constant.numeric.symbol.clojure": ["##Inf", "##-Inf", "##NaN"]
 
     for scope, nums of numbers
       for num in nums


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

Currently, there are some numbers that are highlighted wrong by calva:
![image](https://user-images.githubusercontent.com/2965273/145856750-7c8f96d5-19bd-4eaa-81f8-8a51a875e134.png)


1. Add symbolic values for +/- infinity and "Not a Number"
2. The decimal separator `.` is optional when followed by `e`, `E`, `M`
3. "Arbitrary" radix is constraint to 2-36 (digit 0-9 & a-z). Also, `\w` also matches `_` which is incorrect. 
     - One could argue, that mismatching radix/value (e.g. `2rABZ`) shouldn't be matched either, but I considered it overkill.

- I merged `constant.numeric.bigint.clojure` into `constant.numeric.long.clojure` as it doesn't make sense any more to have it separate.
- I also merged `constant.numeric.bigdecimal.clojure` into `constant.numeric.double.clojure` for consistency.

After:
![image](https://user-images.githubusercontent.com/2965273/145856671-088f7cb8-447a-4a56-a711-857229aa8305.png)


<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes https://github.com/BetterThanTomorrow/calva/issues/1378

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~Added to or updated docs in this branch, if appropriate~
- [x] **Added tests for the changes**
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
     - [x] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - ~If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- ~Created the issue I am fixing/addressing, if it was not present.~

Ping @pez, @bpringe