### PR TITLE
Improves documentation for Jack-In ENV and debugging Java / JVM. 

### DIFF
--- a/docs/site/debugger.md
+++ b/docs/site/debugger.md
@@ -185,7 +185,6 @@ clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version,"0.8.3"},cider/cider-nrepl {:m
 There are times when clojure debugging tools are not enough or not right for the job.
 This is usually true when use an (open source) Java library and you want to set some brake points in Java code.
 For those cases and others, you need to start the JVM in debug mode.
-And for that you nee
 
 Typical use cases:
 
@@ -195,13 +194,13 @@ Typical use cases:
 Calva supports passing environment variables via `jacInEnv`.
 You can set that option inside VSCode `settings.json` file.
 
-You can configre global `settings.json` file or a project wide version.
-I think it's best to put these options inside your project, inside `<project-root>/.vscode/settings.json`.
-This is because we don't know how the changes will impact other VSCode projects that start a JVM.
+You can configre global `settings.json` file or a project wide version, inside `<project-root>/.vscode/settings.json`.
+
+Configuring the global option will impact all projects you work on using Calva, so be aware.
 See documentation for `settings.json` here: https://code.visualstudio.com/docs/getstarted/settings .
 
 The bellow snippet configures `JAVA_TOOL_OPTIONS` environment variable.
-This variable is read by the JVM and the configuration is applied accordingly.
+We configure slf4j-simple logging level via java system property (`-D`) and JVM specific options (`-X`).
 
 NOTE: You can of course pass other env variables here.
 
@@ -214,11 +213,12 @@ NOTE: You can of course pass other env variables here.
 }
 ```
 
-Once you saved the file, the next time you `Jack in` the project, you should see something like:
+Once you saved the file, the next time you `Jack in` the project, this variable is read by the JVM and the configuration is applied accordingly.
+
+ You should see something like the message bellow in the Calva terminal output window:
 
 ```shell
 clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version,"0.8.3"},cider/cider-nrepl {:mvn/version,"0.26.0"}}}' -A:debug -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
-WARNING: Implicit use of clojure.main with options is deprecated, use -M
 Picked up JAVA_TOOL_OPTIONS:  -Dorg.slf4j.simpleLogger.defaultLogLevel=TRACE -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=7896
 Listening for transport dt_socket at address: 7896
 nREPL server started on port 46691 on host localhost - nrepl://localhost:46691

--- a/docs/site/debugger.md
+++ b/docs/site/debugger.md
@@ -179,3 +179,47 @@ Most importantly, make sure you have `cider/cider-nrepl` as a dependency, and `c
 ```sh
 clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version,"0.8.3"},cider/cider-nrepl {:mvn/version,"0.25.8"}}}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
 ```
+
+## Passing options to the REPL JVM
+
+There are times when clojure debugging tools are not enough or not right for the job.
+This is usually true when use an (open source) Java library and you want to set some brake points in Java code.
+For those cases and others, you need to start the JVM in debug mode.
+And for that you nee
+
+Tipical use cases:
+
+* Change java logger configuration for the REPL via java system properties: e.g `-Dorg.slf4j.simpleLogger.defaultLogLevel=TRACE`
+* Enable JVM debugger, change VM memory size, etc
+
+Calva supports passing environment variables via `jacInEnv`.
+You can set that option inside VSCode `settings.json` file.
+
+You can configre global `settings.json` file or a project wide version.
+I think it's best to put these options inside your project, inside `<project-root>/.vscode/settings.json`.
+This is because we don't know how the changes will impact other VSCode projects that start a JVM.
+See documentation for `settings.json` here: https://code.visualstudio.com/docs/getstarted/settings .
+
+The bellow snippet configures `JAVA_TOOL_OPTIONS` environment variable.
+This variable is read by the JVM and the configuration is applied accordingly.
+
+NOTE: You can of course pass other env variables here.
+
+.vscode/settings.json
+```json
+{
+    "calva.jackInEnv": {
+        "JAVA_TOOL_OPTIONS": "${env:JAVA_TOOL_OPTIONS} -Dorg.slf4j.simpleLogger.defaultLogLevel=TRACE -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=7896"
+    }
+}
+```
+
+Once you saved the file, the next time you `Jack in` the project, you should see something like:
+
+```shell
+clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version,"0.8.3"},cider/cider-nrepl {:mvn/version,"0.26.0"}}}' -A:debug -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
+WARNING: Implicit use of clojure.main with options is deprecated, use -M
+Picked up JAVA_TOOL_OPTIONS:  -Dorg.slf4j.simpleLogger.defaultLogLevel=TRACE -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=7896
+Listening for transport dt_socket at address: 7896
+nREPL server started on port 46691 on host localhost - nrepl://localhost:46691
+```

--- a/docs/site/debugger.md
+++ b/docs/site/debugger.md
@@ -187,7 +187,7 @@ This is usually true when use an (open source) Java library and you want to set 
 For those cases and others, you need to start the JVM in debug mode.
 And for that you nee
 
-Tipical use cases:
+Typical use cases:
 
 * Change java logger configuration for the REPL via java system properties: e.g `-Dorg.slf4j.simpleLogger.defaultLogLevel=TRACE`
 * Enable JVM debugger, change VM memory size, etc


### PR DESCRIPTION
## What has Changed?

Improves documentation for Jack-In and debugging Java / JVM. 
This started as debugging enhancement.
Feedback is welcomed. 

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
~- [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.~
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
~- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.~
     ~- [ ] Tested the particular change~
     ~- [ ] Figured if the change might have some side effects and tested those as well.~
     ~- [ ] Smoke tested the extension as such.~
~- [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.~
     ~- [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)~
     ~- [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
~- [ ] Created the issue I am fixing/addressing, if it was not present.~

Ping @pez, @bpringe