### PR TITLE
Fix extraneous newlines in test results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 - [Prevent warning during deps.edn jack-in](https://github.com/BetterThanTomorrow/calva/issues/1355)
 - Fix: [Connecting to an out-of-process nREPL server and a merged Figwheel-main build](https://github.com/BetterThanTomorrow/calva/issues/1386)
+- Fix: [Empty lines in output.calva-repl when running tests](https://github.com/BetterThanTomorrow/calva/issues/1448)
 
 ## [2.0.231] - 2021-12-14
 - Fix: [Calva randomly edits file while in Live Share](https://github.com/BetterThanTomorrow/calva/issues/1434)

--- a/src/extension-test/unit/test-runner-test.ts
+++ b/src/extension-test/unit/test-runner-test.ts
@@ -49,7 +49,7 @@ describe('test result processing', () => {
             index: 0,
             var: 'test',
             message: ''
-        })).toBe('');
+        })).toBe(null);
 
         expect(cider.detailedMessage({
             type: 'fail',

--- a/src/nrepl/cider.ts
+++ b/src/nrepl/cider.ts
@@ -102,24 +102,24 @@ export function totalSummary(summaries: TestSummary[]): TestSummary {
 // The message contains "comment" lines that are prepended with ;
 // and "data" lines that should be printed verbatim into the REPL.
 export function detailedMessage(result: TestResult): string {
-    const msg = [];
+    const messages = [];
     const message = resultMessage(result);
     if (result.type === "error") {
-        msg.push(`; ERROR in ${result.ns}/${result.var} (line ${result.line}):`)
+        messages.push(`; ERROR in ${result.ns}/${result.var} (line ${result.line}):`)
         if (message) {
-            msg.push(`; ${message}`);
+            messages.push(`; ${message}`);
         }
-        msg.push(`; error: ${result.error} (${result.file})`);
-        msg.push("; expected:");
-        msg.push(result.expected);
+        messages.push(`; error: ${result.error} (${result.file})`);
+        messages.push("; expected:");
+        messages.push(result.expected);
     } else if (result.type === 'fail') {
-        msg.push(`; FAIL in ${result.ns}/${result.var} (${result.file}:${result.line}):`);
+        messages.push(`; FAIL in ${result.ns}/${result.var} (${result.file}:${result.line}):`);
         if (message) {
-            msg.push(`; ${message}`);
+            messages.push(`; ${message}`);
         }
-        msg.push(`; expected:\n${result.expected}\n; actual:\n${result.actual}`);
+        messages.push(`; expected:\n${result.expected}\n; actual:\n${result.actual}`);
     }
-    return msg.join("\n");
+    return messages.length > 0 ? messages.join("\n") : null;
 }
 
 // Return a short message that can be shown to user as a Diagnostic.

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -28,11 +28,11 @@ function reportTests(results: cider.TestResults[]) {
             let resultSet = result.results[ns];
             for (const test in resultSet) {
                 for (const a of resultSet[test]) {
-
                     cider.cleanUpWhiteSpace(a);
-
-                    outputWindow.append(cider.detailedMessage(a));
-
+                    const messages = cider.detailedMessage(a);
+                    if (messages) {
+                        outputWindow.append(messages);
+                    }
                     if (a.type === "fail") {
                         recordDiagnostic(a);
                     }

--- a/test-data/projects/pirate-lang/src/pez/pirate_lang.clj
+++ b/test-data/projects/pirate-lang/src/pez/pirate_lang.clj
@@ -5,6 +5,10 @@
                 :vowels      "aeiou"
                 :pirate-char "o"})
 
+(def swedish-o {:alphabet    "abcdefghijklmnopqrstuvwxyz"
+                :vowels      "aeiouåäö"
+                :pirate-char "o"})
+
 (defn- configure
   [{:keys [alphabet vowels pirate-char]}]
   (let [alphabet   (set (seq (string/upper-case alphabet)))

--- a/test-data/projects/pirate-lang/test/pez/pirate_lang_test.clj
+++ b/test-data/projects/pirate-lang/test/pez/pirate_lang_test.clj
@@ -1,14 +1,15 @@
-(ns pez.pirate-talk-test
+(ns pez.pirate-lang-test
   (:require [clojure.test :refer [deftest is testing]]
-            [pez.pirate-talk :as sut]))
+            [pez.pirate-lang :as sut]))
 
 (def swedish-o {:alphabet    "abcdefghijklmnopqrstuvwxyzåäö"
                 :vowels      "aeiouåäö"
                 :pirate-char "o"})
 (deftest a-test
   (testing "Speak rövarspråk"
-    (is (= "HoHaror dodu hohörortot totalolasos omom rorövovarorsospoproråkoketot?"
-           (sut/to-pirate-talk "Har du hört talas om rövarspråket?" sut/swedish-o))))
+    (testing "Swedish"
+      (is (= "HoHaror dodu hohörortot totalolasos omom rorövovarorsospoproråkoketot?"
+             (sut/to-pirate-talk "Har du hört talas om rövarspråket?" sut/swedish-o)))))
   (testing "Hear rövarspråk"
     (is (= "Har du hört talas om rövarspråket?"
            (sut/from-pirate-talk "HoHaror dodu hohörortot totalolasos omom rorövovarorsospoproråkoketot?" sut/swedish-o)))))


### PR DESCRIPTION
## What has Changed?

When producing test results we were appending an empty message when there was no detailed (error/failure) message to print. I made the function that collects the detailed messages return `null` in this case and also stopped this from being appended.

Resolves #1448

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe