### PR TITLE
Improve null safety in Test Runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Improve LSP startup feedback on status bar](https://github.com/BetterThanTomorrow/calva/pull/1454)
+- [Fix errors in test output when fixtures throw exceptions](https://github.com/BetterThanTomorrow/calva/issues/1456).
 
 ## [2.0.233] - 2022-01-07
 - [Add experimental support for Test Explorer](https://github.com/BetterThanTomorrow/calva/issues/953)

--- a/src/extension-test/unit/test-runner-test.ts
+++ b/src/extension-test/unit/test-runner-test.ts
@@ -2,6 +2,39 @@ import * as expect from 'expect';
 import * as cider from '../../nrepl/cider';
 
 describe('test result processing', () => {
+
+    it('handles absent line data nicely', () => {
+
+        const result: cider.TestResult = {
+                type: 'pass',
+                ns: 'core',
+                context: 'ctx',
+                index: 0,
+                var: 'test',
+                message: ''
+            };
+
+        expect(cider.lineInformation(result)).toBe("");
+
+        expect(cider.lineInformation({
+            ...result,
+            file: "socks.clj"
+        })).toBe(" (socks.clj)");
+
+        expect(cider.lineInformation({
+            ...result,
+            line: 19
+        })).toBe(" (line 19)");
+
+        expect(cider.lineInformation({
+            ...result,
+            line: 17,
+            file: "tree.clj"
+
+        })).toBe(" (tree.clj:17)");
+
+    });
+
     it('shows a summary', () => {
 
         expect(cider.summaryMessage({
@@ -84,9 +117,9 @@ orange`);
             line: 9,
             message: 'an extra message'
         })).toBe(
-            `; ERROR in core/test (line 9):
+            `; ERROR in core/test (impl.clj:9):
 ; ctx: an extra message
-; error: shoes fell off (impl.clj)
+; error: shoes fell off (impl.clj:9)
 ; expected:
 apple`);
 

--- a/src/nrepl/cider.ts
+++ b/src/nrepl/cider.ts
@@ -97,6 +97,34 @@ export function totalSummary(summaries: TestSummary[]): TestSummary {
     return result;
 }
 
+
+// Returns the file and line number information of an error, if the data is provided.
+// If there is no information, the empty string is returned.
+// Otherwise, returns a string like:
+// ` (line 7)`
+// ` (core.clj)`
+// ` (core.clj:7)`
+// There is a leading space in these messages so that the return value can be
+// easily spliced into other messages without having to check deal with padding.
+export function lineInformation(result: TestResult): string {
+    let hasFile = (typeof result.file === 'string');
+    let hasLine = (typeof result.line === 'number');
+
+    if (!hasFile && !hasLine) {
+        return "";
+    }
+
+    if (!hasFile) {
+        return ` (line ${result.line})`;
+    }
+
+    if (!hasLine) {
+        return ` (${result.file})`
+    }
+
+    return ` (${result.file}:${result.line})`;
+}
+
 // Return a detailed message about why a test failed.
 // If the test passed, return the empty string.
 // The message contains "comment" lines that are prepended with ;
@@ -104,20 +132,31 @@ export function totalSummary(summaries: TestSummary[]): TestSummary {
 export function detailedMessage(result: TestResult): string {
     const messages = [];
     const message = resultMessage(result);
+    const location = lineInformation(result);
+
     if (result.type === "error") {
-        messages.push(`; ERROR in ${result.ns}/${result.var} (line ${result.line}):`)
+        messages.push(`; ERROR in ${result.ns}/${result.var}${location}:`)
         if (message) {
             messages.push(`; ${message}`);
         }
-        messages.push(`; error: ${result.error} (${result.file})`);
-        messages.push("; expected:");
-        messages.push(result.expected);
+        messages.push(`; error: ${result.error}${location}`);
+
+        if (result.expected) {
+            messages.push("; expected:");
+            messages.push(result.expected);
+        }
+
     } else if (result.type === 'fail') {
-        messages.push(`; FAIL in ${result.ns}/${result.var} (${result.file}:${result.line}):`);
+        messages.push(`; FAIL in ${result.ns}/${result.var}${location}:`);
         if (message) {
             messages.push(`; ${message}`);
         }
-        messages.push(`; expected:\n${result.expected}\n; actual:\n${result.actual}`);
+        if (result.expected) {
+            messages.push(`; expected:\n${result.expected}`)
+        }
+        if (result.actual) {
+            messages.push(`; actual:\n${result.actual}`);
+        }
     }
     return messages.length > 0 ? messages.join("\n") : null;
 }
@@ -140,4 +179,8 @@ export function shortMessage(result: TestResult): string {
                 return result.message + ' expected ' + result.expected + ' actual ' + result.actual;
             }
     }
+}
+
+export function hasLineNumber(result: TestResult): boolean {
+    return typeof result.line === 'number';
 }

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -87,7 +87,7 @@ async function onTestResult(controller: vscode.TestController, session: NReplSes
     // range. If the LSP subsequently scans the file, upsertTest will be called,
     // which will set the range correctly.
     if (!test.range || test.range.isEmpty) {
-        const lines = assertions.map(a => a.line).filter(x => x).sort();
+        const lines = assertions.filter(cider.hasLineNumber).map(a => a.line).sort();
         if (lines.length > 0) {
             test.range = new vscode.Range(lines[0] - 1, 0, lines[lines.length - 1], 1000);
         }
@@ -109,7 +109,10 @@ async function onTestResult(controller: vscode.TestController, session: NReplSes
         let assertionId = test.id + '/' + result.index;
         const assertion = controller.createTestItem(assertionId, assertionName(result), uri);
         test.children.add(assertion);
-        assertion.range = new vscode.Range(result.line - 1, 0, result.line - 1, 1000);
+
+        if (cider.hasLineNumber(result)) {
+            assertion.range = new vscode.Range(result.line - 1, 0, result.line - 1, 1000);
+        }
 
         switch (result.type) {
             case "error":


### PR DESCRIPTION
## What has Changed?
There were a bunch of places where the data from Cider contains null
data, specifically where exceptions are thrown from test fixtures. This
change addresses the nulls, and handles them.

Fixes #1456


## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe