### PR TITLE
Factor all test functions in terms of Var Query

### DIFF
--- a/src/nrepl/cider.ts
+++ b/src/nrepl/cider.ts
@@ -25,6 +25,28 @@ export interface TestResult {
     file?: string;
 }
 
+// https://github.com/clojure-emacs/orchard/blob/febf8169675af1b11a8c00cfe1155ed40db8be42/src/orchard/query.clj#L10-L15
+export interface NamespaceQuery {
+    'exactly': string[]
+    'project?'?: boolean
+    'load-project-ns?'?: boolean
+    'has-tests?'?: boolean
+    'include-regexps'?: string[]
+    'exclude-regexps'?: string[]
+}
+
+// https://github.com/clojure-emacs/orchard/blob/febf8169675af1b11a8c00cfe1155ed40db8be42/src/orchard/query.clj#L45-L52
+export interface VarQuery {
+    'ns-query'?: NamespaceQuery
+    'private?'?: boolean
+    'test?'?: boolean
+    'include-meta-key'?: string[]
+    'exclude-meta-key'?: string[]
+    'search'?: string
+    'search-property'?: 'doc' | 'name'
+    'manipulate-vars'?: unknown
+}
+
 // https://github.com/clojure-emacs/cider-nrepl/blob/a740583c3aa8b582f3097611787a276775131d32/src/cider/nrepl/middleware/test.clj#L45-L46
 export interface TestResults {
     summary: TestSummary;

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -409,52 +409,41 @@ export class NReplSession {
         })
     }
 
-    test(ns: string, test: string): Promise<cider.TestResults> {
+    testVarQuery(query: cider.VarQuery): Promise<cider.TestResults> {
         return new Promise<any>((resolve, reject) => {
             const id = this.client.nextId;
             this.messageHandlers[id] = resultHandler(resolve, reject);
             this.client.write({
                 op: "test-var-query",
-                ns,
                 id,
                 session: this.sessionId,
-                "var-query": {
-                    "ns-query": {
-                        exactly: [ns]
-                    },
-                    search: util.escapeStringRegexp(test),
-                    'test?': true
-                }
+                "var-query": query
             });
         });
     }
 
+    test(ns: string, test: string) {
+        return this.testVarQuery({
+            "ns-query": {
+                exactly: [ns]
+            },
+            search: util.escapeStringRegexp(test),
+            'test?': true
+        });
+    }
+
     testNs(ns: string) {
-        return new Promise<cider.TestResults>((resolve, reject) => {
-            let id = this.client.nextId;
-            this.messageHandlers[id] = resultHandler(resolve, reject);
-            this.client.write({
-                op: "test-var-query", ns, id, session: this.sessionId, "var-query": {
-                    "ns-query": {
-                        exactly: [ns]
-                    }
-                }
-            });
-        })
+        return this.testVarQuery({
+            "ns-query": {
+                exactly: [ns]
+            },
+        });
     }
 
     testAll() {
-        return new Promise<cider.TestResults>((resolve, reject) => {
-            let id = this.client.nextId;
-            this.messageHandlers[id] = resultHandler(resolve, reject);
-            this.client.write({
-                op: "test-var-query", id, session: this.sessionId, "var-query": {
-                    "ns-query": {
-                        'test?': true
-                    }
-                }
-            });
-        })
+        return this.testVarQuery({
+            'test?': true
+        });
     }
 
     retest() {


### PR DESCRIPTION
## What has Changed?

Since a set of recent changes, all of the test runs that Calva runs
are implemented using Cider's test-var-query operation. This allows
us to re-write test, testNs, and testAll all in terms of a new function
to testVarQuery.

We can also define a concrete type for the var-query (and ns-query)
in cider.ts to allow us to make changes more safely.

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.


Ping @pez, @bpringe