### PR TITLE
Fix currentTopLevelFunction function for metadata skipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Improve LSP startup feedback on status bar](https://github.com/BetterThanTomorrow/calva/pull/1454)
+- Fix: [Snippet in custom command doesn't work with function metadata] (https://github.com/BetterThanTomorrow/calva/issues/1463)
 
 ## [2.0.233] - 2022-01-07
 - [Add experimental support for Test Explorer](https://github.com/BetterThanTomorrow/calva/issues/953)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Improve LSP startup feedback on status bar](https://github.com/BetterThanTomorrow/calva/pull/1454)
+- Fix: [Snippet in custom command doesn't work with function metadata] (https://github.com/BetterThanTomorrow/calva/issues/1463)
+
 
 ## [2.0.233] - 2022-01-07
 - [Add experimental support for Test Explorer](https://github.com/BetterThanTomorrow/calva/issues/953)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Improve LSP startup feedback on status bar](https://github.com/BetterThanTomorrow/calva/pull/1454)
-- Fix: [Snippet in custom command doesn't work with function metadata] (https://github.com/BetterThanTomorrow/calva/issues/1463)
 
 ## [2.0.233] - 2022-01-07
 - [Add experimental support for Test Explorer](https://github.com/BetterThanTomorrow/calva/issues/953)

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -229,7 +229,6 @@ export class LispTokenCursor extends TokenCursor {
         if (this.getToken().type === 'close') {
             return false;
         }
-        const initialToken = this.getToken();
         if (this.tokenBeginsMetadata()) {
             isMetadata = true;
         }
@@ -259,15 +258,7 @@ export class LispTokenCursor extends TokenCursor {
                     if (skipMetadata && this.getToken().raw.startsWith('^')) {
                         this.next();
                     } else {
-                        this.forwardWhitespace(skipComments);
-                        // If the cursor is still pointed at the original token,
-                        // or if the cursor is inside a nested sexp, move the cursor forward by one.
-                        // Otherwise, the cursor has already moved past
-                        // the original token, and should not be moved again 
-                        // for this invocation of forwardSexp.
-                        if (token == initialToken || stack.length > 0) {
-                          this.next();
-                        }
+                        this.next();
                         if (stack.length <= 0) {
                             return true;
                         }

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -229,6 +229,7 @@ export class LispTokenCursor extends TokenCursor {
         if (this.getToken().type === 'close') {
             return false;
         }
+        const initialToken = this.getToken();
         if (this.tokenBeginsMetadata()) {
             isMetadata = true;
         }
@@ -258,7 +259,15 @@ export class LispTokenCursor extends TokenCursor {
                     if (skipMetadata && this.getToken().raw.startsWith('^')) {
                         this.next();
                     } else {
-                        this.next();
+                        this.forwardWhitespace(skipComments);
+                        // If the cursor is still pointed at the original token,
+                        // or if the cursor is inside a nested sexp, move the cursor forward by one.
+                        // Otherwise, the cursor has already moved past
+                        // the original token, and should not be moved again 
+                        // for this invocation of forwardSexp.
+                        if (token == initialToken || stack.length > 0) {
+                          this.next();
+                        }
                         if (stack.length <= 0) {
                             return true;
                         }

--- a/src/extension-test/unit/util/cursor-get-text-test.ts
+++ b/src/extension-test/unit/util/cursor-get-text-test.ts
@@ -27,6 +27,13 @@ describe('get text', () => {
             expect(getText.currentTopLevelFunction(a)).toEqual([range, b.model.getText(...range)]);
         });
 
+        it('Finds top level function when function has metadata', () => {
+          const a = docFromTextNotation('(foo bar)•(deftest ^{:some :thing} a-test•  (baz |gaz))');
+          const b = docFromTextNotation('(foo bar)•(deftest ^{:some :thing} |a-test|•  (baz gaz))');
+          const range: [number, number] = [b.selectionLeft, b.selectionRight];
+          expect(getText.currentTopLevelFunction(a)).toEqual([range, b.model.getText(...range)]);
+      });
+
     });
 
     describe('getTopLevelForm', () => {

--- a/src/util/cursor-get-text.ts
+++ b/src/util/cursor-get-text.ts
@@ -14,6 +14,11 @@ export function currentTopLevelFunction(doc: EditableDocument): RangeAndText {
         cursor.forwardWhitespace();
         while (cursor.forwardSexp(true, true, true)) {
             cursor.forwardWhitespace();
+            // skip over metadata, if present
+            while (cursor.getToken().raw.startsWith('^')) {
+              cursor.forwardSexp(true, false, true);
+              cursor.forwardWhitespace();
+            }
             const symbol = cursor.getToken();
             if (symbol.type === 'id') {
                 return [[cursor.offsetStart, cursor.offsetEnd], symbol.raw];


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

~- This PR updates the forwardSexp function for the case where there exists metadata between two `id` nodes and `skipMetadata==true`. Previously, this function would move forward through whitespace and metadata, finally landing on an `id` node. However, in the `switch (token.type) ... case 'id'` code there would be one final call to `this.next()`, thereby moving the cursor past the correct s-expr.~
~- Now, the `switch (token.type) ... case 'id'` scenario has been updated to differentiate between:~
~- the initial iteration of the while loop, where the cursor is still on the original `id` node, and it _is_ correct to move past this original `id` node~
~- any subsequent iteration of the loop, where it is not correct to move the cursor past the current `id` node~

Update:
- The original solution of updating fowardSexp caused unintended consequences with other cursor-motion scenarios. I have reverted my changes there, and instead made the change in `currentTopLevelFunction`. 
- This change updates `currentTopLevelFunction` by checking whether the cursor is on metadata, and, if so, moves forward via `fowardSexp` until a non-metadata node is found. It is a simpler, more specific solution than the first attempt.


<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1463

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     ~- [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [x] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe