### PR TITLE
Add jackIn.useDeprecatedAliasFlag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Continue to support -Aalias for jack-in](https://github.com/BetterThanTomorrow/calva/issues/1474)
 - [Add custom commands from libraries](https://github.com/BetterThanTomorrow/calva/pull/1442)
 - Workaround: [VS Code highlights characters in the output/REPL window prompt](https://github.com/BetterThanTomorrow/calva/pull/1475)
 

--- a/package.json
+++ b/package.json
@@ -331,6 +331,11 @@
                     "calva.customCljsRepl": {
                         "deprecationMessage": "This settings is deprecated. Use `cljsType` in a `calva.replConnectSequences` item instead."
                     },
+                    "calva.jackIn.useDeprecatedAliasFlag": {
+                        "type": "boolean",
+                        "default": false,
+                        "markdownDescription": "Use the `-A` flag instead of `-M` for Clojure CLI versions < `1.10.697`."
+                    },
                     "calva.jackInEnv": {
                         "type": "object",
                         "default": {},

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,7 +99,10 @@ function getConfig() {
         referencesCodeLensEnabled: configOptions.get('referencesCodeLens.enabled') as boolean,
         hideReplUi: configOptions.get('hideReplUi') as boolean,
         strictPreventUnmatchedClosingBracket: pareditOptions.get('strictPreventUnmatchedClosingBracket'),
-        showCalvaSaysOnStart: configOptions.get("showCalvaSaysOnStart") as boolean
+        showCalvaSaysOnStart: configOptions.get("showCalvaSaysOnStart") as boolean,
+        jackIn: {
+          useDeprecatedAliasFlag: configOptions.get("jackIn.useDeprecatedAliasFlag") as boolean,
+        }
     };
 }
 

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -473,7 +473,9 @@ async function cljCommandLine(connectSequence: ReplConnectSequence, cljsType: Cl
         ...serverPrinterDependencies
     };
     const useMiddleware = [...middleware, ...(cljsType ? cljsMiddleware[cljsType] : [])];
-    const aliasesOption = aliases.length > 0 ? `-M${aliases.join("")}` : '-M';
+
+    const aliasesFlag = getConfig().jackIn.useDeprecatedAliasFlag ? ['-A', ''] : ['-M', '-M'];
+    const aliasesOption = aliases.length > 0 ? `${aliasesFlag[0]}${aliases.join("")}` : aliasesFlag[1];
     const q = isWin ? '"' : "'";
     const dQ = isWin ? '""' : '"';
     for (let dep in dependencies)


### PR DESCRIPTION

<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?

This adds an option to use the deprecated -A flag instead of -M for users using Clojure CLI versions < 1.10.697.


<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1474

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- x ] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe