### PR TITLE
added custom tooltip snippets

### DIFF
--- a/docs/site/custom-commands.md
+++ b/docs/site/custom-commands.md
@@ -101,7 +101,7 @@ There are three ways to bind shortcuts to custom commands:
 
 Calva supports custom snippets that will display their result inside the tooltip. They will only work when connected to a repl, since they eval code in it.
 This is mostly useful for tooling authors that want to integrate with calva.
-Be careful with these, since they will be executed anytime Calva displays a tooltip. So they should be fast and probably not have any sideeffects.
+Be careful with these, since they will be executed anytime Calva displays a tooltip. So they should be fast and probably not have any side effects.
 
 The hover snippets accept the same inputs as the Custom REPL Commands, except for the hotkey:
 
@@ -116,7 +116,7 @@ The hover snippets accept the same inputs as the Custom REPL Commands, except fo
     ]
 ```
 
-With this setting anything the mouse is over will be also shown inside it's tooltip.
+With this setting anything the mouse is over will also be shown inside its tooltip.
 There are now also `hover-` versions of most substitutions. Those currently only work inside the hover snippets.
 
 ## config.edn

--- a/docs/site/custom-commands.md
+++ b/docs/site/custom-commands.md
@@ -99,7 +99,8 @@ There are three ways to bind shortcuts to custom commands:
 
 ## Custom REPL hover snippets
 
-Calva supports custom snippets that will display their result inside the tooltip. This is mostly useful for tooling authors that want to integrate with calva.
+Calva supports custom snippets that will display their result inside the tooltip. They will only work when connected to a repl, since they eval code in it.
+This is mostly useful for tooling authors that want to integrate with calva.
 Be careful with these, since they will be executed anytime Calva displays a tooltip. So they should be fast and probably not have any sideeffects.
 
 The hover snippets accept the same inputs as the Custom REPL Commands, except for the hotkey:
@@ -118,6 +119,11 @@ The hover snippets accept the same inputs as the Custom REPL Commands, except fo
 With this setting anything the mouse is over will be also shown inside it's tooltip.
 There are now also `hover-` versions of most substitutions. Those currently only work inside the hover snippets.
 
+## config.edn
+
+Your project can have a `.calva/config.edn` file that holds a map with calva configs. Currently only `:customREPLCommandSnippets` and `:customREPLHoverSnippets` get loaded.
+These will not get synced through vscode settings sync.
+
 ## Snippets inside deps
 
 A new experimental feature lets library authors ship snippets inside their jar files. These accept the same options as above but should be placed in "resources/calva.exports/config.edn" inside the jar.
@@ -127,7 +133,7 @@ A new experimental feature lets library authors ship snippets inside their jar f
  [{:name "edn test"
    :key "a"
    :snippet "($current-form)"}]
- :customHoverSnippets
+ :customREPLHoverSnippets
  [{:name "edn hover"
    :snippet "(str \"$hover-tex\")"}]
  }

--- a/docs/site/custom-commands.md
+++ b/docs/site/custom-commands.md
@@ -116,6 +116,7 @@ The hover snippets accept the same inputs as the Custom REPL Commands, except fo
 ```
 
 With this setting anything the mouse is over will be also shown inside it's tooltip.
+There are now also `hover-` versions of most substitutions. Those currently only work inside the hover snippets.
 
 ## Snippets inside deps
 

--- a/docs/site/custom-commands.md
+++ b/docs/site/custom-commands.md
@@ -96,3 +96,38 @@ There are three ways to bind shortcuts to custom commands:
     * One of `tab`, `backspace`, `,`, `.`, or `-` 
 2. Bind `calva.runCustomREPLCommand` to a shortcut with whatever code you want to evaluate in `args` key. You have access to the substitution variables here as well.
 3. Bind `calva.runCustomREPLCommand` to a keyboard shortcut referencing the `key` of one of your `calva.customREPLCommandSnippets`. (If not using any of the `key`s mentioned in **1.**)
+
+## Custom REPL hover snippets
+
+Calva supports custom snippets that will display their result inside the tooltip. This is mostly useful for tooling authors that want to integrate with calva.
+Be careful with these, since they will be executed anytime Calva displays a tooltip. So they should be fast and probably not have any sideeffects.
+
+The hover snippets accept the same inputs as the Custom REPL Commands, except for the hotkey:
+
+```json
+    "calva.customREPLHoverSnippets": [
+        {
+            "name": "eval text on hover",
+            "repl": "clj",
+            "ns": "example.app",
+            "snippet": "(str \"$hover-text\")"
+        }
+    ]
+```
+
+With this setting anything the mouse is over will be also shown inside it's tooltip.
+
+## Snippets inside deps
+
+A new experimental feature lets library authors ship snippets inside their jar files. These accept the same options as above but should be placed in "resources/calva.exports/config.edn" inside the jar.
+
+```edn
+{:customREPLCommandSnippets 
+ [{:name "edn test"
+   :key "a"
+   :snippet "($current-form)"}]
+ :customHoverSnippets
+ [{:name "edn hover"
+   :snippet "(str \"$hover-tex\")"}]
+ }
+```

--- a/package.json
+++ b/package.json
@@ -427,6 +427,45 @@
                             ]
                         }
                     },
+                    "calva.customREPLHoverSnippets": {
+                        "type": "array",
+                        "default": [],
+                        "description": "Configuration for snippets that get called on hover",
+                        "$schema": "http://json-schema.org/draft-06/schema#",
+                        "items": {
+                            "title": "replHover",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "markDownDescription": "The name of the snippet will show inside the hover text."
+                                },
+                                "snippet": {
+                                    "type": [
+                                        "string",
+                                        "array"
+                                    ],
+                                    "description": "Snippet to send to the REPL"
+                                },
+                                "ns": {
+                                    "type": "string",
+                                    "description": "(optional) Namespace to evaluate the snippet in. If omitted the snippet will be executed in the namespace of the current file."
+                                },
+                                "repl": {
+                                    "type": "string",
+                                    "description": "Choose which REPL should the code should be evaluated in. If omitted, the same REPL as for the current file will be used.",
+                                    "enum": [
+                                        "clj",
+                                        "cljs"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "name",
+                                "snippet"
+                            ]
+                        }
+                    },
                     "calva.myLeinProfiles": {
                         "type": "array",
                         "description": "At Jack in, any profiles listed here will be added to the profiles found in the `project.clj` file.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,8 +47,13 @@ function mergeSnippets(
     newSnippets: customREPLCommandSnippet[]
 ): customREPLCommandSnippet[] {
     return newSnippets.concat(
-        _.reject(oldSnippets, (item) =>
-            _.findIndex(newSnippets, (newItem) => item.name === newItem.name) !== -1
+        _.reject(
+            oldSnippets,
+            (item) =>
+                _.findIndex(
+                    newSnippets,
+                    (newItem) => item.name === newItem.name
+                ) !== -1
         )
     );
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,8 +47,8 @@ function mergeSnippets(
     newSnippets: customREPLCommandSnippet[]
 ): customREPLCommandSnippet[] {
     return newSnippets.concat(
-        _.remove(oldSnippets, (item) =>
-            _.findIndex(newSnippets, (newItem) => item.name === newItem.name)
+        _.reject(oldSnippets, (item) =>
+            _.findIndex(newSnippets, (newItem) => item.name === newItem.name) !== -1
         )
     );
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,6 +63,18 @@ async function addEdnConfig(data: string) {
                     parsed?.customREPLCommandSnippets ?? [],
             });
         }
+
+        if (old && old.customHoverSnippets) {
+            state.setProjectConfig({
+                customHoverSnippets: old.customHoverSnippets.concat(
+                    parsed?.customHoverSnippets ?? []
+                ),
+            });
+        } else {
+            state.setProjectConfig({
+                customHoverSnippets: parsed?.customHoverSnippets ?? [],
+            });
+        }
     } catch (error) {
         return error;
     }
@@ -131,6 +143,9 @@ function getConfig() {
         customREPLCommandSnippetsWorkspaceFolder: configOptions.inspect(
             'customREPLCommandSnippets'
         ).workspaceFolderValue as customREPLCommandSnippet[],
+        customHoverSnippets:
+            (state.getProjectConfig()
+                ?.customHoverSnippets as customREPLCommandSnippet[]) ?? [],
         prettyPrintingOptions: configOptions.get(
             'prettyPrintingOptions'
         ) as PrettyPrintingOptions,

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,16 +63,15 @@ async function addEdnConfig(data: string) {
                     parsed?.customREPLCommandSnippets ?? [],
             });
         }
-
-        if (old && old.customHoverSnippets) {
+        if (old && old.customREPLHoverSnippets) {
             state.setProjectConfig({
-                customHoverSnippets: old.customHoverSnippets.concat(
-                    parsed?.customHoverSnippets ?? []
+                customREPLHoverSnippets: old.customREPLHoverSnippets.concat(
+                    parsed?.customREPLHoverSnippets ?? []
                 ),
             });
         } else {
             state.setProjectConfig({
-                customHoverSnippets: parsed?.customHoverSnippets ?? [],
+                customREPLHoverSnippets: parsed?.customREPLHoverSnippets ?? [],
             });
         }
     } catch (error) {
@@ -101,6 +100,13 @@ function getConfig() {
     const commands = w.concat(
         (state.getProjectConfig()
             ?.customREPLCommandSnippets as customREPLCommandSnippet[]) ?? []
+    );
+    const hoverSnippets = (
+        (configOptions.inspect('customREPLHoverSnippets')
+            .workspaceValue as customREPLCommandSnippet[]) ?? []
+    ).concat(
+        (state.getProjectConfig()
+            ?.customREPLHoverSnippets as customREPLCommandSnippet[]) ?? []
     );
 
     return {
@@ -143,9 +149,7 @@ function getConfig() {
         customREPLCommandSnippetsWorkspaceFolder: configOptions.inspect(
             'customREPLCommandSnippets'
         ).workspaceFolderValue as customREPLCommandSnippet[],
-        customHoverSnippets:
-            (state.getProjectConfig()
-                ?.customHoverSnippets as customREPLCommandSnippet[]) ?? [],
+        customREPLHoverSnippets: hoverSnippets,
         prettyPrintingOptions: configOptions.get(
             'prettyPrintingOptions'
         ) as PrettyPrintingOptions,

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -123,15 +123,26 @@ async function evaluateCodeOrKey(codeOrKey?: string) {
         ns,
         repl,
         selection: editor.document.getText(editor.selection),
-        currentForm: getText.currentFormText(editor)[1],
-        enclosingForm: getText.currentEnclosingFormText(editor)[1],
-        topLevelForm: getText.currentTopLevelFormText(editor)[1],
-        currentFn: getText.currentFunction(editor)[1],
-        topLevelDefinedForm: getText.currentTopLevelFunction(editor)[1],
-        head: getText.toStartOfList(editor)[1],
-        tail: getText.toEndOfList(editor)[1],
+        currentForm: getText.currentFormText(
+            editor?.document,
+            editor?.selection.active
+        )[1],
+        enclosingForm: getText.currentEnclosingFormText(
+            editor.document,
+            editor?.selection.active
+        )[1],
+        topLevelForm: getText.currentTopLevelFormText(
+            editor?.document,
+            editor?.selection.active
+        )[1],
+        currentFn: getText.currentFunction(editor?.document)[1],
+        topLevelDefinedForm: getText.currentTopLevelFunction(
+            editor?.document
+        )[1],
+        head: getText.toStartOfList(editor?.document)[1],
+        tail: getText.toEndOfList(editor?.document)[1],
     };
-    const result = await evaluateSnippet({ snippet: code }, context, options);
+    let result = await evaluateSnippet({ snippet: code }, context, options);
 
     outputWindow.appendPrompt();
 

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -10,11 +10,11 @@ import * as replSession from './nrepl/repl-session';
 import * as evaluate from './evaluate';
 import * as state from './state';
 
-export async function evaluateCustomCodeSnippetCommand(codeOrKey?: string) {
-    await evaluateCustomCodeSnippet(codeOrKey);
+async function evaluateCustomCodeSnippetCommand(codeOrKey?: string) {
+    await evaluateCodeOrKey(codeOrKey);
 }
 
-async function evaluateCustomCodeSnippet(codeOrKey?: string): Promise<void> {
+async function evaluateCodeOrKey(codeOrKey?: string) {
     const editor = vscode.window.activeTextEditor;
     const currentLine = editor.selection.active.line;
     const currentColumn = editor.selection.active.character;
@@ -102,28 +102,6 @@ async function evaluateCustomCodeSnippet(codeOrKey?: string): Promise<void> {
     const code = pick !== undefined ? snippetsDict[pick].snippet : codeOrKey;
     const ns = pick !== undefined ? snippetsDict[pick].ns : editorNS;
     const repl = pick !== undefined ? snippetsDict[pick].repl : editorRepl;
-    const interpolatedCode = code
-        .replace(/\$line/g, currentLine)
-        .replace(/\$column/g, currentColumn)
-        .replace(/\$file/g, currentFilename)
-        .replace(/\$ns/g, ns)
-        .replace(/\$selection/g, editor.document.getText(editor.selection))
-        .replace(/\$current-form/g, getText.currentFormText(editor)[1])
-        .replace(
-            /\$enclosing-form/g,
-            getText.currentEnclosingFormText(editor)[1]
-        )
-        .replace(
-            /\$top-level-form/g,
-            getText.currentTopLevelFormText(editor)[1]
-        )
-        .replace(/\$current-fn/g, getText.currentFunction(editor)[1])
-        .replace(
-            /\$top-level-defined-symbol/g,
-            getText.currentTopLevelFunction(editor)[1]
-        )
-        .replace(/\$head/g, getText.toStartOfList(editor)[1])
-        .replace(/\$tail/g, getText.toEndOfList(editor)[1]);
 
     const options = {};
 
@@ -138,6 +116,60 @@ async function evaluateCustomCodeSnippet(codeOrKey?: string): Promise<void> {
                 : undefined;
     }
 
-    await evaluate.evaluateInOutputWindow(interpolatedCode, repl, ns, options);
+    const context = {
+        currentLine,
+        currentColumn,
+        currentFilename,
+        ns,
+        repl,
+        selection: editor.document.getText(editor.selection),
+        currentForm: getText.currentFormText(editor)[1],
+        enclosingForm: getText.currentEnclosingFormText(editor)[1],
+        topLevelForm: getText.currentTopLevelFormText(editor)[1],
+        currentFn: getText.currentFunction(editor)[1],
+        topLevelDefinedForm: getText.currentTopLevelFunction(editor)[1],
+        head: getText.toStartOfList(editor)[1],
+        tail: getText.toEndOfList(editor)[1],
+    };
+    const result = await evaluateSnippet({ snippet: code }, context, options);
+
     outputWindow.appendPrompt();
+
+    return result;
 }
+
+async function evaluateSnippet(snippet, context, options) {
+    const code = snippet.snippet;
+    const ns = snippet.ns ?? context.ns;
+    const repl = snippet.repl ?? context.repl;
+    const interpolatedCode = interpolateCode(code, context);
+    return await evaluate.evaluateInOutputWindow(
+        interpolatedCode,
+        repl,
+        ns,
+        options
+    );
+}
+
+function interpolateCode(code: string, context): string {
+    return code
+        .replace(/\$line/g, context.currentLine)
+        .replace(/\$hover-line/g, context.hoverLine)
+        .replace(/\$column/g, context.currentColumn)
+        .replace(/\$hover-column/g, context.hoverColumn)
+        .replace(/\$file/g, context.currentFilename)
+        .replace(/\$hover-file/g, context.hoverFilename)
+        .replace(/\$ns/g, context.ns)
+        .replace(/\$repl/g, context.repl)
+        .replace(/\$selection/g, context.selection)
+        .replace(/\$hover-text/g, context.hoverText)
+        .replace(/\$current-form/g, context.currentForm)
+        .replace(/\$enclosing-form/g, context.enclosingForm)
+        .replace(/\$top-level-form/g, context.topLevelForm)
+        .replace(/\$current-fn/g, context.currentFn)
+        .replace(/\$top-level-defined-symbol/g, context.topLevelDefinedForm)
+        .replace(/\$head/g, context.head)
+        .replace(/\$tail/g, context.tail);
+}
+
+export { evaluateCustomCodeSnippetCommand, evaluateSnippet };

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -141,6 +141,7 @@ async function evaluateCodeOrKey(codeOrKey?: string) {
         )[1],
         head: getText.toStartOfList(editor?.document)[1],
         tail: getText.toEndOfList(editor?.document)[1],
+        ...getText.currentContext(editor.document, editor.selection.active),
     };
     let result = await evaluateSnippet({ snippet: code }, context, options);
 
@@ -180,7 +181,17 @@ function interpolateCode(code: string, context): string {
         .replace(/\$current-fn/g, context.currentFn)
         .replace(/\$top-level-defined-symbol/g, context.topLevelDefinedForm)
         .replace(/\$head/g, context.head)
-        .replace(/\$tail/g, context.tail);
+        .replace(/\$tail/g, context.tail)
+        .replace(/\$hover-current-form/g, context.hovercurrentForm)
+        .replace(/\$hover-enclosing-form/g, context.hoverenclosingForm)
+        .replace(/\$hover-top-level-form/g, context.hovertopLevelForm)
+        .replace(/\$hover-current-fn/g, context.hovercurrentFn)
+        .replace(
+            /\$hover-top-level-defined-symbol/g,
+            context.hovertopLevelDefinedForm
+        )
+        .replace(/\$hover-head/g, context.hoverhead)
+        .replace(/\$hover-tail/g, context.hovertail);
 }
 
 export { evaluateCustomCodeSnippetCommand, evaluateSnippet };

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -143,7 +143,7 @@ async function evaluateCodeOrKey(codeOrKey?: string) {
         tail: getText.toEndOfList(editor?.document)[1],
         ...getText.currentContext(editor.document, editor.selection.active),
     };
-    let result = await evaluateSnippet({ snippet: code }, context, options);
+    const result = await evaluateSnippet({ snippet: code }, context, options);
 
     outputWindow.appendPrompt();
 

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -328,7 +328,7 @@ function _currentSelectionElseCurrentForm(
 function _currentTopLevelFormText(
     editor: vscode.TextEditor
 ): getText.SelectionAndText {
-    return getText.currentEnclosingFormText(
+    return getText.currentTopLevelFormText(
         editor?.document,
         editor?.selection.active
     );

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -69,7 +69,7 @@ async function evaluateCode(
     code: string,
     options,
     selection?: vscode.Selection
-): Promise<void> {
+): Promise<string | null> {
     const pprintOptions =
         options.pprintOptions || getConfig().prettyPrintingOptions;
     // passed options overwrite config options
@@ -87,6 +87,7 @@ async function evaluateCode(
     const session: NReplSession = options.session;
     const ns = options.ns;
     const editor = vscode.window.activeTextEditor;
+    let result = null;
 
     if (code.length > 0) {
         if (addToHistory) {
@@ -119,6 +120,7 @@ async function evaluateCode(
                 outputWindow.append(code);
             }
 
+            result = value;
             outputWindow.append(value, async (resultLocation) => {
                 if (selection) {
                     const c = selection.start.character;
@@ -230,6 +232,8 @@ async function evaluateCode(
         outputWindow.setSession(session, context.ns || ns);
         replSession.updateReplSessionType();
     }
+
+    return result;
 }
 
 async function evaluateSelection(document: {}, options) {
@@ -604,7 +608,7 @@ export async function evaluateInOutputWindow(
             outputWindow.appendPrompt();
         }
 
-        await evaluateCode(code, {
+        return await evaluateCode(code, {
             ...options,
             filePath: outputDocument.fileName,
             session,

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -617,7 +617,7 @@ async function instrumentTopLevelForm() {
         {
             pprintOptions: getConfig().prettyPrintingOptions,
             debug: true,
-            selectionFn: getText.currentTopLevelFormText,
+            selectionFn: _currentTopLevelFormText,
         }
     ).catch(printWarningForError);
     state

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -325,6 +325,24 @@ function _currentSelectionElseCurrentForm(
     }
 }
 
+function _currentTopLevelFormText(
+    editor: vscode.TextEditor
+): getText.SelectionAndText {
+    return getText.currentEnclosingFormText(
+        editor?.document,
+        editor?.selection.active
+    );
+}
+
+function _currentEnclosingFormText(
+    editor: vscode.TextEditor
+): getText.SelectionAndText {
+    return getText.currentEnclosingFormText(
+        editor?.document,
+        editor?.selection.active
+    );
+}
+
 function evaluateSelectionReplace(document = {}, options = {}) {
     evaluateSelection(
         document,
@@ -353,7 +371,7 @@ function evaluateTopLevelFormAsComment(document = {}, options = {}) {
         Object.assign({}, options, {
             comment: true,
             pprintOptions: getConfig().prettyPrintingOptions,
-            selectionFn: getText.currentTopLevelFormText,
+            selectionFn: _currentTopLevelFormText,
         })
     ).catch(printWarningForError);
 }
@@ -363,7 +381,7 @@ function evaluateTopLevelForm(document = {}, options = {}) {
         document,
         Object.assign({}, options, {
             pprintOptions: getConfig().prettyPrintingOptions,
-            selectionFn: getText.currentTopLevelFormText,
+            selectionFn: _currentTopLevelFormText,
         })
     ).catch(printWarningForError);
 }
@@ -373,8 +391,9 @@ function evaluateOutputWindowForm(document = {}, options = {}) {
         document,
         Object.assign({}, options, {
             pprintOptions: getConfig().prettyPrintingOptions,
-            selectionFn: getText.currentTopLevelFormText,
+            selectionFn: _currentTopLevelFormText,
             evaluationSendCodeToOutputWindow: false,
+            addToHistory: true,
         })
     ).catch(printWarningForError);
 }
@@ -394,7 +413,7 @@ function evaluateEnclosingForm(document = {}, options = {}) {
         document,
         Object.assign({}, options, {
             pprintOptions: getConfig().prettyPrintingOptions,
-            selectionFn: getText.currentEnclosingFormText,
+            selectionFn: _currentEnclosingFormText,
         })
     ).catch(printWarningForError);
 }

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -643,7 +643,9 @@ export async function evaluateInOutputWindow(
         if (outputWindow.getNs() !== ns) {
             await session.eval(`(in-ns '${ns})`, session.client.ns).value;
             outputWindow.setSession(session, ns);
-            outputWindow.appendPrompt();
+            if (options.evaluationSendCodeToOutputWindow !== false) {
+                outputWindow.appendPrompt();
+            }
         }
 
         return await evaluateCode(code, {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -7,6 +7,7 @@ import * as clojureDocs from '../clojuredocs';
 import { getConfig } from '../config';
 import { evaluateSnippet } from '../custom-snippets';
 import * as getText from '../util/get-text';
+import _ = require('lodash');
 
 export async function provideHover(
     document: vscode.TextDocument,
@@ -56,25 +57,26 @@ export async function provideHover(
                 ...getText.currentContext(document, position, 'hover'),
             };
 
-            await Promise.all(customREPLHoverSnippets.map(async snippet => {
-                try {
-                    const text = await evaluateSnippet(snippet, context, {
-                        evaluationSendCodeToOutputWindow: false,
-                        showErrorMessage: false,
-                        showResult: false
-                    });
-                
-                    if (text) {
-                        const hover = new vscode.MarkdownString();
-                        hover.isTrusted = true;
-                        hover.appendMarkdown(text);
-                        hovers.push(hover);
-                    }    
-                } catch (error) {
-                    console.log('custom hover exploded');
-                }
-                            
-            }));
+            await Promise.all(
+                customREPLHoverSnippets.map(async (snippet) => {
+                    try {
+                        const text = await evaluateSnippet(snippet, context, {
+                            evaluationSendCodeToOutputWindow: false,
+                            showErrorMessage: false,
+                            showResult: false,
+                        });
+
+                        if (text) {
+                            const hover = new vscode.MarkdownString();
+                            hover.isTrusted = true;
+                            hover.appendMarkdown(_.trim(text, '"'));
+                            hovers.push(hover);
+                        }
+                    } catch (error) {
+                        console.log('custom hover exploded');
+                    }
+                })
+            );
             if (hovers.length) {
                 return new vscode.Hover(hovers);
             }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -44,20 +44,25 @@ export async function provideHover(
                 hoverFilename: document.fileName,
             };
 
-            await Promise.all(
-                customHoverSnippets.map(async (snippet) => {
+            await Promise.all(customHoverSnippets.map(async snippet => {
+                try {
                     const text = await evaluateSnippet(snippet, context, {
                         evaluationSendCodeToOutputWindow: false,
+                        showErrorMessage: false,
+                        showResult: false
                     });
-
+                
                     if (text) {
                         const hover = new vscode.MarkdownString();
                         hover.isTrusted = true;
                         hover.appendMarkdown(text);
                         hovers.push(hover);
-                    }
-                })
-            );
+                    }    
+                } catch (error) {
+                    console.log("custom hover exploded");                    
+                }
+                            
+            }));
             if (hovers.length) {
                 return new vscode.Hover(hovers);
             }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -4,8 +4,13 @@ import * as infoparser from './infoparser';
 import * as namespace from '../namespace';
 import * as replSession from '../nrepl/repl-session';
 import * as clojureDocs from '../clojuredocs';
+import { getConfig } from '../config';
+import { evaluateSnippet } from '../custom-snippets';
 
-export async function provideHover(document, position) {
+export async function provideHover(
+    document: vscode.TextDocument,
+    position: vscode.Position
+) {
     if (util.getConnectedState()) {
         const text = util.getWordAtPosition(document, position);
         const ns = namespace.getNamespace(document);
@@ -13,6 +18,8 @@ export async function provideHover(document, position) {
         if (client) {
             await namespace.createNamespaceFromDocumentIfNotExists(document);
             const res = await client.info(ns, text);
+            const customHoverSnippets = getConfig().customHoverSnippets;
+            const hovers = [];
             if (
                 !res.status.includes('error') &&
                 !res.status.includes('no-info')
@@ -22,7 +29,37 @@ export async function provideHover(document, position) {
                     document,
                     position
                 );
-                return new vscode.Hover([docsMd, clojureDocsMd]);
+
+                hovers.push(docsMd, clojureDocsMd);
+            }
+            const context = {
+                ns,
+                repl:
+                    document.languageId === 'clojure'
+                        ? replSession.getReplSessionTypeFromState()
+                        : 'clj',
+                hoverText: text,
+                hoverLine: position.line + 1,
+                hoverColumn: position.character + 1,
+                hoverFilename: document.fileName,
+            };
+
+            await Promise.all(
+                customHoverSnippets.map(async (snippet) => {
+                    const text = await evaluateSnippet(snippet, context, {
+                        evaluationSendCodeToOutputWindow: false,
+                    });
+
+                    if (text) {
+                        const hover = new vscode.MarkdownString();
+                        hover.isTrusted = true;
+                        hover.appendMarkdown(text);
+                        hovers.push(hover);
+                    }
+                })
+            );
+            if (hovers.length) {
+                return new vscode.Hover(hovers);
             }
         }
         return null; //new vscode.Hover(infoparser.getHoverNotAvailable(text));

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -19,7 +19,7 @@ export async function provideHover(
         if (client) {
             await namespace.createNamespaceFromDocumentIfNotExists(document);
             const res = await client.info(ns, text);
-            const customHoverSnippets = getConfig().customHoverSnippets;
+            const customREPLHoverSnippets = getConfig().customREPLHoverSnippets;
             const hovers = [];
             if (
                 !res.status.includes('error') &&
@@ -56,26 +56,25 @@ export async function provideHover(
                 ...getText.currentContext(document, position, 'hover'),
             };
 
-            await Promise.all(
-                customHoverSnippets.map(async (snippet) => {
-                    try {
-                        const text = await evaluateSnippet(snippet, context, {
-                            evaluationSendCodeToOutputWindow: false,
-                            showErrorMessage: false,
-                            showResult: false,
-                        });
-
-                        if (text) {
-                            const hover = new vscode.MarkdownString();
-                            hover.isTrusted = true;
-                            hover.appendMarkdown(text);
-                            hovers.push(hover);
-                        }
-                    } catch (error) {
-                        console.log('custom hover exploded');
-                    }
-                })
-            );
+            await Promise.all(customREPLHoverSnippets.map(async snippet => {
+                try {
+                    const text = await evaluateSnippet(snippet, context, {
+                        evaluationSendCodeToOutputWindow: false,
+                        showErrorMessage: false,
+                        showResult: false
+                    });
+                
+                    if (text) {
+                        const hover = new vscode.MarkdownString();
+                        hover.isTrusted = true;
+                        hover.appendMarkdown(text);
+                        hovers.push(hover);
+                    }    
+                } catch (error) {
+                    console.log('custom hover exploded');
+                }
+                            
+            }));
             if (hovers.length) {
                 return new vscode.Hover(hovers);
             }

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -361,7 +361,7 @@ async function runNamespaceTests(
 function getTestUnderCursor() {
     const editor = vscode.window.activeTextEditor;
     if (editor) {
-        return getText.currentTopLevelFunction(editor)[1];
+        return getText.currentTopLevelFunction(editor?.document)[1];
     }
 }
 

--- a/src/util/get-text.ts
+++ b/src/util/get-text.ts
@@ -116,15 +116,23 @@ export function toEndOfList(doc: vscode.TextDocument): SelectionAndText {
     return fromFn(doc, paredit.rangeToForwardList);
 }
 
-export function currentContext(document: vscode.TextDocument, pos: vscode.Position, prefix = "") {
-    const result = {}
-    result[prefix +  "currentForm"] = currentFormText(document, pos)[1];
-    result[prefix +  "enclosingForm"] = currentEnclosingFormText(document, pos)[1];
-    result[prefix +  "topLevelForm"] = currentTopLevelFormText(document, pos)[1];
-    result[prefix +  "currentFn"] = currentFunction(document)[1];
-    result[prefix +  "topLevelDefinedForm"] = currentTopLevelFunction(document)[1];
-    result[prefix +  "head"] = toStartOfList(document)[1];
-    result[prefix +  "tail"] = toEndOfList(document)[1];
+export function currentContext(
+    document: vscode.TextDocument,
+    pos: vscode.Position,
+    prefix = ''
+) {
+    const result = {};
+    result[prefix + 'currentForm'] = currentFormText(document, pos)[1];
+    result[prefix + 'enclosingForm'] = currentEnclosingFormText(
+        document,
+        pos
+    )[1];
+    result[prefix + 'topLevelForm'] = currentTopLevelFormText(document, pos)[1];
+    result[prefix + 'currentFn'] = currentFunction(document)[1];
+    result[prefix + 'topLevelDefinedForm'] =
+        currentTopLevelFunction(document)[1];
+    result[prefix + 'head'] = toStartOfList(document)[1];
+    result[prefix + 'tail'] = toEndOfList(document)[1];
 
     return result;
 }

--- a/src/util/get-text.ts
+++ b/src/util/get-text.ts
@@ -115,3 +115,16 @@ export function toStartOfList(doc: vscode.TextDocument): SelectionAndText {
 export function toEndOfList(doc: vscode.TextDocument): SelectionAndText {
     return fromFn(doc, paredit.rangeToForwardList);
 }
+
+export function currentContext(document: vscode.TextDocument, pos: vscode.Position, prefix = "") {
+    const result = {}
+    result[prefix +  "currentForm"] = currentFormText(document, pos)[1];
+    result[prefix +  "enclosingForm"] = currentEnclosingFormText(document, pos)[1];
+    result[prefix +  "topLevelForm"] = currentTopLevelFormText(document, pos)[1];
+    result[prefix +  "currentFn"] = currentFunction(document)[1];
+    result[prefix +  "topLevelDefinedForm"] = currentTopLevelFunction(document)[1];
+    result[prefix +  "head"] = toStartOfList(document)[1];
+    result[prefix +  "tail"] = toEndOfList(document)[1];
+
+    return result;
+}

--- a/src/util/get-text.ts
+++ b/src/util/get-text.ts
@@ -8,126 +8,110 @@ import { EditableDocument } from '../cursor-doc/model';
 export type SelectionAndText = [vscode.Selection, string];
 
 function _currentFormText(
-    editor: vscode.TextEditor,
-    topLevel: boolean
+    doc: vscode.TextDocument,
+    topLevel: boolean,
+    pos: vscode.Position
 ): SelectionAndText {
-    const doc = editor.document;
     if (doc) {
-        const codeSelection = select.getFormSelection(
-            doc,
-            editor.selection.active,
-            topLevel
-        );
+        const codeSelection = select.getFormSelection(doc, pos, topLevel);
         return [codeSelection, doc.getText(codeSelection)];
     }
     return [undefined, ''];
 }
 
 export function currentTopLevelFormText(
-    editor: vscode.TextEditor
+    doc: vscode.TextDocument,
+    pos: vscode.Position
 ): SelectionAndText {
-    return _currentFormText(editor, true);
+    return _currentFormText(doc, true, pos);
 }
 
-export function currentFormText(editor: vscode.TextEditor): SelectionAndText {
-    return _currentFormText(editor, false);
+export function currentFormText(
+    doc: vscode.TextDocument,
+    pos: vscode.Position
+): SelectionAndText {
+    return _currentFormText(doc, false, pos);
 }
 
 export function currentEnclosingFormText(
-    editor: vscode.TextEditor
+    doc: vscode.TextDocument,
+    pos: vscode.Position
 ): SelectionAndText {
-    const doc = editor.document;
     if (doc) {
-        const codeSelection = select.getEnclosingFormSelection(
-            doc,
-            editor.selection.active
-        );
+        const codeSelection = select.getEnclosingFormSelection(doc, pos);
         return [codeSelection, doc.getText(codeSelection)];
     }
     return [undefined, ''];
 }
 
-export function currentFunction(editor: vscode.TextEditor): SelectionAndText {
-    if (editor) {
-        const document = editor.document;
-        const tokenCursor = docMirror
-            .getDocument(editor.document)
-            .getTokenCursor();
+export function currentFunction(doc: vscode.TextDocument): SelectionAndText {
+    if (doc) {
+        const tokenCursor = docMirror.getDocument(doc).getTokenCursor();
         const [start, end] = tokenCursor.getFunctionSexpRange();
         if (start && end) {
-            const startPos = document.positionAt(start);
-            const endPos = document.positionAt(end);
+            const startPos = doc.positionAt(start);
+            const endPos = doc.positionAt(end);
             const selection = new vscode.Selection(startPos, endPos);
-            return [selection, document.getText(selection)];
+            return [selection, doc.getText(selection)];
         }
     }
     return [undefined, ''];
 }
 
 function selectionAndText(
-    editor: vscode.TextEditor,
+    doc: vscode.TextDocument,
     textGetter: (doc: EditableDocument) => cursorTextGetter.RangeAndText
 ): SelectionAndText {
-    if (editor) {
-        const document = editor.document;
-        const mirrorDoc = docMirror.getDocument(document);
+    if (doc) {
+        const mirrorDoc = docMirror.getDocument(doc);
         const [range, text] = textGetter(mirrorDoc);
         if (range) {
-            return [select.selectionFromOffsetRange(document, range), text];
+            return [select.selectionFromOffsetRange(doc, range), text];
         }
     }
     return [undefined, ''];
 }
 
 export function currentEnclosingFormToCursor(
-    editor: vscode.TextEditor
+    doc: vscode.TextDocument
 ): SelectionAndText {
-    return selectionAndText(
-        editor,
-        cursorTextGetter.currentEnclosingFormToCursor
-    );
+    return selectionAndText(doc, cursorTextGetter.currentEnclosingFormToCursor);
 }
 
 export function currentTopLevelFunction(
-    editor: vscode.TextEditor
+    doc: vscode.TextDocument
 ): SelectionAndText {
-    return selectionAndText(editor, cursorTextGetter.currentTopLevelFunction);
+    return selectionAndText(doc, cursorTextGetter.currentTopLevelFunction);
 }
 
 export function currentTopLevelFormToCursor(
-    editor: vscode.TextEditor
+    doc: vscode.TextDocument
 ): SelectionAndText {
-    return selectionAndText(
-        editor,
-        cursorTextGetter.currentTopLevelFormToCursor
-    );
+    return selectionAndText(doc, cursorTextGetter.currentTopLevelFormToCursor);
 }
 
-export function startOFileToCursor(
-    editor: vscode.TextEditor
-): SelectionAndText {
-    return selectionAndText(editor, cursorTextGetter.startOfFileToCursor);
+export function startOFileToCursor(doc: vscode.TextDocument): SelectionAndText {
+    return selectionAndText(doc, cursorTextGetter.startOfFileToCursor);
 }
 
 function fromFn(
-    editor: vscode.TextEditor,
+    doc: vscode.TextDocument,
     cursorDocFn: Function
 ): SelectionAndText {
-    if (editor) {
-        const document = editor.document;
-        const cursorDoc = docMirror.getDocument(document);
+    if (doc) {
+        const cursorDoc = docMirror.getDocument(doc);
         const range = cursorDocFn(cursorDoc);
-        const selection = select.selectionFromOffsetRange(document, range);
-        const text = document.getText(selection);
+        const selection = select.selectionFromOffsetRange(doc, range);
+        const text = doc.getText(selection);
         return [selection, text];
     }
     return [undefined, ''];
 }
 
-export function toStartOfList(editor: vscode.TextEditor): SelectionAndText {
-    return fromFn(editor, paredit.rangeToBackwardList);
+export function toStartOfList(doc: vscode.TextDocument): SelectionAndText {
+    return fromFn(doc, paredit.rangeToBackwardList);
 }
 
-export function toEndOfList(editor: vscode.TextEditor): SelectionAndText {
-    return fromFn(editor, paredit.rangeToForwardList);
+export function toEndOfList(doc: vscode.TextDocument): SelectionAndText {
+    return fromFn(doc, paredit.rangeToForwardList);
 }

--- a/test-data/.calva/config.edn
+++ b/test-data/.calva/config.edn
@@ -1,6 +1,10 @@
 {
  :customHoverSnippets
- [{:name "edn hover"
-   :snippet "(str $hover-text)"}]
+ [{:name "edn hover symbol"
+   :snippet "(str $hover-text)"}
+  {:name "edn hover hover-current-form"
+   :snippet "(str \"$hover-current-form\")"}
+  {:name "edn hover current-form"
+   :snippet "(str \"current-form\")"}]
  }
 

--- a/test-data/.calva/config.edn
+++ b/test-data/.calva/config.edn
@@ -1,0 +1,6 @@
+{
+ :customHoverSnippets
+ [{:name "edn hover"
+   :snippet "(str $hover-text)"}]
+ }
+

--- a/test-data/.calva/config.edn
+++ b/test-data/.calva/config.edn
@@ -1,10 +1,10 @@
 {
- :customHoverSnippets
+ :customREPLHoverSnippets
  [{:name "edn hover symbol"
    :snippet "(str $hover-text)"}
   {:name "edn hover hover-current-form"
    :snippet "(str \"$hover-current-form\")"}
   {:name "edn hover current-form"
-   :snippet "(str \"current-form\")"}]
+   :snippet "(str \"$current-form\")"}]
  }
 


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- customHoverSnippets option added, has the same options as customREPLCommandSnippets
- evaluateCode now returns the eval result as a string

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1471 

Usage:
settings.json: 
```
"calva.customHoverSnippets": [
    {
            "name": "always hoverin",
            "snippet": "(str $hover-text)"
    }
]
```

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [~] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [~] Created the issue I am fixing/addressing, if it was not present.~

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe