### PR TITLE
Fix resolve macro as error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+Fix: [Exception thrown when registering "resolve-macro-as" command](https://github.com/BetterThanTomorrow/calva/issues/1495)
 
 ## [2.0.235] - 2022-01-22
 - [Continue to support -Aalias for jack-in](https://github.com/BetterThanTomorrow/calva/issues/1474)

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -30,7 +30,7 @@ class TestTreeFeature implements StaticFeature {
     }
 
     fillClientCapabilities(capabilities: ClientCapabilities): void {
-        capabilities.experimental = {testTree: true };
+        capabilities.experimental = { testTree: true };
     }
 
     dispose(): void {
@@ -110,7 +110,7 @@ function createClient(clojureLspPath: string): LanguageClient {
                 let hover: vscode.Hover;
                 try {
                     hover = await provideHover(document, position);
-                } catch (e) {}
+                } catch (e) { }
 
                 if (hover) {
                     return null;
@@ -256,39 +256,12 @@ async function codeLensReferencesHandler(_, line, character): Promise<void> {
     await vscode.commands.executeCommand('editor.action.referenceSearch.trigger');
 }
 
-
-async function resolveMacroAsCodeActionCommandHandler(document: string, line: number, character: number): Promise<void> {
-    const macroToResolveAs = await vscode.window.showQuickPick([
-        'clojure.core/def',
-        'clojure.core/defn',
-        'clojure.core/let',
-        'clojure.core/for',
-        'clojure.core/->',
-        'clojure.core/->>',
-        'clj-kondo.lint-as/def-catch-all'
-    ]);
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    const rootWorkspaceFolder = workspaceFolders && workspaceFolders[0];
-    const homeDirectory = os.homedir();
-    const cljKondoUserConfig = path.join(homeDirectory, '.config', 'clj-kondo', 'config.edn');
-    const configPaths = [cljKondoUserConfig];
-    if (rootWorkspaceFolder) {
-        const cljKondoProjectConfig = path.join(rootWorkspaceFolder.uri.fsPath, '.clj-kondo', 'config.edn');
-        configPaths.push(cljKondoProjectConfig);
-    }
-    const cljKondoConfigPath = await vscode.window.showQuickPick(configPaths, { placeHolder: 'Select where this setting should be saved:' });
-    if (macroToResolveAs && cljKondoConfigPath) {
-        const args = [document, line, character, macroToResolveAs, cljKondoConfigPath];
-        sendCommandRequest(RESOLVE_MACRO_AS_COMMAND, args);
-    }
-}
-
 function resolveMacroAsCommandHandler(): void {
     const activeTextEditor = vscode.window.activeTextEditor;
     if (activeTextEditor && activeTextEditor.document && activeTextEditor.document.languageId === 'clojure') {
         const documentUri = decodeURIComponent(activeTextEditor.document.uri.toString());
         const { line, character } = activeTextEditor.selection.active;
-        resolveMacroAsCodeActionCommandHandler(documentUri, line + 1, character + 1);
+        sendCommandRequest(RESOLVE_MACRO_AS_COMMAND, [documentUri, line + 1, character + 1]);
     }
 }
 
@@ -299,7 +272,7 @@ const generalCommands = [
         handler: codeLensReferencesHandler
     },
     {
-        name: 'calva.linting.resolveMacro',
+        name: 'calva.linting.resolveMacroAs',
         handler: resolveMacroAsCommandHandler
     }
 ];
@@ -339,7 +312,7 @@ async function startClient(clojureLspPath: string, context: vscode.ExtensionCont
     const client = createClient(clojureLspPath);
     console.log('Starting clojure-lsp at', clojureLspPath);
 
-    const testTree : StaticFeature = new TestTreeFeature();
+    const testTree: StaticFeature = new TestTreeFeature();
     client.registerFeature(testTree);
 
     const onReadyPromise = client.onReady();

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -299,11 +299,6 @@ const generalCommands = [
         handler: codeLensReferencesHandler
     },
     {
-        // The title of this command is dictated by clojure-lsp and is executed when the user executes the Resolve Macro As code action
-        name: RESOLVE_MACRO_AS_COMMAND,
-        handler: resolveMacroAsCodeActionCommandHandler
-    },
-    {
         name: 'calva.linting.resolveMacro',
         handler: resolveMacroAsCommandHandler
     }


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Stops registering `resolve-macro-as` as a command, as it seems the lsp client is now doing this already, maybe as a result of clojure-lsp causing it to. When we try to register the command, it causes an exception, and it seems that the rest of the clojure-lsp client startup code in `lsp/main.ts` is not being run.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1495 

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe