### PR TITLE
Update output queueing and batching logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Results doc gets in a bad state and does not update](https://github.com/BetterThanTomorrow/calva/issues/1509)
+
 ## [2.0.259] - 2022-03-26
 - [Add setting for enabling LiveShare support](https://github.com/BetterThanTomorrow/calva/issues/1629)
 

--- a/src/extension-test/unit/results-output/util-test.ts
+++ b/src/extension-test/unit/results-output/util-test.ts
@@ -1,5 +1,5 @@
 import * as expect from 'expect';
-import { OnAppendedCallback } from '../../../results-output/results-doc';
+import type { ResultsBuffer } from '../../../results-output/results-doc';
 import * as util from '../../../results-output/util';
 
 describe('addToHistory', () => {
@@ -51,57 +51,51 @@ describe('splitEditQueueForTextBatching', () => {
     expect(remainingEditQueue).toHaveLength(0);
   });
   it("doesn't perform batching if first item has callback", () => {
-    const queue: [string, OnAppendedCallback][] = [
-      [
-        'item-with-callback',
-        () => {
+    const queue: ResultsBuffer = [
+      {
+        text: 'item-with-callback',
+        onAppended: () => {
           // do nothing
         },
-      ],
-      ['item2', null],
-      ['item3', null],
+      },
+      { text: 'item2' },
+      { text: 'item3' },
     ];
     const [textBatch, remainingEditQueue] = util.splitEditQueueForTextBatching(queue);
     expect(textBatch).toHaveLength(0);
-    expect(remainingEditQueue.map(([s]) => s)).toEqual(
+    expect(remainingEditQueue.map((x) => x.text)).toEqual(
       expect.arrayContaining(['item-with-callback', 'item2', 'item3'])
     );
   });
   it('batches only leading items with no callback', () => {
-    const queue: [string, OnAppendedCallback][] = [
-      ['item1', null],
-      ['item2', null],
-      [
-        'item3-with-callback',
-        () => {
+    const queue: ResultsBuffer = [
+      { text: 'item1' },
+      { text: 'item2' },
+      {
+        text: 'item3-with-callback',
+        onAppended: () => {
           // do nothing
         },
-      ],
-      ['item4', null],
+      },
+      { text: 'item4' },
     ];
     const [textBatch, remainingEditQueue] = util.splitEditQueueForTextBatching(queue);
     expect(textBatch).toEqual(expect.arrayContaining(['item1', 'item2']));
-    expect(remainingEditQueue.map(([s]) => s)).toEqual(
+    expect(remainingEditQueue.map((x) => x.text)).toEqual(
       expect.arrayContaining(['item3-with-callback', 'item4'])
     );
   });
   it('correctly handles queue containing just items without callbacks', () => {
-    const queue: [string, OnAppendedCallback][] = [
-      ['item1', null],
-      ['item2', null],
-    ];
+    const queue: ResultsBuffer = [{ text: 'item1' }, { text: 'item2' }];
     const [textBatch, remainingEditQueue] = util.splitEditQueueForTextBatching(queue);
     expect(textBatch).toEqual(expect.arrayContaining(['item1', 'item2']));
     expect(remainingEditQueue).toHaveLength(0);
   });
   it('respects maxBatchSize', () => {
-    const queue: [string, OnAppendedCallback][] = [
-      ['item1', null],
-      ['item2', null],
-      ['item3', null],
-    ];
+    const queue: ResultsBuffer = [{ text: 'item1' }, { text: 'item2' }, { text: 'item3' }];
+
     const [textBatch, remainingEditQueue] = util.splitEditQueueForTextBatching(queue, 2);
     expect(textBatch).toEqual(expect.arrayContaining(['item1', 'item2']));
-    expect(remainingEditQueue.map(([s]) => s)).toEqual(expect.arrayContaining(['item3']));
+    expect(remainingEditQueue.map((x) => x.text)).toEqual(expect.arrayContaining(['item3']));
   });
 });

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -27,7 +27,7 @@ const START_GREETINGS =
 ; Happy coding! ♥️';
 
 export const CLJ_CONNECT_GREETINGS =
-  '; TIPS: \n\
+  '; TIPS:\n\
 ;   - You can edit the contents here. Use it as a REPL if you like.\n\
 ;   - `alt+enter` evaluates the current top level form.\n\
 ;   - `ctrl+enter` evaluates the current form.\n\
@@ -295,7 +295,14 @@ async function writeToResultsDoc({ text, onAppended }: ResultsBufferEntry): Prom
   const doc = await vscode.workspace.openTextDocument(docUri);
   const insertPosition = doc.positionAt(Infinity);
   const edit = new vscode.WorkspaceEdit();
-  edit.insert(docUri, insertPosition, `${lastLineIsEmpty(doc) ? '' : '\n'}${text}`);
+  let editText = text;
+  if (!lastLineIsEmpty(doc)) {
+    editText = '\n' + editText;
+  }
+  if (!editText.endsWith('\n')) {
+    editText += '\n';
+  }
+  edit.insert(docUri, insertPosition, editText);
   if (!((await vscode.workspace.applyEdit(edit)) && (await doc.save()))) {
     return;
   }

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -283,7 +283,7 @@ function registerResultDocSubscriptions() {
   let currentResultDocs = visibleResultsEditors();
   const subOpen = vscode.window.onDidChangeVisibleTextEditors((editors) => {
     const current = editors.filter((editor) => isResultsDoc(editor.document));
-    const opened = current.filter((editor) => currentResultDocs.indexOf(editor) < 0);
+    const opened = current.filter((editor) => currentResultDocs.includes(editor));
     currentResultDocs = current;
     opened.forEach(handleResultDocEditorDidOpen);
   });

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -147,6 +147,8 @@ export async function initResultsDoc(): Promise<vscode.TextDocument> {
   await vscode.workspace.applyEdit(edit);
   void resultsDoc.save();
 
+  registerResultDocSubscriptions();
+
   // For some reason onDidChangeTextEditorViewColumn won't fire
   state.extensionContext.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor((event) => {
@@ -263,90 +265,106 @@ export function appendCurrentTopLevelForm() {
   void appendFormGrabbingSessionAndNS(true);
 }
 
-let scrollToBottomSub: vscode.Disposable;
+function lastLineIsEmpty(doc: vscode.TextDocument): boolean {
+  const { lineCount } = doc;
+  const lastLine = doc.getText(new vscode.Range(lineCount - 1, 0, lineCount - 1, Infinity));
+  return lastLine === '';
+}
+
+function visibleResultsEditors(): vscode.TextEditor[] {
+  return vscode.window.visibleTextEditors.filter((editor) => isResultsDoc(editor.document));
+}
+
+function handleResultDocEditorDidOpen(editor: vscode.TextEditor) {
+  util.scrollToBottom(editor);
+}
+
+function registerResultDocSubscriptions() {
+  let currentResultDocs = visibleResultsEditors();
+  const subOpen = vscode.window.onDidChangeVisibleTextEditors((editors) => {
+    const current = editors.filter((editor) => isResultsDoc(editor.document));
+    const opened = current.filter((editor) => currentResultDocs.indexOf(editor) < 0);
+    currentResultDocs = current;
+    opened.forEach(handleResultDocEditorDidOpen);
+  });
+  state.extensionContext.subscriptions.push(subOpen);
+}
+
+async function writeToResultsDoc({ text, onAppended }: ResultsBufferEntry): Promise<void> {
+  const docUri = DOC_URI();
+  const doc = await vscode.workspace.openTextDocument(docUri);
+  const insertPosition = doc.positionAt(Infinity);
+  const edit = new vscode.WorkspaceEdit();
+  edit.insert(docUri, insertPosition, `${lastLineIsEmpty(doc) ? '' : '\n'}${text}`);
+  if (!((await vscode.workspace.applyEdit(edit)) && (await doc.save()))) {
+    return;
+  }
+  onAppended?.(
+    new vscode.Location(docUri, insertPosition),
+    new vscode.Location(docUri, doc.positionAt(Infinity))
+  );
+  const editors = visibleResultsEditors();
+  editors.forEach((editor) => {
+    util.scrollToBottom(editor);
+    highlight(editor);
+  });
+}
+
+export type ResultsBuffer = ResultsBufferEntry[];
+
+export type ResultsBufferEntry = {
+  text: string;
+  onAppended?: OnAppendedCallback;
+};
+
 export interface OnAppendedCallback {
   (insertLocation: vscode.Location, newPosition?: vscode.Location): any;
 }
-let editQueue: [string, OnAppendedCallback | undefined][] = [];
-let applyingEdit = false;
-/* Because this function can be called several times asynchronously by the handling of incoming nrepl messages,
-   we should never await it, because that await could possibly not return until way later, after edits that came in from elsewhere
-   are also applied, causing it to wait for several edits after the one awaited. This is due to the recursion and edit queue, which help
-   apply edits one after another without issues.
 
-   If something must be done after a particular edit, use the onAppended callback. */
-export function append(text: string, onAppended?: OnAppendedCallback): void {
-  let insertPosition: vscode.Position;
-  if (applyingEdit) {
-    editQueue.push([text, onAppended]);
-  } else {
-    applyingEdit = true;
-    void vscode.workspace.openTextDocument(DOC_URI()).then((doc) => {
-      const ansiStrippedText = util.stripAnsi(text);
-      if (doc) {
-        const edit = new vscode.WorkspaceEdit();
-        const currentContent = doc.getText();
-        const lastLineEmpty = currentContent.match(/\n$/) || currentContent === '';
-        const appendText = `${lastLineEmpty ? '' : '\n'}${ansiStrippedText}\n`;
-        insertPosition = doc.positionAt(Infinity);
-        edit.insert(DOC_URI(), insertPosition, `${appendText}`);
-        if (scrollToBottomSub) {
-          scrollToBottomSub.dispose();
-        }
-        const visibleResultsEditors: vscode.TextEditor[] = [];
-        vscode.window.visibleTextEditors.forEach((editor) => {
-          if (isResultsDoc(editor.document)) {
-            visibleResultsEditors.push(editor);
-          }
-        });
-        if (visibleResultsEditors.length == 0) {
-          scrollToBottomSub = vscode.window.onDidChangeActiveTextEditor((editor) => {
-            if (editor && isResultsDoc(editor.document)) {
-              util.scrollToBottom(editor);
-              scrollToBottomSub.dispose();
-            }
-          });
-          state.extensionContext.subscriptions.push(scrollToBottomSub);
-        }
+let resultsBuffer: ResultsBuffer = [];
 
-        void vscode.workspace.applyEdit(edit).then((success) => {
-          applyingEdit = false;
-          void doc.save();
-          if (success) {
-            if (visibleResultsEditors.length > 0) {
-              visibleResultsEditors.forEach((editor) => {
-                util.scrollToBottom(editor);
-                highlight(editor);
-              });
-            }
-          }
-          if (onAppended) {
-            onAppended(
-              new vscode.Location(DOC_URI(), insertPosition),
-              new vscode.Location(DOC_URI(), doc.positionAt(Infinity))
-            );
-          }
+async function writeNextOutputBatch() {
+  if (!resultsBuffer[0]) {
+    return;
+  }
+  // Any entries that contain onAppended are not batched with other pending
+  // entries to simplify providing the correct insert position to the callback.
+  if (resultsBuffer[0].onAppended) {
+    return await writeToResultsDoc(resultsBuffer.shift());
+  }
+  // Batch all remaining entries up until another onAppended callback.
+  const [nextText, remaining] = splitEditQueueForTextBatching(resultsBuffer);
+  resultsBuffer = remaining;
+  await writeToResultsDoc({ text: nextText.join('\n') });
+}
 
-          if (editQueue.length > 0) {
-            const [textBatch, remainingEditQueue] = splitEditQueueForTextBatching(editQueue, 1000);
-            if (textBatch.length > 0) {
-              editQueue = remainingEditQueue;
-              return append(textBatch.join('\n'));
-            } else {
-              // we're sure there's a value in the queue at this point
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              const [text, onAppended] = editQueue.shift()!;
-              return append(text, onAppended);
-            }
-          }
-        });
-      }
-    });
+// Ensures that writeNextOutputBatch is called on buffer sequentially.
+let outputPending = false;
+async function flushOutput() {
+  if (outputPending) {
+    return;
+  }
+  outputPending = true;
+  try {
+    while (resultsBuffer.length > 0) {
+      await writeNextOutputBatch();
+    }
+  } finally {
+    outputPending = false;
   }
 }
 
+/* If something must be done after a particular edit, use the onAppended callback. */
+export function append(text: string, onAppended?: OnAppendedCallback): void {
+  resultsBuffer.push({
+    text: util.stripAnsi(text),
+    onAppended,
+  });
+  void flushOutput();
+}
+
 export function discardPendingPrints(): void {
-  editQueue = [];
+  resultsBuffer = [];
   appendPrompt();
 }
 

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -295,7 +295,7 @@ async function writeToResultsDoc({ text, onAppended }: ResultsBufferEntry): Prom
   const doc = await vscode.workspace.openTextDocument(docUri);
   const insertPosition = doc.positionAt(Infinity);
   const edit = new vscode.WorkspaceEdit();
-  let editText = text;
+  let editText = util.stripAnsi(text);
   if (!lastLineIsEmpty(doc)) {
     editText = '\n' + editText;
   }
@@ -363,10 +363,7 @@ async function flushOutput() {
 
 /* If something must be done after a particular edit, use the onAppended callback. */
 export function append(text: string, onAppended?: OnAppendedCallback): void {
-  resultsBuffer.push({
-    text: util.stripAnsi(text),
-    onAppended,
-  });
+  resultsBuffer.push({ text, onAppended });
   void flushOutput();
 }
 

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -356,6 +356,8 @@ async function flushOutput() {
     while (resultsBuffer.length > 0) {
       await writeNextOutputBatch();
     }
+  } catch (err) {
+    console.error('Error writing to results doc:', err);
   } finally {
     outputPending = false;
   }

--- a/src/results-output/util.ts
+++ b/src/results-output/util.ts
@@ -1,5 +1,5 @@
 import { takeWhile } from 'lodash';
-import { OnAppendedCallback } from './results-doc';
+import type { ResultsBuffer } from './results-doc';
 
 function addToHistory(history: string[], content: string): string[] {
   if (content) {
@@ -18,14 +18,14 @@ function formatAsLineComments(error: string): string {
 }
 
 function splitEditQueueForTextBatching(
-  editQueue: [string, OnAppendedCallback | undefined][],
+  editQueue: ResultsBuffer,
   maxBatchSize: number = 1000
-): [string[], [string, OnAppendedCallback | undefined][]] {
-  const textBatch = takeWhile(editQueue, (value, index) => {
-    return index < maxBatchSize && !value[1];
-  }).map((value) => value[0]);
-  const remainingEditQueue = [...editQueue].slice(textBatch.length);
-  return [textBatch, remainingEditQueue];
+): [string[], ResultsBuffer] {
+  const nextBatch = takeWhile(editQueue, (value, index) => {
+    return index < maxBatchSize && !value.onAppended;
+  }).map((x) => x.text);
+  const remainingEditQueue = [...editQueue].slice(nextBatch.length);
+  return [nextBatch, remainingEditQueue];
 }
 
 export { addToHistory, formatAsLineComments, splitEditQueueForTextBatching };


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

This refactors the logic for queueing and writing to the output window. #1509 points out that certain conditions can cause the output window to get stuck in `isEditing` mode and cause the queue to grow indefinitely.

The main change in this PR is to queue **all** appended output to the new `EditQueue` to try and eliminate some of these edge conditions causing the output to break.

This is still a draft because I still have some questions around the previous batching logic and `OnAppendedCallback`

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1189
Fixes #1509

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
     - [x] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe