### PR TITLE
fixed repl history for forced eval in repl file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 Changes to Calva.
 
 ## [Unreleased]
-
 - Fix: ['Add to history' not working on eval in repl](https://github.com/BetterThanTomorrow/calva/issues/1594)
 
 ## [2.0.237] - 2022-01-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: ['Add to history' not working on eval in repl](https://github.com/BetterThanTomorrow/calva/issues/1594)
+
 ## [2.0.237] - 2022-01-30
 - Fix: ['Show Previous REPL History Entry' command not working on v.2.0.236](https://github.com/BetterThanTomorrow/calva/issues/1594)
 

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -8,6 +8,7 @@ import { customREPLCommandSnippet } from './evaluate';
 import { getConfig } from './config';
 import * as replSession from './nrepl/repl-session';
 import * as evaluate from './evaluate';
+import * as state from './state';
 
 export async function evaluateCustomCodeSnippetCommand(codeOrKey?: string) {
     await evaluateCustomCodeSnippet(codeOrKey);
@@ -103,6 +104,8 @@ async function evaluateCustomCodeSnippet(codeOrKey?: string): Promise<void> {
 
     if (pick !== undefined) {
         options['evaluationSendCodeToOutputWindow'] = snippetsDict[pick].evaluationSendCodeToOutputWindow;
+        // don't allow addToHistory if we don't show the code but are inside the repl
+        options['addToHistory'] = state.extensionContext.workspaceState.get('outputWindowActive') && !snippetsDict[pick].evaluationSendCodeToOutputWindow ? false : undefined;
     }
 
     await evaluate.evaluateInOutputWindow(interpolatedCode, repl, ns, options);

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -51,7 +51,8 @@ async function evaluateCode(code: string, options, selection?: vscode.Selection)
     // passed options overwrite config options
     const evaluationSendCodeToOutputWindow = (options.evaluationSendCodeToOutputWindow === undefined || options.evaluationSendCodeToOutputWindow === true)
         && getConfig().evaluationSendCodeToOutputWindow;
-    const addToHistory = evaluationSendCodeToOutputWindow || state.extensionContext.workspaceState.get('outputWindowActive');
+    const addToHistory = (options.addToHistory === undefined || options.addToHistory === true) &&
+        (evaluationSendCodeToOutputWindow || state.extensionContext.workspaceState.get('outputWindowActive'));
     const line = options.line;
     const column = options.column;
     const filePath = options.filePath;

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -51,7 +51,7 @@ async function evaluateCode(code: string, options, selection?: vscode.Selection)
     // passed options overwrite config options
     const evaluationSendCodeToOutputWindow = (options.evaluationSendCodeToOutputWindow === undefined || options.evaluationSendCodeToOutputWindow === true)
         && getConfig().evaluationSendCodeToOutputWindow;
-    const addToHistory = options.addToHistory === true || evaluationSendCodeToOutputWindow;
+    const addToHistory = evaluationSendCodeToOutputWindow || state.extensionContext.workspaceState.get('outputWindowActive');
     const line = options.line;
     const column = options.column;
     const filePath = options.filePath;
@@ -239,8 +239,7 @@ function evaluateOutputWindowForm(document = {}, options = {}) {
     evaluateSelection(document, Object.assign({}, options, {
         pprintOptions: getConfig().prettyPrintingOptions,
         selectionFn: getText.currentTopLevelFormText,
-        evaluationSendCodeToOutputWindow: false,
-        addToHistory: true
+        evaluationSendCodeToOutputWindow: false
     })).catch(printWarningForError);
 }
 

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -108,6 +108,7 @@ function setViewColumn(column: vscode.ViewColumn) {
 }
 
 export function setContextForOutputWindowActive(isActive: boolean): void {
+    state.extensionContext.workspaceState.update(`outputWindowActive`, isActive);
     vscode.commands.executeCommand("setContext", "calva:outputWindowActive", isActive);
 }
 


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

Instead of handling `evaluateOutputWindowForm` command in a special way to add it to the history, we now check if the eval happened while we are inside the repl.
This is not ideal since it interacts in a complicated way with snippet eval inside the repl.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1504 

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe