### PR TITLE
Formatter config from lsp

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -155,5 +155,6 @@
         "webpacked",
         "xvfb",
         "zprint"
-    ]
+    ],
+    "calva.fmt.configPath": "cljfmt.edn"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "restructuredtext.confPath": "${workspaceFolder}\\docs\\readthedocs\\source",
     "mochaExplorer.files": "src/extension-test/unit/**/*-test.ts",
     "mochaExplorer.require": "ts-node/register",
     "testExplorer.useNativeTesting": true,
@@ -55,6 +54,7 @@
         "enablements",
         "entrypoint",
         "errored",
+        "ESPACEIALLY",
         "être",
         "eval",
         "evals",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 - [Add custom hover snippets](https://github.com/BetterThanTomorrow/calva/issues/1471)
 - [Add option to read cljfmt config from clojure-lsp](https://github.com/BetterThanTomorrow/calva/issues/1545)
-- [Add option to read cljfmt config from clojure-lsp](https://github.com/BetterThanTomorrow/calva/issues/1545)
+- Fix: [Map key/value pair aligning is not working on format](https://github.com/BetterThanTomorrow/calva/issues/1535)
 - Change default keybinding for **Infer parens** to `ctrl+alt+p i` (from `shift+tab`)
 - Change default keybinding for **Tab dedent** to `shift+tab` (from `shift+ctrl+i`)
 - [Make alt+enter evaluate top level form also within line-comments](https://github.com/BetterThanTomorrow/calva/issues/1549)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ Changes to Calva.
 
 ## [Unreleased]
 - [Add custom hover snippets](https://github.com/BetterThanTomorrow/calva/issues/1471)
-- [Make alt+enter evaluate top level form also within line-comments](https://github.com/BetterThanTomorrow/calva/issues/1549)
 - [Add option to read cljfmt config from clojure-lsp](https://github.com/BetterThanTomorrow/calva/issues/1545)
+- [Add option to read cljfmt config from clojure-lsp](https://github.com/BetterThanTomorrow/calva/issues/1545)
+- Change default keybinding for **Infer parens** to `ctrl+alt+p i` (from `shift+tab`)
+- Change default keybinding for **Tab dedent** to `shift+tab` (from `shift+ctrl+i`)
+- [Make alt+enter evaluate top level form also within line-comments](https://github.com/BetterThanTomorrow/calva/issues/1549)
 
 ## [2.0.243] - 2022-02-13
 - [Use vanilla cljfmt for regular formatting](https://github.com/BetterThanTomorrow/calva/pull/1179)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 - [Add custom hover snippets](https://github.com/BetterThanTomorrow/calva/issues/1471)
 - [Make alt+enter evaluate top level form also within line-comments](https://github.com/BetterThanTomorrow/calva/issues/1549)
+- [Add option to read cljfmt config from clojure-lsp](https://github.com/BetterThanTomorrow/calva/issues/1545)
 
 ## [2.0.243] - 2022-02-13
 - [Use vanilla cljfmt for regular formatting](https://github.com/BetterThanTomorrow/calva/pull/1179)

--- a/cljfmt.edn
+++ b/cljfmt.edn
@@ -1,0 +1,13 @@
+{:remove-surrounding-whitespace? true
+ :remove-trailing-whitespace? true
+ :remove-consecutive-blank-lines? true
+
+
+ :insert-missing-whitespace? true
+ :align-associative? false
+ :indents {foo [[:inner 0]]}
+ :test (foo 1
+            2
+            {:a a
+             :aa a
+             :bbb bbb})}

--- a/docs/site/formatting.md
+++ b/docs/site/formatting.md
@@ -1,26 +1,26 @@
 ---
 title: Clojure Formatting
-description: Conforming to the Community Styleguide by default, and it just works
+description: Community Styleguide conforming formatting by default. And it just works.
 ---
 
 # Formatting
 
-We have tried to make Calva's formatter so that it _just works_. It is enabled by default for Clojure files, and unconfigured it mostly follows Bozhidar Batsov's [Clojure Style Guide](https://github.com/bbatsov/clojure-style-guide). Calva uses [cljfmt](https://github.com/weavejester/cljfmt) for the formatting.
+We have tried to make Calva's formatter so that it _just works_. It is enabled by default for Clojure files, and with the default configuration it mostly follows Bozhidar Batsov's [Clojure Style Guide](https://github.com/bbatsov/clojure-style-guide). Calva uses [cljfmt](https://github.com/weavejester/cljfmt) for the formatting.
 
 !!! Tips
-Calva's code formatter sets the default keybinding of its **Format Current Form** command to `tab`. Meaning that most often when things look a bit untidy, you can press `tab` to make things look pretty. Good to know, right? For performance reasons it only formats the current enclosing form, so sometimes you want to move the cursor up/out a form (`ctrl+up`) first. See [The Paredit Guide](paredit.md) for more on moving the cursor structurally through your code.
+    Calva's code formatter sets the default keybinding of its **Format Current Form** command to `tab`. Meaning that most often when things look a bit untidy, you can press `tab` to make things look pretty. Good to know, right? For performance reasons it only formats the current enclosing form, so sometimes you want to move the cursor up/out a form (`ctrl+up`) first. See [The Paredit Guide](paredit.md) for more on moving the cursor structurally through your code.
 
 With the default settings, Calva's formatting behaves like so:
 
--   formats as you type (when entering new lines)
+-   indents as you type (when entering new lines)
 -   formats the current enclosing form when you hit `tab`
 -   formats pasted code
--   formats according to community standards (see above link)
+-   formats according to [community standards](https://github.com/bbatsov/clojure-style-guide)
 -   formats the current form, _aligning map keys and values_, when you press `ctrl+alt+l`
--   formats `(comment ..)` forms special, see [rich comments](#rich-comments)
+-   formats `(comment ...)` forms special, see [rich comments](#rich-comments)
 
 !!! Tips
-Calva has a command that will ”heal” the bracket structure if it is correctly indented. Yes, it is Parinfer behind the scenes. This command is default bound to `shift+tab` to form a nicely balanced pair with the `tab` formatting.
+    Calva has a command that will ”heal” the bracket structure if it is correctly indented using Parinfer **Infer parens**. This command is default bound to `ctrl+alt+p i`.
 
 Also: If you have **Format on Save** enabled in VS Code, it will be Calva doing the formatting for Clojure files.
 
@@ -37,10 +37,14 @@ Not a fan of some default setting? The formatter is quite configurable.
 
 You configure Calva's formatting using [cljfmt's configuration EDN](https://github.com/weavejester/cljfmt#configuration). This means that you can adjust the above mentioned defaults, including the indenting.
 
-!!! Note
-The `cljfmt` docs mention the `:cljfmt` config key of Leiningen projects. Calva does not yet read the config from there, so if your Leiningen project has such a configuration, you will need to copy it out into a file.
+This configuration can either be provided via a file or via clojure-lsp (see [Clojure LSP Settings](https://clojure-lsp.io/settings/)).
 
-To start changing the Calva formatting defaults, paste the following map into a file and save it. It could be somewhere in the project workspace, or some other place, depending on your requirements:
+!!! Note
+    The `cljfmt` docs mention the `:cljfmt` config key of Leiningen projects. Calva does not yet read the config from there, so if your Leiningen project has such a configuration, you will need to copy it out into a file.
+
+To provide the settings via clojure-lsp, set `calva.fmt.configPath` to `CLOJURE-LSP` (case sensitive).
+
+If providing settings via a file, start changing the Calva formatting defaults by pasting the following map into a file and save it. It could be somewhere in the project workspace, or some other place, depending on your requirements:
 
 ```clojure
 {:remove-surrounding-whitespace? true
@@ -49,18 +53,30 @@ To start changing the Calva formatting defaults, paste the following map into a 
  :insert-missing-whitespace? true}
 ```
 
-Then set `calva.fmt.configPath` to the path to the file. The path should either be absolute, or relative to the project root directory. So, if you named the file `.cljfmt.edn` and saved it in the root of the project, then this setting should be `.cljfmt.edn`.
+Then set `calva.fmt.configPath` to the path to this file. The path should either be absolute, or relative to the project root directory. So, if you named the file `.cljfmt.edn` and saved it in the root of the project, then this setting should be `.cljfmt.edn`.
 
 Since you are editing the file in Calva (you are, right?), you can quickly test how different settings affect the formatting. Try:
 
-1. Adding `:align-associative true` to the config
+1. Adding `:align-associative? true` to the config
 2. then save
 3. then hit `tab`, and see what happens.
 
-(This particular setting is experimental and known to cause trouble together with namespaced keywords. Consider using `ctrl+alt+l` instead of `tab` as your formatting command, instead of enabling this setting.)
+!!! Note
+    This particular setting is experimental and known to cause trouble together with namespaced keywords. Consider using `ctrl+alt+l` instead of `tab` as your formatting command, instead of enabling this setting. See below for more info about this.
 
 !!! Note
-The hot reloading of the config file only works for config files inside the project directory structure.
+    The hot reloading of the config file only works for config files inside the project directory structure. And if you are providing the settings via clojure-lsp: no hot-reload for you.
+
+### About aligning associative forms
+
+Calva loooks in the config map for the key `:align-associative?` and if it is `true` it will use an old version of **cljfmt** which is [patched](https://github.com/weavejester/cljfmt/pull/77) with functionality for doing this alignment. Note, though:
+
+* The implementation is a bit buggy and can do a bit crazy formatting on certain forms.
+* The older version of cljfmt lacks updates for some new Clojure features and also some bugs fixed since the fork are not applied.
+
+You are hereby warned, and let us also remind you about the **Format and Align Current Form** command which lets you apply this formatting a bit more surgically, and on demand.
+
+This old version of **cljfmt** is inlined in the Calva repository along with the discontinued `rewrite-cljs` project. Regard it as frozen code. If you want Calva's formatter to have full support for newer Clojure constructs and the bugs in the alignment code fixed, contribute to **cljfmt**. See [this issue](https://github.com/weavejester/cljfmt/issues/36) for starting to collect context.
 
 ### Indentation rules
 
@@ -95,4 +111,4 @@ That's somewhat similar to Nikita Prokopov's [Better Clojure Formatting](https:/
 
 ## Rich Comments
 
-To encourage use of `(comment ...)` forms for development, these forms get a special treatment when formatting. See [Rich Comments](rich-comments.md).
+To encourage use of `(comment ...)` forms for development, the deafult settings give these forms get a special treatment when formatting. Use the `calva.fmt.keepCommentTrailParenOnOwnLine` setting to control this behaviour. See [Rich Comments](rich-comments.md) first.

--- a/package.json
+++ b/package.json
@@ -717,7 +717,7 @@
                 "properties": {
                     "calva.fmt.configPath": {
                         "type": "string",
-                        "markdownDescription": "Path to [cljfmt](https://github.com/weavejester/cljfmt#configuration) configuration file. Absolute or relative to the project root directory."
+                        "markdownDescription": "Path to [cljfmt](https://github.com/weavejester/cljfmt#configuration) configuration file. Absolute or relative to the project root directory. To provide the config via [clojure-lsp](https://clojure-lsp.io), set this to `CLOJURE-LSP` (case sensitive)."
                     },
                     "calva.fmt.formatAsYouType": {
                         "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -2109,7 +2109,7 @@
             },
             {
                 "command": "calva-fmt.inferParens",
-                "key": "shift+tab",
+                "key": "ctrl+alt+p i",
                 "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && !editorReadOnly && !suggestWidgetVisible && !hasOtherSuggestions"
             },
             {
@@ -2119,7 +2119,7 @@
             },
             {
                 "command": "calva-fmt.tabDedent",
-                "key": "shift+ctrl+i",
+                "key": "shift+tab",
                 "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && !editorReadOnly && !suggestWidgetVisible && !hasOtherSuggestions"
             },
             {

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -10,7 +10,8 @@
                              :formatTextAtRange calva.fmt.formatter/format-text-at-range-bridge
                              :formatTextAtIdx calva.fmt.formatter/format-text-at-idx-bridge
                              :formatTextAtIdxOnType calva.fmt.formatter/format-text-at-idx-on-type-bridge
-                             :cljfmtOptions calva.fmt.formatter/read-cljfmt-js-bridge
+                             :cljfmtOptionsFromString calva.fmt.formatter/merge-cljfmt-from-string-js-bridge
+                             :cljfmtOptions calva.fmt.formatter/merge-cljfmt-js-bridge
                              :inferIndents calva.fmt.inferer/infer-indents-bridge
                              :inferParens calva.fmt.inferer/infer-parens-bridge
                              :jsify calva.js-utils/jsify

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -11,7 +11,6 @@
                              :formatTextAtIdx calva.fmt.formatter/format-text-at-idx-bridge
                              :formatTextAtIdxOnType calva.fmt.formatter/format-text-at-idx-on-type-bridge
                              :cljfmtOptionsFromString calva.fmt.formatter/merge-cljfmt-from-string-js-bridge
-                             :cljfmtOptions calva.fmt.formatter/merge-cljfmt-js-bridge
                              :inferIndents calva.fmt.inferer/infer-indents-bridge
                              :inferParens calva.fmt.inferer/infer-parens-bridge
                              :jsify calva.js-utils/jsify

--- a/src/calva-fmt/src/config.ts
+++ b/src/calva-fmt/src/config.ts
@@ -33,7 +33,8 @@ function readConfiguration() {
     const configPath: string = workspaceConfig.get('configPath');
     if (configPath === LSP_CONFIG_KEY && !lspFormatConfig) {
         vscode.window.showErrorMessage(
-            'Fetching formatting settings from clojure-lsp failed. Check that you are running a version of clojure-lsp that provides "cljfmt-raw" in serverInfo.', "Roger that"
+            'Fetching formatting settings from clojure-lsp failed. Check that you are running a version of clojure-lsp that provides "cljfmt-raw" in serverInfo.',
+            'Roger that'
         );
     }
     const cljfmtContent: string =

--- a/src/calva-fmt/src/config.ts
+++ b/src/calva-fmt/src/config.ts
@@ -1,9 +1,6 @@
 import * as vscode from 'vscode';
 import * as filesCache from '../../files-cache';
-import {
-    cljfmtOptionsFromString,
-    cljfmtOptions,
-} from '../../../out/cljs-lib/cljs-lib.js';
+import * as cljsLib from '../../../out/cljs-lib/cljs-lib.js';
 
 const defaultCljfmtContent =
     '\
@@ -14,11 +11,11 @@ const defaultCljfmtContent =
  :align-associative? false}';
 
 const LSP_CONFIG_KEY = 'CLOJURE-LSP';
-let lspFormatConfig: Object;
+let lspFormatConfig: string;
 
 function configuration(
     workspaceConfig: vscode.WorkspaceConfiguration,
-    cljfmt: string | Object
+    cljfmt: string
 ) {
     const config = {
         'format-as-you-type': workspaceConfig.get('formatAsYouType') as boolean,
@@ -26,18 +23,15 @@ function configuration(
             'keepCommentTrailParenOnOwnLine'
         ) as boolean,
     };
-    if (typeof cljfmt === 'string') {
-        config['cljfmt-options'] = cljfmtOptionsFromString(cljfmt);
-    } else {
-        config['cljfmt-options'] = cljfmtOptions(cljfmt);
-    }
+    config['cljfmt-options-string'] = cljfmt;
+    config['cljfmt-options'] = cljsLib.cljfmtOptionsFromString(cljfmt);
     return config;
 }
 
 function readConfiguration() {
     const workspaceConfig = vscode.workspace.getConfiguration('calva.fmt');
     const configPath: string = workspaceConfig.get('configPath');
-    const cljfmtContent: string | Object =
+    const cljfmtContent: string =
         configPath === LSP_CONFIG_KEY
             ? lspFormatConfig
                 ? lspFormatConfig
@@ -57,7 +51,7 @@ function readConfiguration() {
     }
 }
 
-export function setLspFormatConfig(config: Object) {
+export function setLspFormatConfig(config: string) {
     lspFormatConfig = config;
 }
 

--- a/src/calva-fmt/src/config.ts
+++ b/src/calva-fmt/src/config.ts
@@ -31,6 +31,11 @@ function configuration(
 function readConfiguration() {
     const workspaceConfig = vscode.workspace.getConfiguration('calva.fmt');
     const configPath: string = workspaceConfig.get('configPath');
+    if (configPath === LSP_CONFIG_KEY && !lspFormatConfig) {
+        vscode.window.showErrorMessage(
+            'Fetching formatting settings from clojure-lsp failed. Check that you are running a version of clojure-lsp that provides "cljfmt-raw" in serverInfo.', "Roger that"
+        );
+    }
     const cljfmtContent: string =
         configPath === LSP_CONFIG_KEY
             ? lspFormatConfig

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -216,14 +216,14 @@ function _formatIndex(
     onType: boolean = false,
     extraConfig = {}
 ): { 'range-text': string; range: number[]; 'new-index': number } {
-    const d = cljify({
-            'all-text': allText,
-            idx: index,
-            eol: eol,
-            range: range,
-            config: { ...config.getConfig(), ...extraConfig },
-        }),
-        result = jsify(onType ? formatTextAtIdxOnType(d) : formatTextAtIdx(d));
+    const d = {
+        'all-text': allText,
+        idx: index,
+        eol: eol,
+        range: range,
+        config: { ...config.getConfig(), ...extraConfig },
+    };
+    const result = jsify(onType ? formatTextAtIdxOnType(d) : formatTextAtIdx(d));
     if (!result['error']) {
         return result;
     } else {

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -223,7 +223,9 @@ function _formatIndex(
         range: range,
         config: { ...config.getConfig(), ...extraConfig },
     };
-    const result = jsify(onType ? formatTextAtIdxOnType(d) : formatTextAtIdx(d));
+    const result = jsify(
+        onType ? formatTextAtIdxOnType(d) : formatTextAtIdx(d)
+    );
     if (!result['error']) {
         return result;
     } else {

--- a/src/cljs-lib/src/calva/fmt/formatter.cljs
+++ b/src/cljs-lib/src/calva/fmt/formatter.cljs
@@ -38,9 +38,11 @@
       {:error (.-message e)})))
 
 (defn- reformat-string [range-text {:keys [align-associative?] :as config}]
-  (if align-associative?
-    (pez-cljfmt/reformat-string range-text (:cljfmt-options config))
-    (cljfmt/reformat-string range-text (:cljfmt-options config))))
+  (let [cljfmt-options (:cljfmt-options config)]
+    (if (or align-associative?
+            (:align-associative? cljfmt-options))
+      (pez-cljfmt/reformat-string range-text (assoc cljfmt-options :align-associative? true))
+      (cljfmt/reformat-string range-text cljfmt-options))))
 
 (defn format-text
   [{:keys [range-text eol config] :as m}]

--- a/src/cljs-lib/src/calva/parse.cljs
+++ b/src/cljs-lib/src/calva/parse.cljs
@@ -43,6 +43,7 @@
 
 ;[[ar gu ment] {:as extras, :keys [d e :s t r u c t u r e d]}]
 (comment
+  (meta (:indents (parse-clj-edn "{:indents ^:replace {}}")))
   (parse-forms-js-bridge "(deftest fact-rec-test\n  (testing \"returns 1 when passed 1\"\n    (is (= 1 (do (println \"hello\") #break (core/fact-rec 1))))))")
   (= [:a {:foo [(quote bar)], :bar (quote foo)}]
      [:a {:foo ['bar] :bar 'foo}])

--- a/src/cljs-lib/test/calva/fmt/formatter_test.cljs
+++ b/src/cljs-lib/test/calva/fmt/formatter_test.cljs
@@ -317,5 +317,5 @@ bar))" :range [22 25]})))
   (is (= false
          (:align-associative? (sut/cljfmt-options {:cljfmt-string "{}"})))
       ":align-associative? is false by default")
-  (is (nil? (:foo (sut/read-cljfmt {:cljfmt-string "{:bar false}"})))
+  (is (nil? (:foo (sut/merge-cljfmt {:cljfmt-string "{:bar false}"})))
       "most keys don't have any defaults."))

--- a/src/cljs-lib/test/calva/fmt/formatter_test.cljs
+++ b/src/cljs-lib/test/calva/fmt/formatter_test.cljs
@@ -302,20 +302,20 @@ bar))" :range [22 25]})))
 
 (deftest cljfmt-options
   (is (= (count cljfmt/default-indents)
-         (count (:indents (sut/cljfmt-options {}))))
+         (count (:indents (sut/merge-cljfmt {}))))
       "by default uses cljfmt indent rules")
   (is (= (+ 2 (count cljfmt/default-indents))
-         (count (:indents (sut/cljfmt-options {:cljfmt-string "{:indents {foo [[:inner 0]] bar [[:block 1]]}}"}))))
+         (count (:indents (sut/merge-cljfmt '{:indents {foo [[:inner 0]] bar [[:block 1]]}}))))
       "merges indents on top of cljfmt indent rules")
   (is (= {'a [[:inner 0]]}
-         (:indents (sut/cljfmt-options {:cljfmt-string "{:indents ^:replace {a [[:inner 0]]}}"})))
+         (:indents (sut/merge-cljfmt '{:indents ^:replace {a [[:inner 0]]}})))
       "with :replace metadata hint overrides default indents")
   (is (= true
-         (:align-associative? (sut/cljfmt-options {:align-associative? true
+         (:align-associative? (sut/merge-cljfmt {:align-associative? true
                                                    :cljfmt-string "{:align-associative? false}"})))
       "cljfmt :align-associative? has lower priority than config's option")
   (is (= false
-         (:align-associative? (sut/cljfmt-options {:cljfmt-string "{}"})))
+         (:align-associative? (sut/merge-cljfmt {:cljfmt-string "{}"})))
       ":align-associative? is false by default")
   (is (nil? (:foo (sut/merge-cljfmt {:cljfmt-string "{:bar false}"})))
       "most keys don't have any defaults."))

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -432,17 +432,7 @@ async function startClient(
     const serverInfo = await getServerInfo(client);
     serverVersion = serverInfo['server-version'];
     sayClientVersionInfo(serverVersion, serverInfo);
-    // TODO: Remove this hardcode when the indents issue is fixed in clojure-lsp
-    // https://github.com/clojure-lsp/clojure-lsp/issues/763
-    // calvaFmtConfig.setLspFormatConfig(serverInfo['final-settings']['cljfmt']);
-    calvaFmtConfig.setLspFormatConfig({
-        'remove-surrounding-whitespace?': true,
-        'remove-trailing-whitespace?': true,
-        'remove-consecutive-blank-lines?': true,
-        'insert-missing-whitespace?': true,
-        'align-associative?': false,
-        'indents': { 'foo': [['inner', 0]] },
-    });
+    calvaFmtConfig.setLspFormatConfig(serverInfo['cljfmt-raw']);
 
     client.onNotification(
         'clojure/textDocument/testTree',

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -24,6 +24,7 @@ import * as state from '../state';
 import { provideHover } from '../providers/hover';
 import { provideSignatureHelp } from '../providers/signature';
 import { isResultsDoc } from '../results-output/results-doc';
+import * as calvaFmtConfig from '../calva-fmt/src/config';
 
 const LSP_CLIENT_KEY = 'lspClient';
 const RESOLVE_MACRO_AS_COMMAND = 'resolve-macro-as';
@@ -431,6 +432,17 @@ async function startClient(
     const serverInfo = await getServerInfo(client);
     serverVersion = serverInfo['server-version'];
     sayClientVersionInfo(serverVersion, serverInfo);
+    // TODO: Remove this hardcode when the indents issue is fixed in clojure-lsp
+    // https://github.com/clojure-lsp/clojure-lsp/issues/763
+    // calvaFmtConfig.setLspFormatConfig(serverInfo['final-settings']['cljfmt']);
+    calvaFmtConfig.setLspFormatConfig({
+        'remove-surrounding-whitespace?': true,
+        'remove-trailing-whitespace?': true,
+        'remove-consecutive-blank-lines?': true,
+        'insert-missing-whitespace?': true,
+        'align-associative?': false,
+        'indents': { 'foo': [['inner', 0]] },
+    });
 
     client.onNotification(
         'clojure/textDocument/testTree',

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "calva.fmt.configPath": "CLOJURE-LSP",
+  "calva.fmt.configPath": "projects/pirate-lang/.cljfmt.edn",
   "calva.customREPLCommandSnippets": [
     {
       "name": "Double current",

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "calva.fmt.configPath": "CLOJURE-LSP",
   "calva.customREPLCommandSnippets": [
     {
       "name": "Double current",

--- a/test-data/lab/pirate_lang.clj
+++ b/test-data/lab/pirate_lang.clj
@@ -19,6 +19,7 @@
     {:pirate-char pirate-char
      :pirates pirates}))
 
+
 (defn to-pirate-talk
   [text language]
   (let [{:keys [pirate-char pirates]} (configure language)]
@@ -37,14 +38,13 @@
 (comment
   (to-pirate-talk "Have you heard about Pirate talk?" english-o)
   ;; => "HoHavove yoyou hohearordod aboboutot PoPiroratote totalolkok?"
-  
+
   (from-pirate-talk "HoHavove yoyou hohearordod aboboutot PoPiroratote totalolkok?" english-o)
   ;; => "Have you heard about Pirate talk?"
-  
+
   (to-pirate-talk "Har du hört talas om rövarspråket?" swedish-o)
   ;; => "HoHaror dodu hohörortot totalolasos omom rorövovarorsospoproråkoketot?"
-  
+
   (from-pirate-talk "HoHaror dodu hohörortot totalolasos omom rorövovarorsospoproråkoketot?" swedish-o)
   ;; => "Har du hört talas om rövarspråket?"
-
   )

--- a/test-data/projects/pirate-lang/.cljfmt.edn
+++ b/test-data/projects/pirate-lang/.cljfmt.edn
@@ -1,0 +1,13 @@
+{:remove-surrounding-whitespace? true
+ :remove-trailing-whitespace? true
+ :remove-consecutive-blank-lines? true
+ :insert-missing-whitespace? true
+ :align-associative? true
+ :indents ^:replace {foo [[:inner 0]]
+                     #"bar" [[:inner 0]]}
+
+ :test (foo 1
+         2
+         {:a a
+          :aa a
+          :bbb bbb})}

--- a/test-data/projects/pirate-lang/.cljfmt.edn
+++ b/test-data/projects/pirate-lang/.cljfmt.edn
@@ -3,11 +3,11 @@
  :remove-consecutive-blank-lines? true
  :insert-missing-whitespace? true
  :align-associative? true
- :indents ^:replace {foo [[:inner 0]]
-                     #"bar" [[:inner 0]]}
+ :indents  {#"fooa?$" [[:inner 0]]
+            #"bar" [[:block 0]]}
 
- :test (foo 1
-         2
-         {:a a
-          :aa a
-          :bbb bbb})}
+ :test (foob 1
+             2
+             {:a a
+              :aa a
+              :bbb bbb})}

--- a/test-data/projects/pirate-lang/.cljfmt.edn
+++ b/test-data/projects/pirate-lang/.cljfmt.edn
@@ -2,7 +2,7 @@
  :remove-trailing-whitespace? true
  :remove-consecutive-blank-lines? true
  :insert-missing-whitespace? true
- :align-associative? true
+ :align-associative? false
  :indents  {#"fooa?$" [[:inner 0]]
             #"bar" [[:block 0]]}
 

--- a/test-data/projects/pirate-lang/src/pez/pirate_lang.clj
+++ b/test-data/projects/pirate-lang/src/pez/pirate_lang.clj
@@ -19,7 +19,10 @@
                      consonants)]
     {:pirate-char pirate-char
      :pirates pirates}))
-
+(bar 1
+  2)
+(baz 1
+     2)
 (defn to-pirate-talk
   [text language]
   (let [{:keys [pirate-char pirates]} (configure language)]

--- a/test-data/projects/pirate-lang/src/pez/pirate_lang.clj
+++ b/test-data/projects/pirate-lang/src/pez/pirate_lang.clj
@@ -19,10 +19,7 @@
                      consonants)]
     {:pirate-char pirate-char
      :pirates pirates}))
-(bar 1
-  2)
-(baz 1
-     2)
+
 (defn to-pirate-talk
   [text language]
   (let [{:keys [pirate-char pirates]} (configure language)]


### PR DESCRIPTION
## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Added a special treatment of `calva.fmt.configPath === 'CLOJURE-LSP'` where Calva will pick the **cljfmt** config from clojure-lsp.
- Fixed bug with not honoring `:align-associative? true` in config
- Changed default keybindings for **Tab Dedent** and **Infer parens**

Doing this I also cleaned up some of the code around how cljfmt config is provided to Calva's formatter. Hopefully this is a tad less confusing now.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Resolves #1545
Resolves #1535


NB: Latest clojure-lsp does not have the necessary support for Calva to pick up config there. To test it you'll need to use a clojure-lsp build from `master`.

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing  in the description of this PR 
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) or run `npm run eslint`).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe