### PR TITLE
Init resultdoc once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Print stacktrace link in REPL gets duplicated](https://github.com/BetterThanTomorrow/calva/issues/1542)
 
 ## [2.0.244] - 2022-02-20
 - [Add custom hover snippets](https://github.com/BetterThanTomorrow/calva/issues/1471)

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -51,6 +51,8 @@ function outputFileDir() {
     }
 }
 
+let isInitialized = false;
+
 const DOC_URI = () => {
     return vscode.Uri.joinPath(outputFileDir(), RESULTS_DOC_NAME);
 };
@@ -131,24 +133,15 @@ export function setContextForOutputWindowActive(isActive: boolean): void {
 }
 
 export async function initResultsDoc(): Promise<vscode.TextDocument> {
+    const docUri = DOC_URI();
     await vscode.workspace.fs.createDirectory(outputFileDir());
     let resultsDoc: vscode.TextDocument;
     try {
-        resultsDoc = await vscode.workspace.openTextDocument(DOC_URI());
+        resultsDoc = await vscode.workspace.openTextDocument(docUri);
     } catch (e) {
-        await util.writeTextToFile(DOC_URI(), '');
-        resultsDoc = await vscode.workspace.openTextDocument(DOC_URI());
+        await util.writeTextToFile(docUri, '');
+        resultsDoc = await vscode.workspace.openTextDocument(docUri);
     }
-    const greetings = `${START_GREETINGS}\n\n`;
-    const edit = new vscode.WorkspaceEdit();
-    const fullRange = new vscode.Range(
-        resultsDoc.positionAt(0),
-        resultsDoc.positionAt(Infinity)
-    );
-    edit.replace(DOC_URI(), fullRange, greetings);
-    await vscode.workspace.applyEdit(edit);
-    resultsDoc.save();
-
     if (config.getConfig().autoOpenREPLWindow) {
         const resultsEditor = await vscode.window.showTextDocument(
             resultsDoc,
@@ -160,6 +153,20 @@ export async function initResultsDoc(): Promise<vscode.TextDocument> {
         resultsEditor.selection = new vscode.Selection(lastPos, lastPos);
         resultsEditor.revealRange(new vscode.Range(firstPos, firstPos));
     }
+    if (isInitialized) {
+        return resultsDoc;
+    }
+
+    const greetings = `${START_GREETINGS}\n\n`;
+    const edit = new vscode.WorkspaceEdit();
+    const fullRange = new vscode.Range(
+        resultsDoc.positionAt(0),
+        resultsDoc.positionAt(Infinity)
+    );
+    edit.replace(docUri, fullRange, greetings);
+    await vscode.workspace.applyEdit(edit);
+    resultsDoc.save();
+
     // For some reason onDidChangeTextEditorViewColumn won't fire
     state.extensionContext.subscriptions.push(
         vscode.window.onDidChangeActiveTextEditor((event) => {
@@ -222,6 +229,7 @@ export async function initResultsDoc(): Promise<vscode.TextDocument> {
         );
     }
     replHistory.resetState();
+    isInitialized = true;
     return resultsDoc;
 }
 


### PR DESCRIPTION
## What has Changed?

We were creating subscriptions, lenses, and other resources for the output window on every connect. The most visible effect of this was that we crated a new **Show stacktrace** button every time.

This change returns the result doc early if it has already been initialized.

Fixes #1542

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) or run `npm run eslint`).

Ping @pez, @bpringe