### PR TITLE
LSP messages as quick-picks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 - [Print stacktrace link in REPL gets duplicated](https://github.com/BetterThanTomorrow/calva/issues/1542)
 - [Publish pre-releases when dev updates](https://github.com/BetterThanTomorrow/calva/issues/1554)
 - [Apply basic typescript eslint rules](https://github.com/BetterThanTomorrow/calva/issues/1536)
+- [”Resolve macro as...” code action produces unreadable text in pop up](https://github.com/BetterThanTomorrow/calva/issues/1539)
 
 ## [2.0.244] - 2022-02-20
 - [Add custom hover snippets](https://github.com/BetterThanTomorrow/calva/issues/1471)

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -485,7 +485,7 @@ async function startClient(
 }
 
 // A quickPick that expects the same input as showInformationMessage does
-// TODO: How do we make it satisfy the messageFunc interface above? 
+// TODO: How do we make it satisfy the messageFunc interface above?
 function quickPick(
     message: string,
     actions: { title: string }[]

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -9,6 +9,7 @@ import {
     ClientCapabilities,
     ServerCapabilities,
     DocumentSelector,
+    MessageType,
 } from 'vscode-languageclient/node';
 import * as util from '../utilities';
 import * as config from '../config';
@@ -25,6 +26,7 @@ import { provideHover } from '../providers/hover';
 import { provideSignatureHelp } from '../providers/signature';
 import { isResultsDoc } from '../results-output/results-doc';
 import * as calvaFmtConfig from '../calva-fmt/src/config';
+import { MessageItem } from 'vscode';
 
 const LSP_CLIENT_KEY = 'lspClient';
 const RESOLVE_MACRO_AS_COMMAND = 'resolve-macro-as';
@@ -444,6 +446,70 @@ async function startClient(
             handler(tree);
         }
     );
+
+    client.onRequest('window/showMessageRequest', (params) => {
+        // showInformationMessage can't handle some of the menus that clojure-lsp uses
+        // https://github.com/BetterThanTomorrow/calva/issues/1539
+        // We count the sum of the lengths of the button titles and
+        // use a QuickPick menu when it exceeds some number
+        const totalActionsLength = params.actions.reduce(
+            (length: number, action: MessageItem) =>
+                (length += action.title.length),
+            0
+        );
+        if (params.type === MessageType.Info && totalActionsLength > 25) {
+            return quickPick(params.message, params.actions);
+        }
+        // Else we use this, copied from the default client
+        // TODO: Can we reuse the default clients implementation?
+        let messageFunc: <T extends MessageItem>(
+            message: string,
+            ...items: T[]
+        ) => Thenable<T>;
+        switch (params.type) {
+            case MessageType.Error:
+                messageFunc = vscode.window.showErrorMessage;
+                break;
+            case MessageType.Warning:
+                messageFunc = vscode.window.showWarningMessage;
+                break;
+            case MessageType.Info:
+                messageFunc = vscode.window.showInformationMessage;
+                break;
+            default:
+                messageFunc = vscode.window.showInformationMessage;
+        }
+        const actions = params.actions || [];
+        return messageFunc(params.message, ...actions);
+    });
+}
+
+// A quickPick that expects the same input as showInformationMessage does
+// TODO: How do we make it satisfy the messageFunc interface above? 
+function quickPick(
+    message: string,
+    actions: { title: string }[]
+): Promise<{ title: string }> {
+    const qp = vscode.window.createQuickPick();
+    qp.items = actions.map((item) => ({ label: item.title }));
+    qp.title = message;
+    return new Promise<{ title: string }>((resolve, _reject) => {
+        qp.show();
+        qp.onDidAccept(() => {
+            if (qp.selectedItems.length > 0) {
+                resolve({
+                    title: qp.selectedItems[0].label,
+                });
+            } else {
+                resolve(undefined);
+            }
+            qp.hide();
+        });
+        qp.onDidHide(() => {
+            resolve(undefined);
+            qp.hide();
+        });
+    });
 }
 
 function sayClientVersionInfo(serverVersion: string, serverInfo: any) {


### PR DESCRIPTION
## What has Changed?

When LSP messages has many, or long, actions, they don't work well in `showInformationMessage` boxes. Making it use a quick-pick when the guess is that the message box will look funny/be unusable.

Fixes #1539

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [ ] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) or run `npm run eslint`).

Ping @pez, @bpringe