### PR TITLE
Fix: Format on save and format code sent to output-window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Changes to Calva.
 - [Print stacktrace link in REPL gets duplicated](https://github.com/BetterThanTomorrow/calva/issues/1542)
 - [Publish pre-releases when dev updates](https://github.com/BetterThanTomorrow/calva/issues/1554)
 - [Apply basic typescript eslint rules](https://github.com/BetterThanTomorrow/calva/issues/1536)
-- [”Resolve macro as...” code action produces unreadable text in pop up](https://github.com/BetterThanTomorrow/calva/issues/1539)
+- Fix: [”Resolve macro as...” code action produces unreadable text in pop up](https://github.com/BetterThanTomorrow/calva/issues/1539)
+- Fix: [Format on save](https://github.com/BetterThanTomorrow/calva/issues/1556)
 
 ## [2.0.244] - 2022-02-20
 - [Add custom hover snippets](https://github.com/BetterThanTomorrow/calva/issues/1471)

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -194,11 +194,11 @@ export function alignPositionCommand(editor: vscode.TextEditor) {
 }
 
 export function formatCode(code: string, eol: number) {
-    const d = cljify({
+    const d = {
         'range-text': code,
         eol: eol == 2 ? '\r\n' : '\n',
         config: config.getConfig(),
-    });
+    };
     const result = jsify(formatText(d));
     if (!result['error']) {
         return result['range-text'];
@@ -247,8 +247,7 @@ function _formatRange(
         eol: eol,
         config: config.getConfig(),
     };
-    const cljData = cljify(d);
-    const result = jsify(formatTextAtRange(cljData));
+    const result = jsify(formatTextAtRange(d));
     if (!result['error']) {
         return result['range-text'];
     }

--- a/src/cljs-lib/src/calva/fmt/formatter.cljs
+++ b/src/cljs-lib/src/calva/fmt/formatter.cljs
@@ -54,10 +54,6 @@
     (catch js/Error e
       (assoc m :error (.-message e)))))
 
-(defn format-text-bridge
-  [m]
-  (format-text m))
-
 (comment
   {:eol "\n" :all-text "[:foo\n\n(foo)(bar)]" :idx 6}
   (def s "[:foo\n\n(foo\n(bar))]")
@@ -286,9 +282,16 @@
         (cljify)
         (assoc-in [:config :cljfmt-options] (parse-clj-edn edn)))))
 
+(defn format-text-bridge
+  [^js m]
+  (-> m
+      (parse-cljfmt-options-string)
+      (format-text)))
+
 (defn format-text-at-range-bridge
   [^js m]
   (-> m
+      (parse-cljfmt-options-string)
       (format-text-at-range)))
 
 (defn format-text-at-idx-bridge


### PR DESCRIPTION
## What has Changed?

I introduced some regression with the change to vanilla cljfmt. This fixes the regressions I am aware of:

- Formatting selection
- Format document
   - Format on save  
- Format code sent to the REPL window

Fixes #1556 
Fixes #1535 (again)

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [ ] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) or run `npm run eslint`).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe