### PR TITLE
Turn on eslint rule to disallow "floating promises"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
         'no-constructor-return': ['error'],
         '@typescript-eslint/no-inferrable-types': 'off',
         '@typescript-eslint/unbound-method': 'off',
+        '@typescript-eslint/no-floating-promises': ['error'],
 
         // 'no-unused-vars': 'off',
         // '@typescript-eslint/no-unused-vars': [
@@ -48,7 +49,6 @@ module.exports = {
         // ],
 
         '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/no-floating-promises': 'off',
         '@typescript-eslint/no-unsafe-argument': 'off',
         '@typescript-eslint/no-unsafe-assignment': 'off',
         '@typescript-eslint/no-unsafe-call': 'off',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Enable the @typescript-eslint/no-floating-promises eslint rule](https://github.com/BetterThanTomorrow/calva/pull/1564)
 
 ## [2.0.246] - 2022-02-24
 -   Fix: [Format config from clojure-lsp broken](https://github.com/BetterThanTomorrow/calva/issues/1561)

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -49,7 +49,7 @@ export default class Analytics {
         const KEY = 'userLogID';
         if (this.store.get(KEY) == undefined) {
             const newID = uuid.uuid();
-            this.store.update(KEY, newID);
+            void this.store.update(KEY, newID);
             return newID;
         } else {
             return this.store.get(KEY);

--- a/src/calva-fmt/src/config.ts
+++ b/src/calva-fmt/src/config.ts
@@ -44,7 +44,7 @@ async function readConfiguration(): Promise<{
         }
     }
     if (configPath === LSP_CONFIG_KEY && !lspFormatConfig) {
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             'Fetching formatting settings from clojure-lsp failed. Check that you are running a version of clojure-lsp that provides "cljfmt-raw" in serverInfo.',
             'Roger that'
         );
@@ -62,7 +62,7 @@ async function readConfiguration(): Promise<{
     if (!config['cljfmt-options']['error']) {
         return config;
     } else {
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             `Error parsing ${configPath}: ${config['cljfmt-options']['error']}\n\nUsing default formatting configuration.`
         );
         return configuration(workspaceConfig, defaultCljfmtContent);

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -186,11 +186,11 @@ export async function formatPosition(
 }
 
 export function formatPositionCommand(editor: vscode.TextEditor) {
-    formatPosition(editor);
+    void formatPosition(editor);
 }
 
 export function alignPositionCommand(editor: vscode.TextEditor) {
-    formatPosition(editor, true, { 'align-associative?': true });
+    void formatPosition(editor, true, { 'align-associative?': true });
 }
 
 export async function formatCode(code: string, eol: number) {

--- a/src/calva-fmt/src/infer.ts
+++ b/src/calva-fmt/src/infer.ts
@@ -45,7 +45,7 @@ export function indentCommand(
     let deletedText = '',
         doEdit = true;
 
-    editor
+    void editor
         .edit(
             (editBuilder) => {
                 if (forward) {
@@ -113,7 +113,7 @@ export function indentCommand(
 
 function applyResults(r: ResultOptions, editor: vscode.TextEditor) {
     if (r.success) {
-        editor
+        void editor
             .edit(
                 (editBuilder) => {
                     r.edits.forEach((edit: CFEdit) => {
@@ -140,7 +140,7 @@ function applyResults(r: ResultOptions, editor: vscode.TextEditor) {
                 ];
             });
     } else {
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             'Calva Formatter Error: ' +
                 (r.error ? r.error.message : r['error-msg'])
         );

--- a/src/calva-fmt/src/providers/ontype_formatter.ts
+++ b/src/calva-fmt/src/providers/ontype_formatter.ts
@@ -49,12 +49,12 @@ export class FormatOnTypeEditProvider
                     .getConfiguration('calva.fmt')
                     .get('newIndentEngine')
             ) {
-                formatter.indentPosition(pos, document);
+                void formatter.indentPosition(pos, document);
             } else {
                 try {
-                    formatter.formatPosition(editor, true);
+                    void formatter.formatPosition(editor, true);
                 } catch (e) {
-                    formatter.indentPosition(pos, document);
+                    void formatter.indentPosition(pos, document);
                 }
             }
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,7 +91,7 @@ const watcher = vscode.workspace.createFileSystemWatcher(
 );
 
 watcher.onDidChange((uri: vscode.Uri) => {
-    readEdnWorkspaceConfig(uri);
+    void readEdnWorkspaceConfig(uri);
 });
 
 // TODO find a way to validate the configs

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -183,7 +183,7 @@ async function connectToHost(
         return false;
     }
 
-    liveShareSupport.didConnectRepl(port);
+    void liveShareSupport.didConnectRepl(port);
 
     await readRuntimeConfigs();
 
@@ -213,7 +213,7 @@ async function getFigwheelMainBuilds() {
         )
         .map(([name, _]) => name.replace(/\.cljs\.edn$/, ''));
     if (builds.length == 0) {
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             'There are no figwheel build files (.cljs.edn) in the project directory.'
         );
         outputWindow.append(
@@ -401,7 +401,7 @@ function createCLJSReplType(
     const replType: ReplType = {
         name: cljsTypeName,
         connect: async (session, name, checkFn) => {
-            state.extensionContext.workspaceState.update(
+            void state.extensionContext.workspaceState.update(
                 'cljsReplTypeHasBuilds',
                 cljsType.buildsRequired
             );
@@ -505,7 +505,7 @@ function createCLJSReplType(
                                 projectTypeName +
                                 '...'
                         );
-                        state.extensionContext.workspaceState.update(
+                        void state.extensionContext.workspaceState.update(
                             'cljsReplTypeHasBuilds',
                             true
                         );
@@ -625,7 +625,7 @@ async function makeCljsSessionClone(
                     : '');
             outputWindow.append(`; ${failed}`);
             setStateValue('cljsBuild', null);
-            vscode.window
+            void vscode.window
                 .showInformationMessage(failed, { modal: true }, ...['Ok'])
                 .then((value) => {
                     if (value == 'Ok') {
@@ -691,11 +691,11 @@ export async function connect(
 
     const portFile = projectTypes.nreplPortFileUri(connectSequence);
 
-    state.extensionContext.workspaceState.update(
+    void state.extensionContext.workspaceState.update(
         'selectedCljsTypeName',
         cljsTypeName
     );
-    state.extensionContext.workspaceState.update(
+    void state.extensionContext.workspaceState.update(
         'selectedConnectSequence',
         connectSequence
     );
@@ -772,7 +772,7 @@ export default {
             'connect-type',
             'ConnectInterrupted'
         );
-        standaloneConnect(context, connectSequence);
+        void standaloneConnect(context, connectSequence);
     },
     connectCommand: async (context: vscode.ExtensionContext) => {
         status.updateNeedReplUi(true);
@@ -782,7 +782,7 @@ export default {
             await liveShareSupport.setupLiveShareListener();
         } catch {
             // Could be a bae file, user makes the call
-            vscode.commands.executeCommand('calva.startOrConnectRepl');
+            void vscode.commands.executeCommand('calva.startOrConnectRepl');
             return;
         }
         const cljTypes = await projectTypes.detectProjectTypes(),
@@ -791,7 +791,7 @@ export default {
                 'connect-type',
                 'ConnectInterrupted'
             );
-        standaloneConnect(context, connectSequence);
+        void standaloneConnect(context, connectSequence);
     },
     disconnect: (
         options = null,

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -20,7 +20,7 @@ export function killRange(
     end = doc.selectionRight
 ) {
     const [left, right] = [Math.min(...range), Math.max(...range)];
-    doc.model.edit(
+    void doc.model.edit(
         [new ModelEdit('deleteRange', [left, right - left, [start, end]])],
         { selection: new ModelEditSelection(left) }
     );
@@ -476,7 +476,7 @@ export function splitSexp(
         const open = cursor.getPrevToken().raw;
         if (cursor.forwardList()) {
             const close = cursor.getToken().raw;
-            doc.model.edit(
+            void doc.model.edit(
                 [
                     new ModelEdit('changeRange', [
                         splitPos,
@@ -629,7 +629,7 @@ export function forwardSlurpSexp(
                           '',
                       ]
                     : [wsStartOffset, wsEndOffset, ' '];
-            doc.model.edit(
+            void doc.model.edit(
                 [
                     new ModelEdit('insertString', [newCloseOffset, close]),
                     new ModelEdit('changeRange', changeArgs),
@@ -667,7 +667,7 @@ export function backwardSlurpSexp(
         cursor.backwardSexp(true);
         cursor.forwardWhitespace(false);
         if (offset !== cursor.offsetStart) {
-            doc.model.edit(
+            void doc.model.edit(
                 [
                     new ModelEdit('deleteRange', [offset, tk.raw.length]),
                     new ModelEdit('changeRange', [
@@ -705,7 +705,7 @@ export function forwardBarfSexp(
             close = cursor.getToken().raw;
         cursor.backwardSexp(true);
         cursor.backwardWhitespace();
-        doc.model.edit(
+        void doc.model.edit(
             [
                 new ModelEdit('deleteRange', [offset, close.length]),
                 new ModelEdit('insertString', [cursor.offsetStart, close]),
@@ -734,7 +734,7 @@ export function backwardBarfSexp(
         cursor.next();
         cursor.forwardSexp();
         cursor.forwardWhitespace(false);
-        doc.model.edit(
+        void doc.model.edit(
             [
                 new ModelEdit('changeRange', [
                     cursor.offsetStart,
@@ -797,9 +797,12 @@ export function close(
         if (!inString && docIsBalanced(doc)) {
             // Do nothing when there is balance
         } else {
-            doc.model.edit([new ModelEdit('insertString', [start, close])], {
-                selection: new ModelEditSelection(start + close.length),
-            });
+            void doc.model.edit(
+                [new ModelEdit('insertString', [start, close])],
+                {
+                    selection: new ModelEditSelection(start + close.length),
+                }
+            );
         }
     }
 }
@@ -861,7 +864,7 @@ export function deleteForward(
 ) {
     const cursor = doc.getTokenCursor(start);
     if (start != end) {
-        doc.delete();
+        void doc.delete();
     } else {
         const prevToken = cursor.getPrevToken();
         const nextToken = cursor.getToken();
@@ -871,7 +874,7 @@ export function deleteForward(
                 selection: new ModelEditSelection(p),
             });
         } else if (prevToken.type === 'open' && nextToken.type === 'close') {
-            doc.model.edit(
+            void doc.model.edit(
                 [
                     new ModelEdit('deleteRange', [
                         p - prevToken.raw.length,
@@ -907,7 +910,7 @@ export function stringQuote(
             // inside a string, let's be clever
             if (cursor.getToken().type == 'close') {
                 if (doc.model.getText(0, start).endsWith('\\')) {
-                    doc.model.edit(
+                    void doc.model.edit(
                         [new ModelEdit('changeRange', [start, start, '"'])],
                         { selection: new ModelEditSelection(start + 1) }
                     );
@@ -916,19 +919,19 @@ export function stringQuote(
                 }
             } else {
                 if (doc.model.getText(0, start).endsWith('\\')) {
-                    doc.model.edit(
+                    void doc.model.edit(
                         [new ModelEdit('changeRange', [start, start, '"'])],
                         { selection: new ModelEditSelection(start + 1) }
                     );
                 } else {
-                    doc.model.edit(
+                    void doc.model.edit(
                         [new ModelEdit('changeRange', [start, start, '\\"'])],
                         { selection: new ModelEditSelection(start + 2) }
                     );
                 }
             }
         } else {
-            doc.model.edit(
+            void doc.model.edit(
                 [new ModelEdit('changeRange', [start, start, '""'])],
                 { selection: new ModelEditSelection(start + 1) }
             );
@@ -1051,7 +1054,7 @@ export function raiseSexp(
         if (startCursor.getPrevToken().type == 'open') {
             startCursor.previous();
             if (endCursor.getToken().type == 'close') {
-                doc.model.edit(
+                void doc.model.edit(
                     [
                         new ModelEdit('changeRange', [
                             startCursor.offsetStart,
@@ -1097,7 +1100,7 @@ export function convolute(
                             headEnd.forwardList() &&
                             cursorEnd.getToken().type == 'close'
                         ) {
-                            doc.model.edit(
+                            void doc.model.edit(
                                 [
                                     new ModelEdit('changeRange', [
                                         headEnd.offsetEnd,
@@ -1162,7 +1165,7 @@ export function transpose(
                 } else if (newPosOffset.fromRight != undefined) {
                     newCursorPos = rightEnd - newPosOffset.fromRight;
                 }
-                doc.model.edit(
+                void doc.model.edit(
                     [
                         new ModelEdit('changeRange', [
                             rightStart,
@@ -1268,7 +1271,7 @@ export function dragSexprBackward(
         // there is a sexp to the left
         const leftText = doc.model.getText(backRange[0], backRange[1]);
         const currentText = doc.model.getText(currentRange[0], currentRange[1]);
-        doc.model.edit(
+        void doc.model.edit(
             [
                 new ModelEdit('changeRange', [
                     currentRange[0],
@@ -1308,7 +1311,7 @@ export function dragSexprForward(
         // there is a sexp to the right
         const rightText = doc.model.getText(forwardRange[0], forwardRange[1]);
         const currentText = doc.model.getText(currentRange[0], currentRange[1]);
-        doc.model.edit(
+        void doc.model.edit(
             [
                 new ModelEdit('changeRange', [
                     forwardRange[0],
@@ -1415,7 +1418,7 @@ export function dragSexprBackwardUp(
                 wsInfo.rightWsRange[1] - currentRange[0],
             ]);
         }
-        doc.model.edit(
+        void doc.model.edit(
             [
                 deleteEdit,
                 new ModelEdit('insertString', [
@@ -1453,7 +1456,7 @@ export function dragSexprForwardDown(
             const insertText =
                 doc.model.getText(...currentRange) +
                 (wsInfo.rightWsHasNewline ? '\n' : ' ');
-            doc.model.edit(
+            void doc.model.edit(
                 [
                     new ModelEdit('insertString', [
                         insertStart,
@@ -1498,7 +1501,7 @@ export function dragSexprForwardUp(
             deleteLength = wsInfo.rightWsRange[1] - deleteStart;
         }
         const newCursorPos = listEnd + newPosOffset + 1 - deleteLength;
-        doc.model.edit(
+        void doc.model.edit(
             [
                 new ModelEdit('insertString', [
                     listEnd,
@@ -1542,7 +1545,7 @@ export function dragSexprBackwardDown(
             let insertText = doc.model.getText(...currentRange);
             insertText =
                 (siblingWsInfo.leftWsHasNewline ? '\n' : ' ') + insertText;
-            doc.model.edit(
+            void doc.model.edit(
                 [
                     new ModelEdit('deleteRange', [
                         wsInfo.leftWsRange[0],
@@ -1613,7 +1616,7 @@ export function addRichComment(
             checkIfRichCommentExistsCursor.forwardWhitespace(false);
             // insert nothing, just place cursor
             const newCursorPos = checkIfRichCommentExistsCursor.offsetStart;
-            doc.model.edit(
+            void doc.model.edit(
                 [
                     new ModelEdit('insertString', [
                         newCursorPos,
@@ -1646,7 +1649,7 @@ export function addRichComment(
     const insertText = `${prepend}${richComment}${append}`;
     const newCursorPos =
         insertStart + 11 + numPrependNls * doc.model.lineEndingLength;
-    doc.model.edit(
+    void doc.model.edit(
         [
             new ModelEdit('insertString', [
                 insertStart,

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -61,7 +61,7 @@ async function evaluateCodeOrKey(codeOrKey?: string) {
     });
 
     if (configErrors.length > 0) {
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             'Errors found in the `calva.customREPLCommandSnippets` setting. Values missing for: ' +
                 JSON.stringify(configErrors),
             'OK'

--- a/src/debugger/calva-debug.ts
+++ b/src/debugger/calva-debug.ts
@@ -121,11 +121,16 @@ class CalvaDebugSession extends LoggingDebugSession {
 
         if (cljSession) {
             const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
-            cljSession.sendDebugInput(':continue', id, key).then((response) => {
-                this.sendEvent(
-                    new StoppedEvent('breakpoint', CalvaDebugSession.THREAD_ID)
-                );
-            });
+            void cljSession
+                .sendDebugInput(':continue', id, key)
+                .then((response) => {
+                    this.sendEvent(
+                        new StoppedEvent(
+                            'breakpoint',
+                            CalvaDebugSession.THREAD_ID
+                        )
+                    );
+                });
         } else {
             response.success = false;
         }
@@ -158,7 +163,7 @@ class CalvaDebugSession extends LoggingDebugSession {
 
         if (cljSession) {
             const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
-            cljSession.sendDebugInput(':next', id, key).then((_) => {
+            void cljSession.sendDebugInput(':next', id, key).then((_) => {
                 this.sendEvent(
                     new StoppedEvent('breakpoint', CalvaDebugSession.THREAD_ID)
                 );
@@ -186,7 +191,7 @@ class CalvaDebugSession extends LoggingDebugSession {
 
         if (cljSession) {
             const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
-            cljSession.sendDebugInput(':in', id, key).then((_) => {
+            void cljSession.sendDebugInput(':in', id, key).then((_) => {
                 this.sendEvent(
                     new StoppedEvent('breakpoint', CalvaDebugSession.THREAD_ID)
                 );
@@ -214,7 +219,7 @@ class CalvaDebugSession extends LoggingDebugSession {
 
         if (cljSession) {
             const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
-            cljSession.sendDebugInput(':out', id, key).then((_) => {
+            void cljSession.sendDebugInput(':out', id, key).then((_) => {
                 this.sendEvent(
                     new StoppedEvent('breakpoint', CalvaDebugSession.THREAD_ID)
                 );
@@ -288,7 +293,7 @@ class CalvaDebugSession extends LoggingDebugSession {
         try {
             moveTokenCursorToBreakpoint(tokenCursor, debugResponse);
         } catch (e) {
-            window.showErrorMessage(
+            void window.showErrorMessage(
                 'An error occurred in the breakpoint-finding logic. We would love if you submitted an issue in the Calva repo with the instrumented code, or a similar reproducible case.'
             );
             this.sendEvent(new TerminatedEvent());
@@ -316,7 +321,7 @@ class CalvaDebugSession extends LoggingDebugSession {
 
         this.sendResponse(response);
 
-        this._showDebugAnnotation(
+        void this._showDebugAnnotation(
             debugResponse['debug-value'],
             document,
             line,
@@ -375,7 +380,7 @@ class CalvaDebugSession extends LoggingDebugSession {
 
         if (cljSession) {
             const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
-            cljSession.sendDebugInput(':quit', id, key);
+            void cljSession.sendDebugInput(':quit', id, key);
         }
 
         this.sendResponse(response);
@@ -472,7 +477,7 @@ class CalvaDebugAdapterDescriptorFactory
 function onNreplMessage(data: any): void {
     if (vscode.debug.activeDebugSession && (data['value'] || data['err'])) {
         annotations.clearAllEvaluationDecorations();
-        vscode.debug.activeDebugSession.customRequest(
+        void vscode.debug.activeDebugSession.customRequest(
             REQUESTS.SEND_TERMINATED_EVENT
         );
     } else if (
@@ -493,12 +498,12 @@ function handleNeedDebugInput(response: any): void {
         setStateValue(DEBUG_RESPONSE_KEY, response);
 
         if (!debug.activeDebugSession) {
-            debug.startDebugging(undefined, CALVA_DEBUG_CONFIGURATION);
+            void debug.startDebugging(undefined, CALVA_DEBUG_CONFIGURATION);
         }
     } else {
         const cljSession = replSession.getSession(CLOJURE_SESSION_NAME);
-        cljSession.sendDebugInput(':quit', response.id, response.key);
-        vscode.window.showInformationMessage(
+        void cljSession.sendDebugInput(':quit', response.id, response.key);
+        void vscode.window.showInformationMessage(
             'Forms containing breakpoints that were not evaluated in the editor (such as if you evaluated a form in the REPL window) cannot be debugged. Evaluate the form in the editor in order to debug it.'
         );
     }
@@ -506,7 +511,7 @@ function handleNeedDebugInput(response: any): void {
 
 debug.onDidStartDebugSession((session) => {
     // We only start debugger sessions when a breakpoint is hit
-    session.customRequest(REQUESTS.SEND_STOPPED_EVENT, {
+    void session.customRequest(REQUESTS.SEND_STOPPED_EVENT, {
         reason: 'breakpoint',
     });
 });
@@ -523,7 +528,7 @@ function initializeDebugger(cljSession: NReplSession): void {
 
 function terminateDebugSession(): void {
     if (vscode.debug.activeDebugSession) {
-        vscode.debug.activeDebugSession.customRequest(
+        void vscode.debug.activeDebugSession.customRequest(
             REQUESTS.SEND_TERMINATED_EVENT
         );
     }

--- a/src/debugger/decorations.ts
+++ b/src/debugger/decorations.ts
@@ -149,7 +149,7 @@ function triggerUpdateAndRenderDecorations() {
             timeout = setTimeout(() => {
                 const cljSession = replSession.getSession('clj');
                 const lspClient = getStateValue(lsp.LSP_CLIENT_KEY);
-                update(editor, cljSession, lspClient).then(
+                void update(editor, cljSession, lspClient).then(
                     renderInAllVisibleEditors
                 );
             }, 50);

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -173,7 +173,7 @@ export class MirroredDocument implements EditableDocument {
                 text
             );
         wsEdit.set(this.document.uri, [edit]);
-        vscode.workspace.applyEdit(wsEdit).then((_v) => {
+        void vscode.workspace.applyEdit(wsEdit).then((_v) => {
             editor.selection = selection;
         });
     }
@@ -218,7 +218,7 @@ function processChanges(event: vscode.TextDocumentChangeEvent) {
             myEndOffset =
                 model.getOffsetForLine(change.range.end.line) +
                 change.range.end.character;
-        model.lineInputModel.edit(
+        void model.lineInputModel.edit(
             [
                 new ModelEdit('changeRange', [
                     myStartOffset,

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -26,7 +26,7 @@ export function continueCommentCommand() {
         const bulletText = newNum ? bullet.replace(/\d+/, '' + newNum) : bullet;
         const pad = ' '.repeat(commentOffset);
         const newText = `${pad}${startText}${bullet ? bulletText : ''}`;
-        editor
+        void editor
             .edit((edits) => edits.insert(position, `\n${newText}`), {
                 undoStopAfter: false,
                 undoStopBefore: true,

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -29,18 +29,18 @@ function interruptAllEvaluations() {
             session.interruptAll();
         });
         if (nums > 0) {
-            vscode.window.showInformationMessage(
+            void vscode.window.showInformationMessage(
                 `Interrupted ${nums} running evaluation(s).`
             );
         } else {
-            vscode.window.showInformationMessage(
+            void vscode.window.showInformationMessage(
                 'Interruption command finished (unknown results)'
             );
         }
         outputWindow.discardPendingPrints();
         return;
     }
-    vscode.window.showInformationMessage('Not connected to a REPL server');
+    void vscode.window.showInformationMessage('Not connected to a REPL server');
 }
 
 async function addAsComment(
@@ -139,7 +139,7 @@ async function evaluateCode(
                                 ),
                                 wsEdit = new vscode.WorkspaceEdit();
                             wsEdit.set(editor.document.uri, [edit]);
-                            vscode.workspace.applyEdit(wsEdit);
+                            void vscode.workspace.applyEdit(wsEdit);
                         } else {
                             if (options.comment) {
                                 await addAsComment(
@@ -292,7 +292,7 @@ async function evaluateSelection(document = {}, options) {
             outputWindow.appendPrompt();
         }
     } else {
-        vscode.window.showErrorMessage('Not connected to a REPL');
+        void vscode.window.showErrorMessage('Not connected to a REPL');
     }
 }
 
@@ -528,7 +528,9 @@ async function evaluateUser(code: string) {
             chan.appendLine(`Eval failure: ${e}`);
         }
     } else {
-        vscode.window.showInformationMessage('Not connected to a REPL server');
+        void vscode.window.showInformationMessage(
+            'Not connected to a REPL server'
+        );
     }
 }
 
@@ -563,7 +565,9 @@ async function requireREPLUtilitiesCommand() {
             }
         }
     } else {
-        vscode.window.showInformationMessage('Not connected to a REPL server');
+        void vscode.window.showInformationMessage(
+            'Not connected to a REPL server'
+        );
     }
 }
 
@@ -575,8 +579,8 @@ async function copyLastResultCommand() {
 
     const value = await session.eval('*1', session.client.ns).value;
     if (value !== null) {
-        vscode.env.clipboard.writeText(value);
-        vscode.window.showInformationMessage(
+        void vscode.env.clipboard.writeText(value);
+        void vscode.window.showInformationMessage(
             'Results copied to the clipboard.'
         );
     } else {

--- a/src/extension-test/integration/runTests.ts
+++ b/src/extension-test/integration/runTests.ts
@@ -35,4 +35,4 @@ async function main() {
     }
 }
 
-main();
+void main();

--- a/src/extension-test/integration/suite/extension-test.ts
+++ b/src/extension-test/integration/suite/extension-test.ts
@@ -14,11 +14,11 @@ import * as outputWindow from '../../../results-output/results-doc';
 import { commands } from 'vscode';
 import { getDocument } from '../../../doc-mirror';
 
-vscode.window.showInformationMessage('Tests running. Yay!');
+void vscode.window.showInformationMessage('Tests running. Yay!');
 
 suite('Extension Test Suite', () => {
     after(() => {
-        vscode.window.showInformationMessage('All tests done!');
+        void vscode.window.showInformationMessage('All tests done!');
     });
 
     // test("We have a context", async () => {
@@ -53,7 +53,7 @@ suite('Extension Test Suite', () => {
         // pre-select deps.edn as the repl connect sequence
         // qps = quickPickSingle
         const saveAs = `qps-${uri.toString()}/jack-in-type`;
-        state.extensionContext.workspaceState.update(saveAs, 'deps.edn');
+        void state.extensionContext.workspaceState.update(saveAs, 'deps.edn');
         assert.equal(
             state.extensionContext.workspaceState.get(saveAs),
             'deps.edn',

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -997,119 +997,119 @@ describe('paredit', () => {
             it('Leaves closing paren of empty list alone', () => {
                 const a = docFromTextNotation('{::foo ()|• ::bar :foo}');
                 const b = docFromTextNotation('{::foo (|)• ::bar :foo}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes closing paren if unbalance', () => {
                 const a = docFromTextNotation('{::foo )|• ::bar :foo}');
                 const b = docFromTextNotation('{::foo |• ::bar :foo}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Leaves opening paren of non-empty list alone', () => {
                 const a = docFromTextNotation('{::foo (|a)• ::bar :foo}');
                 const b = docFromTextNotation('{::foo |(a)• ::bar :foo}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Leaves opening quote of non-empty string alone', () => {
                 const a = docFromTextNotation('{::foo "|a"• ::bar :foo}');
                 const b = docFromTextNotation('{::foo |"a"• ::bar :foo}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Leaves closing quote of non-empty string alone', () => {
                 const a = docFromTextNotation('{::foo "a"|• ::bar :foo}');
                 const b = docFromTextNotation('{::foo "a|"• ::bar :foo}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes contents in strings', () => {
                 const a = docFromTextNotation('{::foo "a|"• ::bar :foo}');
                 const b = docFromTextNotation('{::foo "|"• ::bar :foo}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes contents in strings 2', () => {
                 const a = docFromTextNotation('{::foo "a|a"• ::bar :foo}');
                 const b = docFromTextNotation('{::foo "|a"• ::bar :foo}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes contents in strings 3', () => {
                 const a = docFromTextNotation('{::foo "aa|"• ::bar :foo}');
                 const b = docFromTextNotation('{::foo "a|"• ::bar :foo}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes quoted quote', () => {
                 const a = docFromTextNotation('{::foo \\"|• ::bar :foo}');
                 const b = docFromTextNotation('{::foo |• ::bar :foo}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes quoted quote in string', () => {
                 const a = docFromTextNotation('{::foo "\\"|"• ::bar :foo}');
                 const b = docFromTextNotation('{::foo "|"• ::bar :foo}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes contents in list', () => {
                 const a = docFromTextNotation('{::foo (a|)• ::bar :foo}');
                 const b = docFromTextNotation('{::foo (|)• ::bar :foo}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes empty list function', () => {
                 const a = docFromTextNotation('{::foo (|)• ::bar :foo}');
                 const b = docFromTextNotation('{::foo |• ::bar :foo}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes empty set', () => {
                 const a = docFromTextNotation('#{|}');
                 const b = docFromTextNotation('|');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes empty literal function with trailing newline', () => {
                 // https://github.com/BetterThanTomorrow/calva/issues/1079
                 const a = docFromTextNotation('{::foo #(|)• ::bar :foo}');
                 const b = docFromTextNotation('{::foo |• ::bar :foo}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes open paren prefix characters', () => {
                 // https://github.com/BetterThanTomorrow/calva/issues/1122
                 const a = docFromTextNotation('#|(foo)');
                 const b = docFromTextNotation('|(foo)');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes open map curly prefix/ns characters', () => {
                 const a = docFromTextNotation('#:same|{:thing :here}');
                 const b = docFromTextNotation('#:sam|{:thing :here}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes open set hash characters', () => {
                 // https://github.com/BetterThanTomorrow/calva/issues/1122
                 const a = docFromTextNotation('#|{:thing :here}');
                 const b = docFromTextNotation('|{:thing :here}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Moves cursor past entire open paren, including prefix characters', () => {
                 const a = docFromTextNotation('#(|foo)');
                 const b = docFromTextNotation('|#(foo)');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Moves cursor only past the open curly for namespaced maps', () => {
                 // Could be argued it should move past the entire reader tag, but anyway
                 const a = docFromTextNotation('#:same{|:thing :here}');
                 const b = docFromTextNotation('#:same|{:thing :here}');
-                paredit.backspace(a);
+                void paredit.backspace(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
         });
@@ -1118,80 +1118,80 @@ describe('paredit', () => {
             it('Leaves closing paren of empty list alone', () => {
                 const a = docFromTextNotation('{::foo |()• ::bar :foo}');
                 const b = docFromTextNotation('{::foo (|)• ::bar :foo}');
-                paredit.deleteForward(a);
+                void paredit.deleteForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes closing paren if unbalance', () => {
                 const a = docFromTextNotation('{::foo |)• ::bar :foo}');
                 const b = docFromTextNotation('{::foo |• ::bar :foo}');
-                paredit.deleteForward(a);
+                void paredit.deleteForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Leaves opening paren of non-empty list alone', () => {
                 const a = docFromTextNotation('{::foo |(a)• ::bar :foo}');
                 const b = docFromTextNotation('{::foo (|a)• ::bar :foo}');
-                paredit.deleteForward(a);
+                void paredit.deleteForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Leaves opening quote of non-empty string alone', () => {
                 const a = docFromTextNotation('{::foo |"a"• ::bar :foo}');
                 const b = docFromTextNotation('{::foo "|a"• ::bar :foo}');
-                paredit.deleteForward(a);
+                void paredit.deleteForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Leaves closing quote of non-empty string alone', () => {
                 const a = docFromTextNotation('{::foo "a|"• ::bar :foo}');
                 const b = docFromTextNotation('{::foo "a"|• ::bar :foo}');
-                paredit.deleteForward(a);
+                void paredit.deleteForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes contents in strings', () => {
                 const a = docFromTextNotation('{::foo "|a"• ::bar :foo}');
                 const b = docFromTextNotation('{::foo "|"• ::bar :foo}');
-                paredit.deleteForward(a);
+                void paredit.deleteForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes contents in strings 2', () => {
                 const a = docFromTextNotation('{::foo "|aa"• ::bar :foo}');
                 const b = docFromTextNotation('{::foo "|a"• ::bar :foo}');
-                paredit.deleteForward(a);
+                void paredit.deleteForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes quoted quote', () => {
                 const a = docFromTextNotation('{::foo |\\"• ::bar :foo}');
                 const b = docFromTextNotation('{::foo |• ::bar :foo}');
-                paredit.deleteForward(a);
+                void paredit.deleteForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes quoted quote in string', () => {
                 const a = docFromTextNotation('{::foo "|\\""• ::bar :foo}');
                 const b = docFromTextNotation('{::foo "|"• ::bar :foo}');
-                paredit.deleteForward(a);
+                void paredit.deleteForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes contents in list', () => {
                 const a = docFromTextNotation('{::foo (|a)• ::bar :foo}');
                 const b = docFromTextNotation('{::foo (|)• ::bar :foo}');
-                paredit.deleteForward(a);
+                void paredit.deleteForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes empty list function', () => {
                 const a = docFromTextNotation('{::foo (|)• ::bar :foo}');
                 const b = docFromTextNotation('{::foo |• ::bar :foo}');
-                paredit.deleteForward(a);
+                void paredit.deleteForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes empty set', () => {
                 const a = docFromTextNotation('#{|}');
                 const b = docFromTextNotation('|');
-                paredit.deleteForward(a);
+                void paredit.deleteForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
             it('Deletes empty literal function with trailing newline', () => {
                 // https://github.com/BetterThanTomorrow/calva/issues/1079
                 const a = docFromTextNotation('{::foo #(|)• ::bar :foo}');
                 const b = docFromTextNotation('{::foo |• ::bar :foo}');
-                paredit.deleteForward(a);
+                void paredit.deleteForward(a);
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
         });
@@ -1249,38 +1249,38 @@ describe('paredit', () => {
         describe('splice sexp', () => {
             it('splice empty', () => {
                 const a = docFromTextNotation('|');
-                paredit.spliceSexp(a);
+                void paredit.spliceSexp(a);
                 expect(text(a)).toEqual('');
             });
 
             it('splice list', () => {
                 const a = docFromTextNotation('(a| b c)');
-                paredit.spliceSexp(a);
+                void paredit.spliceSexp(a);
                 expect(text(a)).toEqual('a b c');
             });
 
             it('splice vector', () => {
                 const a = docFromTextNotation('[a| b c]');
-                paredit.spliceSexp(a);
+                void paredit.spliceSexp(a);
                 expect(text(a)).toEqual('a b c');
             });
 
             it('splice map', () => {
                 const a = docFromTextNotation('{a| b}');
-                paredit.spliceSexp(a);
+                void paredit.spliceSexp(a);
                 expect(text(a)).toEqual('a b');
             });
 
             it('splice nested', () => {
                 const a = docFromTextNotation('[1 {ab| cd} 2]');
-                paredit.spliceSexp(a);
+                void paredit.spliceSexp(a);
                 expect(text(a)).toEqual('[1 ab cd 2]');
             });
 
             // TODO: enable after fixing spliceSexp
             it('splice set', () => {
                 const a = docFromTextNotation('#{a| b}');
-                paredit.spliceSexp(a);
+                void paredit.spliceSexp(a);
                 expect(text(a)).toEqual('a b');
             });
 
@@ -1288,7 +1288,7 @@ describe('paredit', () => {
             //     Not sure why, but it can be run successfully by itself.
             xit('splice string', () => {
                 const a = docFromTextNotation('"h|ello"');
-                paredit.spliceSexp(a);
+                void paredit.spliceSexp(a);
                 expect(text(a)).toEqual('hello');
             });
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ async function onDidSave(
     }
 
     if (test && util.getConnectedState()) {
-        testRunner.runNamespaceTests(testController, document);
+        void testRunner.runNamespaceTests(testController, document);
         state.analytics().logEvent('Calva', 'OnSaveTest').send();
     } else if (evaluate) {
         if (!outputWindow.isResultsDoc(document)) {
@@ -76,7 +76,7 @@ function setKeybindingsEnabledContext() {
     const keybindingsEnabled = vscode.workspace
         .getConfiguration()
         .get(config.KEYBINDINGS_ENABLED_CONFIG_KEY);
-    vscode.commands.executeCommand(
+    void vscode.commands.executeCommand(
         'setContext',
         config.KEYBINDINGS_ENABLED_CONTEXT_KEY,
         keybindingsEnabled
@@ -113,7 +113,7 @@ async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(controller);
     testRunner.initialize(controller);
 
-    lsp.activate(context, (testTree) => {
+    void lsp.activate(context, (testTree) => {
         testRunner.onTestTree(controller, testTree);
     });
 
@@ -152,7 +152,7 @@ async function activate(context: vscode.ExtensionContext) {
     const VIEWED_CALVA_DOCS = 'viewedCalvaDocs';
     if (customCljsRepl && replConnectSequences.length == 0) {
         chan.appendLine('Old customCljsRepl settings detected.');
-        vscode.window
+        void vscode.window
             .showErrorMessage(
                 'Old customCljsRepl settings detected. You need to specify it using the new calva.customConnectSequence setting. See the Calva user documentation for instructions.',
                 ...[BUTTON_GOTO_DOC, BUTTON_OK]
@@ -167,7 +167,7 @@ async function activate(context: vscode.ExtensionContext) {
     }
 
     if (legacyExtension) {
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             'Calva Legacy extension detected. Things will break. Please uninstall, or disable, the old Calva extension.',
             'Roger that. Right away!'
         );
@@ -177,12 +177,12 @@ async function activate(context: vscode.ExtensionContext) {
 
     if (!fmtExtension) {
         try {
-            fmt.activate(context);
+            void fmt.activate(context);
         } catch (e) {
             console.error('Failed activating Formatter: ' + e.message);
         }
     } else {
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             'Calva Format extension detected, which will break things. Please uninstall or, disable, it before continuing using Calva.',
             'Got it. Will do!'
         );
@@ -194,7 +194,7 @@ async function activate(context: vscode.ExtensionContext) {
             console.error('Failed activating Paredit: ' + e.message);
         }
     } else {
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             'Calva Paredit extension detected, which will cause problems. Please uninstall, or disable, it.',
             'I hear ya. Doing it!'
         );
@@ -211,7 +211,7 @@ async function activate(context: vscode.ExtensionContext) {
     );
     context.subscriptions.push(
         vscode.commands.registerCommand('calva.startStandaloneRepl', () => {
-            replStart.startStandaloneRepl(
+            void replStart.startStandaloneRepl(
                 context,
                 replStart.USER_TEMPLATE,
                 true
@@ -222,7 +222,7 @@ async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             'calva.startStandaloneHelloRepl',
             () => {
-                replStart.startStandaloneRepl(
+                void replStart.startStandaloneRepl(
                     context,
                     replStart.HELLO_TEMPLATE,
                     false
@@ -234,7 +234,7 @@ async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             'calva.startStandaloneCljsBrowserRepl',
             () => {
-                replStart.startStandaloneRepl(
+                void replStart.startStandaloneRepl(
                     context,
                     replStart.HELLO_CLJS_BROWSER_TEMPLATE,
                     false
@@ -246,7 +246,7 @@ async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             'calva.startStandaloneCljsNodeRepl',
             () => {
-                replStart.startStandaloneRepl(
+                void replStart.startStandaloneRepl(
                     context,
                     replStart.HELLO_CLJS_NODE_TEMPLATE,
                     false
@@ -265,7 +265,7 @@ async function activate(context: vscode.ExtensionContext) {
     );
     context.subscriptions.push(
         vscode.commands.registerCommand('calva.connectNonProjectREPL', () => {
-            connector.connectNonProjectREPLCommand(context);
+            void connector.connectNonProjectREPLCommand(context);
         })
     );
     context.subscriptions.push(
@@ -468,7 +468,7 @@ async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             'calva.showFileForOutputWindowNS',
             () => {
-                outputWindow.revealDocForCurrentNS(false);
+                void outputWindow.revealDocForCurrentNS(false);
             }
         )
     );
@@ -476,7 +476,7 @@ async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             'calva.toggleBetweenImplAndTest',
             () => {
-                fileSwitcher.toggleBetweenImplAndTest();
+                void fileSwitcher.toggleBetweenImplAndTest();
             }
         )
     );
@@ -529,7 +529,7 @@ async function activate(context: vscode.ExtensionContext) {
                 const keybindingsEnabled = vscode.workspace
                     .getConfiguration()
                     .get(config.KEYBINDINGS_ENABLED_CONFIG_KEY);
-                vscode.workspace
+                void vscode.workspace
                     .getConfiguration()
                     .update(
                         config.KEYBINDINGS_ENABLED_CONFIG_KEY,
@@ -541,7 +541,7 @@ async function activate(context: vscode.ExtensionContext) {
     );
     context.subscriptions.push(
         vscode.commands.registerCommand('calva.openCalvaDocs', () => {
-            context.globalState.update(VIEWED_CALVA_DOCS, true);
+            void context.globalState.update(VIEWED_CALVA_DOCS, true);
             open(CALVA_DOCS_URL)
                 .then(() => {
                     state.analytics().logEvent('Calva', 'Docs opened');
@@ -590,9 +590,13 @@ async function activate(context: vscode.ExtensionContext) {
 
     // Initial set of the provided contexts
     outputWindow.setContextForOutputWindowActive(false);
-    vscode.commands.executeCommand('setContext', 'calva:launching', false);
-    vscode.commands.executeCommand('setContext', 'calva:connected', false);
-    vscode.commands.executeCommand('setContext', 'calva:connecting', false);
+    void vscode.commands.executeCommand('setContext', 'calva:launching', false);
+    void vscode.commands.executeCommand('setContext', 'calva:connected', false);
+    void vscode.commands.executeCommand(
+        'setContext',
+        'calva:connecting',
+        false
+    );
     setKeybindingsEnabledContext();
 
     // PROVIDERS
@@ -642,7 +646,7 @@ async function activate(context: vscode.ExtensionContext) {
     );
     context.subscriptions.push(
         vscode.workspace.onDidSaveTextDocument((document) => {
-            onDidSave(controller, document);
+            void onDidSave(controller, document);
         })
     );
     context.subscriptions.push(
@@ -726,7 +730,7 @@ async function activate(context: vscode.ExtensionContext) {
         context.subscriptions.push(factory);
     }
 
-    vscode.commands.executeCommand('setContext', 'calva:activated', true);
+    void vscode.commands.executeCommand('setContext', 'calva:activated', true);
 
     greetings.activationGreetings(chan);
 
@@ -735,14 +739,14 @@ async function activate(context: vscode.ExtensionContext) {
             `VIM Extension detected. Please read: ${VIM_DOC_URL} now and then.\n`
         );
         if (!context.globalState.get(VIEWED_VIM_DOCS)) {
-            vscode.window
+            void vscode.window
                 .showErrorMessage(
                     'VIM Extension detected. Please view the docs for tips (and to stop this info box from appearing).',
                     ...[BUTTON_GOTO_DOC]
                 )
                 .then((v) => {
                     if (v == BUTTON_GOTO_DOC) {
-                        context.globalState.update(VIEWED_VIM_DOCS, true);
+                        void context.globalState.update(VIEWED_VIM_DOCS, true);
                         open(VIM_DOC_URL).catch(() => {
                             // do nothing
                         });
@@ -754,7 +758,7 @@ async function activate(context: vscode.ExtensionContext) {
     if (clojureExtension) {
         chan.appendLine(`The Clojure Extension is installed.\n`);
         if (!context.globalState.get(DONT_SHOW_CLOJURE_EXT_NAG)) {
-            vscode.window
+            void vscode.window
                 .showWarningMessage(
                     'You have the Clojure extension installed. Please note that it will conflict with Calva.',
                     "Don't show again",
@@ -762,7 +766,7 @@ async function activate(context: vscode.ExtensionContext) {
                 )
                 .then((v) => {
                     if (v == "Don't show again") {
-                        context.globalState.update(
+                        void context.globalState.update(
                             DONT_SHOW_CLOJURE_EXT_NAG,
                             true
                         );
@@ -784,7 +788,7 @@ async function activate(context: vscode.ExtensionContext) {
             console.error('Failed activating Highlight: ' + e.message);
         }
     } else {
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             "Clojure Warrior extension detected. This will not work well together with Calva's highlighting (which is an improvement on Clojure Warrior). Please uninstall/disable it.",
             ...['Got it.', 'Will do!']
         );

--- a/src/file-switcher/file-switcher.ts
+++ b/src/file-switcher/file-switcher.ts
@@ -30,8 +30,8 @@ function askToCreateANewFile(dir, file) {
     return showConfirmationDialog(`Create ${filePath}?`, 'Create').then(
         (answer) => {
             if (answer === 'Create') {
-                createNewFile(dir, file).then(() => {
-                    openFile(filePath);
+                void createNewFile(dir, file).then(() => {
+                    void openFile(filePath);
                 });
             }
         }
@@ -51,7 +51,7 @@ export async function toggleBetweenImplAndTest() {
 
     const { success, message } = util.isFileValid(fullFileName, pathAfterRoot);
     if (!success) {
-        vscode.window.showErrorMessage(message);
+        void vscode.window.showErrorMessage(message);
         return;
     }
 
@@ -61,15 +61,17 @@ export async function toggleBetweenImplAndTest() {
     const filePath = path.join(projectRootPath, sourcePath, newFilename);
     const fileToOpen = vscode.workspace.asRelativePath(filePath);
 
-    vscode.workspace.findFiles(fileToOpen, '**/.calva/**').then((files) => {
-        if (!files.length) {
-            askToCreateANewFile(
-                path.join(projectRootPath, sourcePath),
-                newFilename
-            );
-        } else {
-            const file = files[0].fsPath;
-            openFile(file);
-        }
-    });
+    void vscode.workspace
+        .findFiles(fileToOpen, '**/.calva/**')
+        .then((files) => {
+            if (!files.length) {
+                void askToCreateANewFile(
+                    path.join(projectRootPath, sourcePath),
+                    newFilename
+                );
+            } else {
+                const file = files[0].fsPath;
+                void openFile(file);
+            }
+        });
 }

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -535,7 +535,7 @@ async function serverInfoCommandHandler(): Promise<void> {
         calvaSaysChannel.appendLine(serverInfoPretty);
         calvaSaysChannel.show(true);
     } else {
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             SERVER_NOT_RUNNING_OR_INITIALIZED_MESSAGE
         );
     }
@@ -640,9 +640,9 @@ async function openLogFile(): Promise<void> {
     if (client) {
         const serverInfo = await getServerInfo(client);
         const logPath = serverInfo['log-path'];
-        vscode.window.showTextDocument(vscode.Uri.file(logPath));
+        void vscode.window.showTextDocument(vscode.Uri.file(logPath));
     } else {
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             SERVER_NOT_RUNNING_OR_INITIALIZED_MESSAGE
         );
     }

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -260,7 +260,7 @@ function getCustomConnectSequences(): ReplConnectSequence[] {
             sequence.projectType == undefined ||
             sequence.cljsType == undefined
         ) {
-            vscode.window.showWarningMessage(
+            void vscode.window.showWarningMessage(
                 'Check your calva.replConnectSequences. You need to supply `name`, `projectType`, and `cljsType` for every sequence.',
                 ...['Roger That!']
             );
@@ -318,7 +318,7 @@ async function askForConnectSequence(
     const saveAsFull = projectRootUri
         ? `${projectRootUri.toString()}/${saveAs}`
         : saveAs;
-    state.extensionContext.workspaceState.update(
+    void state.extensionContext.workspaceState.update(
         'askForConnectSequenceQuickPick',
         true
     );
@@ -330,7 +330,7 @@ async function askForConnectSequence(
         saveAs: saveAsFull,
         autoSelect: true,
     });
-    state.extensionContext.workspaceState.update(
+    void state.extensionContext.workspaceState.update(
         'askForConnectSequenceQuickPick',
         false
     );
@@ -344,7 +344,7 @@ async function askForConnectSequence(
     const sequence = sequences.find(
         (seq) => seq.name === projectConnectSequenceName
     );
-    state.extensionContext.workspaceState.update(
+    void state.extensionContext.workspaceState.update(
         'selectedCljTypeName',
         sequence.projectType
     );

--- a/src/nrepl/jack-in-terminal.ts
+++ b/src/nrepl/jack-in-terminal.ts
@@ -42,7 +42,7 @@ export class JackInTerminal implements vscode.Pseudoterminal {
                 this.options.args
             )}`
         );
-        this.startClojureProgram();
+        void this.startClojureProgram();
     }
 
     close(): void {

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -74,7 +74,7 @@ function executeJackInTask(
             terminalOptions,
             (_p, hostname: string, port: string) => {
                 utilities.setLaunchingState(null);
-                connector
+                void connector
                     .connect(connectSequence, true, hostname, port)
                     .then(() => {
                         outputWindow.append('; Jack-in done.');
@@ -92,7 +92,7 @@ function executeJackInTask(
                 outputWindow.append(
                     '; You may have chosen the wrong jack-in configuration for your project.'
                 );
-                vscode.window.showErrorMessage(
+                void vscode.window.showErrorMessage(
                     'Error in Jack-in: unable to read port file. See output window for more information.'
                 );
                 cancelJackInTask();
@@ -164,13 +164,15 @@ export async function copyJackInCommandToClipboard(): Promise<void> {
             projectConnectSequence
         );
         if (executable && args) {
-            vscode.env.clipboard.writeText(createCommandLine(executable, args));
-            vscode.window.showInformationMessage(
+            void vscode.env.clipboard.writeText(
+                createCommandLine(executable, args)
+            );
+            void vscode.window.showInformationMessage(
                 'Jack-in command copied to the clipboard.'
             );
         }
     } else {
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             'No supported project types detected.'
         );
     }
@@ -310,13 +312,13 @@ export async function jackIn(
             );
         }
     } else {
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             'No supported project types detected. Maybe try starting your project manually and use the Connect command?'
         );
         return;
     }
 
-    liveShareSupport.didJackIn();
+    void liveShareSupport.didJackIn();
 }
 
 export async function jackInCommand(connectSequence?: ReplConnectSequence) {
@@ -341,7 +343,7 @@ export function calvaDisconnect() {
         utilities.getConnectingState() ||
         utilities.getLaunchingState()
     ) {
-        vscode.window
+        void vscode.window
             .showInformationMessage(
                 'Do you want to interrupt the connection process?',
                 { modal: true },
@@ -359,5 +361,5 @@ export function calvaDisconnect() {
             });
         return;
     }
-    vscode.window.showInformationMessage('Not connected to a REPL server');
+    void vscode.window.showInformationMessage('Not connected to a REPL server');
 }

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -107,7 +107,7 @@ export function leinShadowBuilds(defproject: any): string[] {
                     ...['node-repl', 'browser-repl'],
                 ];
             } catch (error) {
-                vscode.window.showErrorMessage(
+                void vscode.window.showErrorMessage(
                     'The project.clj file is not sane. ' + error.message
                 );
                 console.log(error);
@@ -152,7 +152,7 @@ async function leinDefProject(): Promise<any> {
         const parsed = parseForms(data);
         return parsed.find((x) => x[0] == 'defproject');
     } catch (e) {
-        vscode.window.showErrorMessage('Could not parse project.clj');
+        void vscode.window.showErrorMessage('Could not parse project.clj');
         throw e;
     }
 }
@@ -193,7 +193,7 @@ async function leinProfilesAndAlias(
                     }
                 }
             } catch (error) {
-                vscode.window.showErrorMessage(
+                void vscode.window.showErrorMessage(
                     'The project.clj file is not sane. ' + error.message
                 );
                 console.log(error);
@@ -524,7 +524,7 @@ async function cljCommandLine(
     }
     let parsed;
     if (connectSequence.projectType !== 'generic') {
-        vscode.workspace.fs.stat(depsUri);
+        void vscode.workspace.fs.stat(depsUri);
         const bytes = await vscode.workspace.fs.readFile(
             vscode.Uri.joinPath(state.getProjectRootUri(), 'deps.edn')
         );
@@ -532,7 +532,7 @@ async function cljCommandLine(
         try {
             parsed = parseEdn(data);
         } catch (e) {
-            vscode.window.showErrorMessage('Could not parse deps.edn');
+            void vscode.window.showErrorMessage('Could not parse deps.edn');
             throw e;
         }
     }
@@ -562,7 +562,7 @@ async function cljCommandLine(
         if (aliasesWithMain.length > 0) {
             const alertKey = 'calva.jackInMainOptsWarningEnabled';
             if (state.extensionContext.workspaceState.get(alertKey, true)) {
-                vscode.window
+                void vscode.window
                     .showInformationMessage(
                         `The aliases [${aliasesWithMain.join(
                             ' '
@@ -572,7 +572,7 @@ async function cljCommandLine(
                     )
                     .then((answer) => {
                         if (answer === "OK, Don't show again") {
-                            state.extensionContext.workspaceState.update(
+                            void state.extensionContext.workspaceState.update(
                                 alertKey,
                                 false
                             );

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -182,7 +182,7 @@ export async function startStandaloneRepl(
             docNames
         ).catch((err) => {
             console.error(`Error downloading drams: ${err.message}`);
-            vscode.window.showWarningMessage(
+            void vscode.window.showWarningMessage(
                 `Error downloading files: ${err.message}`
             );
         });
@@ -286,9 +286,9 @@ export function startOrConnectRepl() {
         Object.keys(commands),
         PREFERRED_ORDER
     );
-    vscode.window.showQuickPick(sortedCommands).then((v) => {
+    void vscode.window.showQuickPick(sortedCommands).then((v) => {
         if (commands[v]) {
-            vscode.commands.executeCommand(commands[v]);
+            void vscode.commands.executeCommand(commands[v]);
         }
     });
 }

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -26,7 +26,7 @@ const enabled = true;
  */
 function copyRangeToClipboard(doc: EditableDocument, [start, end]) {
     const text = doc.model.getText(start, end);
-    vscode.env.clipboard.writeText(text);
+    void vscode.env.clipboard.writeText(text);
 }
 
 /**
@@ -270,7 +270,7 @@ const pareditCommands: PareditCommand[] = [
             if (shouldKillAlsoCutToClipboard()) {
                 copyRangeToClipboard(doc, range);
             }
-            paredit.killForwardList(doc, range).then((isFulfilled) => {
+            void paredit.killForwardList(doc, range).then((isFulfilled) => {
                 return paredit.spliceSexp(doc, doc.selectionRight, false);
             });
         },
@@ -282,7 +282,7 @@ const pareditCommands: PareditCommand[] = [
             if (shouldKillAlsoCutToClipboard()) {
                 copyRangeToClipboard(doc, range);
             }
-            paredit.killBackwardList(doc, range).then((isFulfilled) => {
+            void paredit.killBackwardList(doc, range).then((isFulfilled) => {
                 return paredit.spliceSexp(doc, doc.selectionRight, false);
             });
         },
@@ -290,49 +290,49 @@ const pareditCommands: PareditCommand[] = [
     {
         command: 'paredit.wrapAroundParens',
         handler: (doc: EditableDocument) => {
-            paredit.wrapSexpr(doc, '(', ')');
+            void paredit.wrapSexpr(doc, '(', ')');
         },
     },
     {
         command: 'paredit.wrapAroundSquare',
         handler: (doc: EditableDocument) => {
-            paredit.wrapSexpr(doc, '[', ']');
+            void paredit.wrapSexpr(doc, '[', ']');
         },
     },
     {
         command: 'paredit.wrapAroundCurly',
         handler: (doc: EditableDocument) => {
-            paredit.wrapSexpr(doc, '{', '}');
+            void paredit.wrapSexpr(doc, '{', '}');
         },
     },
     {
         command: 'paredit.wrapAroundQuote',
         handler: (doc: EditableDocument) => {
-            paredit.wrapSexpr(doc, '"', '"');
+            void paredit.wrapSexpr(doc, '"', '"');
         },
     },
     {
         command: 'paredit.rewrapParens',
         handler: (doc: EditableDocument) => {
-            paredit.rewrapSexpr(doc, '(', ')');
+            void paredit.rewrapSexpr(doc, '(', ')');
         },
     },
     {
         command: 'paredit.rewrapSquare',
         handler: (doc: EditableDocument) => {
-            paredit.rewrapSexpr(doc, '[', ']');
+            void paredit.rewrapSexpr(doc, '[', ']');
         },
     },
     {
         command: 'paredit.rewrapCurly',
         handler: (doc: EditableDocument) => {
-            paredit.rewrapSexpr(doc, '{', '}');
+            void paredit.rewrapSexpr(doc, '{', '}');
         },
     },
     {
         command: 'paredit.rewrapQuote',
         handler: (doc: EditableDocument) => {
-            paredit.rewrapSexpr(doc, '"', '"');
+            void paredit.rewrapSexpr(doc, '"', '"');
         },
     },
     {
@@ -346,13 +346,13 @@ const pareditCommands: PareditCommand[] = [
     {
         command: 'paredit.forceDeleteForward',
         handler: () => {
-            vscode.commands.executeCommand('deleteRight');
+            void vscode.commands.executeCommand('deleteRight');
         },
     },
     {
         command: 'paredit.forceDeleteBackward',
         handler: () => {
-            vscode.commands.executeCommand('deleteLeft');
+            void vscode.commands.executeCommand('deleteLeft');
         },
     },
     {
@@ -389,7 +389,7 @@ function setKeyMapConf() {
     const keyMap = workspace
         .getConfiguration()
         .get('calva.paredit.defaultKeyMap');
-    commands.executeCommand('setContext', 'paredit:keyMap', keyMap);
+    void commands.executeCommand('setContext', 'paredit:keyMap', keyMap);
     onPareditKeyMapChangedEmitter.fire(String(keyMap));
 }
 setKeyMapConf();
@@ -405,7 +405,7 @@ export function activate(context: ExtensionContext) {
                 .get('calva.paredit.defaultKeyMap');
             keyMap = String(keyMap).trim().toLowerCase();
             if (keyMap == 'original') {
-                workspace
+                void workspace
                     .getConfiguration()
                     .update(
                         'calva.paredit.defaultKeyMap',
@@ -413,7 +413,7 @@ export function activate(context: ExtensionContext) {
                         vscode.ConfigurationTarget.Global
                     );
             } else if (keyMap == 'strict') {
-                workspace
+                void workspace
                     .getConfiguration()
                     .update(
                         'calva.paredit.defaultKeyMap',

--- a/src/providers/annotations.ts
+++ b/src/providers/annotations.ts
@@ -217,7 +217,7 @@ function onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent) {
 }
 
 function copyHoverTextCommand(args: { [x: string]: string }) {
-    vscode.env.clipboard.writeText(args['text']);
+    void vscode.env.clipboard.writeText(args['text']);
 }
 export default {
     AnnotationStatus,

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -27,11 +27,11 @@ function refresh(document = {}) {
 
     if (client != undefined) {
         chan.appendLine('Reloading...');
-        client.refresh().then((res) => {
+        void client.refresh().then((res) => {
             report(res, chan);
         });
     } else {
-        vscode.window.showErrorMessage('Not connected to a REPL.');
+        void vscode.window.showErrorMessage('Not connected to a REPL.');
     }
 }
 
@@ -42,11 +42,11 @@ function refreshAll(document = {}) {
 
     if (client != undefined) {
         chan.appendLine('Reloading all the things...');
-        client.refreshAll().then((res) => {
+        void client.refreshAll().then((res) => {
             report(res, chan);
         });
     } else {
-        vscode.window.showErrorMessage('Not connected to a REPL.');
+        void vscode.window.showErrorMessage('Not connected to a REPL.');
     }
 }
 

--- a/src/results-output/repl-history.ts
+++ b/src/results-output/repl-history.ts
@@ -21,7 +21,7 @@ function setReplHistoryCommandsActiveContext(editor: vscode.TextEditor): void {
             getIndexAfterLastNonWhitespace(document.getText())
         );
         if (selection.start.isAfterOrEqual(positionAtEndOfContent)) {
-            vscode.commands.executeCommand(
+            void vscode.commands.executeCommand(
                 'setContext',
                 replHistoryCommandsActiveContext,
                 true
@@ -29,7 +29,7 @@ function setReplHistoryCommandsActiveContext(editor: vscode.TextEditor): void {
             return;
         }
     }
-    vscode.commands.executeCommand(
+    void vscode.commands.executeCommand(
         'setContext',
         replHistoryCommandsActiveContext,
         false
@@ -59,7 +59,7 @@ function updateReplHistory(
 ) {
     const newHistory = [...history];
     newHistory[index] = content.trim();
-    state.extensionContext.workspaceState.update(
+    void state.extensionContext.workspaceState.update(
         getHistoryKey(replSessionType),
         newHistory
     );
@@ -67,7 +67,7 @@ function updateReplHistory(
 
 function addToReplHistory(replSessionType: ReplSessionType, content: string) {
     const newHistory = addToHistory(getHistory(replSessionType), content);
-    state.extensionContext.workspaceState.update(
+    void state.extensionContext.workspaceState.update(
         getHistoryKey(replSessionType),
         newHistory
     );
@@ -76,7 +76,7 @@ function addToReplHistory(replSessionType: ReplSessionType, content: string) {
 function clearHistory() {
     const replType = getSessionType();
     const key = getHistoryKey(replType);
-    state.extensionContext.workspaceState.update(key, []);
+    void state.extensionContext.workspaceState.update(key, []);
     resetState();
     append('; REPL history cleared');
     append(getPrompt());
@@ -106,8 +106,8 @@ function showReplHistoryEntry(
     const entry = historyEntry || '\n';
     const edit = new vscode.WorkspaceEdit();
     edit.replace(resultsDoc.uri, range, entry);
-    vscode.workspace.applyEdit(edit).then((_) => {
-        resultsDoc.save();
+    void vscode.workspace.applyEdit(edit).then((_) => {
+        void resultsDoc.save();
         util.scrollToBottom(resultsEditor);
     });
 }

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -121,11 +121,11 @@ function setViewColumn(column: vscode.ViewColumn) {
 }
 
 export function setContextForOutputWindowActive(isActive: boolean): void {
-    state.extensionContext.workspaceState.update(
+    void state.extensionContext.workspaceState.update(
         `outputWindowActive`,
         isActive
     );
-    vscode.commands.executeCommand(
+    void vscode.commands.executeCommand(
         'setContext',
         'calva:outputWindowActive',
         isActive
@@ -165,7 +165,7 @@ export async function initResultsDoc(): Promise<vscode.TextDocument> {
     );
     edit.replace(docUri, fullRange, greetings);
     await vscode.workspace.applyEdit(edit);
-    resultsDoc.save();
+    void resultsDoc.save();
 
     // For some reason onDidChangeTextEditorViewColumn won't fire
     state.extensionContext.subscriptions.push(
@@ -174,7 +174,7 @@ export async function initResultsDoc(): Promise<vscode.TextDocument> {
                 const isOutputWindow = isResultsDoc(event.document);
                 setContextForOutputWindowActive(isOutputWindow);
                 if (isOutputWindow) {
-                    setViewColumn(event.viewColumn);
+                    void setViewColumn(event.viewColumn);
                 }
             }
         })
@@ -205,7 +205,7 @@ export async function initResultsDoc(): Promise<vscode.TextDocument> {
                     }
                 }
             }
-            vscode.commands.executeCommand(
+            void vscode.commands.executeCommand(
                 'setContext',
                 'calva:outputWindowSubmitOnEnter',
                 submitOnEnter
@@ -239,14 +239,18 @@ export async function openResultsDoc(): Promise<vscode.TextDocument> {
 }
 
 export function revealResultsDoc(preserveFocus: boolean = true) {
-    openResultsDoc().then((doc) => {
-        vscode.window.showTextDocument(doc, getViewColumn(), preserveFocus);
+    void openResultsDoc().then((doc) => {
+        void vscode.window.showTextDocument(
+            doc,
+            getViewColumn(),
+            preserveFocus
+        );
     });
 }
 
 export async function revealDocForCurrentNS(preserveFocus: boolean = true) {
     const uri = await getUriForCurrentNamespace();
-    vscode.workspace.openTextDocument(uri).then((doc) =>
+    void vscode.workspace.openTextDocument(uri).then((doc) =>
         vscode.window.showTextDocument(doc, {
             preserveFocus,
         })
@@ -290,11 +294,11 @@ async function appendFormGrabbingSessionAndNS(topLevel: boolean) {
 }
 
 export function appendCurrentForm() {
-    appendFormGrabbingSessionAndNS(false);
+    void appendFormGrabbingSessionAndNS(false);
 }
 
 export function appendCurrentTopLevelForm() {
-    appendFormGrabbingSessionAndNS(true);
+    void appendFormGrabbingSessionAndNS(true);
 }
 
 let scrollToBottomSub: vscode.Disposable;
@@ -315,7 +319,7 @@ export function append(text: string, onAppended?: OnAppendedCallback): void {
         editQueue.push([text, onAppended]);
     } else {
         applyingEdit = true;
-        vscode.workspace.openTextDocument(DOC_URI()).then((doc) => {
+        void vscode.workspace.openTextDocument(DOC_URI()).then((doc) => {
             const ansiStrippedText = util.stripAnsi(text);
             if (doc) {
                 const edit = new vscode.WorkspaceEdit();
@@ -349,9 +353,9 @@ export function append(text: string, onAppended?: OnAppendedCallback): void {
                     );
                 }
 
-                vscode.workspace.applyEdit(edit).then((success) => {
+                void vscode.workspace.applyEdit(edit).then((success) => {
                     applyingEdit = false;
-                    doc.save();
+                    void doc.save();
                     if (success) {
                         if (visibleResultsEditors.length > 0) {
                             visibleResultsEditors.forEach((editor) => {

--- a/src/state.ts
+++ b/src/state.ts
@@ -10,7 +10,7 @@ let extensionContext: vscode.ExtensionContext;
 export function setExtensionContext(context: vscode.ExtensionContext) {
     extensionContext = context;
     if (context.workspaceState.get('selectedCljTypeName') == undefined) {
-        context.workspaceState.update('selectedCljTypeName', 'unknown');
+        void context.workspaceState.update('selectedCljTypeName', 'unknown');
     }
 }
 

--- a/src/status.ts
+++ b/src/status.ts
@@ -5,7 +5,7 @@ import { getConfig } from './config';
 import { updateReplSessionType } from './nrepl/repl-session';
 
 function updateNeedReplUi(isNeeded: boolean, context = state.extensionContext) {
-    context.workspaceState.update('needReplUi', isNeeded);
+    void context.workspaceState.update('needReplUi', isNeeded);
     update(context);
 }
 
@@ -14,7 +14,7 @@ function shouldshowReplUi(context = state.extensionContext): boolean {
 }
 
 function update(context = state.extensionContext) {
-    vscode.commands.executeCommand(
+    void vscode.commands.executeCommand(
         'setContext',
         'calva:showReplUi',
         shouldshowReplUi(context)

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -228,7 +228,7 @@ function reportTests(
     };
 
     if (useTestExplorer()) {
-        onTestResults(controller, session, results);
+        void onTestResults(controller, session, results);
     }
 
     for (const result of results) {
@@ -256,7 +256,7 @@ function reportTests(
 
     if (!useTestExplorer()) {
         for (const fileName in diagnostics) {
-            uriForFile(fileName).then((uri) => {
+            void uriForFile(fileName).then((uri) => {
                 diagnosticCollection.set(uri, diagnostics[fileName]);
             });
         }
@@ -278,13 +278,13 @@ async function runAllTests(controller: vscode.TestController, document = {}) {
 
 function runAllTestsCommand(controller: vscode.TestController) {
     if (!util.getConnectedState()) {
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             'You must connect to a REPL server to run this command.'
         );
         return;
     }
     runAllTests(controller).catch((msg) => {
-        vscode.window.showWarningMessage(msg);
+        void vscode.window.showWarningMessage(msg);
     });
 }
 
@@ -313,14 +313,14 @@ async function runNamespaceTestsImpl(
     nss: string[]
 ) {
     if (!util.getConnectedState()) {
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             'You must connect to a REPL server to run this command.'
         );
         return;
     }
 
     if (nss.length === 0) {
-        vscode.window.showInformationMessage('No namespace selected.');
+        void vscode.window.showInformationMessage('No namespace selected.');
         return;
     }
 
@@ -355,7 +355,7 @@ async function runNamespaceTests(
     const session = getSession(util.getFileType(document));
     const ns = namespace.getNamespace(doc);
     const nss = await considerTestNS(ns, session);
-    runNamespaceTestsImpl(controller, document, nss);
+    void runNamespaceTestsImpl(controller, document, nss);
 }
 
 function getTestUnderCursor() {
@@ -387,19 +387,19 @@ async function runTestUnderCursor(controller: vscode.TestController) {
 
 function runTestUnderCursorCommand(controller: vscode.TestController) {
     if (!util.getConnectedState()) {
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             'You must connect to a REPL server to run this command.'
         );
         return;
     }
     runTestUnderCursor(controller).catch((msg) => {
-        vscode.window.showWarningMessage(msg);
+        void vscode.window.showWarningMessage(msg);
     });
 }
 
 function runNamespaceTestsCommand(controller: vscode.TestController) {
     if (!util.getConnectedState()) {
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             'You must connect to a REPL server to run this command.'
         );
         return;
@@ -408,7 +408,7 @@ function runNamespaceTestsCommand(controller: vscode.TestController) {
         controller,
         vscode.window.activeTextEditor.document
     ).catch((msg) => {
-        vscode.window.showWarningMessage(msg);
+        void vscode.window.showWarningMessage(msg);
     });
 }
 
@@ -428,13 +428,13 @@ async function rerunTests(controller: vscode.TestController, document = {}) {
 
 function rerunTestsCommand(controller: vscode.TestController) {
     if (!util.getConnectedState()) {
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             'You must connect to a REPL server to run this command.'
         );
         return;
     }
     rerunTests(controller).catch((msg) => {
-        vscode.window.showWarningMessage(msg);
+        void vscode.window.showWarningMessage(msg);
     });
 }
 
@@ -445,21 +445,21 @@ function initialize(controller: vscode.TestController): void {
 
         (request: vscode.TestRunRequest, token: vscode.CancellationToken) => {
             if (!util.getConnectedState()) {
-                vscode.window.showInformationMessage(
+                void vscode.window.showInformationMessage(
                     'You must connect to a REPL server to run tests.'
                 );
                 return;
             }
 
             if (request.exclude && request.exclude.length > 0) {
-                vscode.window.showWarningMessage(
+                void vscode.window.showWarningMessage(
                     'Excluding tests from a test run is not currently supported - running all tests.'
                 );
             }
 
             if (!request.include) {
                 runAllTests(controller).catch((msg) => {
-                    vscode.window.showWarningMessage(msg);
+                    void vscode.window.showWarningMessage(msg);
                 });
                 return;
             }
@@ -476,7 +476,7 @@ function initialize(controller: vscode.TestController): void {
             const namespaces = util.distinct(runItems.map((ri) => ri[0]));
             const doc = vscode.window.activeTextEditor.document;
             runNamespaceTestsImpl(controller, doc, namespaces).catch((msg) => {
-                vscode.window.showWarningMessage(msg);
+                void vscode.window.showWarningMessage(msg);
             });
         },
         true
@@ -522,7 +522,7 @@ function onTestTree(
             );
         });
     } catch (e) {
-        vscode.window.showErrorMessage('Error in test tree parsing', e);
+        void vscode.window.showErrorMessage('Error in test tree parsing', e);
     }
 }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -53,7 +53,7 @@ async function quickPickSingle(opts: {
             ignoreFocusOut: true,
         });
     }
-    state.extensionContext.workspaceState.update(saveAs, result);
+    void state.extensionContext.workspaceState.update(saveAs, result);
     return result;
 }
 
@@ -72,7 +72,7 @@ async function quickPickMulti(opts: {
         canPickMany: true,
         ignoreFocusOut: true,
     });
-    state.extensionContext.workspaceState.update(saveAs, result);
+    void state.extensionContext.workspaceState.update(saveAs, result);
     return result;
 }
 
@@ -210,7 +210,7 @@ function getLaunchingState() {
 }
 
 function setLaunchingState(value: any) {
-    vscode.commands.executeCommand(
+    void vscode.commands.executeCommand(
         'setContext',
         'calva:launching',
         Boolean(value)
@@ -223,7 +223,7 @@ function getConnectedState() {
 }
 
 function setConnectedState(value: boolean) {
-    vscode.commands.executeCommand('setContext', 'calva:connected', value);
+    void vscode.commands.executeCommand('setContext', 'calva:connected', value);
     cljsLib.setStateValue('connected', value);
 }
 
@@ -233,10 +233,18 @@ function getConnectingState() {
 
 function setConnectingState(value: boolean) {
     if (value) {
-        vscode.commands.executeCommand('setContext', 'calva:connecting', true);
+        void vscode.commands.executeCommand(
+            'setContext',
+            'calva:connecting',
+            true
+        );
         cljsLib.setStateValue('connecting', true);
     } else {
-        vscode.commands.executeCommand('setContext', 'calva:connecting', false);
+        void vscode.commands.executeCommand(
+            'setContext',
+            'calva:connecting',
+            false
+        );
         cljsLib.setStateValue('connecting', false);
     }
 }

--- a/src/when-contexts.ts
+++ b/src/when-contexts.ts
@@ -34,7 +34,7 @@ function determineCursorContexts(
 function setCursorContexts(currentContexts: context.CursorContext[]) {
     lastContexts = currentContexts;
     context.allCursorContexts.forEach((context) => {
-        vscode.commands.executeCommand(
+        void vscode.commands.executeCommand(
             'setContext',
             context,
             currentContexts.indexOf(context) > -1


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?

I turned on an ESLint rule to enforce the await or then+catch of all promises, or if not doing those then at least sticking void in front of them to signal that you're not awaiting/fully handling them on purpose.

This change does not affect how things run at all since adding void is just documentation stating to other developers "I am intentionally not handling this promise fully". Whether to change any of these to be awaited or then+catch was not evaluated for this PR and is outside of the scope of it.

@PEZ requested this change here: https://github.com/BetterThanTomorrow/calva/pull/1562#issuecomment-1050582743

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [~] Tests
     - [~] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [~] Smoke tested the extension as such.
     - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [~] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [~] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [~] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [~] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
