### PR TITLE
Include metadata in current form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ Changes to Calva.
 
 ## [Unreleased]
 - [Enable the @typescript-eslint/no-floating-promises eslint rule](https://github.com/BetterThanTomorrow/calva/pull/1564)
+- [Include metadata in current form selection/evaluation/etcetera](https://github.com/BetterThanTomorrow/calva/pull/1551)
 
 ## [2.0.246] - 2022-02-24
+
 -   Fix: [Format config from clojure-lsp broken](https://github.com/BetterThanTomorrow/calva/issues/1561)
 -   Fix2: [Format on save](https://github.com/BetterThanTomorrow/calva/issues/1556)
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -145,7 +145,7 @@ export function forwardSexpRange(
 ): [number, number] {
     const cursor = doc.getTokenCursor(offset);
     cursor.forwardWhitespace();
-    if (cursor.forwardSexp()) {
+    if (cursor.forwardSexp(true, true)) {
         if (goPastWhitespace) {
             cursor.forwardWhitespace();
         }
@@ -167,7 +167,7 @@ export function backwardSexpRange(
         cursor.forwardSexp();
     }
     cursor.backwardWhitespace();
-    if (cursor.backwardSexp()) {
+    if (cursor.backwardSexp(true, true)) {
         if (goPastWhitespace) {
             cursor.backwardWhitespace();
         }
@@ -307,7 +307,7 @@ export function rangeToBackwardUpList(
 ): [number, number] {
     const cursor = doc.getTokenCursor(offset);
     cursor.backwardList();
-    if (cursor.backwardUpList()) {
+    if (cursor.backwardUpList(true)) {
         if (goPastWhitespace) {
             cursor.backwardWhitespace();
         }
@@ -326,11 +326,14 @@ export function rangeToForwardDownList(
     do {
         cursor.forwardThroughAnyReader();
         cursor.forwardWhitespace();
-        if (cursor.getToken().type === 'open') {
+        if (
+            cursor.getToken().type === 'open' &&
+            !cursor.tokenBeginsMetadata()
+        ) {
             break;
         }
     } while (cursor.forwardSexp());
-    if (cursor.downList()) {
+    if (cursor.downList(true)) {
         if (goPastWhitespace) {
             cursor.forwardWhitespace();
         }

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -656,7 +656,7 @@ export class LispTokenCursor extends TokenCursor {
      */
     rangeForCurrentForm(offset: number): [number, number] {
         let afterCurrentFormOffset: number;
-        console.log(-1, offset);
+        // console.log(-1, offset);
 
         // 0. If `offset` is within or before, a symbol, literal or keyword
         if (
@@ -665,7 +665,7 @@ export class LispTokenCursor extends TokenCursor {
         ) {
             afterCurrentFormOffset = this.offsetEnd;
         }
-        console.log(0, afterCurrentFormOffset);
+        // console.log(0, afterCurrentFormOffset);
 
         // 1. Else, if `offset` is adjacent after form
         if (afterCurrentFormOffset === undefined) {
@@ -683,7 +683,7 @@ export class LispTokenCursor extends TokenCursor {
                 }
             }
         }
-        console.log(1, afterCurrentFormOffset);
+        // console.log(1, afterCurrentFormOffset);
 
         // 2. Else, if `offset` is adjacent before a form
         if (afterCurrentFormOffset === undefined) {
@@ -695,7 +695,7 @@ export class LispTokenCursor extends TokenCursor {
                 pTk.type === 'reader' ||
                 this.prevTokenBeginsMetadata() ||
                 tk.type === 'open';
-            console.log(2.1, afterCurrentFormOffset);
+            // console.log(2.1, afterCurrentFormOffset);
             if (!isAdjacentBefore) {
                 const cursor = this.clone();
                 cursor.backwardWhitespace();
@@ -703,7 +703,7 @@ export class LispTokenCursor extends TokenCursor {
                     cursor.prevTokenBeginsMetadata() ||
                     cursor.getPrevToken().type === 'reader';
             }
-            console.log(2.2, afterCurrentFormOffset);
+            // console.log(2.2, afterCurrentFormOffset);
             if (!isAdjacentBefore) {
                 const cursor = this.clone();
                 cursor.forwardWhitespace();
@@ -711,7 +711,7 @@ export class LispTokenCursor extends TokenCursor {
                     cursor.tokenBeginsMetadata() ||
                     cursor.getToken().type === 'reader';
             }
-            console.log(2.3, afterCurrentFormOffset);
+            // console.log(2.3, afterCurrentFormOffset);
             if (isAdjacentBefore) {
                 const cursor = this.clone();
                 cursor.forwardWhitespace();
@@ -720,7 +720,7 @@ export class LispTokenCursor extends TokenCursor {
                 }
             }
         }
-        console.log(2, afterCurrentFormOffset);
+        // console.log(2, afterCurrentFormOffset);
 
         // 3. Else, if the previous form is on the same line
         if (afterCurrentFormOffset === undefined) {
@@ -733,7 +733,7 @@ export class LispTokenCursor extends TokenCursor {
                 }
             }
         }
-        console.log(3, afterCurrentFormOffset);
+        // console.log(3, afterCurrentFormOffset);
 
         // 4. Else, if the next form is on the same line
         if (afterCurrentFormOffset === undefined) {
@@ -745,7 +745,7 @@ export class LispTokenCursor extends TokenCursor {
                 }
             }
         }
-        console.log(4, afterCurrentFormOffset);
+        // console.log(4, afterCurrentFormOffset);
 
         // 5. Else, the previous form, if any
         if (afterCurrentFormOffset === undefined) {
@@ -756,7 +756,7 @@ export class LispTokenCursor extends TokenCursor {
                 afterCurrentFormOffset = afterOffset;
             }
         }
-        console.log(5, afterCurrentFormOffset);
+        // console.log(5, afterCurrentFormOffset);
 
         // 6. Else, the next form, if any
         if (afterCurrentFormOffset === undefined) {
@@ -766,7 +766,7 @@ export class LispTokenCursor extends TokenCursor {
                 afterCurrentFormOffset = cursor.offsetStart;
             }
         }
-        console.log(6, afterCurrentFormOffset);
+        // console.log(6, afterCurrentFormOffset);
 
         // 7. Else, the current enclosing form, if any
         if (afterCurrentFormOffset === undefined) {
@@ -777,7 +777,7 @@ export class LispTokenCursor extends TokenCursor {
                 }
             }
         }
-        console.log(7, afterCurrentFormOffset);
+        // console.log(7, afterCurrentFormOffset);
 
         // 8. Else, ¯\_(ツ)_/¯
         if (afterCurrentFormOffset === undefined) {

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -261,8 +261,7 @@ export class LispTokenCursor extends TokenCursor {
     forwardSexp(
         skipComments = true,
         skipMetadata = false,
-        skipIgnoredForms = false,
-        skipReaders = true
+        skipIgnoredForms = false
     ): boolean {
         // TODO: Consider using a proper bracket stack
         const stack = [];
@@ -300,14 +299,8 @@ export class LispTokenCursor extends TokenCursor {
                 case 'kw':
                 case 'junk':
                 case 'str-inside':
-                    //if (skipReaders) {
-                    //    this.forwardThroughAnyReader();
-                    //}
                     if (skipMetadata && this.getToken().raw.startsWith('^')) {
                         this.next();
-                        //if (skipReaders) {
-                        //    this.forwardThroughAnyReader();
-                        //}
                     } else {
                         this.next();
                         if (stack.length <= 0) {
@@ -324,15 +317,9 @@ export class LispTokenCursor extends TokenCursor {
                             break;
                         }
                     }
-                    //if (skipReaders) {
-                    //    this.forwardThroughAnyReader();
-                    //}
                     if (skipMetadata && isMetadata) {
                         this.forwardSexp(skipComments, skipMetadata);
                     }
-                    //if (skipReaders) {
-                    //    this.forwardThroughAnyReader();
-                    //}
                     if (stack.length <= 0) {
                         return true;
                     }

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -658,9 +658,7 @@ export class LispTokenCursor extends TokenCursor {
         // console.log(-1, offset);
 
         // 0. If `offset` is within or before, a symbol, literal or keyword
-        if (
-            ['id', 'kw', 'lit', 'str-inside'].includes(this.getToken().type)
-        ) {
+        if (['id', 'kw', 'lit', 'str-inside'].includes(this.getToken().type)) {
             afterCurrentFormOffset = this.offsetEnd;
         }
         // console.log(0, afterCurrentFormOffset);

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -613,13 +613,14 @@ export class LispTokenCursor extends TokenCursor {
      * If possible, moves this cursor backwards past any whitespace, and then backwards past the immediately following open-paren and returns true.
      * If the source does not match this, returns false and does not move the cursor.
      */
-    backwardUpList(): boolean {
+    backwardUpList(skipMetadata = false): boolean {
         const cursor = this.clone();
         cursor.backwardThroughAnyReader();
         cursor.backwardWhitespace();
         if (cursor.getPrevToken().type == 'open') {
             cursor.previous();
-            cursor.backwardThroughAnyReader();
+            cursor.forwardSexp(true, skipMetadata);
+            cursor.backwardSexp(true, skipMetadata);
             this.set(cursor);
             return true;
         }

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -181,9 +181,12 @@ export class LispTokenCursor extends TokenCursor {
     }
 
     tokenBeginsMetadata(): boolean {
-        return this.getToken().raw.endsWith('^{');
+        return this.getToken().raw.startsWith('^');
     }
 
+    prevTokenBeginsMetadata(): boolean {
+        return this.getPrevToken().raw.startsWith('^');
+    }
     /**
      * Moves this token past any whitespace or comment.
      */
@@ -258,7 +261,8 @@ export class LispTokenCursor extends TokenCursor {
     forwardSexp(
         skipComments = true,
         skipMetadata = false,
-        skipIgnoredForms = false
+        skipIgnoredForms = false,
+        skipReaders = true
     ): boolean {
         // TODO: Consider using a proper bracket stack
         const stack = [];
@@ -267,9 +271,7 @@ export class LispTokenCursor extends TokenCursor {
         if (this.getToken().type === 'close') {
             return false;
         }
-        if (this.tokenBeginsMetadata()) {
-            isMetadata = true;
-        }
+        isMetadata = this.tokenBeginsMetadata();
         while (!this.atEnd()) {
             this.forwardWhitespace(skipComments);
             const token = this.getToken();
@@ -298,8 +300,14 @@ export class LispTokenCursor extends TokenCursor {
                 case 'kw':
                 case 'junk':
                 case 'str-inside':
+                    //if (skipReaders) {
+                    //    this.forwardThroughAnyReader();
+                    //}
                     if (skipMetadata && this.getToken().raw.startsWith('^')) {
                         this.next();
+                        //if (skipReaders) {
+                        //    this.forwardThroughAnyReader();
+                        //}
                     } else {
                         this.next();
                         if (stack.length <= 0) {
@@ -316,9 +324,15 @@ export class LispTokenCursor extends TokenCursor {
                             break;
                         }
                     }
+                    //if (skipReaders) {
+                    //    this.forwardThroughAnyReader();
+                    //}
                     if (skipMetadata && isMetadata) {
                         this.forwardSexp(skipComments, skipMetadata);
                     }
+                    //if (skipReaders) {
+                    //    this.forwardThroughAnyReader();
+                    //}
                     if (stack.length <= 0) {
                         return true;
                     }
@@ -344,7 +358,12 @@ export class LispTokenCursor extends TokenCursor {
      *
      * @returns true if the cursor was moved, false otherwise.
      */
-    backwardSexp(skipComments = true) {
+    backwardSexp(
+        skipComments = true,
+        skipMetadata = false,
+        skipIgnoredForms = false,
+        skipReaders = true
+    ) {
         const stack = [];
         this.backwardWhitespace(skipComments);
         if (this.getPrevToken().type === 'open') {
@@ -361,13 +380,30 @@ export class LispTokenCursor extends TokenCursor {
                 case 'junk':
                 case 'comment':
                 case 'prompt':
-                case 'str-inside':
+                case 'str-inside': {
                     this.previous();
-                    this.backwardThroughAnyReader();
+                    if (skipReaders) {
+                        this.backwardThroughAnyReader();
+                    }
+                    if (skipMetadata) {
+                        const metaCursor = this.clone();
+                        metaCursor.backwardSexp(true, false, false, false);
+                        if (metaCursor.tokenBeginsMetadata()) {
+                            this.backwardSexp(
+                                skipComments,
+                                skipMetadata,
+                                skipIgnoredForms
+                            );
+                        }
+                    }
+                    if (skipReaders) {
+                        this.backwardThroughAnyReader();
+                    }
                     if (stack.length <= 0) {
                         return true;
                     }
                     break;
+                }
                 case 'close':
                     stack.push(tk.raw);
                     this.previous();
@@ -381,7 +417,23 @@ export class LispTokenCursor extends TokenCursor {
                         }
                     }
                     this.previous();
-                    this.backwardThroughAnyReader();
+                    if (skipReaders) {
+                        this.backwardThroughAnyReader();
+                    }
+                    if (skipMetadata) {
+                        const metaCursor = this.clone();
+                        metaCursor.backwardSexp(true, false, false, false);
+                        if (metaCursor.tokenBeginsMetadata()) {
+                            this.backwardSexp(
+                                skipComments,
+                                skipMetadata,
+                                skipIgnoredForms
+                            );
+                        }
+                    }
+                    if (skipReaders) {
+                        this.backwardThroughAnyReader();
+                    }
                     if (stack.length <= 0) {
                         return true;
                     }
@@ -400,15 +452,18 @@ export class LispTokenCursor extends TokenCursor {
      */
     backwardThroughAnyReader() {
         const cursor = this.clone();
+        let hasReader = false;
         while (true) {
             cursor.backwardWhitespace();
             if (cursor.getPrevToken().type === 'reader') {
                 cursor.previous();
                 this.set(cursor);
+                hasReader = true;
             } else {
                 break;
             }
         }
+        return hasReader;
     }
 
     /**
@@ -417,15 +472,18 @@ export class LispTokenCursor extends TokenCursor {
      */
     forwardThroughAnyReader() {
         const cursor = this.clone();
+        let hasReader = false;
         while (true) {
             cursor.forwardWhitespace();
             if (cursor.getToken().type === 'reader') {
                 cursor.next();
                 this.set(cursor);
+                hasReader = true;
             } else {
                 break;
             }
         }
+        return hasReader;
     }
 
     /**
@@ -609,79 +667,132 @@ export class LispTokenCursor extends TokenCursor {
      * @param offset the current cursor (caret) offset in the document
      */
     rangeForCurrentForm(offset: number): [number, number] {
+        let afterCurrentFormOffset: number;
+        // console.log(-1, offset);
+
+        // 0. If `offset` is within or before, a symbol, literal or keyword
         if (
-            ['id', 'kw', 'lit', 'str-inside'].includes(this.getToken().type) &&
-            offset !== this.offsetStart
+            ['id', 'kw', 'lit', 'str-inside'].includes(this.getToken().type)
         ) {
-            // 0
+            afterCurrentFormOffset = this.offsetEnd;
+        }
+        // console.log(0, afterCurrentFormOffset);
+
+        // 1. Else, if `offset` is adjacent after form
+        if (afterCurrentFormOffset === undefined) {
             const cursor = this.clone();
-            cursor.backwardThroughAnyReader();
-            return [cursor.offsetStart, this.offsetEnd];
-        }
-        const afterCursor = this.clone();
-        afterCursor.backwardWhitespace(true);
-        if (
-            afterCursor.offsetStart == offset &&
-            afterCursor.getPrevToken().type !== 'reader'
-        ) {
-            if (afterCursor.backwardSexp()) {
-                // 1.
-                return [afterCursor.offsetStart, offset];
-            }
-        }
-        const beforeCursor = this.clone();
-        beforeCursor.forwardThroughAnyReader();
-        beforeCursor.forwardWhitespace(true);
-        const readerCursor = beforeCursor.clone();
-        readerCursor.backwardThroughAnyReader();
-        if (
-            (offset >= beforeCursor.offsetStart &&
-                offset <= beforeCursor.offsetEnd) ||
-            readerCursor.offsetStart !== beforeCursor.offsetStart
-        ) {
-            if (beforeCursor.forwardSexp()) {
-                // 2.
-                return [readerCursor.offsetStart, beforeCursor.offsetStart];
-            }
-        }
-        if (afterCursor.rowCol[0] === this.rowCol[0]) {
-            const peekBehindBackwards = afterCursor.clone();
-            if (peekBehindBackwards.backwardSexp()) {
-                // 3.
-                return [
-                    peekBehindBackwards.offsetStart,
-                    afterCursor.offsetStart,
-                ];
-            }
-        }
-        if (beforeCursor.rowCol[0] === this.rowCol[0]) {
-            const peekPastForwards = beforeCursor.clone();
-            if (peekPastForwards.forwardSexp()) {
-                // 4.
-                return [beforeCursor.offsetStart, peekPastForwards.offsetStart];
-            }
-        }
-        const peekBehindBackwards = afterCursor.clone();
-        if (peekBehindBackwards.backwardSexp()) {
-            // 5.
-            return [peekBehindBackwards.offsetStart, afterCursor.offsetStart];
-        } else {
-            const peekPastForwards = beforeCursor.clone();
-            if (peekPastForwards.forwardSexp()) {
-                // 6.
-                return [beforeCursor.offsetStart, peekPastForwards.offsetStart];
-            } else {
-                const peekUp = this.clone();
-                if (peekUp.upList()) {
-                    const peekBehindUp = peekUp.clone();
-                    if (peekBehindUp.backwardSexp()) {
-                        // 7.
-                        return [peekBehindUp.offsetStart, peekUp.offsetStart];
-                    }
+            cursor.backwardWhitespace(true);
+            if (
+                cursor.offsetStart == offset &&
+                cursor.getPrevToken().type !== 'reader'
+            ) {
+                if (cursor.backwardSexp()) {
+                    afterCurrentFormOffset = offset;
                 }
             }
         }
-        return undefined; // 8.
+        // console.log(1, afterCurrentFormOffset);
+
+        // 2. Else, if `offset` is adjacent before a form
+        if (afterCurrentFormOffset === undefined) {
+            const tk = this.getToken();
+            const pTk = this.getPrevToken();
+            let isAdjacentBefore =
+                tk.type === 'reader' ||
+                this.tokenBeginsMetadata() ||
+                pTk.type === 'reader' ||
+                this.prevTokenBeginsMetadata() ||
+                tk.type === 'open';
+            if (!isAdjacentBefore) {
+                const cursor = this.clone();
+                cursor.backwardWhitespace();
+                isAdjacentBefore =
+                    cursor.prevTokenBeginsMetadata() ||
+                    cursor.getPrevToken().type === 'reader';
+            }
+            if (!isAdjacentBefore) {
+                const cursor = this.clone();
+                cursor.forwardWhitespace();
+                isAdjacentBefore =
+                    cursor.tokenBeginsMetadata() ||
+                    cursor.getToken().type === 'reader';
+            }
+            if (isAdjacentBefore) {
+                const cursor = this.clone();
+                if (cursor.forwardSexp(true, true)) {
+                    afterCurrentFormOffset = cursor.offsetStart;
+                }
+            }
+        }
+        // console.log(2, afterCurrentFormOffset);
+
+        // 3. Else, if the previous form is on the same line
+        if (afterCurrentFormOffset === undefined) {
+            const cursor = this.clone();
+            cursor.backwardWhitespace(true);
+            const afterOffset = cursor.offsetStart;
+            if (cursor.rowCol[0] === this.rowCol[0]) {
+                if (cursor.backwardSexp()) {
+                    afterCurrentFormOffset = afterOffset;
+                }
+            }
+        }
+        // console.log(3, afterCurrentFormOffset);
+
+        // 4. Else, if the next form is on the same line
+        if (afterCurrentFormOffset === undefined) {
+            const cursor = this.clone();
+            cursor.forwardWhitespace(true);
+            if (cursor.rowCol[0] === this.rowCol[0]) {
+                if (cursor.forwardSexp()) {
+                    afterCurrentFormOffset = cursor.offsetStart;
+                }
+            }
+        }
+        // console.log(4, afterCurrentFormOffset);
+
+        // 5. Else, the previous form, if any
+        if (afterCurrentFormOffset === undefined) {
+            const cursor = this.clone();
+            cursor.backwardWhitespace(true);
+            const afterOffset = cursor.offsetStart;
+            if (cursor.backwardSexp()) {
+                afterCurrentFormOffset = afterOffset;
+            }
+        }
+        // console.log(5, afterCurrentFormOffset);
+
+        // 6. Else, the next form, if any
+        if (afterCurrentFormOffset === undefined) {
+            const cursor = this.clone();
+            cursor.forwardWhitespace();
+            if (cursor.forwardSexp()) {
+                afterCurrentFormOffset = cursor.offsetStart;
+            }
+        }
+        // console.log(6, afterCurrentFormOffset);
+
+        // 7. Else, the current enclosing form, if any
+        if (afterCurrentFormOffset === undefined) {
+            const cursor = this.clone();
+            if (cursor.backwardUpList()) {
+                if (cursor.forwardSexp()) {
+                    afterCurrentFormOffset = cursor.offsetStart;
+                }
+            }
+        }
+        // console.log(7, afterCurrentFormOffset);
+
+        // 8. Else, ¯\_(ツ)_/¯
+        if (afterCurrentFormOffset === undefined) {
+            return undefined; // 8.
+        }
+
+        const currentFormCursor = this.doc.getTokenCursor(
+            afterCurrentFormOffset
+        );
+        currentFormCursor.backwardSexp(true, true);
+        return [currentFormCursor.offsetStart, afterCurrentFormOffset];
     }
 
     rangeForDefun(

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -33,6 +33,27 @@ describe('paredit', () => {
                     textAndSelection(b)[1]
                 );
             });
+            it('Finds the list in front through metadata', () => {
+                const a = docFromTextNotation('|^:foo (def foo [vec])');
+                const b = docFromTextNotation('|^:foo (def foo [vec])|');
+                expect(paredit.forwardSexpRange(a)).toEqual(
+                    textAndSelection(b)[1]
+                );
+            });
+            it('Finds the list in front through metadata and readers', () => {
+                const a = docFromTextNotation('|^:f #a #b (def foo [vec])');
+                const b = docFromTextNotation('|^:f #a #b (def foo [vec])|');
+                expect(paredit.forwardSexpRange(a)).toEqual(
+                    textAndSelection(b)[1]
+                );
+            });
+            it('Finds the list in front through reader metadata reader', () => {
+                const a = docFromTextNotation('|#c ^:f #a #b (def foo [vec])');
+                const b = docFromTextNotation('|#c ^:f #a #b (def foo [vec])|');
+                expect(paredit.forwardSexpRange(a)).toEqual(
+                    textAndSelection(b)[1]
+                );
+            });
             it('Finds the symbol in front', () => {
                 const a = docFromTextNotation('(|def foo [vec])');
                 const b = docFromTextNotation('(|def| foo [vec])');
@@ -106,6 +127,34 @@ describe('paredit', () => {
         });
 
         describe('rangeToSexprBackward', () => {
+            it('Finds the list preceding', () => {
+                const a = docFromTextNotation('(def foo [vec])|');
+                const b = docFromTextNotation('|(def foo [vec])|');
+                expect(paredit.backwardSexpRange(a)).toEqual(
+                    textAndSelection(b)[1]
+                );
+            });
+            it('Finds the list preceding through metadata', () => {
+                const a = docFromTextNotation('^:foo (def foo [vec])|');
+                const b = docFromTextNotation('|^:foo (def foo [vec])|');
+                expect(paredit.backwardSexpRange(a)).toEqual(
+                    textAndSelection(b)[1]
+                );
+            });
+            it('Finds the list preceding through metadata and readers', () => {
+                const a = docFromTextNotation('^:f #a #b (def foo [vec])|');
+                const b = docFromTextNotation('|^:f #a #b (def foo [vec])|');
+                expect(paredit.backwardSexpRange(a)).toEqual(
+                    textAndSelection(b)[1]
+                );
+            });
+            it('Finds the list preceding through reader metadata reader', () => {
+                const a = docFromTextNotation('#c ^:f #a #b (def foo [vec])|');
+                const b = docFromTextNotation('|#c ^:f #a #b (def foo [vec])|');
+                expect(paredit.backwardSexpRange(a)).toEqual(
+                    textAndSelection(b)[1]
+                );
+            });
             it('Finds previous form, including space, and reverses direction', () => {
                 // TODO: Should we really be reversing the direction here?
                 const a = docFromTextNotation('(def |<|foo [vec]|<|)');
@@ -400,25 +449,75 @@ describe('paredit', () => {
         });
     });
 
-    describe('Reader tags', () => {
+    describe('Down list', () => {
         it('rangeToForwardDownList', () => {
-            const a = docFromTextNotation(
-                '(a(b(|c•#f•(#b •[:f :b :z])•#z•1)))'
-            );
-            const b = docFromTextNotation(
-                '(a(b(|c•#f•(|#b •[:f :b :z])•#z•1)))'
-            );
+            const a = docFromTextNotation('(|c•(#b •[:f :b :z])•#z•1)');
+            const b = docFromTextNotation('(|c•(|#b •[:f :b :z])•#z•1)');
             expect(paredit.rangeToForwardDownList(a)).toEqual(
                 textAndSelection(b)[1]
             );
         });
+        it('rangeToForwardDownList through readers', () => {
+            const a = docFromTextNotation('(|c•#f•(#b •[:f :b :z])•#z•1)');
+            const b = docFromTextNotation('(|c•#f•(|#b •[:f :b :z])•#z•1)');
+            expect(paredit.rangeToForwardDownList(a)).toEqual(
+                textAndSelection(b)[1]
+            );
+        });
+        it('rangeToForwardDownList through metadata', () => {
+            const a = docFromTextNotation('(|c•^f•(#b •[:f :b]))');
+            const b = docFromTextNotation('(|c•^f•(|#b •[:f :b]))');
+            expect(paredit.rangeToForwardDownList(a)).toEqual(
+                textAndSelection(b)[1]
+            );
+        });
+        it('rangeToForwardDownList through metadata collection', () => {
+            const a = docFromTextNotation('(|c•^{:f 1}•(#b •[:f :b]))');
+            const b = docFromTextNotation('(|c•^{:f 1}•(|#b •[:f :b]))');
+            expect(paredit.rangeToForwardDownList(a)).toEqual(
+                textAndSelection(b)[1]
+            );
+        });
+        it('rangeToForwardDownList through metadata and readers', () => {
+            const a = docFromTextNotation('(|c•^:a #f•(#b •[:f :b]))');
+            const b = docFromTextNotation('(|c•^:a #f•(|#b •[:f :b]))');
+            expect(paredit.rangeToForwardDownList(a)).toEqual(
+                textAndSelection(b)[1]
+            );
+        });
+        it('rangeToForwardDownList through metadata collection and reader', () => {
+            const a = docFromTextNotation('(|c•^{:f 1}•#a •(#b •[:f :b]))');
+            const b = docFromTextNotation('(|c•^{:f 1}•#a •(|#b •[:f :b]))');
+            expect(paredit.rangeToForwardDownList(a)).toEqual(
+                textAndSelection(b)[1]
+            );
+        });
+    });
+    describe('Backward Up list', () => {
         it('rangeToBackwardUpList', () => {
-            const a = docFromTextNotation(
-                '(a(b(c•#f•(|#b •[:f :b :z])•#z•1)))'
+            const a = docFromTextNotation('(c•(|#b •[:f :b :z])•#z•1)');
+            const b = docFromTextNotation('(c•|(|#b •[:f :b :z])•#z•1)');
+            expect(paredit.rangeToBackwardUpList(a)).toEqual(
+                textAndSelection(b)[1]
             );
-            const b = docFromTextNotation(
-                '(a(b(c•|#f•(|#b •[:f :b :z])•#z•1)))'
+        });
+        it('rangeToBackwardUpList through readers', () => {
+            const a = docFromTextNotation('(c•#f•(|#b •[:f :b :z])•#z•1)');
+            const b = docFromTextNotation('(c•|#f•(|#b •[:f :b :z])•#z•1)');
+            expect(paredit.rangeToBackwardUpList(a)).toEqual(
+                textAndSelection(b)[1]
             );
+        });
+        it('rangeToBackwardUpList through metadata', () => {
+            const a = docFromTextNotation('(c•^f•(|#b •[:f :b]))');
+            const b = docFromTextNotation('(c•|^f•(|#b •[:f :b]))');
+            expect(paredit.rangeToBackwardUpList(a)).toEqual(
+                textAndSelection(b)[1]
+            );
+        });
+        it('rangeToBackwardUpList through metadata and readers', () => {
+            const a = docFromTextNotation('(c•^:a #f•(|#b •[:f :b]))');
+            const b = docFromTextNotation('(c•|^:a #f•(|#b •[:f :b]))');
             expect(paredit.rangeToBackwardUpList(a)).toEqual(
                 textAndSelection(b)[1]
             );
@@ -435,6 +534,8 @@ describe('paredit', () => {
                 textAndSelection(b)[1]
             );
         });
+    });
+    describe('Reader tags', () => {
         it('dragSexprBackward', () => {
             const a = docFromTextNotation(
                 '(a(b(c•#f•|(#b •[:f :b :z])•#z•1)))'
@@ -483,6 +584,7 @@ describe('paredit', () => {
                 expect(textAndSelection(a)).toEqual(textAndSelection(b));
             });
         });
+
         describe('Top Level Readers', () => {
             const docText = '#f\n(#b \n[:f :b :z])\n#x\n#y\n1\n#å#ä#ö';
             let doc: model.StringDocument;

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -423,10 +423,10 @@ describe('Token Cursor', () => {
     describe('Current Form', () => {
         it('0: selects from within non-list form', () => {
             const a = docFromTextNotation(
-                '(a|aa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)))'
+                '(a|aa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x'
             );
             const b = docFromTextNotation(
-                '(|aaa| (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)))'
+                '(|aaa| (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x'
             );
             const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
             expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(
@@ -506,36 +506,24 @@ describe('Token Cursor', () => {
             );
         });
         it('2: selects from adjacent before form', () => {
-            const a = docFromTextNotation(
-                '(aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•|#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)))'
-            );
-            const b = docFromTextNotation(
-                '(aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•|#(a b c)|)•#baz•yyy•   z z z   •foo•   •   bar)))'
-            );
+            const a = docFromTextNotation('#bar •#baz•[:a :b :c]•x•|#(a b c)');
+            const b = docFromTextNotation('#bar •#baz•[:a :b :c]•x•|#(a b c)|');
             const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
             expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(
                 textAndSelection(b)[1]
             );
         });
         it('2: selects from adjacent before form, including reader tags', () => {
-            const a = docFromTextNotation(
-                '(aaa (bbb (ccc •#foo•(|#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)))'
-            );
-            const b = docFromTextNotation(
-                '(aaa (bbb (ccc •#foo•(|#bar •#baz•[:a :b :c]|•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)))'
-            );
+            const a = docFromTextNotation('|#bar •#baz•[:a :b :c]•x');
+            const b = docFromTextNotation('|#bar •#baz•[:a :b :c]|•x');
             const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
             expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(
                 textAndSelection(b)[1]
             );
         });
         it.skip('2: selects from adjacent before form, including meta data', () => {
-            const a = docFromTextNotation(
-                '(aaa (bbb (ccc •#foo•(|^bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)))'
-            );
-            const b = docFromTextNotation(
-                '(aaa (bbb (ccc •#foo•(|^bar •#baz•[:a :b :c]|•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)))'
-            );
+            const a = docFromTextNotation('|^bar •#baz•[:a :b :c]•x');
+            const b = docFromTextNotation('|^bar •#baz•[:a :b :c]|•x');
             const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
             expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(
                 textAndSelection(b)[1]
@@ -543,10 +531,10 @@ describe('Token Cursor', () => {
         });
         it('2: selects from adjacent before form, or in readers', () => {
             const a = docFromTextNotation(
-                '(aaa (bbb (ccc •#foo•|(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)))'
+                'ccc •#foo•|(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy'
             );
             const b = docFromTextNotation(
-                '(aaa (bbb (ccc •|#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))|•#baz•yyy•   z z z   •foo•   •   bar)))'
+                'ccc •|#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))|•#baz•yyy'
             );
             const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
             expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(
@@ -554,12 +542,8 @@ describe('Token Cursor', () => {
             );
         });
         it('2: selects from adjacent before a form with reader tags', () => {
-            const a = docFromTextNotation(
-                '(aaa (bbb (ccc •#foo•(#bar |•#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)))'
-            );
-            const b = docFromTextNotation(
-                '(aaa (bbb (ccc •#foo•(|#bar •#baz•[:a :b :c]|•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)))'
-            );
+            const a = docFromTextNotation('#bar |•#baz•[:a :b :c]•x');
+            const b = docFromTextNotation('|#bar •#baz•[:a :b :c]|•x');
             const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
             expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(
                 textAndSelection(b)[1]

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -15,6 +15,5 @@
       "snippet": "(with-out-str (clojure.repl/doc $hover-text))"
     }
   ],
-  "calva.fmt.configPath": "CLOJURE-LSP",
-  "editor.formatOnSave": true
+  "calva.fmt.configPath": "CLOJURE-LSP"
 }

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -9,6 +9,10 @@
     {
       "name": "edn hover hover-text",
       "snippet": "(str \"**JSON edn hover hover-text** \" \"$hover-text\")"
+    },
+    {
+      "name": "Show doc string",
+      "snippet": "(with-out-str (clojure.repl/doc $hover-text))"
     }
   ],
   "calva.fmt.configPath": "CLOJURE-LSP",

--- a/test-data/issue418.cljc
+++ b/test-data/issue418.cljc
@@ -29,10 +29,10 @@
   ;; => Syntax error reading source at (REPL:36:1).
   ;;    EOF while reading character
 
-  #{:foo :foo}|
+  #{:foo :bar}|
    ;; => {:foo :foo}
 
-  #{:foo :foo}
+  #{:foo :bar}
   ;; => Syntax error reading source at (REPL:43:1).
   ;;    EOF while reading character
   )

--- a/test-data/select.clj
+++ b/test-data/select.clj
@@ -9,15 +9,17 @@
 
 ^:a #a a b
 
-#a ^:a a b
+b aaa bbb ^{:aa aa}
 
-^{:aa aa} aaa bbb
+#a ^:a a
+
+a
 
 ^{:aa aa} #aa aaa bbb
 
+bbb
 #aa (def foo
       bar)
-bbb
 
 ^aa (def foo
       bar)

--- a/test-data/select.clj
+++ b/test-data/select.clj
@@ -1,3 +1,59 @@
 (comment
-  @(rf/subscribe [:foo])
-  )
+  @(rf/subscribe [:foo]))
+
+#aa aaa bbb
+
+^aa aaa bbb
+
+^:aa aaa bbb
+
+^:a #a a b
+
+#a ^:a a b
+
+^{:aa aa} aaa bbb
+
+^{:aa aa} #aa aaa bbb
+
+#aa (def foo
+      bar)
+bbb
+
+^aa (def foo
+      bar)
+bbb
+
+^:aa (def foo
+       bar)
+bbb
+
+^{:aa aa} (def foo
+            bar)
+bbb
+
+^{:aa aa} #aa (def foo
+                bar)
+bbb
+
+#aa ^{:aa aa} (def foo
+                bar)
+bbb
+
+#a #b a
+
+#_(def foo
+    bar)
+
+(defn test-reader [_ form]
+  {:meta (meta form)
+   :form form})
+
+(set! *default-data-reader-fn* test-reader)
+
+(c
+ #f
+  (#b
+    [:f :b :z])
+ #x
+  #y
+   1)


### PR DESCRIPTION
## What has Changed?

- Updated `TokenCursor.backwardSexp()` to be metadata aware.
- Updated `TokenCursor.currentForm()` to be metadata aware.

In the process I vastly simplified/dummyfied how we calculate the current form. It was extremely brittle with how the state of the various cursors were reused. Now each candidate is using its own cursor (if any) and the result is the offset of the end of the form if it was selected. Then in the end we do `backwardSexp` from this offset, skipping metadata and readers and return the tuple of `[backward-sexp-offset, selected-form-end-offset]`.

**UPDATE**: The below limitations are now gone. I figured out what was going wrong. The tests are now activated and some more tests in the same area are added. 🚀 

**UPDATE 2**: I've fixed some Paredit movement cases now as well:

* Forward sexp
* Backward sexp
* Forward Down List 
* Backward Down List

There are probably more Paredit things we will need to update. But we can take those as we discover them.

**NB: Known limitations:** I couldn't figure out how to solve the case when there is metadata then reader-tags before the form. I am leaving the failing test in, just skipped:

```typescript
        it.skip('2: selects from adjacent before form, including meta data', () => {
            const a = docFromTextNotation('|^bar •#baz•[:a :b :c]•x');
            const b = docFromTextNotation('|^bar •#baz•[:a :b :c]|•x');
            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
            expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(
                textAndSelection(b)[1]
            );
        });
```

This probably is related to that `TokenCursor.forwardSexp()` has problems with metadata and readers in the mis. Though it is not completely clear to me how it is related.  I am leaving that failing test in, and skipped, as well:

```typescript
        it('Skip metadata and reader if skipMetadata is true', () => {
            const a = docFromTextNotation('(a |^{:a 1} #a (= 1 1))');
            const b = docFromTextNotation('(a ^{:a 1} #a (= 1 1)|)');
            const cursor = a.getTokenCursor(a.selectionLeft);
            cursor.forwardSexp(true, true);
            expect(cursor.offsetStart).toBe(b.selectionLeft);
        });
        it.skip('Skip reader and metadata if skipMetadata is true', () => {
            const a = docFromTextNotation('(a |#a ^{:a 1} (= 1 1))');
            const b = docFromTextNotation('(a #a ^{:a 1} (= 1 1)|)');
            const cursor = a.getTokenCursor(a.selectionLeft);
            cursor.forwardSexp(true, true);
            expect(cursor.offsetStart).toBe(b.selectionLeft);
        });
```

Note that the test most corresponding to the `currentForm` failing test is  actually passing. Very strange. Anyway, I've been at this for several days and am starting to be really dizzy around it so need to put it away for a while. Maybe it dawns on me what I am missing...

I'm planning to merge this with the above warts, because things generally improve and it is probably rare with the cases that don't work.

As always when we change fundamental building blocks like `currentForm`, and the even more fundamental `backwardSexp` it is a bit scary. Please take a critical look, and please help test the VSIX.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1551

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe