### PR TITLE
Fix current form selection when cursor is on a row between to forms and next form has metadata or readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Metadata affects the Current Form being recognized](https://github.com/BetterThanTomorrow/calva/pull/1577)
 
 ## [2.0.250] - 2022-03-05
 - Fix: [Version 2.0.247 regression with structural editing, hangs at unbalance + structural delete](https://github.com/BetterThanTomorrow/calva/pull/1573)

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -723,9 +723,7 @@ export class LispTokenCursor extends TokenCursor {
             if (isAdjacentBefore) {
                 const cursor = this.clone();
                 cursor.forwardWhitespace();
-                if (
-                    cursor.forwardSexp(true, true)
-                ) {
+                if (cursor.forwardSexp(true, true)) {
                     afterCurrentFormOffset = cursor.offsetStart;
                 }
             }

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -662,7 +662,7 @@ export class LispTokenCursor extends TokenCursor {
      */
     rangeForCurrentForm(offset: number): [number, number] {
         let afterCurrentFormOffset: number;
-        // console.log(-1, offset);
+        console.log(-1, offset);
 
         // 0. If `offset` is within or before, a symbol, literal or keyword
         if (
@@ -671,7 +671,7 @@ export class LispTokenCursor extends TokenCursor {
         ) {
             afterCurrentFormOffset = this.offsetEnd;
         }
-        // console.log(0, afterCurrentFormOffset);
+        console.log(0, afterCurrentFormOffset);
 
         // 1. Else, if `offset` is adjacent after form
         if (afterCurrentFormOffset === undefined) {
@@ -689,7 +689,7 @@ export class LispTokenCursor extends TokenCursor {
                 }
             }
         }
-        // console.log(1, afterCurrentFormOffset);
+        console.log(1, afterCurrentFormOffset);
 
         // 2. Else, if `offset` is adjacent before a form
         if (afterCurrentFormOffset === undefined) {
@@ -701,7 +701,7 @@ export class LispTokenCursor extends TokenCursor {
                 pTk.type === 'reader' ||
                 this.prevTokenBeginsMetadata() ||
                 tk.type === 'open';
-            // console.log(2.1, afterCurrentFormOffset);
+            console.log(2.1, isAdjacentBefore);
             if (!isAdjacentBefore) {
                 const cursor = this.clone();
                 cursor.backwardWhitespace();
@@ -709,24 +709,28 @@ export class LispTokenCursor extends TokenCursor {
                     cursor.prevTokenBeginsMetadata() ||
                     cursor.getPrevToken().type === 'reader';
             }
-            // console.log(2.2, afterCurrentFormOffset);
+            console.log(2.2, isAdjacentBefore);
             if (!isAdjacentBefore) {
                 const cursor = this.clone();
                 cursor.forwardWhitespace();
-                isAdjacentBefore =
-                    cursor.tokenBeginsMetadata() ||
-                    cursor.getToken().type === 'reader';
+                if (cursor.rowCol[0] === this.rowCol[0]) {
+                    isAdjacentBefore =
+                        cursor.tokenBeginsMetadata() ||
+                        cursor.getToken().type === 'reader';
+                }
             }
-            // console.log(2.3, afterCurrentFormOffset);
+            console.log(2.3, isAdjacentBefore);
             if (isAdjacentBefore) {
                 const cursor = this.clone();
                 cursor.forwardWhitespace();
-                if (cursor.forwardSexp(true, true)) {
+                if (
+                    cursor.forwardSexp(true, true)
+                ) {
                     afterCurrentFormOffset = cursor.offsetStart;
                 }
             }
         }
-        // console.log(2, afterCurrentFormOffset);
+        console.log(2, afterCurrentFormOffset);
 
         // 3. Else, if the previous form is on the same line
         if (afterCurrentFormOffset === undefined) {
@@ -739,7 +743,7 @@ export class LispTokenCursor extends TokenCursor {
                 }
             }
         }
-        // console.log(3, afterCurrentFormOffset);
+        console.log(3, afterCurrentFormOffset);
 
         // 4. Else, if the next form is on the same line
         if (afterCurrentFormOffset === undefined) {
@@ -751,7 +755,7 @@ export class LispTokenCursor extends TokenCursor {
                 }
             }
         }
-        // console.log(4, afterCurrentFormOffset);
+        console.log(4, afterCurrentFormOffset);
 
         // 5. Else, the previous form, if any
         if (afterCurrentFormOffset === undefined) {
@@ -762,7 +766,7 @@ export class LispTokenCursor extends TokenCursor {
                 afterCurrentFormOffset = afterOffset;
             }
         }
-        // console.log(5, afterCurrentFormOffset);
+        console.log(5, afterCurrentFormOffset);
 
         // 6. Else, the next form, if any
         if (afterCurrentFormOffset === undefined) {
@@ -772,7 +776,7 @@ export class LispTokenCursor extends TokenCursor {
                 afterCurrentFormOffset = cursor.offsetStart;
             }
         }
-        // console.log(6, afterCurrentFormOffset);
+        console.log(6, afterCurrentFormOffset);
 
         // 7. Else, the current enclosing form, if any
         if (afterCurrentFormOffset === undefined) {
@@ -783,7 +787,7 @@ export class LispTokenCursor extends TokenCursor {
                 }
             }
         }
-        // console.log(7, afterCurrentFormOffset);
+        console.log(7, afterCurrentFormOffset);
 
         // 8. Else, ¯\_(ツ)_/¯
         if (afterCurrentFormOffset === undefined) {

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -729,6 +729,14 @@ describe('Token Cursor', () => {
                 textAndSelection(b)[1]
             );
         });
+        it('5: selects previous form, if any, when next form has metadata', () => {
+            const a = docFromTextNotation('z•foo•|•^{:a b}•bar');
+            const b = docFromTextNotation('z•|foo|••^{:a b}•bar');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(
+                textAndSelection(b)[1]
+            );
+        });
         it('6: selects next form, if any', () => {
             const a = docFromTextNotation(' | •  (foo {:a b})•(c)');
             const b = docFromTextNotation('  •  |(foo {:a b})|•(c)');

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -687,10 +687,10 @@ describe('Token Cursor', () => {
         });
         it('2: selects from adjacent before form, or in readers', () => {
             const a = docFromTextNotation(
-                'ccc •#foo•|(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy'
+                'ccc •#foo•|•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy'
             );
             const b = docFromTextNotation(
-                'ccc •|#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))|•#baz•yyy'
+                'ccc •|#foo••(#bar •#baz•[:a :b :c]•x•#(a b c))|•#baz•yyy'
             );
             const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
             expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(

--- a/test-data/select.clj
+++ b/test-data/select.clj
@@ -52,6 +52,8 @@ bbb
 
 (set! *default-data-reader-fn* test-reader)
 
+
+
 (c
  #f
   (#b
@@ -60,6 +62,16 @@ bbb
   #y
    1)
 
-^{:a b} #c ^d "foo" ()
 
-#{a b}
+
+^{:a b}
+#c
+ ^d
+ "foo"  
+
+
+  ()
+
+
+
+   #{a b}


### PR DESCRIPTION
We were missing a check that adjacent form metadata or reader is on the same line as the cursor.

Fixes #1577

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [s] Tested the particular change
     - [s] Figured if the change might have some side effects and tested those as well.
     - [s] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe