### PR TITLE
def-hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Fix hover snippet markdown and adds example](https://github.com/BetterThanTomorrow/calva/pull/1582)
 - Maintenance: [Begin work on enabling strictNullChecks in the TypeScript config.](https://github.com/BetterThanTomorrow/calva/pull/1568)
 
 ## [2.0.252] - 2022-03-05

--- a/docs/site/custom-commands.md
+++ b/docs/site/custom-commands.md
@@ -129,12 +129,15 @@ These will not get synced through vscode settings sync.
 A new experimental feature lets library authors ship snippets inside their jar files. These accept the same options as above but should be placed in "resources/calva.exports/config.edn" inside the jar.
 
 ```edn
-{:customREPLCommandSnippets 
+{:customREPLCommandSnippets
  [{:name "edn test"
    :key "a"
    :snippet "($current-form)"}]
  :customREPLHoverSnippets
  [{:name "edn hover"
-   :snippet "(str \"$hover-tex\")"}]
+   :snippet "(str \"$hover-tex\")"}
+  {:name "edn hover show val"
+   :snippet "(str \"**EDN edn hover show val**\n\n```clojure\n\" (pr-str (eval (symbol (str \"$ns\" \"/\" \"$hover-top-level-defined-symbol\")))) \"\n```\")"}
+ ]
  }
 ```

--- a/docs/site/custom-commands.md
+++ b/docs/site/custom-commands.md
@@ -137,7 +137,7 @@ A new experimental feature lets library authors ship snippets inside their jar f
  [{:name "edn hover"
    :snippet "(str \"$hover-tex\")"}
   {:name "edn hover show val"
-   :snippet "(str \"**EDN edn hover show val**\n\n```clojure\n\" (pr-str (eval (symbol (str \"$ns\" \"/\" \"$hover-top-level-defined-symbol\")))) \"\n```\")"}
+   :snippet "(str \"### EDN show val\n```clojure\n\" (pr-str (eval (symbol (str \"$ns\" \"/\" \"$hover-top-level-defined-symbol\")))) \"\n```\")"}
  ]
  }
 ```

--- a/package.json
+++ b/package.json
@@ -426,12 +426,7 @@
                     },
                     "calva.customREPLHoverSnippets": {
                         "type": "array",
-                        "default": [
-                            {
-                                "name": "def var",
-                                "snippet": "(pr-str $hover-text)"
-                            }
-                        ],
+                        "default": [],
                         "description": "Configuration for snippets that get called on hover",
                         "$schema": "http://json-schema.org/draft-06/schema#",
                         "items": {

--- a/package.json
+++ b/package.json
@@ -426,7 +426,12 @@
                     },
                     "calva.customREPLHoverSnippets": {
                         "type": "array",
-                        "default": [],
+                        "default": [
+                            {
+                                "name": "def var",
+                                "snippet": "(pr-str $hover-text)"
+                            }
+                        ],
                         "description": "Configuration for snippets that get called on hover",
                         "$schema": "http://json-schema.org/draft-06/schema#",
                         "items": {

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -135,7 +135,8 @@ async function evaluateCodeOrKey(codeOrKey?: string) {
         )[1],
         currentFn: getText.currentFunction(editor?.document)[1],
         topLevelDefinedForm: getText.currentTopLevelFunction(
-            editor?.document
+            editor?.document,
+            editor?.selection.active
         )[1],
         head: getText.toStartOfList(editor?.document)[1],
         tail: getText.toEndOfList(editor?.document)[1],

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -421,7 +421,7 @@ function evaluateEnclosingForm(document = {}, options = {}) {
 }
 
 function evaluateUsingTextAndSelectionGetter(
-    getter: (doc: vscode.TextDocument) => getText.SelectionAndText,
+    getter: (doc: vscode.TextDocument, pos: vscode.Position) => getText.SelectionAndText,
     formatter: (s: string) => string,
     document = {},
     options = {}
@@ -431,7 +431,7 @@ function evaluateUsingTextAndSelectionGetter(
         Object.assign({}, options, {
             pprintOptions: getConfig().prettyPrintingOptions,
             selectionFn: (editor: vscode.TextEditor) => {
-                const [selection, code] = getter(editor?.document);
+                const [selection, code] = getter(editor?.document, editor?.selection.active);
                 return [selection, formatter(code)];
             },
         })

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -421,7 +421,10 @@ function evaluateEnclosingForm(document = {}, options = {}) {
 }
 
 function evaluateUsingTextAndSelectionGetter(
-    getter: (doc: vscode.TextDocument, pos: vscode.Position) => getText.SelectionAndText,
+    getter: (
+        doc: vscode.TextDocument,
+        pos: vscode.Position
+    ) => getText.SelectionAndText,
     formatter: (s: string) => string,
     document = {},
     options = {}
@@ -431,7 +434,10 @@ function evaluateUsingTextAndSelectionGetter(
         Object.assign({}, options, {
             pprintOptions: getConfig().prettyPrintingOptions,
             selectionFn: (editor: vscode.TextEditor) => {
-                const [selection, code] = getter(editor?.document, editor?.selection.active);
+                const [selection, code] = getter(
+                    editor?.document,
+                    editor?.selection.active
+                );
                 return [selection, formatter(code)];
             },
         })

--- a/src/extension-test/unit/util/cursor-get-text-test.ts
+++ b/src/extension-test/unit/util/cursor-get-text-test.ts
@@ -3,64 +3,60 @@ import { docFromTextNotation } from '../common/text-notation';
 import * as getText from '../../../util/cursor-get-text';
 
 describe('get text', () => {
-    // describe('getTopLevelFunction', () => {
-    //     it('Finds top level function at top', () => {
-    //         const a = docFromTextNotation(
-    //             '(foo bar)•(deftest a-test•  (baz |gaz))'
-    //         );
-    //         const b = docFromTextNotation(
-    //             '(foo bar)•(deftest |a-test|•  (baz gaz))'
-    //         );
-    //         const range: [number, number] = [b.selectionLeft, b.selectionRight];
-    //         expect(getText.currentTopLevelFunction(a)).toEqual([
-    //             range,
-    //             b.model.getText(...range),
-    //         ]);
-    //     });
+    describe('getTopLevelFunction', () => {
+        it('Finds top level function at top', () => {
+            const a = docFromTextNotation(
+                '(foo bar)•(deftest a-test•  (baz |gaz))'
+            );
+            const b = docFromTextNotation(
+                '(foo bar)•(deftest |a-test|•  (baz gaz))'
+            );
+            const range: [number, number] = [b.selectionLeft, b.selectionRight];
+            expect(
+                getText.currentTopLevelFunction(a, a.selection.active)
+            ).toEqual([range, b.model.getText(...range)]);
+        });
 
-    //     it('Finds top level function when nested', () => {
-    //         const a = docFromTextNotation(
-    //             '(foo bar)•(with-test•  (deftest a-test•    (baz |gaz)))'
-    //         );
-    //         const b = docFromTextNotation(
-    //             '(foo bar)•(with-test•  (deftest |a-test|•    (baz gaz)))'
-    //         );
-    //         const range: [number, number] = [b.selectionLeft, b.selectionRight];
-    //         expect(getText.currentTopLevelFunction(a)).toEqual([
-    //             range,
-    //             b.model.getText(...range),
-    //         ]);
-    //     });
+        it('Finds top level function when nested', () => {
+            const a = docFromTextNotation(
+                '(foo bar)•(with-test•  (deftest a-test•    (baz |gaz)))'
+            );
+            const b = docFromTextNotation(
+                '(foo bar)•(with-test•  (deftest |a-test|•    (baz gaz)))'
+            );
+            const range: [number, number] = [b.selectionLeft, b.selectionRight];
+            expect(
+                getText.currentTopLevelFunction(a, a.selection.active)
+            ).toEqual([range, b.model.getText(...range)]);
+        });
 
-    //     it('Finds top level function when namespaced def-macro', () => {
-    //         // https://github.com/BetterThanTomorrow/calva/issues/1086
-    //         const a = docFromTextNotation(
-    //             '(foo bar)•(with-test•  (t/deftest a-test•    (baz |gaz)))'
-    //         );
-    //         const b = docFromTextNotation(
-    //             '(foo bar)•(with-test•  (t/deftest |a-test|•    (baz gaz)))'
-    //         );
-    //         const range: [number, number] = [b.selectionLeft, b.selectionRight];
-    //         expect(getText.currentTopLevelFunction(a)).toEqual([
-    //             range,
-    //             b.model.getText(...range),
-    //         ]);
-    //     });
+        it('Finds top level function when namespaced def-macro', () => {
+            // https://github.com/BetterThanTomorrow/calva/issues/1086
+            const a = docFromTextNotation(
+                '(foo bar)•(with-test•  (t/deftest a-test•    (baz |gaz)))'
+            );
+            const b = docFromTextNotation(
+                '(foo bar)•(with-test•  (t/deftest |a-test|•    (baz gaz)))'
+            );
+            const range: [number, number] = [b.selectionLeft, b.selectionRight];
+            expect(
+                getText.currentTopLevelFunction(a, a.selection.active)
+            ).toEqual([range, b.model.getText(...range)]);
+        });
 
-    //     it('Finds top level function when function has metadata', () => {
-    //         const a = docFromTextNotation(
-    //             '(foo bar)•(deftest ^{:some :thing} a-test•  (baz |gaz))'
-    //         );
-    //         const b = docFromTextNotation(
-    //             '(foo bar)•(deftest ^{:some :thing} |a-test|•  (baz gaz))'
-    //         );
-    //         const range: [number, number] = [b.selectionLeft, b.selectionRight];
-    //         expect(getText.currentTopLevelFunction(a)).toEqual([
-    //             range,
-    //             b.model.getText(...range),
-    //         ]);
-    //     });
-    // });
+        it('Finds top level function when function has metadata', () => {
+            const a = docFromTextNotation(
+                '(foo bar)•(deftest ^{:some :thing} a-test•  (baz |gaz))'
+            );
+            const b = docFromTextNotation(
+                '(foo bar)•(deftest ^{:some :thing} |a-test|•  (baz gaz))'
+            );
+            const range: [number, number] = [b.selectionLeft, b.selectionRight];
+            expect(
+                getText.currentTopLevelFunction(a, a.selection.active)
+            ).toEqual([range, b.model.getText(...range)]);
+        });
+    });
 
     describe('getTopLevelForm', () => {
         it('Finds top level form', () => {

--- a/src/extension-test/unit/util/cursor-get-text-test.ts
+++ b/src/extension-test/unit/util/cursor-get-text-test.ts
@@ -3,64 +3,64 @@ import { docFromTextNotation } from '../common/text-notation';
 import * as getText from '../../../util/cursor-get-text';
 
 describe('get text', () => {
-    describe('getTopLevelFunction', () => {
-        it('Finds top level function at top', () => {
-            const a = docFromTextNotation(
-                '(foo bar)•(deftest a-test•  (baz |gaz))'
-            );
-            const b = docFromTextNotation(
-                '(foo bar)•(deftest |a-test|•  (baz gaz))'
-            );
-            const range: [number, number] = [b.selectionLeft, b.selectionRight];
-            expect(getText.currentTopLevelFunction(a)).toEqual([
-                range,
-                b.model.getText(...range),
-            ]);
-        });
+    // describe('getTopLevelFunction', () => {
+    //     it('Finds top level function at top', () => {
+    //         const a = docFromTextNotation(
+    //             '(foo bar)•(deftest a-test•  (baz |gaz))'
+    //         );
+    //         const b = docFromTextNotation(
+    //             '(foo bar)•(deftest |a-test|•  (baz gaz))'
+    //         );
+    //         const range: [number, number] = [b.selectionLeft, b.selectionRight];
+    //         expect(getText.currentTopLevelFunction(a)).toEqual([
+    //             range,
+    //             b.model.getText(...range),
+    //         ]);
+    //     });
 
-        it('Finds top level function when nested', () => {
-            const a = docFromTextNotation(
-                '(foo bar)•(with-test•  (deftest a-test•    (baz |gaz)))'
-            );
-            const b = docFromTextNotation(
-                '(foo bar)•(with-test•  (deftest |a-test|•    (baz gaz)))'
-            );
-            const range: [number, number] = [b.selectionLeft, b.selectionRight];
-            expect(getText.currentTopLevelFunction(a)).toEqual([
-                range,
-                b.model.getText(...range),
-            ]);
-        });
+    //     it('Finds top level function when nested', () => {
+    //         const a = docFromTextNotation(
+    //             '(foo bar)•(with-test•  (deftest a-test•    (baz |gaz)))'
+    //         );
+    //         const b = docFromTextNotation(
+    //             '(foo bar)•(with-test•  (deftest |a-test|•    (baz gaz)))'
+    //         );
+    //         const range: [number, number] = [b.selectionLeft, b.selectionRight];
+    //         expect(getText.currentTopLevelFunction(a)).toEqual([
+    //             range,
+    //             b.model.getText(...range),
+    //         ]);
+    //     });
 
-        it('Finds top level function when namespaced def-macro', () => {
-            // https://github.com/BetterThanTomorrow/calva/issues/1086
-            const a = docFromTextNotation(
-                '(foo bar)•(with-test•  (t/deftest a-test•    (baz |gaz)))'
-            );
-            const b = docFromTextNotation(
-                '(foo bar)•(with-test•  (t/deftest |a-test|•    (baz gaz)))'
-            );
-            const range: [number, number] = [b.selectionLeft, b.selectionRight];
-            expect(getText.currentTopLevelFunction(a)).toEqual([
-                range,
-                b.model.getText(...range),
-            ]);
-        });
+    //     it('Finds top level function when namespaced def-macro', () => {
+    //         // https://github.com/BetterThanTomorrow/calva/issues/1086
+    //         const a = docFromTextNotation(
+    //             '(foo bar)•(with-test•  (t/deftest a-test•    (baz |gaz)))'
+    //         );
+    //         const b = docFromTextNotation(
+    //             '(foo bar)•(with-test•  (t/deftest |a-test|•    (baz gaz)))'
+    //         );
+    //         const range: [number, number] = [b.selectionLeft, b.selectionRight];
+    //         expect(getText.currentTopLevelFunction(a)).toEqual([
+    //             range,
+    //             b.model.getText(...range),
+    //         ]);
+    //     });
 
-        it('Finds top level function when function has metadata', () => {
-            const a = docFromTextNotation(
-                '(foo bar)•(deftest ^{:some :thing} a-test•  (baz |gaz))'
-            );
-            const b = docFromTextNotation(
-                '(foo bar)•(deftest ^{:some :thing} |a-test|•  (baz gaz))'
-            );
-            const range: [number, number] = [b.selectionLeft, b.selectionRight];
-            expect(getText.currentTopLevelFunction(a)).toEqual([
-                range,
-                b.model.getText(...range),
-            ]);
-        });
-    });
+    //     it('Finds top level function when function has metadata', () => {
+    //         const a = docFromTextNotation(
+    //             '(foo bar)•(deftest ^{:some :thing} a-test•  (baz |gaz))'
+    //         );
+    //         const b = docFromTextNotation(
+    //             '(foo bar)•(deftest ^{:some :thing} |a-test|•  (baz gaz))'
+    //         );
+    //         const range: [number, number] = [b.selectionLeft, b.selectionRight];
+    //         expect(getText.currentTopLevelFunction(a)).toEqual([
+    //             range,
+    //             b.model.getText(...range),
+    //         ]);
+    //     });
+    // });
 
     describe('getTopLevelForm', () => {
         it('Finds top level form', () => {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -69,13 +69,11 @@ export async function provideHover(
                         if (text) {
                             const hover = new vscode.MarkdownString();
                             hover.isTrusted = true;
-                            hover.appendMarkdown(
-                                _.replace(
-                                    _.replace(_.trim(text, '"'), /\\n/g, '\n'),
-                                    /\\"/g,
-                                    '"'
-                                )
-                            );
+                            const hoverText = text
+                                .replace(/^"|"$/g, '')
+                                .replace(/\\n/g, '\n')
+                                .replace(/\\"/g, '"');
+                            hover.appendMarkdown(hoverText);
                             hovers.push(hover);
                         }
                     } catch (error) {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -71,7 +71,7 @@ export async function provideHover(
                             hover.isTrusted = true;
                             hover.appendMarkdown(
                                 _.replace(
-                                    _.replace(_.trim(text, '"'), /\\n)/g, '\n'),
+                                    _.replace(_.trim(text, '"'), /\\n/g, '\n'),
                                     /\\"/g,
                                     '"'
                                 )

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -70,7 +70,11 @@ export async function provideHover(
                             const hover = new vscode.MarkdownString();
                             hover.isTrusted = true;
                             hover.appendMarkdown(
-                                _.replace(_.trim(text, '"'), /\\n/g, '\n')
+                                _.replace(
+                                    _.replace(_.trim(text, '"'), /\\n)/g, '\n'),
+                                    /\\"/g,
+                                    '"'
+                                )
                             );
                             hovers.push(hover);
                         }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -69,7 +69,9 @@ export async function provideHover(
                         if (text) {
                             const hover = new vscode.MarkdownString();
                             hover.isTrusted = true;
-                            hover.appendMarkdown(_.trim(text, '"'));
+                            hover.appendMarkdown(
+                                _.replace(_.trim(text, '"'), /\\n/g, '\n')
+                            );
                             hovers.push(hover);
                         }
                     } catch (error) {

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -361,7 +361,10 @@ async function runNamespaceTests(
 function getTestUnderCursor() {
     const editor = util.getActiveTextEditor();
     if (editor) {
-        return getText.currentTopLevelFunction(editor?.document, editor?.selection.active)[1];
+        return getText.currentTopLevelFunction(
+            editor?.document,
+            editor?.selection.active
+        )[1];
     }
 }
 

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -361,7 +361,7 @@ async function runNamespaceTests(
 function getTestUnderCursor() {
     const editor = util.getActiveTextEditor();
     if (editor) {
-        return getText.currentTopLevelFunction(editor?.document)[1];
+        return getText.currentTopLevelFunction(editor?.document, editor?.selection.active)[1];
     }
 }
 

--- a/src/util/cursor-get-text.ts
+++ b/src/util/cursor-get-text.ts
@@ -6,7 +6,10 @@ import { EditableDocument } from '../cursor-doc/model';
 
 export type RangeAndText = [[number, number], string];
 
-export function currentTopLevelFunction(doc: EditableDocument, active: number): RangeAndText {
+export function currentTopLevelFunction(
+    doc: EditableDocument,
+    active: number
+): RangeAndText {
     const defunCursor = doc.getTokenCursor(active);
     const defunStart = defunCursor.rangeForDefun(active)[0];
     const cursor = doc.getTokenCursor(defunStart);

--- a/src/util/cursor-get-text.ts
+++ b/src/util/cursor-get-text.ts
@@ -8,7 +8,7 @@ export type RangeAndText = [[number, number], string];
 
 export function currentTopLevelFunction(
     doc: EditableDocument,
-    active: number
+    active: number = doc.selection.active
 ): RangeAndText {
     const defunCursor = doc.getTokenCursor(active);
     const defunStart = defunCursor.rangeForDefun(active)[0];

--- a/src/util/cursor-get-text.ts
+++ b/src/util/cursor-get-text.ts
@@ -6,9 +6,9 @@ import { EditableDocument } from '../cursor-doc/model';
 
 export type RangeAndText = [[number, number], string];
 
-export function currentTopLevelFunction(doc: EditableDocument): RangeAndText {
-    const defunCursor = doc.getTokenCursor(doc.selection.active);
-    const defunStart = defunCursor.rangeForDefun(doc.selection.active)[0];
+export function currentTopLevelFunction(doc: EditableDocument, active: number): RangeAndText {
+    const defunCursor = doc.getTokenCursor(active);
+    const defunStart = defunCursor.rangeForDefun(active)[0];
     const cursor = doc.getTokenCursor(defunStart);
     while (cursor.downList()) {
         cursor.forwardWhitespace();

--- a/src/util/get-text.ts
+++ b/src/util/get-text.ts
@@ -60,11 +60,15 @@ export function currentFunction(doc: vscode.TextDocument): SelectionAndText {
 
 function selectionAndText(
     doc: vscode.TextDocument,
-    textGetter: (doc: EditableDocument) => cursorTextGetter.RangeAndText
+    textGetter: (
+        doc: EditableDocument,
+        active: number
+    ) => cursorTextGetter.RangeAndText,
+    pos: vscode.Position
 ): SelectionAndText {
     if (doc) {
         const mirrorDoc = docMirror.mustGetDocument(doc);
-        const [range, text] = textGetter(mirrorDoc);
+        const [range, text] = textGetter(mirrorDoc, doc.offsetAt(pos));
         if (range) {
             return [select.selectionFromOffsetRange(doc, range), text];
         }
@@ -73,25 +77,39 @@ function selectionAndText(
 }
 
 export function currentEnclosingFormToCursor(
-    doc: vscode.TextDocument
+    doc: vscode.TextDocument,
+    pos: vscode.Position
 ): SelectionAndText {
-    return selectionAndText(doc, cursorTextGetter.currentEnclosingFormToCursor);
+    return selectionAndText(
+        doc,
+        cursorTextGetter.currentEnclosingFormToCursor,
+        pos
+    );
 }
 
 export function currentTopLevelFunction(
-    doc: vscode.TextDocument
+    doc: vscode.TextDocument,
+    pos: vscode.Position
 ): SelectionAndText {
-    return selectionAndText(doc, cursorTextGetter.currentTopLevelFunction);
+    return selectionAndText(doc, cursorTextGetter.currentTopLevelFunction, pos);
 }
 
 export function currentTopLevelFormToCursor(
-    doc: vscode.TextDocument
+    doc: vscode.TextDocument,
+    pos: vscode.Position
 ): SelectionAndText {
-    return selectionAndText(doc, cursorTextGetter.currentTopLevelFormToCursor);
+    return selectionAndText(
+        doc,
+        cursorTextGetter.currentTopLevelFormToCursor,
+        pos
+    );
 }
 
-export function startOFileToCursor(doc: vscode.TextDocument): SelectionAndText {
-    return selectionAndText(doc, cursorTextGetter.startOfFileToCursor);
+export function startOFileToCursor(
+    doc: vscode.TextDocument,
+    pos: vscode.Position
+): SelectionAndText {
+    return selectionAndText(doc, cursorTextGetter.startOfFileToCursor, pos);
 }
 
 function fromFn(
@@ -130,7 +148,7 @@ export function currentContext(
     result[prefix + 'topLevelForm'] = currentTopLevelFormText(document, pos)[1];
     result[prefix + 'currentFn'] = currentFunction(document)[1];
     result[prefix + 'topLevelDefinedForm'] =
-        currentTopLevelFunction(document)[1];
+        currentTopLevelFunction(document, pos)[1];
     result[prefix + 'head'] = toStartOfList(document)[1];
     result[prefix + 'tail'] = toEndOfList(document)[1];
 

--- a/src/util/get-text.ts
+++ b/src/util/get-text.ts
@@ -147,8 +147,10 @@ export function currentContext(
     )[1];
     result[prefix + 'topLevelForm'] = currentTopLevelFormText(document, pos)[1];
     result[prefix + 'currentFn'] = currentFunction(document)[1];
-    result[prefix + 'topLevelDefinedForm'] =
-        currentTopLevelFunction(document, pos)[1];
+    result[prefix + 'topLevelDefinedForm'] = currentTopLevelFunction(
+        document,
+        pos
+    )[1];
     result[prefix + 'head'] = toStartOfList(document)[1];
     result[prefix + 'tail'] = toEndOfList(document)[1];
 

--- a/test-data/.calva/config.edn
+++ b/test-data/.calva/config.edn
@@ -1,12 +1,12 @@
-{
- :customREPLHoverSnippets
+{:customREPLHoverSnippets
  [{:name "edn hover symbol"
    :snippet "(str \"**EDN edn hover symbol**: \" $hover-text)"}
   {:name "edn hover symbol quoted"
    :snippet "(str \"**EDN edn hover symbol quoted** \" '$hover-text)"}
   {:name "edn hover hover-current-form"
    :snippet "(str \"**EDN edn hover hover-current-form** \" \"$hover-current-form\")"}
+  {:name "edn hover show val"
+   :snippet "(str \"**EDN edn hover show val**\n\n```clojure\n\" (pr-str (eval (symbol (str \"$ns\" \"/\" \"$hover-text\")))) \"\n```\")"}
   {:name "edn hover current-form"
-   :snippet "(str \"**EDN edn hover current-form** \" \"$current-form\")"}]
- }
+   :snippet "(str \"**EDN edn hover current-form** \" \"$current-form\")"}]}
 

--- a/test-data/.calva/config.edn
+++ b/test-data/.calva/config.edn
@@ -6,7 +6,7 @@
   {:name "edn hover hover-current-form"
    :snippet "(str \"**EDN edn hover hover-current-form** \" \"$hover-current-form\")"}
   {:name "edn hover show val"
-   :snippet "(str \"**EDN edn hover show val**\n\n```clojure\n\" (pr-str (eval (symbol (str \"$ns\" \"/\" \"$hover-text\")))) \"\n```\")"}
+   :snippet "(str \"### EDN show val\n```clojure\n\" (pr-str (eval (symbol (str \"$ns\" \"/\" \"$hover-top-level-defined-symbol\")))) \"\n```\")"}
   {:name "edn hover current-form"
    :snippet "(str \"**EDN edn hover current-form** \" \"$current-form\")"}]}
 

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -16,7 +16,7 @@
         },
         {
             "name": "def var",
-            "snippet": "(pr-str $hover-text)"
+            "snippet": "(str \"```clojure\n\" (pr-str $hover-text) \"\n```\")"
         }
     ],
     "calva.fmt.configPath": "CLOJURE-LSP"

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -1,19 +1,23 @@
 {
-  "calva.customREPLCommandSnippets": [
-    {
-      "name": "Double current",
-      "snippet": "(tap> [$current-form $current-form])"
-    }
-  ],
-  "calva.customREPLHoverSnippets": [
-    {
-      "name": "edn hover hover-text",
-      "snippet": "(str \"**JSON edn hover hover-text** \" \"$hover-text\")"
-    },
-    {
-      "name": "Show doc string",
-      "snippet": "(with-out-str (clojure.repl/doc $hover-text))"
-    }
-  ],
-  "calva.fmt.configPath": "CLOJURE-LSP"
+    "calva.customREPLCommandSnippets": [
+        {
+            "name": "Double current",
+            "snippet": "(tap> [$current-form $current-form])"
+        }
+    ],
+    "calva.customREPLHoverSnippets": [
+        {
+            "name": "edn hover hover-text",
+            "snippet": "(str \"**JSON edn hover hover-text** \" \"$hover-text\")"
+        },
+        {
+            "name": "Show doc string",
+            "snippet": "(clojure.string/replace (with-out-str (clojure.repl/doc $hover-text)) \"\n\" \"\n\n\")"
+        },
+        {
+            "name": "def var",
+            "snippet": "(pr-str $hover-text)"
+        }
+    ],
+    "calva.fmt.configPath": "CLOJURE-LSP"
 }

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -13,10 +13,6 @@
         {
             "name": "Show doc string",
             "snippet": "(clojure.string/replace (with-out-str (clojure.repl/doc $hover-text)) \"\n\" \"\n\n\")"
-        },
-        {
-            "name": "def var",
-            "snippet": "(str \"```clojure\n\" (pr-str $hover-text) \"\n```\")"
         }
     ],
     "calva.fmt.configPath": "CLOJURE-LSP"

--- a/test-data/integration-test/test.clj
+++ b/test-data/integration-test/test.clj
@@ -4,3 +4,8 @@
   (println "bar"))
 
 (foo)
+
+(def hover-map
+  {:stuff "in-here"
+   :ohter "yeah"
+   :deeper {:a 1, "foo" :bar, [1 2 3] (range 1)}})

--- a/test-data/integration-test/test.clj
+++ b/test-data/integration-test/test.clj
@@ -1,11 +1,11 @@
 (ns test)
 
-(defn foo []
-  (println "bar"))
-
-(foo)
-
 (def hover-map
   {:stuff "in-here"
    :ohter "yeah"
    :deeper {:a 1, "foo" :bar, [1 2 3] (range 1)}})
+
+(defn foo []
+  (println "bar"))
+
+(foo)

--- a/test-data/integration-test/test.clj
+++ b/test-data/integration-test/test.clj
@@ -3,7 +3,7 @@
 (def hover-map
   {:stuff "in-here"
    :ohter "yeah"
-   :deeper {:a 1, "foo" :bar, [1 2 3] (range 100)}})
+   :deeper {:a 1, "foo" :bar, [1 2 3] (vec (range 2000))}})
 
 (defn foo []
   (println "bar"))

--- a/test-data/integration-test/test.clj
+++ b/test-data/integration-test/test.clj
@@ -3,7 +3,7 @@
 (def hover-map
   {:stuff "in-here"
    :ohter "yeah"
-   :deeper {:a 1, "foo" :bar, [1 2 3] (range 1)}})
+   :deeper {:a 1, "foo" :bar, [1 2 3] (range 100)}})
 
 (defn foo []
   (println "bar"))


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- fixed hover markdown newlines (the problem was mentioned on slack)
- added "def var" hover as a default to the config

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Closes #1538 

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe