### PR TITLE
Fix another unbalance hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 Changes to Calva.
 
 ## [Unreleased]
-- [Fix hover snippet markdown and adds example](https://github.com/BetterThanTomorrow/calva/pull/1582)
+- Fix: [Structural editing hangs in specific cases of unbalanced forms](https://github.com/BetterThanTomorrow/calva/pull/1585)
+- Fix: [over snippet markdown and adds example](https://github.com/BetterThanTomorrow/calva/pull/1582)
 - Maintenance: [Begin work on enabling strictNullChecks in the TypeScript config.](https://github.com/BetterThanTomorrow/calva/pull/1568)
 
 ## [2.0.252] - 2022-03-05

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -307,7 +307,9 @@ export function rangeToBackwardUpList(
 ): [number, number] {
     const cursor = doc.getTokenCursor(offset);
     cursor.backwardList();
-    if (cursor.backwardUpList(true)) {
+    if (cursor.backwardUpList()) {
+        cursor.forwardSexp(true, true);
+        cursor.backwardSexp(true, true);
         if (goPastWhitespace) {
             cursor.backwardWhitespace();
         }

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -618,14 +618,12 @@ export class LispTokenCursor extends TokenCursor {
      * If possible, moves this cursor backwards past any whitespace, and then backwards past the immediately following open-paren and returns true.
      * If the source does not match this, returns false and does not move the cursor.
      */
-    backwardUpList(skipMetadata = false): boolean {
+    backwardUpList(): boolean {
         const cursor = this.clone();
         cursor.backwardThroughAnyReader();
         cursor.backwardWhitespace();
         if (cursor.getPrevToken().type == 'open') {
             cursor.previous();
-            cursor.forwardSexp(true, skipMetadata);
-            cursor.backwardSexp(true, skipMetadata);
             this.set(cursor);
             return true;
         }

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1177,6 +1177,14 @@ describe('paredit', () => {
                     paredit.forwardBarfSexp(a);
                     expect(textAndSelection(a)).toEqual(textAndSelection(b));
                 });
+                it('barfs form from balanced list, when inside unclosed list', () => {
+                    // Trying to expose:
+                    // https://github.com/BetterThanTomorrow/calva/issues/1585
+                    const a = docFromTextNotation('(let [a| a)');
+                    const b = docFromTextNotation('(let [a|) a');
+                    paredit.forwardBarfSexp(a);
+                    expect(textAndSelection(a)).toEqual(textAndSelection(b));
+                });
             });
 
             describe('Barfing backwards', () => {

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -386,7 +386,7 @@ describe('Token Cursor', () => {
             cursor.forwardList();
             expect(cursor.offsetStart).toBe(b.selectionLeft);
         });
-        it('Does not move when unbalanced from extra opens', () => {
+        it('Does not move when at start of unbalanced list', () => {
             // https://github.com/BetterThanTomorrow/calva/issues/1573
             // https://github.com/BetterThanTomorrow/calva/commit/d77359fcea16bc052ab829853d5711434330a375
             const a = docFromTextNotation('([|');
@@ -394,6 +394,14 @@ describe('Token Cursor', () => {
             const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
             const result = cursor.backwardList();
             expect(result).toBe(false);
+            expect(cursor.offsetStart).toBe(b.selectionLeft);
+        });
+        it('Moves to stary of unbalanced list', () => {
+            const a = docFromTextNotation('(let [a| a');
+            const b = docFromTextNotation('(let [|a a');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            const result = cursor.backwardList();
+            expect(result).toBe(true);
             expect(cursor.offsetStart).toBe(b.selectionLeft);
         });
         it('Finds the list start when unbalanced from extra closes outside the current list', () => {

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -396,13 +396,23 @@ describe('Token Cursor', () => {
             expect(result).toBe(false);
             expect(cursor.offsetStart).toBe(b.selectionLeft);
         });
-        it('Moves to stary of unbalanced list', () => {
+        it('Does not move to start of an unbalanced list when outer list is also unbalanced', () => {
+            // NB: This is a bit arbitrary, this test documents the current behaviour
             const a = docFromTextNotation('(let [a| a');
-            const b = docFromTextNotation('(let [|a a');
+            const b = docFromTextNotation('(let [a| a');
             const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
             const result = cursor.backwardList();
-            expect(result).toBe(true);
             expect(cursor.offsetStart).toBe(b.selectionLeft);
+            expect(result).toBe(false);
+        });
+        it('Moves to start of an unbalanced list when outer list is balanced', () => {
+            // NB: This is a bit arbitrary, this test documents the current behaviour
+            const a = docFromTextNotation('(let [a| a)');
+            const b = docFromTextNotation('(let [|a a)');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            const result = cursor.backwardList();
+            expect(cursor.offsetStart).toBe(b.selectionLeft);
+            expect(result).toBe(true);
         });
         it('Finds the list start when unbalanced from extra closes outside the current list', () => {
             const a = docFromTextNotation('([]|))');
@@ -501,11 +511,11 @@ describe('Token Cursor', () => {
             expect(cursor.offsetStart).toBe(b.selectionLeft);
             expect(result).toBe(true);
         });
-        it.skip('Moves backward in balanced list when inner list is unbalanced', () => {
+        it('Moves backward in balanced list when inner list is unbalanced', () => {
             // This never conmpletes in Calva v2.0.252
             // https://github.com/BetterThanTomorrow/calva/issues/1585
             const a = docFromTextNotation('(let [a|)');
-            const b = docFromTextNotation('(let [|a)');
+            const b = docFromTextNotation('(|let [a)');
             const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
             const result = cursor.backwardListOfType('(');
             expect(cursor.offsetStart).toBe(b.selectionLeft);
@@ -523,7 +533,7 @@ describe('Token Cursor', () => {
 
     it('backwardUpList', () => {
         const a = docFromTextNotation('(a(b(c•#f•(#b •|[:f :b :z])•#z•1)))');
-        const b = docFromTextNotation('(a(b(c•|#f•(#b •[:f :b :z])•#z•1)))');
+        const b = docFromTextNotation('(a(b(c•#f•|(#b •[:f :b :z])•#z•1)))');
         const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
         cursor.backwardUpList();
         expect(cursor.offsetStart).toBe(b.selectionLeft);

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -492,6 +492,25 @@ describe('Token Cursor', () => {
             expect(cursor.offsetStart).toBe(b.selectionLeft);
             expect(result).toBe(false);
         });
+        it('Moves backward in unbalanced list when outer list is balanced', () => {
+            // https://github.com/BetterThanTomorrow/calva/issues/1585
+            const a = docFromTextNotation('(let [a|)');
+            const b = docFromTextNotation('(let [|a)');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            const result = cursor.backwardListOfType('[');
+            expect(cursor.offsetStart).toBe(b.selectionLeft);
+            expect(result).toBe(true);
+        });
+        it.skip('Moves backward in balanced list when inner list is unbalanced', () => {
+            // This never conmpletes in Calva v2.0.252
+            // https://github.com/BetterThanTomorrow/calva/issues/1585
+            const a = docFromTextNotation('(let [a|)');
+            const b = docFromTextNotation('(let [|a)');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            const result = cursor.backwardListOfType('(');
+            expect(cursor.offsetStart).toBe(b.selectionLeft);
+            expect(result).toBe(true);
+        });
         it('Does not move when list type is not found', () => {
             const a = docFromTextNotation('([|])');
             const b = docFromTextNotation('([|])');

--- a/test-data/calva-252-hang.clj
+++ b/test-data/calva-252-hang.clj
@@ -11,5 +11,11 @@
 
 (let [a "123"] a)
 
+
+;; This reproduces it for me (PEZ)
+;; Delete the closing square bracket
+;; With the cursor behind `[a` do **Paredit Barf Forward**
+;; BOOM
+
 (let [a] a)
 

--- a/test-data/calva-252-hang.clj
+++ b/test-data/calva-252-hang.clj
@@ -1,0 +1,15 @@
+;; https://github.com/BetterThanTomorrow/calva/issues/1585
+
+;; Confirm that structural editing works here:
+
+(defn foo [{:keys [bar]}] 'baz)
+
+;; Here a repro that works for at least one user:
+;; Place the cursor to the right of the closing square bracket and press delete
+;; until the text is `(let [a] a)`. Then highlight the select the closing square
+;; bracket and press delete. Structural editing and rainbow parens is now broken.
+
+(let [a "123"] a)
+
+(let [a] a)
+


### PR DESCRIPTION
## What has Changed?

Make token-cursor backward-list dumber. Only consider the opening paren, not any meta data or readers attached. This is now the responsibility of higher order functions, like Paredit.

Fixes #1585

Planning to release this fix ASAP, and then spend some time on making the same type of change to other Token Cursor primitives.

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe