### PR TITLE
Remove some cursor meta-data awareness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Changes to Calva.
 - Maintenance: [Dumb down the token cursor some dealing with meta data and readers](https://github.com/BetterThanTomorrow/calva/pull/1585)
 
 ## [2.0.253] - 2022-03-09
-- Fix: [over snippet markdown and adds example](https://github.com/BetterThanTomorrow/calva/pull/1582)
+- Fix: [Structural editing hangs in specific cases of unbalanced forms](https://github.com/BetterThanTomorrow/calva/pull/1585)
+- Fix: [Hover snippet markdown and adds example](https://github.com/BetterThanTomorrow/calva/pull/1582)
 - Maintenance: [Begin work on enabling strictNullChecks in the TypeScript config.](https://github.com/BetterThanTomorrow/calva/pull/1568)
 
 ## [2.0.252] - 2022-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Maintenance: [Dumb down the token cursor some dealing with meta data and readers](https://github.com/BetterThanTomorrow/calva/pull/1585)
 
 ## [2.0.253] - 2022-03-09
-- Fix: [Structural editing hangs in specific cases of unbalanced forms](https://github.com/BetterThanTomorrow/calva/pull/1585)
 - Fix: [over snippet markdown and adds example](https://github.com/BetterThanTomorrow/calva/pull/1582)
 - Maintenance: [Begin work on enabling strictNullChecks in the TypeScript config.](https://github.com/BetterThanTomorrow/calva/pull/1568)
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -335,7 +335,7 @@ export function rangeToForwardDownList(
             break;
         }
     } while (cursor.forwardSexp());
-    if (cursor.downList(true)) {
+    if (cursor.downList()) {
         if (goPastWhitespace) {
             cursor.forwardWhitespace();
         }

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -325,17 +325,7 @@ export function rangeToForwardDownList(
     goPastWhitespace = false
 ): [number, number] {
     const cursor = doc.getTokenCursor(offset);
-    do {
-        cursor.forwardThroughAnyReader();
-        cursor.forwardWhitespace();
-        if (
-            cursor.getToken().type === 'open' &&
-            !cursor.tokenBeginsMetadata()
-        ) {
-            break;
-        }
-    } while (cursor.forwardSexp());
-    if (cursor.downList()) {
+    if (cursor.downListSkippingMeta()) {
         if (goPastWhitespace) {
             cursor.forwardWhitespace();
         }

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -581,17 +581,11 @@ export class LispTokenCursor extends TokenCursor {
      * If possible, moves this cursor forwards past any whitespace, and then past the immediately following open-paren and returns true.
      * If the source does not match this, returns false and does not move the cursor.
      */
-    downList(skipMetadata = false): boolean {
+    downList(): boolean {
         const cursor = this.clone();
         cursor.forwardThroughAnyReader();
         cursor.forwardWhitespace();
         if (cursor.getToken().type === 'open') {
-            if (skipMetadata) {
-                while (cursor.tokenBeginsMetadata()) {
-                    cursor.forwardSexp();
-                    cursor.forwardWhitespace();
-                }
-            }
             cursor.next();
             this.set(cursor);
             return true;

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -578,7 +578,8 @@ export class LispTokenCursor extends TokenCursor {
     }
 
     /**
-     * If possible, moves this cursor forwards past any whitespace, and then past the immediately following open-paren and returns true.
+     * If possible, moves this cursor forwards past any readers and whitespace,
+     * and then past the immediately following open-paren and returns true.
      * If the source does not match this, returns false and does not move the cursor.
      */
     downList(): boolean {
@@ -587,6 +588,30 @@ export class LispTokenCursor extends TokenCursor {
         cursor.forwardWhitespace();
         if (cursor.getToken().type === 'open') {
             cursor.next();
+            this.set(cursor);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * If possible, moves this cursor forwards past any readers, whitespace, and metadata,
+     * and then past the immediately following open-paren and returns true.
+     * If the source does not match this, returns false and does not move the cursor.
+     */
+    downListSkippingMeta(): boolean {
+        const cursor = this.clone();
+        do {
+            cursor.forwardThroughAnyReader();
+            cursor.forwardWhitespace();
+            if (
+                cursor.getToken().type === 'open' &&
+                !cursor.tokenBeginsMetadata()
+            ) {
+                break;
+            }
+        } while (cursor.forwardSexp());
+        if (cursor.downList()) {
             this.set(cursor);
             return true;
         }

--- a/src/debugger/util.ts
+++ b/src/debugger/util.ts
@@ -31,7 +31,7 @@ function moveTokenCursorToBreakpoint(
     const coor = [...debugResponse.coor]; // Copy the array so we do not modify the one stored in state
 
     for (let i = 0; i < coor.length; i++) {
-        while (!tokenCursor.downList(true)) {
+        while (!tokenCursor.downList()) {
             tokenCursor.next();
         }
         const previousToken = tokenCursor.getPrevToken();

--- a/src/debugger/util.ts
+++ b/src/debugger/util.ts
@@ -31,7 +31,7 @@ function moveTokenCursorToBreakpoint(
     const coor = [...debugResponse.coor]; // Copy the array so we do not modify the one stored in state
 
     for (let i = 0; i < coor.length; i++) {
-        while (!tokenCursor.downList()) {
+        while (!tokenCursor.downListSkippingMeta()) {
             tokenCursor.next();
         }
         const previousToken = tokenCursor.getPrevToken();

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -282,6 +282,23 @@ describe('Token Cursor', () => {
         });
     });
 
+    describe('downListSkippingMeta', () => {
+        it('Moves down, skipping metadata', () => {
+            const a = docFromTextNotation('(|a #b ^{:x 1} (c 1))');
+            const b = docFromTextNotation('(a #b ^{:x 1} (|c 1))');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            cursor.downListSkippingMeta();
+            expect(cursor.offsetStart).toBe(b.selectionLeft);
+        });
+        it('Moves down when there is no metadata', () => {
+            const a = docFromTextNotation('(|a #b (c 1))');
+            const b = docFromTextNotation('(a #b (|c 1))');
+            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+            cursor.downListSkippingMeta();
+            expect(cursor.offsetStart).toBe(b.selectionLeft);
+        });
+    });
+
     it('upList', () => {
         const a = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1|)))');
         const b = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1)|))');

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -273,18 +273,11 @@ describe('Token Cursor', () => {
             cursor.downList();
             expect(cursor.offsetStart).toBe(b.selectionLeft);
         });
-        it('Does not skip metadata by default', () => {
+        it('Does not skip metadata', () => {
             const a = docFromTextNotation('(a| ^{:x 1} (b 1))');
             const b = docFromTextNotation('(a ^{|:x 1} (b 1))');
             const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
             cursor.downList();
-            expect(cursor.offsetStart).toBe(b.selectionLeft);
-        });
-        it('Skips metadata when skipMetadata is true', () => {
-            const a = docFromTextNotation('(a| ^{:x 1} (b 1))');
-            const b = docFromTextNotation('(a ^{:x 1} (|b 1))');
-            const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-            cursor.downList(true);
             expect(cursor.offsetStart).toBe(b.selectionLeft);
         });
     });

--- a/src/extension-test/unit/debugger/test-files/metadata-map-last.clj
+++ b/src/extension-test/unit/debugger/test-files/metadata-map-last.clj
@@ -1,0 +1,7 @@
+;; 3, 2, 2, 2
+#dbg
+ (defn test-metadata-symbol
+   [x]
+   (let [y x]
+     ^{:hello "world"}
+     (+ x ^{:inner "meta"} (+ 1 y|))))

--- a/src/extension-test/unit/debugger/test-files/metadata-map.clj
+++ b/src/extension-test/unit/debugger/test-files/metadata-map.clj
@@ -1,0 +1,6 @@
+;; 3, 2, 2, 2
+(defn test-metadata-symbol
+  [x]
+  (let [y x]
+    ^{:hello "world"}
+    (+ x ^{:inner "meta"} (+ 1 #break y|))))

--- a/src/extension-test/unit/debugger/util-test.ts
+++ b/src/extension-test/unit/debugger/util-test.ts
@@ -60,6 +60,14 @@ describe('Debugger Util', () => {
             expectBreakpointToBeFound('metadata-symbol.clj');
         });
 
+        it('metadata map', () => {
+            expectBreakpointToBeFound('metadata-map.clj');
+        });
+
+        it('metadata map last sexp', () => {
+            expectBreakpointToBeFound('metadata-map-last.clj');
+        });
+
         it('ignored forms', () => {
             expectBreakpointToBeFound('ignored-forms.clj');
         });

--- a/test-data/debugger_metadata.clj
+++ b/test-data/debugger_metadata.clj
@@ -1,0 +1,18 @@
+(ns debugger-metadata)
+
+#dbg
+ (defn test-metadata-symbol
+   [x]
+   (let [y x]
+     ^{:hello "world"}
+     (+ x ^{:inner "meta"} (+ 1 y))))
+
+(defn test-metadata-symbol2
+  [x]
+  (let [y x]
+    ^{:hello "world"}
+    (+ x ^{:inner "meta"} (+ 1 #break y))))
+
+(comment
+  (test-metadata-symbol 42)
+  (test-metadata-symbol2 42))


### PR DESCRIPTION
## What has Changed?

Following up on #1587, I set out to remove more of the meta data awareness I added to the token cursor when addressing #1551. Much to my surprise none of that could actually be removed. The addition to handle metadata in `cursor.backWardSecp()` must be there, or we're in for a major rewrite of things.

The only place where we were considering metadata outside of this was in `cursor.downList()`, and was added long ago (by @bpringe) to support metadata when the debugger uses the cursor. Since I have decided that we need to move the support of metadata navigation out of the cursor primitives (except for forward/backward sexp) I then removed this from `cursor.downList()` as well. Then prepared to fix all test cases that now would break.

Surprise number two: No test cases broke, except the one testin that `cursor.downList()` could be made to skip metadata. Not even the debugger util tests that tested this. And everything seems to keep working when I try it manually. I don't quite understand why, but if I have found some potentially problematic code that can be removed without any issues, I'm happy.

Can you throw some testing on this from the debugger use, @bpringe? The unit tests you wrote seem to cover the needed bases, but anyway.

Fixes #1588

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik  