### PR TITLE
WIP: #1607 - Cleanup selection/cursor API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Maintenance: [Cleanup/removal of EditableDocument.selectionLeft/Right APIs](https://github.com/BetterThanTomorrow/calva/issues/1607)]
 
 ## [2.0.261] - 2022-04-01
 - Fix: [Results doc gets in a bad state and does not update](https://github.com/BetterThanTomorrow/calva/issues/1509)

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -1,7 +1,7 @@
-import { Scanner, Token, ScannerState } from './clojure-lexer';
-import { LispTokenCursor } from './token-cursor';
-import { deepEqual as equal } from '../util/object';
 import { isUndefined } from 'lodash';
+import { deepEqual as equal } from '../util/object';
+import { Scanner, ScannerState, Token } from './clojure-lexer';
+import { LispTokenCursor } from './token-cursor';
 
 let scanner: Scanner;
 
@@ -104,8 +104,6 @@ export interface EditableModel {
 }
 
 export interface EditableDocument {
-  readonly selectionLeft: number;
-  readonly selectionRight: number;
   selection: ModelEditSelection;
   model: EditableModel;
   selectionStack: ModelEditSelection[];
@@ -534,17 +532,7 @@ export class StringDocument implements EditableDocument {
     }
   }
 
-  selectionLeft: number;
-  selectionRight: number;
-
-  get selection() {
-    return new ModelEditSelection(this.selectionLeft, this.selectionRight);
-  }
-
-  set selection(sel: ModelEditSelection) {
-    this.selectionLeft = sel.anchor;
-    this.selectionRight = sel.active;
-  }
+  selection: ModelEditSelection;
 
   model: LineInputModel = new LineInputModel(1, this);
 
@@ -565,14 +553,14 @@ export class StringDocument implements EditableDocument {
   getSelectionText: () => string;
 
   delete() {
-    const p = this.selectionLeft;
+    const p = this.selection.anchor;
     return this.model.edit([new ModelEdit('deleteRange', [p, 1])], {
       selection: new ModelEditSelection(p),
     });
   }
 
   backspace() {
-    const p = this.selectionLeft;
+    const p = this.selection.anchor;
     return this.model.edit([new ModelEdit('deleteRange', [p - 1, 1])], {
       selection: new ModelEditSelection(p - 1),
     });

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -1,7 +1,7 @@
-import { isUndefined } from 'lodash';
-import { deepEqual as equal } from '../util/object';
-import { Scanner, ScannerState, Token } from './clojure-lexer';
+import { Scanner, Token, ScannerState } from './clojure-lexer';
 import { LispTokenCursor } from './token-cursor';
+import { deepEqual as equal } from '../util/object';
+import { isUndefined } from 'lodash';
 
 let scanner: Scanner;
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1,5 +1,5 @@
 import { validPair } from './clojure-lexer';
-import { EditableDocument, ModelEdit, ModelEditSelection } from './model';
+import { ModelEdit, EditableDocument, ModelEditSelection } from './model';
 import { LispTokenCursor } from './token-cursor';
 
 // NB: doc.model.edit returns a Thenable, so that the vscode Editor can compose commands.

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1,6 +1,5 @@
-import { includes } from 'lodash';
 import { validPair } from './clojure-lexer';
-import { ModelEdit, EditableDocument, ModelEditSelection } from './model';
+import { EditableDocument, ModelEdit, ModelEditSelection } from './model';
 import { LispTokenCursor } from './token-cursor';
 
 // NB: doc.model.edit returns a Thenable, so that the vscode Editor can compose commands.
@@ -16,8 +15,8 @@ import { LispTokenCursor } from './token-cursor';
 export function killRange(
   doc: EditableDocument,
   range: [number, number],
-  start = doc.selectionLeft,
-  end = doc.selectionRight
+  start = doc.selection.anchor,
+  end = doc.selection.active
 ) {
   const [left, right] = [Math.min(...range), Math.max(...range)];
   void doc.model.edit([new ModelEdit('deleteRange', [left, right - left, [start, end]])], {
@@ -86,7 +85,7 @@ export function selectBackwardDownSexp(doc: EditableDocument) {
 }
 
 export function selectForwardUpSexp(doc: EditableDocument) {
-  selectRangeForward(doc, rangeToForwardUpList(doc, doc.selectionRight));
+  selectRangeForward(doc, rangeToForwardUpList(doc, doc.selection.active));
 }
 
 export function selectBackwardUpSexp(doc: EditableDocument) {
@@ -98,7 +97,7 @@ export function selectBackwardUpSexp(doc: EditableDocument) {
 }
 
 export function selectCloseList(doc: EditableDocument) {
-  selectRangeForward(doc, rangeToForwardList(doc, doc.selectionRight));
+  selectRangeForward(doc, rangeToForwardList(doc, doc.selection.active));
 }
 
 export function selectOpenList(doc: EditableDocument) {
@@ -159,7 +158,7 @@ export function backwardSexpRange(
 
 export function forwardListRange(
   doc: EditableDocument,
-  start: number = doc.selectionRight
+  start: number = doc.selection.active
 ): [number, number] {
   const cursor = doc.getTokenCursor(start);
   cursor.forwardList();
@@ -168,7 +167,7 @@ export function forwardListRange(
 
 export function backwardListRange(
   doc: EditableDocument,
-  start: number = doc.selectionRight
+  start: number = doc.selection.active
 ): [number, number] {
   const cursor = doc.getTokenCursor(start);
   cursor.backwardList();
@@ -358,8 +357,8 @@ export function wrapSexpr(
   doc: EditableDocument,
   open: string,
   close: string,
-  start: number = doc.selectionLeft,
-  end: number = doc.selectionRight,
+  start: number = doc.selection.anchor,
+  end: number = doc.selection.active,
   options = { skipFormat: false }
 ): Thenable<boolean> {
   const cursor = doc.getTokenCursor(end);
@@ -407,8 +406,8 @@ export function rewrapSexpr(
   doc: EditableDocument,
   open: string,
   close: string,
-  start: number = doc.selectionLeft,
-  end: number = doc.selectionRight
+  start: number = doc.selection.anchor,
+  end: number = doc.selection.active
 ): Thenable<boolean> {
   const cursor = doc.getTokenCursor(end);
   if (cursor.backwardList()) {
@@ -428,7 +427,7 @@ export function rewrapSexpr(
   }
 }
 
-export function splitSexp(doc: EditableDocument, start: number = doc.selectionRight) {
+export function splitSexp(doc: EditableDocument, start: number = doc.selection.active) {
   const cursor = doc.getTokenCursor(start);
   if (!cursor.withinString() && !(cursor.isWhiteSpace() || cursor.previousIsWhiteSpace())) {
     cursor.forwardWhitespace();
@@ -452,7 +451,7 @@ export function splitSexp(doc: EditableDocument, start: number = doc.selectionRi
  */
 export function joinSexp(
   doc: EditableDocument,
-  start: number = doc.selectionRight
+  start: number = doc.selection.active
 ): Thenable<boolean> {
   const cursor = doc.getTokenCursor(start);
   cursor.backwardWhitespace();
@@ -481,7 +480,7 @@ export function joinSexp(
 
 export function spliceSexp(
   doc: EditableDocument,
-  start: number = doc.selectionRight,
+  start: number = doc.selection.active,
   undoStopBefore = true
 ): Thenable<boolean> {
   const cursor = doc.getTokenCursor(start);
@@ -542,7 +541,7 @@ export function killForwardList(
 
 export function forwardSlurpSexp(
   doc: EditableDocument,
-  start: number = doc.selectionRight,
+  start: number = doc.selection.active,
   extraOpts = { formatDepth: 1 }
 ) {
   const cursor = doc.getTokenCursor(start);
@@ -587,7 +586,7 @@ export function forwardSlurpSexp(
 
 export function backwardSlurpSexp(
   doc: EditableDocument,
-  start: number = doc.selectionRight,
+  start: number = doc.selection.active,
   extraOpts = {}
 ) {
   const cursor = doc.getTokenCursor(start);
@@ -621,7 +620,7 @@ export function backwardSlurpSexp(
   }
 }
 
-export function forwardBarfSexp(doc: EditableDocument, start: number = doc.selectionRight) {
+export function forwardBarfSexp(doc: EditableDocument, start: number = doc.selection.active) {
   const cursor = doc.getTokenCursor(start);
   cursor.forwardList();
   if (cursor.getToken().type == 'close') {
@@ -644,7 +643,7 @@ export function forwardBarfSexp(doc: EditableDocument, start: number = doc.selec
   }
 }
 
-export function backwardBarfSexp(doc: EditableDocument, start: number = doc.selectionRight) {
+export function backwardBarfSexp(doc: EditableDocument, start: number = doc.selection.active) {
   const cursor = doc.getTokenCursor(start);
   cursor.backwardList();
   const tk = cursor.getPrevToken();
@@ -674,9 +673,9 @@ export function open(
   doc: EditableDocument,
   open: string,
   close: string,
-  start: number = doc.selectionRight
+  start: number = doc.selection.active
 ) {
-  const [cs, ce] = [doc.selectionLeft, doc.selectionRight];
+  const [cs, ce] = [doc.selection.anchor, doc.selection.active];
   doc.insertString(open + doc.getSelectionText() + close);
   if (cs != ce) {
     doc.selection = new ModelEditSelection(cs + open.length, ce + open.length);
@@ -694,7 +693,7 @@ function docIsBalanced(doc: EditableDocument, start: number = doc.selection.acti
   return cursor.atEnd();
 }
 
-export function close(doc: EditableDocument, close: string, start: number = doc.selectionRight) {
+export function close(doc: EditableDocument, close: string, start: number = doc.selection.active) {
   const cursor = doc.getTokenCursor(start);
   const inString = cursor.withinString();
   cursor.forwardWhitespace(false);
@@ -754,8 +753,8 @@ export function backspace(
 
 export function deleteForward(
   doc: EditableDocument,
-  start: number = doc.selectionLeft,
-  end: number = doc.selectionRight
+  start: number = doc.selection.anchor,
+  end: number = doc.selection.active
 ) {
   if (start != end) {
     void doc.delete();
@@ -788,8 +787,8 @@ export function deleteForward(
 
 export function stringQuote(
   doc: EditableDocument,
-  start: number = doc.selectionLeft,
-  end: number = doc.selectionRight
+  start: number = doc.selection.anchor,
+  end: number = doc.selection.active
 ) {
   if (start != end) {
     doc.insertString('"');
@@ -826,8 +825,8 @@ export function stringQuote(
 
 export function growSelection(
   doc: EditableDocument,
-  start: number = doc.selectionLeft,
-  end: number = doc.selectionRight
+  start: number = doc.selection.anchor,
+  end: number = doc.selection.active
 ) {
   const startC = doc.getTokenCursor(start),
     endC = doc.getTokenCursor(end),
@@ -876,7 +875,7 @@ export function growSelectionStack(doc: EditableDocument, range: [number, number
   const [start, end] = range;
   if (doc.selectionStack.length > 0) {
     const prev = doc.selectionStack[doc.selectionStack.length - 1];
-    if (!(doc.selectionLeft == prev.anchor && doc.selectionRight == prev.active)) {
+    if (!(doc.selection.anchor == prev.anchor && doc.selection.active == prev.active)) {
       setSelectionStack(doc);
     } else if (prev.anchor === range[0] && prev.active === range[1]) {
       return;
@@ -893,8 +892,8 @@ export function shrinkSelection(doc: EditableDocument) {
     const latest = doc.selectionStack.pop();
     if (
       doc.selectionStack.length &&
-      latest.anchor == doc.selectionLeft &&
-      latest.active == doc.selectionRight
+      latest.anchor == doc.selection.anchor &&
+      latest.active == doc.selection.active
     ) {
       doc.selection = doc.selectionStack[doc.selectionStack.length - 1];
     }
@@ -907,8 +906,8 @@ export function setSelectionStack(doc: EditableDocument, selection = doc.selecti
 
 export function raiseSexp(
   doc: EditableDocument,
-  start = doc.selectionLeft,
-  end = doc.selectionRight
+  start = doc.selection.anchor,
+  end = doc.selection.active
 ) {
   const cursor = doc.getTokenCursor(end);
   const [formStart, formEnd] = cursor.rangeForCurrentForm(start);
@@ -937,8 +936,8 @@ export function raiseSexp(
 
 export function convolute(
   doc: EditableDocument,
-  start = doc.selectionLeft,
-  end = doc.selectionRight
+  start = doc.selection.anchor,
+  end = doc.selection.active
 ) {
   if (start == end) {
     const cursorStart = doc.getTokenCursor(end);
@@ -977,8 +976,8 @@ export function convolute(
 
 export function transpose(
   doc: EditableDocument,
-  left = doc.selectionLeft,
-  right = doc.selectionRight,
+  left = doc.selection.anchor,
+  right = doc.selection.active,
   newPosOffset: { fromLeft?: number; fromRight?: number } = {}
 ) {
   const cursor = doc.getTokenCursor(right);
@@ -1088,8 +1087,8 @@ function currentSexpsRange(
 export function dragSexprBackward(
   doc: EditableDocument,
   pairForms = bindingForms,
-  left = doc.selectionLeft,
-  right = doc.selectionRight
+  left = doc.selection.anchor,
+  right = doc.selection.active
 ) {
   const cursor = doc.getTokenCursor(right);
   const usePairs = isInPairsList(cursor, pairForms);
@@ -1115,8 +1114,8 @@ export function dragSexprBackward(
 export function dragSexprForward(
   doc: EditableDocument,
   pairForms = bindingForms,
-  left = doc.selectionLeft,
-  right = doc.selectionRight
+  left = doc.selection.anchor,
+  right = doc.selection.active
 ) {
   const cursor = doc.getTokenCursor(right);
   const usePairs = isInPairsList(cursor, pairForms);
@@ -1161,7 +1160,7 @@ export type WhitespaceInfo = {
  */
 export function collectWhitespaceInfo(
   doc: EditableDocument,
-  p = doc.selectionRight
+  p = doc.selection.active
 ): WhitespaceInfo {
   const cursor = doc.getTokenCursor(p);
   const currentRange = cursor.rangeForCurrentForm(p);
@@ -1189,7 +1188,7 @@ export function collectWhitespaceInfo(
   };
 }
 
-export function dragSexprBackwardUp(doc: EditableDocument, p = doc.selectionRight) {
+export function dragSexprBackwardUp(doc: EditableDocument, p = doc.selection.active) {
   const wsInfo = collectWhitespaceInfo(doc, p);
   const cursor = doc.getTokenCursor(p);
   const currentRange = cursor.rangeForCurrentForm(p);
@@ -1230,7 +1229,7 @@ export function dragSexprBackwardUp(doc: EditableDocument, p = doc.selectionRigh
   }
 }
 
-export function dragSexprForwardDown(doc: EditableDocument, p = doc.selectionRight) {
+export function dragSexprForwardDown(doc: EditableDocument, p = doc.selection.active) {
   const wsInfo = collectWhitespaceInfo(doc, p);
   const currentRange = doc.getTokenCursor(p).rangeForCurrentForm(p);
   const newPosOffset = p - currentRange[0];
@@ -1266,7 +1265,7 @@ export function dragSexprForwardDown(doc: EditableDocument, p = doc.selectionRig
   }
 }
 
-export function dragSexprForwardUp(doc: EditableDocument, p = doc.selectionRight) {
+export function dragSexprForwardUp(doc: EditableDocument, p = doc.selection.active) {
   const wsInfo = collectWhitespaceInfo(doc, p);
   const cursor = doc.getTokenCursor(p);
   const currentRange = cursor.rangeForCurrentForm(p);
@@ -1297,7 +1296,7 @@ export function dragSexprForwardUp(doc: EditableDocument, p = doc.selectionRight
   }
 }
 
-export function dragSexprBackwardDown(doc: EditableDocument, p = doc.selectionRight) {
+export function dragSexprBackwardDown(doc: EditableDocument, p = doc.selection.active) {
   const wsInfo = collectWhitespaceInfo(doc, p);
   const currentRange = doc.getTokenCursor(p).rangeForCurrentForm(p);
   const newPosOffset = p - currentRange[0];

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -1,17 +1,17 @@
 export { getIndent } from '../cursor-doc/indent';
-import { isUndefined } from 'lodash';
 import * as vscode from 'vscode';
+import * as utilities from '../utilities';
 import * as formatter from '../calva-fmt/src/format';
+import { LispTokenCursor } from '../cursor-doc/token-cursor';
 import {
+  ModelEdit,
   EditableDocument,
   EditableModel,
-  LineInputModel,
-  ModelEdit,
   ModelEditOptions,
+  LineInputModel,
   ModelEditSelection,
 } from '../cursor-doc/model';
-import { LispTokenCursor } from '../cursor-doc/token-cursor';
-import * as utilities from '../utilities';
+import { isUndefined } from 'lodash';
 
 const documents = new Map<vscode.TextDocument, MirroredDocument>();
 

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -725,9 +725,7 @@ describe('Token Cursor', () => {
       const a = docFromTextNotation('(map #|(println %) [1 2])');
       const b = docFromTextNotation('(map |#(println %)| [1 2])');
       const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
-      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(
-        textAndSelection(b)[1]
-      );
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('8: does not croak on unbalance', () => {
       // This hangs the structural editing in the real editor

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -1,6 +1,5 @@
 import * as expect from 'expect';
 import { LispTokenCursor } from '../../../cursor-doc/token-cursor';
-import { currentEnclosingFormToCursor } from '../../../util/cursor-get-text';
 import { docFromTextNotation, textAndSelection } from '../common/text-notation';
 
 describe('Token Cursor', () => {
@@ -8,16 +7,16 @@ describe('Token Cursor', () => {
     it('it moves past whitespace', () => {
       const a = docFromTextNotation('a •|c');
       const b = docFromTextNotation('a| •c');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardWhitespace();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('it moves past whitespace from inside symbol', () => {
       const a = docFromTextNotation('a •c|c');
       const b = docFromTextNotation('a| •cc');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardWhitespace();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
   });
 
@@ -25,115 +24,115 @@ describe('Token Cursor', () => {
     it('moves from beginning to end of symbol', () => {
       const a = docFromTextNotation('(|c•#f)');
       const b = docFromTextNotation('(c|•#f)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('moves from beginning to end of nested list ', () => {
       const a = docFromTextNotation('|(a(b(c•#f•(#b •[:f])•#z•1)))');
       const b = docFromTextNotation('(a(b(c•#f•(#b •[:f])•#z•1)))|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Includes reader tag as part of a list form', () => {
       const a = docFromTextNotation('(c|•#f•(#b •[:f :b :z])•#z•1)');
       const b = docFromTextNotation('(c•#f•(#b •[:f :b :z])|•#z•1)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Includes reader tag as part of a symbol', () => {
       const a = docFromTextNotation('(c•#f•(#b •[:f :b :z])|•#z•1)');
       const b = docFromTextNotation('(c•#f•(#b •[:f :b :z])•#z•1|)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Does not move out of a list', () => {
       const a = docFromTextNotation('(c•#f•(#b •[:f :b :z])•#z•1|)');
       const b = docFromTextNotation('(c•#f•(#b •[:f :b :z])•#z•1|)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Skip metadata if skipMetadata is true', () => {
       const a = docFromTextNotation('(a |^{:a 1} (= 1 1))');
       const b = docFromTextNotation('(a ^{:a 1} (= 1 1)|)');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Skip metadata and reader if skipMetadata is true', () => {
       const a = docFromTextNotation('(a |^{:a 1} #a (= 1 1))');
       const b = docFromTextNotation('(a ^{:a 1} #a (= 1 1)|)');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Skip reader and metadata if skipMetadata is true', () => {
       const a = docFromTextNotation('(a |#a ^{:a 1} (= 1 1))');
       const b = docFromTextNotation('(a #a ^{:a 1} (= 1 1)|)');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Skips multiple metadata maps if skipMetadata is true', () => {
       const a = docFromTextNotation('(a |^{:a 1} ^{:b 2} (= 1 1))');
       const b = docFromTextNotation('(a ^{:a 1} ^{:b 2} (= 1 1)|)');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Skips symbol shorthand for metadata if skipMetadata is true', () => {
       const a = docFromTextNotation('(a| ^String (= 1 1))');
       const b = docFromTextNotation('(a ^String (= 1 1)|)');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Skips keyword shorthand for metadata if skipMetadata is true', () => {
       const a = docFromTextNotation('(a| ^:hello (= 1 1))');
       const b = docFromTextNotation('(a ^:hello (= 1 1)|)');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Skips multiple keyword shorthands for metadata if skipMetadata is true', () => {
       const a = docFromTextNotation('(a| ^:hello ^:world (= 1 1))');
       const b = docFromTextNotation('(a ^:hello ^:world (= 1 1)|)');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Does not skip ignored forms if skipIgnoredForms is false', () => {
       const a = docFromTextNotation('(a| #_1 #_2 3)');
       const b = docFromTextNotation('(a #_|1 #_2 3)');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Skip ignored forms if skipIgnoredForms is true', () => {
       const a = docFromTextNotation('(a| #_1 #_2 3)');
       const b = docFromTextNotation('(a #_1 #_2 3|)');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp(true, true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('should skip stacked ignored forms if skipIgnoredForms is true', () => {
       const a = docFromTextNotation('(a| #_ #_ 1 2 3)');
       const b = docFromTextNotation('(a #_ #_ 1 2 3|)');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp(true, true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it.skip('Does not move past unbalanced top level form', () => {
       //TODO: Figure out why this doesn't work
       //TODO: Figure out why this breaks some tests run after this one
       const d = docFromTextNotation('|(foo "bar"');
-      const cursor: LispTokenCursor = d.getTokenCursor(d.selectionLeft);
+      const cursor: LispTokenCursor = d.getTokenCursor(d.selection.anchor);
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(d.selectionLeft);
+      expect(cursor.offsetStart).toBe(d.selection.anchor);
     });
   });
 
@@ -141,79 +140,79 @@ describe('Token Cursor', () => {
     it('moves from end to beginning of symbol', () => {
       const a = docFromTextNotation('(a(b(c|•#f•(#b •[:f :b :z])•#z•1)))');
       const b = docFromTextNotation('(a(b(|c•#f•(#b •[:f :b :z])•#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardSexp();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('moves from end to beginning of nested list ', () => {
       const a = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1)))|');
       const b = docFromTextNotation('|(a(b(c•#f•(#b •[:f :b :z])•#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardSexp();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Includes reader tag as part of a list form', () => {
       const a = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])|•#z•1)))');
       const b = docFromTextNotation('(a(b(c•|#f•(#b •[:f :b :z])•#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardSexp();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Includes reader tag as part of a symbol', () => {
       const a = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1|)))');
       const b = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•|#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardSexp();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Does not move out of a list', () => {
       const a = docFromTextNotation('(a(|b(c•#f•(#b •[:f :b :z])•#z•1)))');
       const b = docFromTextNotation('(a(|b(c•#f•(#b •[:f :b :z])•#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardSexp();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Skip metadata if skipMetadata is true', () => {
       const a = docFromTextNotation('(a ^{:a 1} (= 1 1)|)');
       const b = docFromTextNotation('(a |^{:a 1} (= 1 1))');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Treats metadata as part of the sexp if skipMetadata is true', () => {
       const a = docFromTextNotation('(a ^{:a 1}| (= 1 1))');
       const b = docFromTextNotation('(a |^{:a 1} (= 1 1))');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Skips multiple metadata maps if skipMetadata is true', () => {
       const a = docFromTextNotation('(a ^{:a 1} ^{:b 2} (= 1 1)|)');
       const b = docFromTextNotation('(a |^{:a 1} ^{:b 2} (= 1 1))');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Treats metadata and readers as part of the sexp if skipMetadata is true', () => {
       const a = docFromTextNotation('#bar •^baz•|[:a :b :c]•x');
       const b = docFromTextNotation('|#bar •^baz•[:a :b :c]•x');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Treats reader and metadata as part of the sexp if skipMetadata is true', () => {
       const a = docFromTextNotation('^bar •#baz•|[:a :b :c]•x');
       const b = docFromTextNotation('|^bar •#baz•[:a :b :c]•x');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Treats readers and metadata:s mixed as part of the sexp from behind the sexp if skipMetadata is true', () => {
       const a = docFromTextNotation('^d #c ^b •#a•[:a :b :c]|•x');
       const b = docFromTextNotation('|^d #c ^b •#a•[:a :b :c]•x');
-      const cursor = a.getTokenCursor(a.selectionLeft);
+      const cursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
   });
 
@@ -221,44 +220,44 @@ describe('Token Cursor', () => {
     it('Puts cursor to the right of the following open paren', () => {
       const a = docFromTextNotation('(a |(b 1))');
       const b = docFromTextNotation('(a (|b 1))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.downList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Puts cursor to the right of the following open curly brace:', () => {
       const a = docFromTextNotation('(a |{:b 1}))');
       const b = docFromTextNotation('(a {|:b 1}))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.downList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Puts cursor to the right of the following open bracket', () => {
       const a = docFromTextNotation('(a| [1 2]))');
       const b = docFromTextNotation('(a [|1 2]))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.downList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it(`Puts cursor to the right of the following opening quoted list`, () => {
       const a = docFromTextNotation(`(a| '(b 1))`);
       const b = docFromTextNotation(`(a '(|b 1))`);
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.downList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Skips whitespace', () => {
       const a = docFromTextNotation('(a|•  (b 1))');
       const b = docFromTextNotation('(a•  (|b 1))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.downList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Does not skip metadata', () => {
       const a = docFromTextNotation('(a| ^{:x 1} (b 1))');
       const b = docFromTextNotation('(a ^{|:x 1} (b 1))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.downList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
   });
 
@@ -266,84 +265,84 @@ describe('Token Cursor', () => {
     it('Moves down, skipping metadata', () => {
       const a = docFromTextNotation('(|a #b ^{:x 1} (c 1))');
       const b = docFromTextNotation('(a #b ^{:x 1} (|c 1))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.downListSkippingMeta();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Moves down when there is no metadata', () => {
       const a = docFromTextNotation('(|a #b (c 1))');
       const b = docFromTextNotation('(a #b (|c 1))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.downListSkippingMeta();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
   });
 
   it('upList', () => {
     const a = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1|)))');
     const b = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1)|))');
-    const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+    const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
     cursor.upList();
-    expect(cursor.offsetStart).toBe(b.selectionLeft);
+    expect(cursor.offsetStart).toBe(b.selection.anchor);
   });
 
   describe('forwardList', () => {
     it('Finds end of list', () => {
       const a = docFromTextNotation('(|foo (bar baz) [])');
       const b = docFromTextNotation('(foo (bar baz) []|)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Finds end of list through readers and meta', () => {
       const a = docFromTextNotation('(|#a ^{:b c} #d (bar baz) [])');
       const b = docFromTextNotation('(#a ^{:b c} #d (bar baz) []|)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Does not move at top level', () => {
       const a = docFromTextNotation('|foo (bar baz)');
       const b = docFromTextNotation('|foo (bar baz)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Does not move at top level when unbalanced document from extra closings', () => {
       const a = docFromTextNotation('|foo (bar baz))');
       const b = docFromTextNotation('|foo (bar baz))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Does not move at top level when unbalanced document from extra opens', () => {
       const a = docFromTextNotation('|foo ((bar baz)');
       const b = docFromTextNotation('|foo ((bar baz)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Does not move when unbalanced from extra opens', () => {
       const a = docFromTextNotation('(|[');
       const b = docFromTextNotation('(|[');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Does not move when at end of list, returns true', () => {
       const a = docFromTextNotation('(|)');
       const b = docFromTextNotation('(|)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.forwardList();
       expect(result).toBe(true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Finds the list end when unbalanced from extra closes outside the current list', () => {
       const a = docFromTextNotation('(|a #b []))');
       const b = docFromTextNotation('(a #b []|))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
   });
 
@@ -351,66 +350,66 @@ describe('Token Cursor', () => {
     it('Finds start of list', () => {
       const a = docFromTextNotation('(((c•(#b •[:f])•#z•|1)))');
       const b = docFromTextNotation('(((|c•(#b •[:f])•#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Finds start of list through readers', () => {
       const a = docFromTextNotation('(((c•#a• #f•(#b •[:f])•#z•|1)))');
       const b = docFromTextNotation('(((|c•#a• #f•(#b •[:f])•#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Finds start of list through metadata', () => {
       const a = docFromTextNotation('(((c•^{:a c} (#b •[:f])•#z•|1)))');
       const b = docFromTextNotation('(((|c•^{:a c} (#b •[:f])•#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Does not move at top level', () => {
       const a = docFromTextNotation('foo |(bar baz)');
       const b = docFromTextNotation('foo |(bar baz)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Does not move when at start of unbalanced list', () => {
       // https://github.com/BetterThanTomorrow/calva/issues/1573
       // https://github.com/BetterThanTomorrow/calva/commit/d77359fcea16bc052ab829853d5711434330a375
       const a = docFromTextNotation('([|');
       const b = docFromTextNotation('([|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.backwardList();
       expect(result).toBe(false);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Does not move to start of an unbalanced list when outer list is also unbalanced', () => {
       // NB: This is a bit arbitrary, this test documents the current behaviour
       const a = docFromTextNotation('(let [a| a');
       const b = docFromTextNotation('(let [a| a');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.backwardList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
       expect(result).toBe(false);
     });
     it('Moves to start of an unbalanced list when outer list is balanced', () => {
       // NB: This is a bit arbitrary, this test documents the current behaviour
       const a = docFromTextNotation('(let [a| a)');
       const b = docFromTextNotation('(let [|a a)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.backwardList();
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
       expect(result).toBe(true);
     });
     it('Finds the list start when unbalanced from extra closes outside the current list', () => {
       const a = docFromTextNotation('([]|))');
       const b = docFromTextNotation('(|[]))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.backwardList();
       expect(result).toBe(true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
   });
 
@@ -418,41 +417,41 @@ describe('Token Cursor', () => {
     it('Finds end of list', () => {
       const a = docFromTextNotation('([#{|c•(#b •[:f])•#z•1}])');
       const b = docFromTextNotation('([#{c•(#b •[:f])•#z•1}]|)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.forwardListOfType(')');
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
       expect(result).toBe(true);
     });
     it('Finds end of vector', () => {
       const a = docFromTextNotation('([(c•(#b| •[:f])•#z•1)])');
       const b = docFromTextNotation('([(c•(#b •[:f])•#z•1)|])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.forwardListOfType(']');
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
       expect(result).toBe(true);
     });
     it('Finds end of map', () => {
       const a = docFromTextNotation('({:a [(c•(#|b •[:f])•#z•|1)]})');
       const b = docFromTextNotation('({:a [(c•(#b •[:f])•#z•1)]|})');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.forwardListOfType('}');
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
       expect(result).toBe(true);
     });
     it('Does not move when list is unbalanced from missing open', () => {
       const a = docFromTextNotation('|])');
       const b = docFromTextNotation('|])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.forwardListOfType(')');
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
       expect(result).toBe(false);
     });
     it('Does not move when list type is not found', () => {
       const a = docFromTextNotation('([|])');
       const b = docFromTextNotation('([|])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.forwardListOfType('}');
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
       expect(result).toBe(false);
     });
   });
@@ -461,25 +460,25 @@ describe('Token Cursor', () => {
     it('Finds start of list', () => {
       const a = docFromTextNotation('([#{c•(#b •[:f])•#z•|1}])');
       const b = docFromTextNotation('(|[#{c•(#b •[:f])•#z•1}])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.backwardListOfType('(');
       expect(result).toBe(true);
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
     it('Finds start of vector', () => {
       const a = docFromTextNotation('([(c•(#b •[:f])•#z•|1)])');
       const b = docFromTextNotation('([|(c•(#b •[:f])•#z•1)])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.backwardListOfType('[');
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
       expect(result).toBe(true);
     });
     it('Finds start of map', () => {
       const a = docFromTextNotation('({:a [(c•(#b •[:f])•#z•|1)]})');
       const b = docFromTextNotation('({|:a [(c•(#b •[:f])•#z•1)]})');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.backwardListOfType('{');
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
       expect(result).toBe(true);
     });
     it('Does not move when list type is unbalanced from missing close', () => {
@@ -487,36 +486,36 @@ describe('Token Cursor', () => {
       // https://github.com/BetterThanTomorrow/calva/issues/1573
       const a = docFromTextNotation('([|');
       const b = docFromTextNotation('([|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.backwardListOfType('(');
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
       expect(result).toBe(false);
     });
     it('Moves backward in unbalanced list when outer list is balanced', () => {
       // https://github.com/BetterThanTomorrow/calva/issues/1585
       const a = docFromTextNotation('(let [a|)');
       const b = docFromTextNotation('(let [|a)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.backwardListOfType('[');
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
       expect(result).toBe(true);
     });
     it('Moves backward in balanced list when inner list is unbalanced', () => {
-      // This never conmpletes in Calva v2.0.252
+      // This never completes in Calva v2.0.252
       // https://github.com/BetterThanTomorrow/calva/issues/1585
       const a = docFromTextNotation('(let [a|)');
       const b = docFromTextNotation('(|let [a)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.backwardListOfType('(');
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
       expect(result).toBe(true);
     });
     it('Does not move when list type is not found', () => {
       const a = docFromTextNotation('([|])');
       const b = docFromTextNotation('([|])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       const result = cursor.backwardListOfType('{');
-      expect(cursor.offsetStart).toBe(b.selectionLeft);
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
       expect(result).toBe(false);
     });
   });
@@ -524,9 +523,9 @@ describe('Token Cursor', () => {
   it('backwardUpList', () => {
     const a = docFromTextNotation('(a(b(c•#f•(#b •|[:f :b :z])•#z•1)))');
     const b = docFromTextNotation('(a(b(c•#f•|(#b •[:f :b :z])•#z•1)))');
-    const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+    const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
     cursor.backwardUpList();
-    expect(cursor.offsetStart).toBe(b.selectionLeft);
+    expect(cursor.offsetStart).toBe(b.selection.anchor);
   });
 
   // TODO: Figure out why adding these tests make other test break!
@@ -534,23 +533,23 @@ describe('Token Cursor', () => {
     it('backwardList moves to start of string', () => {
       const a = docFromTextNotation('(str [] "", "foo" "f |  b  b"   "   f b b   " "\\"" \\")');
       const b = docFromTextNotation('(str [] "", "foo" "|f   b  b"   "   f b b   " "\\"" \\")');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardList();
-      expect(cursor.offsetStart).toEqual(b.selectionLeft);
+      expect(cursor.offsetStart).toEqual(b.selection.anchor);
     });
     it('forwardList moves to end of string', () => {
       const a = docFromTextNotation('(str [] "", "foo" "f |  b  b"   "   f b b   " "\\"" \\")');
       const b = docFromTextNotation('(str [] "", "foo" "f   b  b|"   "   f b b   " "\\"" \\")');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toEqual(b.selectionLeft);
+      expect(cursor.offsetStart).toEqual(b.selection.anchor);
     });
     it('backwardSexpr inside string moves past quoted characters', () => {
       const a = docFromTextNotation('(str [] "foo \\"| bar")');
       const b = docFromTextNotation('(str [] "foo |\\" bar")');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardSexp();
-      expect(cursor.offsetStart).toEqual(b.selectionLeft);
+      expect(cursor.offsetStart).toEqual(b.selection.anchor);
     });
   });
 
@@ -558,14 +557,14 @@ describe('Token Cursor', () => {
     it('Backward sexp bypasses prompt', () => {
       const a = docFromTextNotation('foo•clj꞉foo꞉> |');
       const b = docFromTextNotation('|foo•clj꞉foo꞉> ');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardSexp();
       expect(cursor.offsetStart).toEqual(b.selection.active);
     });
     it('Backward sexp not skipping comments bypasses prompt finding its start', () => {
       const a = docFromTextNotation('foo•clj꞉foo꞉> |');
       const b = docFromTextNotation('foo•|clj꞉foo꞉> ');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.backwardSexp(false);
       expect(cursor.offsetStart).toEqual(b.selection.active);
     });
@@ -575,165 +574,167 @@ describe('Token Cursor', () => {
     it('0: selects from within non-list form', () => {
       const a = docFromTextNotation('(a|aa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x');
       const b = docFromTextNotation('(|aaa| (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('0: selects from within non-list form including reader tag', () => {
       const a = docFromTextNotation('(#a a|aa (foo bar)))');
       const b = docFromTextNotation('(|#a aaa| (foo bar)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('0: selects from within non-list form including multiple reader tags', () => {
       const a = docFromTextNotation('(#aa #a #b a|aa (foo bar)))');
       const b = docFromTextNotation('(|#aa #a #b aaa| (foo bar)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('0: selects from within non-list form including metadata', () => {
       const a = docFromTextNotation('(^aa #a a|aa (foo bar)))');
       const b = docFromTextNotation('(|^aa #a aaa| (foo bar)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('0: selects from within non-list form including readers and metadata', () => {
       const a = docFromTextNotation('(^aa #a a|aa (foo bar))');
       const b = docFromTextNotation('(|^aa #a aaa| (foo bar))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('0: selects from within non-list form including metadata and readers', () => {
       const a = docFromTextNotation('(#a ^aa a|aa (foo bar))');
       const b = docFromTextNotation('(|#a ^aa aaa| (foo bar))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('1: selects from adjacent when after form', () => {
       const a = docFromTextNotation('(aaa •x•#(a b c)|)•#baz•yyy•)');
       const b = docFromTextNotation('(aaa •x•|#(a b c)|)•#baz•yyy•)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('1: selects from adjacent when after form, including reader tags', () => {
       const a = docFromTextNotation('(x• #a #b •#(a b c)|)•#baz•yyy•)');
       const b = docFromTextNotation('(x• |#a #b •#(a b c)|)•#baz•yyy•)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('1: selects from adjacent when after form, including readers and meta data', () => {
       const a = docFromTextNotation('(x• ^a #b •#(a b c)|)•#baz•yyy•)');
       const b = docFromTextNotation('(x• |^a #b •#(a b c)|)•#baz•yyy•)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('1: selects from adjacent when after form, including meta data and readers', () => {
       const a = docFromTextNotation('(x• #a ^b •#(a b c)|)•#baz•yyy•)');
       const b = docFromTextNotation('(x• |#a ^b •#(a b c)|)•#baz•yyy•)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before form', () => {
       const a = docFromTextNotation('#bar •#baz•[:a :b :c]•x•|#(a b c)');
       const b = docFromTextNotation('#bar •#baz•[:a :b :c]•x•|#(a b c)|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before form, including reader tags', () => {
       const a = docFromTextNotation('|#bar •#baz•[:a :b :c]•x');
       const b = docFromTextNotation('|#bar •#baz•[:a :b :c]|•x');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before form, including meta data', () => {
       const a = docFromTextNotation('|^bar •[:a :b :c]•x');
       const b = docFromTextNotation('|^bar •[:a :b :c]|•x');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before form, including meta data and reader', () => {
       const a = docFromTextNotation('|^bar •#baz•[:a :b :c]•x');
       const b = docFromTextNotation('|^bar •#baz•[:a :b :c]|•x');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before form, including preceding reader and meta data', () => {
       const a = docFromTextNotation('^bar •#baz•|[:a :b :c]•x');
       const b = docFromTextNotation('|^bar •#baz•[:a :b :c]|•x');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before form, including preceding meta data and reader', () => {
       const a = docFromTextNotation('#bar •^baz•|[:a :b :c]•x');
       const b = docFromTextNotation('|#bar •^baz•[:a :b :c]|•x');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before form, or in readers', () => {
       const a = docFromTextNotation('ccc •#foo•|•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy');
       const b = docFromTextNotation('ccc •|#foo••(#bar •#baz•[:a :b :c]•x•#(a b c))|•#baz•yyy');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before a form with reader tags', () => {
       const a = docFromTextNotation('#bar |•#baz•[:a :b :c]•x');
       const b = docFromTextNotation('|#bar •#baz•[:a :b :c]|•x');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('3: selects previous form, if on the same line', () => {
       const a = docFromTextNotation('z z  | •foo•   •   bar');
       const b = docFromTextNotation('z |z|   •foo•   •   bar');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('4: selects next form, if on the same line', () => {
       const a = docFromTextNotation('yyy•|   z z z   •foo•   •   bar');
       const b = docFromTextNotation('yyy•   |z| z z   •foo•   •   bar');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('5: selects previous form, if any', () => {
       const a = docFromTextNotation('yyy•   z z z   •foo•   |•   bar');
       const b = docFromTextNotation('yyy•   z z z   •|foo|•   •   bar');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('5: selects previous form, if any, when next form has metadata', () => {
       const a = docFromTextNotation('z•foo•|•^{:a b}•bar');
       const b = docFromTextNotation('z•|foo|••^{:a b}•bar');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('6: selects next form, if any', () => {
       const a = docFromTextNotation(' | •  (foo {:a b})•(c)');
       const b = docFromTextNotation('  •  |(foo {:a b})|•(c)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('7: selects enclosing form, if any', () => {
       const a = docFromTextNotation('(|)  •  (foo {:a b})•(c)');
       const b = docFromTextNotation('|()|  •  (foo {:a b})•(c)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('2: selects anonymous function when cursor is before #', () => {
       const a = docFromTextNotation('(map |#(println %) [1 2])');
       const b = docFromTextNotation('(map |#(println %)| [1 2])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('2: selects anonymous function when cursor is after # and before (', () => {
       const a = docFromTextNotation('(map #|(println %) [1 2])');
       const b = docFromTextNotation('(map |#(println %)| [1 2])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toEqual(
+        textAndSelection(b)[1]
+      );
     });
     it('8: does not croak on unbalance', () => {
       // This hangs the structural editing in the real editor
       // https://github.com/BetterThanTomorrow/calva/issues/1573
       const a = docFromTextNotation('([|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
-      expect(cursor.rangeForCurrentForm(a.selectionLeft)).toBeUndefined();
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      expect(cursor.rangeForCurrentForm(a.selection.anchor)).toBeUndefined();
     });
   });
 
@@ -840,25 +841,25 @@ describe('Token Cursor', () => {
         'aaa |(comment (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar))| (ddd eee)'
       );
       const cursor: LispTokenCursor = a.getTokenCursor(0);
-      expect(cursor.rangeForDefun(a.selectionLeft, false)).toEqual(textAndSelection(b)[1]);
+      expect(cursor.rangeForDefun(a.selection.anchor, false)).toEqual(textAndSelection(b)[1]);
     });
     it('Finds closest form inside multiple nested comments', () => {
       const a = docFromTextNotation('aaa (comment (comment [bbb ccc] | ddd))');
       const b = docFromTextNotation('aaa (comment (comment |[bbb ccc]|  ddd))');
       const cursor: LispTokenCursor = a.getTokenCursor(0);
-      expect(cursor.rangeForDefun(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      expect(cursor.rangeForDefun(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('Finds the preceding range when cursor is between two forms on the same line', () => {
       const a = docFromTextNotation('aaa (comment [bbb ccc] | ddd)');
       const b = docFromTextNotation('aaa (comment |[bbb ccc]|  ddd)');
       const cursor: LispTokenCursor = a.getTokenCursor(0);
-      expect(cursor.rangeForDefun(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      expect(cursor.rangeForDefun(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
     it('Finds top level form when deref in comment', () => {
       const a = docFromTextNotation('(comment @(foo [bar|]))');
       const b = docFromTextNotation('(comment |@(foo [bar])|)');
       const cursor: LispTokenCursor = a.getTokenCursor(0);
-      expect(cursor.rangeForDefun(a.selectionLeft)).toEqual(textAndSelection(b)[1]);
+      expect(cursor.rangeForDefun(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
     });
   });
 
@@ -866,14 +867,14 @@ describe('Token Cursor', () => {
     describe('getFunctionName', () => {
       it('Finds function name in the current list', () => {
         const a = docFromTextNotation('(foo [|])');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
         expect(cursor.getFunctionName()).toEqual('foo');
       });
       it('Does not croak finding function name in unbalance', () => {
         // This hung the structural editing in the real editor
         // https://github.com/BetterThanTomorrow/calva/issues/1573
         const a = docFromTextNotation('([|');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selectionLeft);
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
         expect(cursor.getFunctionName()).toBeUndefined();
       });
     });

--- a/src/extension-test/unit/util/cursor-get-text-test.ts
+++ b/src/extension-test/unit/util/cursor-get-text-test.ts
@@ -1,13 +1,13 @@
 import * as expect from 'expect';
-import { docFromTextNotation } from '../common/text-notation';
 import * as getText from '../../../util/cursor-get-text';
+import { docFromTextNotation } from '../common/text-notation';
 
 describe('get text', () => {
   describe('getTopLevelFunction', () => {
     it('Finds top level function at top', () => {
       const a = docFromTextNotation('(foo bar)•(deftest a-test•  (baz |gaz))');
       const b = docFromTextNotation('(foo bar)•(deftest |a-test|•  (baz gaz))');
-      const range: [number, number] = [b.selectionLeft, b.selectionRight];
+      const range: [number, number] = [b.selection.anchor, b.selection.active];
       expect(getText.currentTopLevelFunction(a, a.selection.active)).toEqual([
         range,
         b.model.getText(...range),
@@ -17,7 +17,7 @@ describe('get text', () => {
     it('Finds top level function when nested', () => {
       const a = docFromTextNotation('(foo bar)•(with-test•  (deftest a-test•    (baz |gaz)))');
       const b = docFromTextNotation('(foo bar)•(with-test•  (deftest |a-test|•    (baz gaz)))');
-      const range: [number, number] = [b.selectionLeft, b.selectionRight];
+      const range: [number, number] = [b.selection.anchor, b.selection.active];
       expect(getText.currentTopLevelFunction(a, a.selection.active)).toEqual([
         range,
         b.model.getText(...range),
@@ -28,7 +28,7 @@ describe('get text', () => {
       // https://github.com/BetterThanTomorrow/calva/issues/1086
       const a = docFromTextNotation('(foo bar)•(with-test•  (t/deftest a-test•    (baz |gaz)))');
       const b = docFromTextNotation('(foo bar)•(with-test•  (t/deftest |a-test|•    (baz gaz)))');
-      const range: [number, number] = [b.selectionLeft, b.selectionRight];
+      const range: [number, number] = [b.selection.anchor, b.selection.active];
       expect(getText.currentTopLevelFunction(a, a.selection.active)).toEqual([
         range,
         b.model.getText(...range),
@@ -38,7 +38,7 @@ describe('get text', () => {
     it('Finds top level function when function has metadata', () => {
       const a = docFromTextNotation('(foo bar)•(deftest ^{:some :thing} a-test•  (baz |gaz))');
       const b = docFromTextNotation('(foo bar)•(deftest ^{:some :thing} |a-test|•  (baz gaz))');
-      const range: [number, number] = [b.selectionLeft, b.selectionRight];
+      const range: [number, number] = [b.selection.anchor, b.selection.active];
       expect(getText.currentTopLevelFunction(a, a.selection.active)).toEqual([
         range,
         b.model.getText(...range),
@@ -50,7 +50,7 @@ describe('get text', () => {
     it('Finds top level form', () => {
       const a = docFromTextNotation('(foo bar)•(deftest a-test•  (baz |gaz))');
       const b = docFromTextNotation('(foo bar)•|(deftest a-test•  (baz gaz))|');
-      const range: [number, number] = [b.selectionLeft, b.selectionRight];
+      const range: [number, number] = [b.selection.anchor, b.selection.active];
       expect(getText.currentTopLevelForm(a)).toEqual([range, b.model.getText(...range)]);
     });
   });
@@ -59,7 +59,7 @@ describe('get text', () => {
     it('Current enclosing form from start to cursor, then folded', () => {
       const a = docFromTextNotation('(foo bar)•(deftest a-test•  [baz ; f|oo•     gaz])');
       const b = docFromTextNotation('(foo bar)•(deftest a-test•  |[baz| ; foo•     gaz])');
-      const range: [number, number] = [b.selectionLeft, b.selectionRight];
+      const range: [number, number] = [b.selection.anchor, b.selection.active];
       const trail = ']';
       expect(getText.currentEnclosingFormToCursor(a)).toEqual([
         range,
@@ -72,7 +72,7 @@ describe('get text', () => {
     it('Finds top level form from start to cursor', () => {
       const a = docFromTextNotation('(foo bar)•(deftest a-test•  [baz ; f|oo•     gaz])');
       const b = docFromTextNotation('(foo bar)•|(deftest a-test•  [baz| ; foo•     gaz])');
-      const range: [number, number] = [b.selectionLeft, b.selectionRight];
+      const range: [number, number] = [b.selection.anchor, b.selection.active];
       const trail = '])';
       expect(getText.currentTopLevelFormToCursor(a)).toEqual([
         range,
@@ -87,7 +87,7 @@ describe('get text', () => {
       const b = docFromTextNotation(
         '|(foo bar)•(deftest a-test•  [baz| ; foo•     gaz])•(bar baz)'
       );
-      const range: [number, number] = [b.selectionLeft, b.selectionRight];
+      const range: [number, number] = [b.selection.anchor, b.selection.active];
       const trail = '])';
       expect(getText.startOfFileToCursor(a)).toEqual([
         range,
@@ -101,7 +101,7 @@ describe('get text', () => {
       const b = docFromTextNotation(
         '|(foo bar)(comment• (deftest a-test•  [baz| ; foo•     gaz])•(bar baz))'
       );
-      const range: [number, number] = [b.selectionLeft, b.selectionRight];
+      const range: [number, number] = [b.selection.anchor, b.selection.active];
       const trail = ']))';
       expect(getText.startOfFileToCursor(a)).toEqual([
         range,

--- a/src/extension-test/unit/util/cursor-get-text-test.ts
+++ b/src/extension-test/unit/util/cursor-get-text-test.ts
@@ -1,6 +1,6 @@
 import * as expect from 'expect';
-import * as getText from '../../../util/cursor-get-text';
 import { docFromTextNotation } from '../common/text-notation';
+import * as getText from '../../../util/cursor-get-text';
 
 describe('get text', () => {
   describe('getTopLevelFunction', () => {

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -1,19 +1,19 @@
 'use strict';
+import { StatusBar } from './statusbar';
 import * as vscode from 'vscode';
 import {
   commands,
-  ConfigurationChangeEvent,
+  window,
   Event,
   EventEmitter,
   ExtensionContext,
-  window,
   workspace,
+  ConfigurationChangeEvent,
 } from 'vscode';
-import { EditableDocument } from '../cursor-doc/model';
 import * as paredit from '../cursor-doc/paredit';
 import * as docMirror from '../doc-mirror/index';
+import { EditableDocument } from '../cursor-doc/model';
 import { assertIsDefined } from '../utilities';
-import { StatusBar } from './statusbar';
 
 const onPareditKeyMapChangedEmitter = new EventEmitter<string>();
 

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -1,19 +1,19 @@
 'use strict';
-import { StatusBar } from './statusbar';
 import * as vscode from 'vscode';
 import {
   commands,
-  window,
+  ConfigurationChangeEvent,
   Event,
   EventEmitter,
   ExtensionContext,
+  window,
   workspace,
-  ConfigurationChangeEvent,
 } from 'vscode';
+import { EditableDocument } from '../cursor-doc/model';
 import * as paredit from '../cursor-doc/paredit';
 import * as docMirror from '../doc-mirror/index';
-import { EditableDocument } from '../cursor-doc/model';
 import { assertIsDefined } from '../utilities';
+import { StatusBar } from './statusbar';
 
 const onPareditKeyMapChangedEmitter = new EventEmitter<string>();
 
@@ -270,7 +270,7 @@ const pareditCommands: PareditCommand[] = [
         copyRangeToClipboard(doc, range);
       }
       void paredit.killForwardList(doc, range).then((isFulfilled) => {
-        return paredit.spliceSexp(doc, doc.selectionRight, false);
+        return paredit.spliceSexp(doc, doc.selection.active, false);
       });
     },
   },
@@ -282,7 +282,7 @@ const pareditCommands: PareditCommand[] = [
         copyRangeToClipboard(doc, range);
       }
       void paredit.killBackwardList(doc, range).then((isFulfilled) => {
-        return paredit.spliceSexp(doc, doc.selectionRight, false);
+        return paredit.spliceSexp(doc, doc.selection.active, false);
       });
     },
   },


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- The `.selectionLeft` and `.selectionRight` props on EditableDocument and its children have been removed in favor of more basic or explicit calls to `.selection.anchor` and `.selection.active`, respectively.
- All call sites or references to those previous properties have accordingly been modified to reference the suggested replacements.
- All default arguments in functions also have been refactored accordingly.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [❓] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing. **Do I need to do this one for an internal change?**
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR. **I think? I tested on mac + win, and no changes were observed in smoke tests. Of course, unit tests have been fixed to pass in light of changes.**
- [❓] Added to or updated docs in this branch, if appropriate. **I will defer to maintainers as to whether more are needed from these changes.**
- [x] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. **I did personally on windows, not sure about maintainers. Mac was "smoke tested" purely in extension host.**
- [X] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [X] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [X] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [X] Created the issue I am fixing/addressing, if it was not present.
- [X] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe