### PR TITLE
Configure a default print engine and make it `calva`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Make `calva` the default pretty printer](https://github.com/BetterThanTomorrow/calva/issues/1619)
 - [Add default Clojure associations for file extensions `.bb` and `.cljd`](https://github.com/BetterThanTomorrow/calva/issues/1617)
 
 ## [2.0.257] - 2022-03-23

--- a/docs/site/pprint.md
+++ b/docs/site/pprint.md
@@ -20,7 +20,7 @@ For most people the defaults will probably work, but Calva pretty printing comes
 Setting          | Type    | Effect
 -------          | ----    | ------
 `enabled`        | boolean | So this is a third way you can change this mode 😄
-`printEngine`    | enum    | Which printer function that will be used. Default is `pprint`, more about this setting below
+`printEngine`    | enum    | Which printer function that will be used. Default is `calva`, more about this setting below
 `printFn`        | object  | You can configure Calva to use a custom `nREPL` compatible `print` function, more below.
 `width`          | number  | The maximum line length of printed output (or at least the printers will try)
 `maxLength`      | number  | The maximum number of elements printed in nested nodes, [good for evaluating something like `(iterate inc 0)`](https://clojuredocs.org/clojure.core/*print-length*#example-542692cac026201cdc326b12), which you shouldn't do without setting `maxLength`. Most printers will indicate truncated lists with `...` at the end.
@@ -41,17 +41,17 @@ Pretty printing can happen on the _server_ (i.e. in the JVM, via nREPL), or on t
 
 Print Engine | Client or Server Side | Comments
 --------------------- | --------------------- | --------
-`calva`             | client                | The nREPL server will plain print the results, and then Calva will pretty it.
-[`pprint`](https://clojure.github.io/clojure/clojure.pprint-api.html) | server | Current Calva default (`clojure.core/pprint` is a bit basic, but it's tried and tested, and has none of the server side printing issues mentioned below.
+`calva`             | client                | Current Calva default. The nREPL server will plain print the results, and then Calva will pretty it (using `zprint`).
+[`pprint`](https://clojure.github.io/clojure/clojure.pprint-api.html) | server | (`clojure.core/pprint` is a bit basic, but it's tried and tested, and has none of the server side printing issues mentioned below.
 [`fipp`](https://github.com/brandonbloom/fipp) | server |
 [`puget`](https://github.com/greglook/puget) | server | Lacks `maxDepth` option.
-[`zprint`](https://github.com/kkinnear/zprint) | server | Recommended. Will need to be configured before [Jack-in](connect.md) if you want Calva's help to inject its dependencies
+[`zprint`](https://github.com/kkinnear/zprint) | server | A very good option. However, it will need to be configured before [Jack-in](connect.md) if you want Calva's help to inject its dependencies
 
 These particular server side functions were chosen because they have pre-configured print-functions in [`cider-nrepl`](https://docs.cider.mx/cider-nrepl/).
 
 #### Or configure `printFn`
 
-If the selection of built-in `printEngine` support doesn't cut it, you can configure a custom function. This function will need to conform to the requirements of nREPL print functions. The VS Code settings editor will help you configure this one.
+If the selection of built-in `printEngine` support doesn't cut it, you can configure a custom function. This function will need to conform to the requirements of nREPL print functions. The VS Code settings editor will help you configure this one. (This is also a bit experimental, please consider giving feedback about how it works for you if you try it.)
 
 ### Why does Server or Client Side Matter?
 

--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
               "enabled"
             ],
             "default": {
+              "printEngine": "calva",
               "enabled": true,
               "width": 120,
               "maxLength": 50


### PR DESCRIPTION
## What has Changed?

Updated the default configuration so that there is now a default print engine set, and I set it to `calva`.

Fixes #1619

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @Cyrik, @corasaurus-hex 