### PR TITLE
Fix warning when error loading file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - [Add default Clojure associations for file extensions `.bb` and `.cljd`](https://github.com/BetterThanTomorrow/calva/issues/1617)
+- Fix: [Warning when loading a file produces an error: n.filter is not a function](https://github.com/BetterThanTomorrow/calva/issues/1567)
 
 ## [2.0.257] - 2022-03-23
 - Maintenance: [Update _even more_ TypeScript code to be compatible with strictNullChecks.](https://github.com/BetterThanTomorrow/calva/pull/1605)

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -436,7 +436,7 @@ async function loadFile(
     } catch (e) {
       outputWindow.append(`; Evaluation of file ${fileName} failed: ${e}`);
       if (res.stacktrace) {
-        outputWindow.saveStacktrace(res.stacktrace);
+        outputWindow.saveStacktrace(res.stacktrace.stacktrace);
         outputWindow.printLastStacktrace();
       }
     }

--- a/src/extension-test/integration/suite/extension-test.ts
+++ b/src/extension-test/integration/suite/extension-test.ts
@@ -91,6 +91,7 @@ suite('Extension Test Suite', () => {
     console.log('opened document again');
 
     await commands.executeCommand('calva.loadFile');
+    await sleep(500); // wait a little longer for repl output to be done
     const reversedLines = resultsDoc.model.lineInputModel.lines.reverse();
     assert.deepEqual(
       ['', 'clj꞉test꞉> ', 'nil', 'bar', '; Evaluating file: test.clj'],

--- a/src/extension-test/integration/suite/extension-test.ts
+++ b/src/extension-test/integration/suite/extension-test.ts
@@ -91,7 +91,6 @@ suite('Extension Test Suite', () => {
     console.log('opened document again');
 
     await commands.executeCommand('calva.loadFile');
-    await sleep(500); // wait a little longer for repl output to be done
     const reversedLines = resultsDoc.model.lineInputModel.lines.reverse();
     assert.deepEqual(
       ['', 'clj꞉test꞉> ', 'nil', 'bar', '; Evaluating file: test.clj'],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -229,8 +229,9 @@ async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('calva.selectCurrentForm', select.selectCurrentForm)
   );
   context.subscriptions.push(
-    vscode.commands.registerCommand('calva.loadFile', () => {
-      void eval.loadFile({}, config.getConfig().prettyPrintingOptions);
+    vscode.commands.registerCommand('calva.loadFile', async () => {
+      await eval.loadFile({}, config.getConfig().prettyPrintingOptions);
+      outputWindow.appendPrompt();
     })
   );
   context.subscriptions.push(
@@ -385,7 +386,10 @@ async function activate(context: vscode.ExtensionContext) {
     )
   );
   context.subscriptions.push(
-    vscode.commands.registerCommand('calva.printLastStacktrace', outputWindow.printLastStacktrace)
+    vscode.commands.registerCommand('calva.printLastStacktrace', () => {
+      outputWindow.printLastStacktrace();
+      outputWindow.appendPrompt();
+    })
   );
   context.subscriptions.push(
     vscode.commands.registerCommand(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -229,11 +229,8 @@ async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('calva.selectCurrentForm', select.selectCurrentForm)
   );
   context.subscriptions.push(
-    vscode.commands.registerCommand('calva.loadFile', async () => {
-      await eval.loadFile({}, config.getConfig().prettyPrintingOptions);
-      return new Promise((finished) => {
-        outputWindow.appendPrompt(finished);
-      });
+    vscode.commands.registerCommand('calva.loadFile', () => {
+      void eval.loadFile({}, config.getConfig().prettyPrintingOptions);
     })
   );
   context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -231,7 +231,9 @@ async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('calva.loadFile', async () => {
       await eval.loadFile({}, config.getConfig().prettyPrintingOptions);
-      outputWindow.appendPrompt();
+      return new Promise((resolve) => {
+        outputWindow.appendPrompt(resolve);
+      });
     })
   );
   context.subscriptions.push(

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -401,7 +401,6 @@ export function printLastStacktrace(): void {
   append(text, (_location) => {
     _lastStackTraceRange = undefined;
   });
-  append(getPrompt());
 }
 
 export function appendPrompt(onAppended?: OnAppendedCallback) {


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Accesses the stacktrace array on an nrepl eval result correctly (before it was just accessing the stacktrace object, but not the array within it, which caused an error when another function called .filter on what it expected to be an array)
- Removes appending of the prompt from `printLastStacktrace` in favor of leaving the responsibility up to the caller and removing a responsibility from the function that isn't related to its main task. (This follows the single responsibility principle.)

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1567 

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe