### PR TITLE
Always add ws roots to project root candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Connect fails when there is no project file (deps.edn, etc)](https://github.com/BetterThanTomorrow/calva/issues/1613)
 - [Add default Clojure associations for file extensions `.bb` and `.cljd`](https://github.com/BetterThanTomorrow/calva/issues/1617)
 
 ## [2.0.257] - 2022-03-23

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -4,14 +4,26 @@ import * as config from './config';
 import * as path from 'path';
 
 export async function findProjectRootPaths() {
-  const projectFileNames: string[] = ['project.clj', 'shadow-cljs.edn', 'deps.edn'];
+  const projectFileNames: string[] = [
+    'project.clj',
+    'shadow-cljs.edn',
+    'deps.edn',
+    'bb.edn',
+    '.nrepl-port',
+  ];
   const projectFilesGlob = `**/{${projectFileNames.join(',')}}`;
   const excludeDirsGlob = `**/{${config.getConfig().projectRootsSearchExclude.join(',')}}`;
   const t0 = new Date().getTime();
+  const rootPaths: string[] = [];
+  if (vscode.workspace.workspaceFolders?.length > 0) {
+    const wsRootPaths = vscode.workspace.workspaceFolders.map((f) => f.uri.fsPath);
+    rootPaths.push(...wsRootPaths);
+  }
   const candidateUris = await vscode.workspace.findFiles(projectFilesGlob, excludeDirsGlob, 10000);
   console.debug('glob took', new Date().getTime() - t0, 'ms');
   const projectFilePaths = candidateUris.map((uri) => path.dirname(uri.fsPath));
-  const candidatePaths = [...new Set(projectFilePaths)].sort();
+  rootPaths.push(...projectFilePaths);
+  const candidatePaths = [...new Set(rootPaths)].sort();
   return candidatePaths;
 }
 


### PR DESCRIPTION
This restores the ability to connect/jack-in to projects that have no project files. Which is the case with many Babashka projects.

Fixes #1613

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @Cyrik , @corasaurus-hex 