### PR TITLE
Add `useLiveShare` setting, default `disabled`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Add setting for enabling LiveShare support](https://github.com/BetterThanTomorrow/calva/issues/1629)
 
 ## [2.0.258] - 2022-03-25
 - Fix: [Connect fails when there is no project file (deps.edn, etc)](https://github.com/BetterThanTomorrow/calva/issues/1613)

--- a/docs/site/live-share.md
+++ b/docs/site/live-share.md
@@ -24,6 +24,9 @@ REPL. When using Live Share, Calva allows the host to share the REPL with guests
 as well. If you use any of the supported configuration, this will be pretty much
 automatic.
 
+!!! Note "You need to enable the LiveShare support"
+    Due to [an issue in the LiveShare API](https://github.com/MicrosoftDocs/live-share/issues/4551), for some users, this feature stops Calva from connecting the REPL. Therefore the support is disabled by default. The setting is `calva.useLiveShare`.
+
 This is what a typical scenario looks like:
 
 1. **The host** jacks-in.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "vscode-debugadapter": "1.38.0",
         "vscode-extension-telemetry": "0.0.15",
         "vscode-languageclient": "^7.0.0",
-        "vsls": "^1.0.2594"
+        "vsls": "^1.0.4753"
       },
       "devDependencies": {
         "@types/chai": "^4.2.6",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,11 @@
         "type": "object",
         "title": "Calva",
         "properties": {
+          "calva.useLiveShare": {
+            "type": "boolean",
+            "markdownDescription": "Enable support for LiveShare. Currently defaults to false, because of [ive-share/issues/4551](https://github.com/MicrosoftDocs/live-share/issues/4551). This issue makes Calva fail to connect to a REPL for some users.",
+            "default": false
+          },
           "calva.useTestExplorer": {
             "type": "boolean",
             "description": "Enable experimental support for the VSCode Test Explorer",

--- a/package.json
+++ b/package.json
@@ -2721,7 +2721,7 @@
     "vscode-debugadapter": "1.38.0",
     "vscode-extension-telemetry": "0.0.15",
     "vscode-languageclient": "^7.0.0",
-    "vsls": "^1.0.2594"
+    "vsls": "^1.0.4753"
   },
   "devDependencies": {
     "@types/chai": "^4.2.6",

--- a/src/config.ts
+++ b/src/config.ts
@@ -162,6 +162,7 @@ function getConfig() {
     },
     enableClojureLspOnStart: configOptions.get<boolean>('enableClojureLspOnStart'),
     projectRootsSearchExclude: configOptions.get<string[]>('projectRootsSearchExclude', []),
+    useLiveShare: configOptions.get<boolean>('useLiveShare'),
   };
 }
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -17,7 +17,7 @@ import { keywordize } from './util/string';
 import { initializeDebugger } from './debugger/calva-debug';
 import * as outputWindow from './results-output/results-doc';
 import { evaluateInOutputWindow } from './evaluate';
-import * as liveShareSupport from './liveShareSupport';
+import * as liveShareSupport from './live-share';
 import * as calvaDebug from './debugger/calva-debug';
 import { setStateValue, getStateValue } from '../out/cljs-lib/cljs-lib';
 import * as replSession from './nrepl/repl-session';

--- a/src/live-share.ts
+++ b/src/live-share.ts
@@ -1,5 +1,6 @@
 import { Disposable } from 'vscode';
 import * as vsls from 'vsls';
+import * as config from './config';
 
 // Keeps hold of the LiveShare API instance, so that it is requested only once.
 let liveShare: vsls.LiveShare = null;
@@ -16,7 +17,11 @@ export async function setupLiveShareListener() {
     return;
   }
 
-  liveShare = await vsls.getApi();
+  // Due to https://github.com/MicrosoftDocs/live-share/issues/4551
+  // this is only done if the user enables LiveShare support in settings
+  if (config.getConfig().useLiveShare) {
+    liveShare = await vsls.getApi();
+  }
 
   if (liveShare) {
     liveShareListener = liveShare.onDidChangeSession(async (e: vsls.SessionChangeEvent) => {

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -11,7 +11,7 @@ import { askForConnectSequence, ReplConnectSequence, CljsTypes } from './connect
 import * as projectTypes from './project-types';
 import * as outputWindow from '../results-output/results-doc';
 import { JackInTerminal, JackInTerminalOptions, createCommandLine } from './jack-in-terminal';
-import * as liveShareSupport from '../liveShareSupport';
+import * as liveShareSupport from '../live-share';
 import { getConfig } from '../config';
 
 let jackInPTY: JackInTerminal = undefined;


### PR DESCRIPTION
## What has Changed?

As a workaround for https://github.com/MicrosoftDocs/live-share/issues/4551 I've added a setting for enabling LiveShare support. This way it won't hit users that are not even using LiveShare. And for users where the MS LiveShare API issue doesn't happen, they can still use LiveShare (we'll after we have figured out #1625 at least). 

Fixes #1569
Fixes #1629

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe