### PR TITLE
Don't croak activating highlight if there is no active editor

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -104,7 +104,10 @@
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
-      "args": ["--extensionDevelopmentPath=${workspaceRoot}", "${workspaceFolder}/test-data/empty-folder"],
+      "args": [
+        "--extensionDevelopmentPath=${workspaceRoot}",
+        "${workspaceFolder}/test-data/empty-folder"
+      ],
       "stopOnEntry": false,
       "sourceMaps": true,
       "env": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -100,6 +100,21 @@
       "outFiles": ["${workspaceFolder}/dist/**/*.js"]
     },
     {
+      "name": "Launch w/ empty folder",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceRoot}", "${workspaceFolder}/test-data/empty-folder"],
+      "stopOnEntry": false,
+      "sourceMaps": true,
+      "env": {
+        "IS_DEBUG": "true",
+        "CALVA_DEV_GA": "FUBAR-69796730-4",
+        "DEBUG": "no-debug-universal-analytics"
+      },
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"]
+    },
+    {
       "name": "Theia node launch",
       "type": "node",
       "request": "launch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Rainbow parentheses sometimes not activating](https://github.com/BetterThanTomorrow/calva/issues/1616)
 
 ## [2.0.259] - 2022-03-26
 - [Add setting for enabling LiveShare support](https://github.com/BetterThanTomorrow/calva/issues/1629)

--- a/src/extension-test/integration/suite/highlight-test.ts
+++ b/src/extension-test/integration/suite/highlight-test.ts
@@ -1,0 +1,36 @@
+import * as assert from 'assert';
+import { before, after } from 'mocha';
+import * as path from 'path';
+import * as testUtil from './util';
+
+import * as vscode from 'vscode';
+import * as highlight from '../../../highlight/src/extension';
+
+
+suite('Highlight suite', () => {
+  const suite = 'Highlight';
+
+  before(() => {
+    testUtil.showMessage(suite, `suite starting!`);
+  });
+
+  after(() => {
+    testUtil.showMessage(suite, `suite done!`);
+  });
+
+  test('activeEditor', async function () {
+    testUtil.log(suite, 'activeEditor');
+
+    assert.strictEqual(highlight.activeEditor, undefined);
+
+    const testFilePath = path.join(testUtil.testDataDir, 'test.clj');
+    await testUtil.openFile(testFilePath);
+    testUtil.log(suite, 'test.clj opened');
+
+    assert.notStrictEqual(highlight.activeEditor, undefined);
+
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    testUtil.log(suite, 'test.clj closed');
+  });
+
+});

--- a/src/extension-test/integration/suite/highlight-test.ts
+++ b/src/extension-test/integration/suite/highlight-test.ts
@@ -6,7 +6,6 @@ import * as testUtil from './util';
 import * as vscode from 'vscode';
 import * as highlight from '../../../highlight/src/extension';
 
-
 suite('Highlight suite', () => {
   const suite = 'Highlight';
 
@@ -32,5 +31,4 @@ suite('Highlight suite', () => {
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     testUtil.log(suite, 'test.clj closed');
   });
-
 });

--- a/src/extension-test/integration/suite/jack-in-test.ts
+++ b/src/extension-test/integration/suite/jack-in-test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { after } from 'mocha';
+import { before, after } from 'mocha';
 import * as path from 'path';
 import * as testUtil from './util';
 import * as state from '../../../state';
@@ -18,13 +18,12 @@ import * as projectRoot from '../../../project-root';
 suite('Jack-in suite', () => {
   const suite = 'Jack-in';
 
-  // TODO: Why can't we use before()?
-  //before(() => {
-  //  void vscode.window.showInformationMessage(`${suite} suite starting!`);
-  //});
+  before(() => {
+    testUtil.showMessage(suite, `suite starting!`);
+  });
 
   after(() => {
-    void vscode.window.showInformationMessage(`${suite} suite done!`);
+    testUtil.showMessage(suite, `suite done!`);
   });
 
   test('start repl and connect (jack-in)', async function () {

--- a/src/extension-test/integration/suite/util.ts
+++ b/src/extension-test/integration/suite/util.ts
@@ -27,3 +27,7 @@ export function sleep(ms: number): Promise<void> {
 export function log(suite: string, ...things: any[]) {
   console.log(`Integration testing, ${suite}:`, ...things);
 }
+
+export function showMessage(suite: string, message: string) {
+  void vscode.window.showInformationMessage(`Integration testing, ${suite}: ${message}`);
+}

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -22,8 +22,10 @@ function is_clojure(editor) {
   return !!editor && editor.document.languageId === 'clojure';
 }
 
-let activeEditor: vscode.TextEditor,
-  lastHighlightedEditor,
+// Exported for integration testing purposes
+export let activeEditor: vscode.TextEditor;
+
+let lastHighlightedEditor,
   rainbowColors,
   rainbowTypes: vscode.TextEditorDecorationType[],
   rainbowGuidesTypes: vscode.TextEditorDecorationType[],
@@ -500,7 +502,7 @@ function decorateActiveGuides() {
 }
 
 export function activate(context: vscode.ExtensionContext) {
-  activeEditor = getActiveTextEditor();
+  activeEditor = tryToGetActiveTextEditor();
 
   vscode.window.onDidChangeActiveTextEditor(
     (editor) => {


### PR DESCRIPTION
## What has Changed?

In implementing strict null checks we made the highlight sub extension depend on there being an active editor at start of Calva for it to activate. Using `tryToGetActiveTextEditor()` instead restores the previous behavior.

Also added an integration test checking that the highlight module has an undefined `activeEditor` in this startup scenario and that the `activeEditor` is set when we open a file.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1616 

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik 