### PR TITLE
Stop indenting vectors using indent rules meant for lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - Fix: [Results doc gets in a bad state and does not update](https://github.com/BetterThanTomorrow/calva/issues/1509)
+- Fix: [Indenting not working correctly in vectors starting with fn-like symbols](https://github.com/BetterThanTomorrow/calva/issues/1622)
 
 ## [2.0.260] - 2022-03-27
 - Fix: [Rainbow parentheses sometimes not activating](https://github.com/BetterThanTomorrow/calva/issues/1616)

--- a/src/cursor-doc/indent.ts
+++ b/src/cursor-doc/indent.ts
@@ -60,6 +60,7 @@ export function collectIndents(
   let lastLine = cursor.line;
   let lastIndent = 0;
   const indents: IndentInformation[] = [];
+  const rules = config['cljfmt-options']['indents'];
   do {
     if (!cursor.backwardSexp()) {
       // this needs some work..
@@ -73,12 +74,12 @@ export function collectIndents(
       nextCursor.forwardWhitespace();
 
       // if the first item of this list is a a function, and the second item is on the same line, indent to that second item. otherwise indent to the open paren.
+      const isList = prevToken.type === 'open' && prevToken.raw.endsWith('(');
       const firstItemIdent =
         ['id', 'kw'].includes(cursor.getToken().type) &&
-        nextCursor.line == cursor.line &&
-        !nextCursor.atEnd() &&
-        prevToken.type === 'open' &&
-        prevToken.raw.endsWith('(')
+          nextCursor.line == cursor.line &&
+          !nextCursor.atEnd() &&
+          isList
           ? nextCursor.rowCol[1]
           : cursor.rowCol[1];
 
@@ -88,8 +89,7 @@ export function collectIndents(
         break;
       }
 
-      const rules = config['cljfmt-options']['indents'];
-      const pattern = _.find(
+      const pattern = isList && _.find(
         _.keys(rules),
         (pattern) => pattern == token || testCljRe(pattern, token)
       );

--- a/src/cursor-doc/indent.ts
+++ b/src/cursor-doc/indent.ts
@@ -3,16 +3,20 @@ import * as _ from 'lodash';
 
 const whitespace = new Set(['ws', 'comment', 'eol']);
 
-type IndentRule = ['block', number] | ['inner', number] | ['inner', number, number];
+export type IndentRule = ['block', number] | ['inner', number] | ['inner', number, number];
 
-const indentRules: { [id: string]: IndentRule[] } = {
+export type IndentRules = {
+  [id: string]: IndentRule[];
+};
+
+const indentRules: IndentRules = {
   '#"^\\w"': [['inner', 0]],
 };
 
 /**
  * The information about an enclosing s-expr, returned by collectIndents
  */
-interface IndentInformation {
+export interface IndentInformation {
   /** The first token in the expression (after the open paren/bracket etc.), as a raw string */
   first: string;
 

--- a/src/cursor-doc/indent.ts
+++ b/src/cursor-doc/indent.ts
@@ -90,7 +90,7 @@ export function collectIndents(
       }
 
       const pattern =
-        isList && _.find(_.keys(rules), (pattern) => pattern == token || testCljRe(pattern, token));
+        isList && _.find(_.keys(rules), (pattern) => pattern === token || testCljRe(pattern, token));
       const indentRule = pattern ? rules[pattern] : [];
       indents.unshift({
         first: token,

--- a/src/cursor-doc/indent.ts
+++ b/src/cursor-doc/indent.ts
@@ -90,7 +90,8 @@ export function collectIndents(
       }
 
       const pattern =
-        isList && _.find(_.keys(rules), (pattern) => pattern === token || testCljRe(pattern, token));
+        isList &&
+        _.find(_.keys(rules), (pattern) => pattern === token || testCljRe(pattern, token));
       const indentRule = pattern ? rules[pattern] : [];
       indents.unshift({
         first: token,

--- a/src/cursor-doc/indent.ts
+++ b/src/cursor-doc/indent.ts
@@ -77,9 +77,9 @@ export function collectIndents(
       const isList = prevToken.type === 'open' && prevToken.raw.endsWith('(');
       const firstItemIdent =
         ['id', 'kw'].includes(cursor.getToken().type) &&
-          nextCursor.line == cursor.line &&
-          !nextCursor.atEnd() &&
-          isList
+        nextCursor.line == cursor.line &&
+        !nextCursor.atEnd() &&
+        isList
           ? nextCursor.rowCol[1]
           : cursor.rowCol[1];
 
@@ -89,10 +89,8 @@ export function collectIndents(
         break;
       }
 
-      const pattern = isList && _.find(
-        _.keys(rules),
-        (pattern) => pattern == token || testCljRe(pattern, token)
-      );
+      const pattern =
+        isList && _.find(_.keys(rules), (pattern) => pattern == token || testCljRe(pattern, token));
       const indentRule = pattern ? rules[pattern] : [];
       indents.unshift({
         first: token,

--- a/src/extension-test/unit/cursor-doc/indent-test.ts
+++ b/src/extension-test/unit/cursor-doc/indent-test.ts
@@ -9,15 +9,19 @@ model.initScanner(20000);
 describe('indent', () => {
   describe('getIndent', () => {
     describe('lists', () => {
-      it('calculates indents for empty list', () => {
+      it('calculates indents for cursor in empty list', () => {
         const doc = docFromTextNotation('(|)');
         expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(1);
+      });
+      it('calculates indents for cursor in empty list prepended by text', () => {
+        const doc = docFromTextNotation('  a b (|)');
+        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(7);
       });
       it('calculates indents for empty list inside vector', () => {
         const doc = docFromTextNotation('[(|)]');
         expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(2);
       });
-      it("calculates indents for arg 0 in `[['inner' 0]]`", () => {
+      it("calculates indents for cursor in at arg 0 in `[['inner' 0]]`", () => {
         const doc = docFromTextNotation('(foo|)');
         expect(
           indent.getIndent(
@@ -41,7 +45,7 @@ describe('indent', () => {
           )
         ).toEqual(2);
       });
-      it("calculates indents for arg 0 in `[['block' 1]]`", () => {
+      it("calculates indents for cursor at arg 0 in `[['block' 1]]`", () => {
         const doc = docFromTextNotation('(foo|)');
         expect(
           indent.getIndent(
@@ -53,7 +57,7 @@ describe('indent', () => {
           )
         ).toEqual(1);
       });
-      it("calculates indents for arg 1 in `[['block' 1]]`", () => {
+      it("calculates indents for cursor at arg 1 in `[['block' 1]]`", () => {
         const doc = docFromTextNotation('(foo x|)');
         expect(
           indent.getIndent(
@@ -68,15 +72,15 @@ describe('indent', () => {
     });
 
     describe('vectors', () => {
-      it('calculates indents for empty vector', () => {
+      it('calculates indents for cursor in empty vector', () => {
         const doc = docFromTextNotation('[|]');
         expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(1);
       });
-      it('calculates indents for empty vector inside list', () => {
+      it('calculates indents for cursor in empty vector inside list', () => {
         const doc = docFromTextNotation('([|])');
         expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(2);
       });
-      it('does not use indent rules for vectors with', () => {
+      it('does not use indent rules for vectors with symbols at ”call” position', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1622
         const doc = docFromTextNotation('[foo|]');
         expect(
@@ -90,11 +94,59 @@ describe('indent', () => {
         ).toEqual(1);
       });
     });
+
+    describe('maps', () => {
+      it('calculates indents for cursor in empty map', () => {
+        const doc = docFromTextNotation('{|}');
+        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(1);
+      });
+      it('calculates indents for cursor in empty map inside list inside a vector', () => {
+        const doc = docFromTextNotation('([{|}])');
+        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(3);
+      });
+      it('does not use indent rules for maps with symbols at ”call” position', () => {
+        // https://github.com/BetterThanTomorrow/calva/issues/1622
+        const doc = docFromTextNotation('{foo|}');
+        expect(
+          indent.getIndent(
+            doc.model,
+            textAndSelection(doc)[1][0],
+            mkConfig({
+              '#"^\\w"': [['inner', 0]],
+            })
+          )
+        ).toEqual(1);
+      });
+    });
+
+    describe('sets', () => {
+      it('calculates indents for cursor in empty set', () => {
+        const doc = docFromTextNotation('#{|}');
+        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(2);
+      });
+      it('calculates indents for cursor in empty set inside list inside a vector', () => {
+        const doc = docFromTextNotation('([#{|}])');
+        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(4);
+      });
+      it('does not use indent rules for maps with symbols at ”call” position', () => {
+        // https://github.com/BetterThanTomorrow/calva/issues/1622
+        const doc = docFromTextNotation('#{foo|}');
+        expect(
+          indent.getIndent(
+            doc.model,
+            textAndSelection(doc)[1][0],
+            mkConfig({
+              '#"^\\w"': [['inner', 0]],
+            })
+          )
+        ).toEqual(2);
+      });
+    });
   });
 
   describe('collectIndents', () => {
     describe('lists', () => {
-      it('collects indents for empty list', () => {
+      it('collects indents for cursor in empty list', () => {
         const doc = docFromTextNotation('(|)');
         const rules: indent.IndentRules = {
           '#"^\\w"': [['inner', 0]],
@@ -106,6 +158,33 @@ describe('indent', () => {
         );
         expect(state.length).toEqual(1);
         expect(state[0].rules).toEqual([]);
+      });
+      it('collects indents for cursor in empty list with structure around', () => {
+        const doc = docFromTextNotation('[](|)(foo)');
+        const rules: indent.IndentRules = {
+          '#"^\\w"': [['inner', 0]],
+        };
+        const state: indent.IndentInformation[] = indent.collectIndents(
+          doc.model,
+          textAndSelection(doc)[1][0],
+          mkConfig(rules)
+        );
+        expect(state.length).toEqual(1);
+        expect(state[0].rules).toEqual([]);
+      });
+      it('collects indents for cursor in nested structure', () => {
+        const doc = docFromTextNotation('[]•(aa []•(bb•(cc :dd|)))•[]');
+        const rule1: indent.IndentRule[] = [['inner', 0], ['block', 1]];
+        const rules: indent.IndentRules = {
+          '#"^\\w"': rule1,
+        };
+        const state: indent.IndentInformation[] = indent.collectIndents(
+          doc.model,
+          textAndSelection(doc)[1][0],
+          mkConfig(rules)
+        );
+        expect(state.length).toEqual(1);
+        expect(state[0].rules).toEqual(rule1);
       });
       it('collects indents for empty list inside vector', () => {
         const doc = docFromTextNotation('[(|)]');
@@ -122,9 +201,9 @@ describe('indent', () => {
       });
       it('collects indents for arg 0', () => {
         const doc = docFromTextNotation('(foo|)');
-        const rule1: indent.IndentRule = ['inner', 0];
+        const rule1: indent.IndentRule[] = [['inner', 0]];
         const rules: indent.IndentRules = {
-          '#"^\\w"': [rule1],
+          '#"^\\w"': rule1,
         };
         const state: indent.IndentInformation[] = indent.collectIndents(
           doc.model,
@@ -132,7 +211,7 @@ describe('indent', () => {
           mkConfig(rules)
         );
         expect(state.length).toEqual(1);
-        expect(state[0].rules).toEqual([rule1]);
+        expect(state[0].rules).toEqual(rule1);
       });
     });
 
@@ -140,9 +219,27 @@ describe('indent', () => {
       it('ignores rule arg 0', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1622
         const doc = docFromTextNotation('[foo|]');
-        const rule1: indent.IndentRule = ['inner', 0];
+        const rule1: indent.IndentRule[] = [['inner', 0]];
         const rules: indent.IndentRules = {
-          '#"^\\w"': [rule1],
+          '#"^\\w"': rule1,
+        };
+        const state: indent.IndentInformation[] = indent.collectIndents(
+          doc.model,
+          textAndSelection(doc)[1][0],
+          mkConfig(rules)
+        );
+        expect(state.length).toEqual(1);
+        expect(state[0].rules).toEqual([]);
+      });
+    });
+
+    describe('maps', () => {
+      it('ignores rule arg 0', () => {
+        // https://github.com/BetterThanTomorrow/calva/issues/1622
+        const doc = docFromTextNotation('{foo|}');
+        const rule1: indent.IndentRule[] = [['inner', 0]];
+        const rules: indent.IndentRules = {
+          '#"^\\w"': rule1,
         };
         const state: indent.IndentInformation[] = indent.collectIndents(
           doc.model,

--- a/src/extension-test/unit/cursor-doc/indent-test.ts
+++ b/src/extension-test/unit/cursor-doc/indent-test.ts
@@ -1,0 +1,119 @@
+import * as expect from 'expect';
+import * as model from '../../../cursor-doc/model';
+import * as indent from '../../../cursor-doc/indent';
+import { docFromTextNotation, textAndSelection, text } from '../common/text-notation';
+import { ModelEditSelection } from '../../../cursor-doc/model';
+
+model.initScanner(20000);
+
+describe('indent', () => {
+  describe('getIndent', () => {
+    describe('lists', () => {
+      it('calculates indents for empty list', () => {
+        const doc = docFromTextNotation('(|)');
+        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(1);
+      });
+      it('calculates indents for empty list inside vector', () => {
+        const doc = docFromTextNotation('[(|)]');
+        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(2);
+      });
+      it("calculates indents for arg 0 in `[['inner' 0]]`", () => {
+        const doc = docFromTextNotation('(foo|)');
+        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0], mkConfig({
+          '#"^\\w"': [['inner', 0]],
+        }))).toEqual(2);
+      });
+      it("calculates indents for arg 1 in `[['inner' 0]]`", () => {
+        const doc = docFromTextNotation('(foo x|)');
+        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0], mkConfig({
+          '#"^\\w"': [['inner', 0]],
+        }))).toEqual(2);
+      });
+      it("calculates indents for arg 0 in `[['block' 1]]`", () => {
+        const doc = docFromTextNotation('(foo|)');
+        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0], mkConfig({
+          '#"^\\w"': [['block', 1]],
+        }))).toEqual(1);
+      });
+      it("calculates indents for arg 1 in `[['block' 1]]`", () => {
+        const doc = docFromTextNotation('(foo x|)');
+        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0], mkConfig({
+          '#"^\\w"': [['block', 1]],
+        }))).toEqual(2);
+      });
+    });
+
+    describe('vectors', () => {
+      it('calculates indents for empty vector', () => {
+        const doc = docFromTextNotation('[|]');
+        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(1);
+      });
+      it('calculates indents for empty vector inside list', () => {
+        const doc = docFromTextNotation('([|])');
+        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(2);
+      });
+      it('does not use indent rules for vectors with', () => {
+        // https://github.com/BetterThanTomorrow/calva/issues/1622
+        const doc = docFromTextNotation('[foo|]');
+        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0], mkConfig({
+          '#"^\\w"': [['inner', 0]],
+        }))).toEqual(1);
+      });
+    });
+  });
+
+  describe('collectIndents', () => {
+    describe('lists', () => {
+      it('collects indents for empty list', () => {
+        const doc = docFromTextNotation('(|)');
+        const rules: indent.IndentRules = {
+          '#"^\\w"': [['inner', 0]],
+        };
+        const state: indent.IndentInformation[] = indent.collectIndents(doc.model, textAndSelection(doc)[1][0], mkConfig(rules));
+        expect(state.length).toEqual(1);
+        expect(state[0].rules).toEqual([]);
+      });
+      it('collects indents for empty list inside vector', () => {
+        const doc = docFromTextNotation('[(|)]');
+        const rules: indent.IndentRules = {
+          '#"^\\w"': [['inner', 0]],
+        };
+        const state: indent.IndentInformation[] = indent.collectIndents(doc.model, textAndSelection(doc)[1][0], mkConfig(rules));
+        expect(state.length).toEqual(1);
+        expect(state[0].rules).toEqual([]);
+      });
+      it("collects indents for arg 0", () => {
+        const doc = docFromTextNotation('(foo|)');
+        const rule1: indent.IndentRule = ['inner', 0];
+        const rules: indent.IndentRules = {
+          '#"^\\w"': [rule1],
+        };
+        const state: indent.IndentInformation[] = indent.collectIndents(doc.model, textAndSelection(doc)[1][0], mkConfig(rules));
+        expect(state.length).toEqual(1);
+        expect(state[0].rules).toEqual([rule1]);
+      });
+    });
+
+    describe('vectors', () => {
+      it("ignores rule arg 0", () => {
+        // https://github.com/BetterThanTomorrow/calva/issues/1622
+        const doc = docFromTextNotation('[foo|]');
+        const rule1: indent.IndentRule = ['inner', 0];
+        const rules: indent.IndentRules = {
+          '#"^\\w"': [rule1],
+        };
+        const state: indent.IndentInformation[] = indent.collectIndents(doc.model, textAndSelection(doc)[1][0], mkConfig(rules));
+        expect(state.length).toEqual(1);
+        expect(state[0].rules).toEqual([]);
+      });
+    });
+  });
+});
+
+function mkConfig(rules: indent.IndentRules) {
+  return {
+    'cljfmt-options': {
+      indents: rules,
+    }
+  }
+}

--- a/src/extension-test/unit/cursor-doc/indent-test.ts
+++ b/src/extension-test/unit/cursor-doc/indent-test.ts
@@ -174,7 +174,10 @@ describe('indent', () => {
       });
       it('collects indents for cursor in nested structure', () => {
         const doc = docFromTextNotation('[]•(aa []•(bb•(cc :dd|)))•[]');
-        const rule1: indent.IndentRule[] = [['inner', 0], ['block', 1]];
+        const rule1: indent.IndentRule[] = [
+          ['inner', 0],
+          ['block', 1],
+        ];
         const rules: indent.IndentRules = {
           '#"^\\w"': rule1,
         };

--- a/src/extension-test/unit/cursor-doc/indent-test.ts
+++ b/src/extension-test/unit/cursor-doc/indent-test.ts
@@ -19,27 +19,51 @@ describe('indent', () => {
       });
       it("calculates indents for arg 0 in `[['inner' 0]]`", () => {
         const doc = docFromTextNotation('(foo|)');
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0], mkConfig({
-          '#"^\\w"': [['inner', 0]],
-        }))).toEqual(2);
+        expect(
+          indent.getIndent(
+            doc.model,
+            textAndSelection(doc)[1][0],
+            mkConfig({
+              '#"^\\w"': [['inner', 0]],
+            })
+          )
+        ).toEqual(2);
       });
       it("calculates indents for arg 1 in `[['inner' 0]]`", () => {
         const doc = docFromTextNotation('(foo x|)');
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0], mkConfig({
-          '#"^\\w"': [['inner', 0]],
-        }))).toEqual(2);
+        expect(
+          indent.getIndent(
+            doc.model,
+            textAndSelection(doc)[1][0],
+            mkConfig({
+              '#"^\\w"': [['inner', 0]],
+            })
+          )
+        ).toEqual(2);
       });
       it("calculates indents for arg 0 in `[['block' 1]]`", () => {
         const doc = docFromTextNotation('(foo|)');
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0], mkConfig({
-          '#"^\\w"': [['block', 1]],
-        }))).toEqual(1);
+        expect(
+          indent.getIndent(
+            doc.model,
+            textAndSelection(doc)[1][0],
+            mkConfig({
+              '#"^\\w"': [['block', 1]],
+            })
+          )
+        ).toEqual(1);
       });
       it("calculates indents for arg 1 in `[['block' 1]]`", () => {
         const doc = docFromTextNotation('(foo x|)');
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0], mkConfig({
-          '#"^\\w"': [['block', 1]],
-        }))).toEqual(2);
+        expect(
+          indent.getIndent(
+            doc.model,
+            textAndSelection(doc)[1][0],
+            mkConfig({
+              '#"^\\w"': [['block', 1]],
+            })
+          )
+        ).toEqual(2);
       });
     });
 
@@ -55,9 +79,15 @@ describe('indent', () => {
       it('does not use indent rules for vectors with', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1622
         const doc = docFromTextNotation('[foo|]');
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0], mkConfig({
-          '#"^\\w"': [['inner', 0]],
-        }))).toEqual(1);
+        expect(
+          indent.getIndent(
+            doc.model,
+            textAndSelection(doc)[1][0],
+            mkConfig({
+              '#"^\\w"': [['inner', 0]],
+            })
+          )
+        ).toEqual(1);
       });
     });
   });
@@ -69,7 +99,11 @@ describe('indent', () => {
         const rules: indent.IndentRules = {
           '#"^\\w"': [['inner', 0]],
         };
-        const state: indent.IndentInformation[] = indent.collectIndents(doc.model, textAndSelection(doc)[1][0], mkConfig(rules));
+        const state: indent.IndentInformation[] = indent.collectIndents(
+          doc.model,
+          textAndSelection(doc)[1][0],
+          mkConfig(rules)
+        );
         expect(state.length).toEqual(1);
         expect(state[0].rules).toEqual([]);
       });
@@ -78,31 +112,43 @@ describe('indent', () => {
         const rules: indent.IndentRules = {
           '#"^\\w"': [['inner', 0]],
         };
-        const state: indent.IndentInformation[] = indent.collectIndents(doc.model, textAndSelection(doc)[1][0], mkConfig(rules));
+        const state: indent.IndentInformation[] = indent.collectIndents(
+          doc.model,
+          textAndSelection(doc)[1][0],
+          mkConfig(rules)
+        );
         expect(state.length).toEqual(1);
         expect(state[0].rules).toEqual([]);
       });
-      it("collects indents for arg 0", () => {
+      it('collects indents for arg 0', () => {
         const doc = docFromTextNotation('(foo|)');
         const rule1: indent.IndentRule = ['inner', 0];
         const rules: indent.IndentRules = {
           '#"^\\w"': [rule1],
         };
-        const state: indent.IndentInformation[] = indent.collectIndents(doc.model, textAndSelection(doc)[1][0], mkConfig(rules));
+        const state: indent.IndentInformation[] = indent.collectIndents(
+          doc.model,
+          textAndSelection(doc)[1][0],
+          mkConfig(rules)
+        );
         expect(state.length).toEqual(1);
         expect(state[0].rules).toEqual([rule1]);
       });
     });
 
     describe('vectors', () => {
-      it("ignores rule arg 0", () => {
+      it('ignores rule arg 0', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1622
         const doc = docFromTextNotation('[foo|]');
         const rule1: indent.IndentRule = ['inner', 0];
         const rules: indent.IndentRules = {
           '#"^\\w"': [rule1],
         };
-        const state: indent.IndentInformation[] = indent.collectIndents(doc.model, textAndSelection(doc)[1][0], mkConfig(rules));
+        const state: indent.IndentInformation[] = indent.collectIndents(
+          doc.model,
+          textAndSelection(doc)[1][0],
+          mkConfig(rules)
+        );
         expect(state.length).toEqual(1);
         expect(state[0].rules).toEqual([]);
       });
@@ -114,6 +160,6 @@ function mkConfig(rules: indent.IndentRules) {
   return {
     'cljfmt-options': {
       indents: rules,
-    }
-  }
+    },
+  };
 }

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -14,6 +14,5 @@
       "name": "Show doc string",
       "snippet": "(clojure.string/replace (with-out-str (clojure.repl/doc $hover-text)) \"\n\" \"\n\n\")"
     }
-  ],
-  "calva.fmt.configPath": "CLOJURE-LSP"
+  ]
 }

--- a/test-data/indent.clj
+++ b/test-data/indent.clj
@@ -1,8 +1,7 @@
 ;; https://github.com/BetterThanTomorrow/calva/issues/1622
 
 ;; Misbehaves in the indenter
-(let [context
-       |])
+(let [context|])
 
 ;; Behaves in the indenter
 (let [contexs|])
@@ -22,3 +21,9 @@
 
 ;; `[[:inner 0]]`
 [foo|]
+
+;; Also goes for maps and sets
+
+{fn|}
+
+#{fn|}

--- a/test-data/indent.clj
+++ b/test-data/indent.clj
@@ -1,0 +1,24 @@
+;; https://github.com/BetterThanTomorrow/calva/issues/1622
+
+;; Misbehaves in the indenter
+(let [context
+       |])
+
+;; Behaves in the indenter
+(let [contexs|])
+
+;; (Both behave in the formatter)
+
+;; Probably because `context` has default indents `[[:inner 0]]`
+
+;; `[[:inner 0]]`
+[fn|]
+
+;; `[[:block 0]]`
+[do|]
+
+;; `[[:block 1]]`
+[let|]
+
+;; `[[:inner 0]]`
+[foo|]


### PR DESCRIPTION
## What has Changed?

#1622 reports a bug with our indent engine (not to be confused with our formatter) where vectors maps have a symbol in ”call”. position produces indents as if the vector was a list. So we get:

``` clojure
[do|]
```

<kbd>enter</kbd>

``` clojure
[do
  |]
```

Instead of 

``` clojure
[do
 |]
```

I've added some unit tests for the indenter. Some of which expose the bug. And now all those are green.

Fixes #1622

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik