### PR TITLE
Dev: Create new lint, test, format, watcher scripts and tasks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
     "arglists",
     "autoindent",
     "Batsov",
+    "behaviour",
     "bencode",
     "betterthantomorrow",
     "bhauman",
@@ -33,6 +34,7 @@
     "cljify",
     "cljslib",
     "CLJSREPL",
+    "Clojuredocs",
     "clojurians",
     "Clojurists",
     "cmdline",
@@ -58,6 +60,7 @@
     "docmirror",
     "Docstring",
     "Dorg",
+    "doseq",
     "dotimes",
     "Dvlaaad",
     "eckstein",
@@ -103,6 +106,7 @@
     "jszip",
     "junit",
     "keywordize",
+    "keywordized",
     "klepsch",
     "kondo",
     "lein",
@@ -201,5 +205,17 @@
       "languageId": ["clojure", "json", "typescript"],
       "allowCompoundWords": false
     }
-  ]
+  ],
+  "githubIssues.issueBranchTitle": "wip/${user}/issue-#${issueNumber}/${sanitizedIssueTitle}",
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
+  },
+  "peacock.color": "#e48141"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -67,12 +67,85 @@
       }
     },
     {
+      "label": "Calva Prettier Check Watch",
+      "type": "npm",
+      "script": "prettier-check-watch",
+      "isBackground": true,
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      },
+      "problemMatcher": [
+        {
+          "owner": "prettier",
+          "source": "prettier",
+          "fileLocation": ["relative", "${workspaceRoot}"],
+          "severity": "warning",
+          "pattern": {
+            "regexp": "\\[warn\\] (.+)",
+            "kind": "file",
+            "file": 1,
+            "message": 1
+          },
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": "Checking formatting",
+            "endsPattern": "(\\[warn\\] Code style issues found in the above file\\(s\\))|(All matched files use Prettier code style!)"
+          }
+        },
+        {
+          "owner": "prettier",
+          "source": "prettier",
+          "fileLocation": ["relative", "${workspaceRoot}"],
+          "severity": "error",
+          "pattern": {
+            "regexp": "\\[(error)\\] (.+?): (.+) \\((\\d+?):(\\d+?)\\)",
+            "kind": "location",
+            "severity": 1,
+            "file": 2,
+            "message": 3,
+            "line": 4,
+            "column": 5
+          },
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": "Checking formatting",
+            "endsPattern": "(\\[warn\\] Code style issues found in the above file\\(s\\))|(All matched files use Prettier code style!)"
+          }
+        }
+      ],
+      "presentation": {
+        "panel": "dedicated",
+        "group": "defaultCalva"
+      }
+    },
+    {
+      "label": "Calva Prettier Format Watch",
+      "type": "npm",
+      "script": "prettier-format-watch",
+      "isBackground": true,
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      },
+
+      "presentation": {
+        "panel": "dedicated",
+        "group": "defaultCalva"
+      }
+    },
+    {
       "label": "Calva Dev",
       "group": {
         "kind": "build",
         "isDefault": false
       },
-      "dependsOn": ["Calva Watch", "Calva Test Watch", "Calva Lint Watch"]
+      "dependsOn": [
+        "Calva Watch",
+        "Calva Test Watch",
+        "Calva Lint Watch",
+        "Calva Prettier Format Watch"
+      ]
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,67 @@
         "kind": "build",
         "isDefault": true
       },
-      "problemMatcher": "$tsc-watch"
+      "problemMatcher": "$tsc-watch",
+      "presentation": {
+        "panel": "dedicated",
+        "group": "defaultCalva"
+      }
+    },
+    {
+      "label": "Calva Test Watch",
+      "type": "npm",
+      "script": "unit-test-watch",
+      "isBackground": true,
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "problemMatcher": {
+        // "owner": "mocha",
+        "fileLocation": ["relative", "${workspaceRoot}"],
+        "pattern": [
+          {
+            "regexp": "^not\\sok\\s\\d+\\s(.*)$"
+          },
+          {
+            "regexp": "\\s+(.*)$",
+            "message": 1
+          },
+          {
+            "regexp": "\\s+at\\s(.*)\\s\\((.*):(\\d+):(\\d+)\\)",
+            "file": 2,
+            "line": 3,
+            "column": 4
+          }
+        ]
+      },
+      "presentation": {
+        "panel": "dedicated",
+        "group": "defaultCalva"
+      }
+    },
+    {
+      "label": "Calva Lint Watch",
+      "type": "npm",
+      "script": "eslint-watch",
+      "isBackground": true,
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      },
+      "problemMatcher": "$eslint-compact",
+      "presentation": {
+        "panel": "dedicated",
+        "group": "defaultCalva"
+      }
+    },
+    {
+      "label": "Calva Dev",
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      },
+      "dependsOn": ["Calva Watch", "Calva Test Watch", "Calva Lint Watch"]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Maintenance: Create npm scripts for prettier format+check watching, and expose vsc tasks for watching unit tests, prettier format, eslint and a compound task to run them all in one go.
+
 ## [2.0.261] - 2022-04-01
 - Fix: [Results doc gets in a bad state and does not update](https://github.com/BetterThanTomorrow/calva/issues/1509)
 - Fix: [Indenting not working correctly in vectors starting with fn-like symbols](https://github.com/BetterThanTomorrow/calva/issues/1622)

--- a/package.json
+++ b/package.json
@@ -2698,6 +2698,8 @@
     "publish": "bb publish.clj",
     "prettier-format": "npx prettier --write './**/*.{ts,js,json}'",
     "prettier-check": "npx prettier --check './**/*.{ts,js,json}'",
+    "prettier-check-watch": "npx onchange './**/*.{ts,js,json}' -- prettier --check {{changed}}",
+    "prettier-format-watch": "npx onchange './**/*.{ts,js,json}' -- prettier --write {{changed}}",
     "eslint": "npx eslint . --ext .js,.jsx,.ts,.tsx",
     "eslint-watch": "npx esw . --ext .js,.jsx,.ts,.tsx --watch"
   },

--- a/package.json
+++ b/package.json
@@ -2694,6 +2694,7 @@
     "calva-lib-test": "node ./out/cljs-lib/test/cljs-lib-tests.js",
     "integration-test": "node ./out/extension-test/integration/runTests.js",
     "unit-test": "npx mocha --require ts-node/register 'src/extension-test/unit/**/*-test.ts'",
+    "unit-test-watch": "npx mocha --watch --require ts-node/register 'src/extension-test/unit/**/*-test.ts'",
     "publish": "bb publish.clj",
     "prettier-format": "npx prettier --write './**/*.{ts,js,json}'",
     "prettier-check": "npx prettier --check './**/*.{ts,js,json}'",


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
- Created npm scripts to run prettier check and prettier format in "watch mode", using `onchange` package, [per prettier docs](https://prettier.io/docs/en/watching-files.html)
- Created new vsc Tasks for:
  - Mocha test watcher
  - Eslint watch
  - new Prettier check watch
  - new Prettier format watch
  - compound task that runs the above unit test, eslint, prettier format watchers + existing Build watch task

- I personally like to run these all at once, and would consider making the compound watcher the "default build task", such that it's bound to `cmd+shift+b`, but I'm sure many others might prefer otherwise.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes # (I did not create an issue for this, @pez, should I?)

Here's a screenshot 
![image](https://user-images.githubusercontent.com/22646419/161332697-208e6e23-ae39-4e52-9947-a527bc553170.png)


## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
     - [x] Tested the particular change
     - [-] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [-] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [-] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [-] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [-] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [ ] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik