### PR TITLE
Provide clojure-lsp with fallback rootUri and defer starting until we have a Clojure file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 - Change paredit navigation command labels and paredit "Or Up" labels from [Issue #1660](https://github.com/BetterThanTomorrow/calva/issues/1660)
+- Fix: [clojure-lsp initialized in a non-working state when there is no VS Code folder](https://github.com/BetterThanTomorrow/calva/issues/1664)
 
 ## [2.0.264] - 2022-04-07
 - Fix: [Shadowcljs shows error when running calva.loadFile command](https://github.com/BetterThanTomorrow/calva/issues/1670)

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -440,7 +440,7 @@ async function getFallbackFolder(): Promise<FallbackFolder> {
   };
 }
 
-async function startClientCommand() {
+export async function startClientCommand() {
   lspStatus.show();
   await maybeDownloadLspServer();
   await startClient(await getFallbackFolder());

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -163,7 +163,7 @@ export async function startStandaloneRepl(
       void vscode.window.showWarningMessage(`Error downloading files: ${err.message}`);
     });
   }
-  if (calvaConfig.getConfig().enableClojureLspOnStart) {
+  if (clojureLsp.lspStatus === 'stopped' && calvaConfig.getConfig().enableClojureLspOnStart) {
     void clojureLsp.startClientCommand();
   }
 

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -10,6 +10,8 @@ import { getConfig } from '../config';
 import * as replSession from './repl-session';
 import * as cljsLib from '../../out/cljs-lib/cljs-lib';
 import { ReplConnectSequence } from './connectSequence';
+import * as clojureLsp from '../lsp/main';
+import * as calvaConfig from '../config';
 
 const TEMPLATES_SUB_DIR = 'bundled';
 const DRAM_BASE_URL = 'https://raw.githubusercontent.com/BetterThanTomorrow/dram';
@@ -160,6 +162,9 @@ export async function startStandaloneRepl(
       console.error(`Error downloading drams: ${err.message}`);
       void vscode.window.showWarningMessage(`Error downloading files: ${err.message}`);
     });
+  }
+  if (calvaConfig.getConfig().enableClojureLspOnStart) {
+    void clojureLsp.startClientCommand();
   }
 
   const [mainDoc, mainEditor] = await openStoredDoc(storageUri, tempDirUri, config.files[0]);

--- a/src/state.ts
+++ b/src/state.ts
@@ -111,7 +111,7 @@ export async function setOrCreateNonProjectRoot(
   }
   if (!root) {
     const subDir = util.randomSlug();
-    root = vscode.Uri.file(path.join(os.tmpdir(), 'betterthantomorrow.calva', subDir));
+    root = vscode.Uri.file(path.join(util.calvaTmpDir(), subDir));
     await setNonProjectRootDir(context, root);
   }
   await setStateValue(PROJECT_DIR_KEY, path.resolve(root.fsPath ? root.fsPath : root.path));

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -498,6 +498,10 @@ function randomSlug(length = 7) {
   return Math.random().toString(36).substring(7);
 }
 
+function calvaTmpDir() {
+  return path.join(os.tmpdir(), 'betterthantomorrow.calva');
+}
+
 const isWindows = process.platform === 'win32';
 
 export async function isDocumentWritable(document: vscode.TextDocument): Promise<boolean> {
@@ -578,4 +582,5 @@ export {
   tryToGetActiveTextEditor,
   getActiveTextEditor,
   pathExists,
+  calvaTmpDir,
 };


### PR DESCRIPTION
## What has Changed?

VS Code sends `rootUri: null` to the LSP server if there is no folder open in the window. This doesn't work for clojure-lsp. So now, Instead of just blindly starting the server when Calva activates:

* We check if there is a folder open in the window
    * If so we proceed as before
    * If not:
        * We check if we have a Clojure file
           * If we do we start the clojure-lsp server
           * If we don't we don't start it
    * When staring the server
       * We do our best to figure out a fallback rootUri from the file, falling back to a generic fallback if it is untitled.
       * Start the server providing this fallback

The above approach alone would result in no clojure-lsp when starting standalone REPLs. So what we do there is that we: 

1.  wait until we have prepared the ”project” for the standalone REP
2. then we start clojure-lsp.

Fixes #1664 
Fixes #1601

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik, @ericdallo 