### PR TITLE
Append prompt after switching namespace of output window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ Changes to Calva.
 ## [Unreleased]
 - [Improve kondo configuration documentation](https://github.com/BetterThanTomorrow/calva/issues/1282)
 - [Require VS Code 1.66+ (and update project node version to 16+)](https://github.com/BetterThanTomorrow/calva/issues/1638#issuecomment-1086726236)
-
 - Maintenance: [Upgrade TS + some ts eslint plugins + fix any necessary changes thereof](https://github.com/BetterThanTomorrow/calva/issues/1639)
+- Fix: [Command not working: sync the Output/REPL window namespace with the current file](https://github.com/BetterThanTomorrow/calva/issues/1503)
+
 
 ## [2.0.262] - 2022-04-02
 - Tech debt mortgage: [Cleanup/removal of EditableDocument.selectionLeft/Right APIs](https://github.com/BetterThanTomorrow/calva/issues/1607)]

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -93,7 +93,7 @@ async function evaluateCode(
     const err: string[] = [];
 
     if (outputWindow.getNs() !== ns) {
-      await session.eval("(in-ns '" + ns + ')', session.client.ns).value;
+      await session.eval(`(in-ns '${ns}) (clojure.core/refer-clojure)`, session.client.ns).value;
     }
 
     const context: NReplEvaluation = session.eval(code, ns, {
@@ -417,7 +417,7 @@ async function loadFile(
 
     outputWindow.append('; Evaluating file: ' + fileName);
 
-    await session.eval("(in-ns '" + ns + ')', session.client.ns).value;
+    await session.eval(`(in-ns '${ns}) (clojure.core/refer-clojure)`, session.client.ns).value;
 
     const res = session.loadFile(fileContents, {
       fileName,
@@ -474,7 +474,7 @@ async function requireREPLUtilitiesCommand() {
     if (session) {
       try {
         await namespace.createNamespaceFromDocumentIfNotExists(util.tryToGetDocument({}));
-        await session.eval("(in-ns '" + ns + ')', session.client.ns).value;
+        await session.eval(`(in-ns '${ns}) (clojure.core/refer-clojure)`, session.client.ns).value;
         await session.eval(form, ns).value;
         chan.appendLine(`REPL utilities are now available in namespace ${ns}.`);
       } catch (e) {
@@ -548,7 +548,7 @@ export async function evaluateInOutputWindow(
     const session = replSession.getSession(sessionType);
     replSession.updateReplSessionType();
     if (outputWindow.getNs() !== ns) {
-      await session.eval(`(in-ns '${ns})`, session.client.ns).value;
+      await session.eval(`(in-ns '${ns}) (clojure.core/refer-clojure)`, session.client.ns).value;
       outputWindow.setSession(session, ns);
       if (options.evaluationSendCodeToOutputWindow !== false) {
         outputWindow.appendPrompt();

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -229,10 +229,11 @@ export async function setNamespaceFromCurrentFile() {
   const session = replSession.getSession();
   const ns = namespace.getNamespace(util.tryToGetDocument({}));
   if (getNs() !== ns && util.isDefined(ns)) {
-    await session.eval("(in-ns '" + ns + ')', session.client.ns).value;
+    await session.eval(`(in-ns '${ns}) (clojure.core/refer-clojure)`, session.client.ns).value;
   }
   setSession(session, ns);
   replSession.updateReplSessionType();
+  appendPrompt();
 }
 
 async function appendFormGrabbingSessionAndNS(topLevel: boolean) {
@@ -250,7 +251,7 @@ async function appendFormGrabbingSessionAndNS(topLevel: boolean) {
   }
   if (code != '') {
     if (getNs() !== ns) {
-      await session.eval("(in-ns '" + ns + ')', session.client.ns).value;
+      await session.eval(`(in-ns '${ns}) (clojure.core/refer-clojure)`, session.client.ns).value;
     }
     setSession(session, ns);
     append(code, (_) => revealResultsDoc(false));


### PR DESCRIPTION
## What has Changed?

For some reason no prompt was appended to the output window when using the command for switching the namespace of the output window to match the current file. This caused it to seem like the command did nothing at all. Now fixed.

Fixes #1503

While at it also added `(clojure.core/refer-clojure)` after the `(in-ns ...)` since the output window wouldn't really work if we switched it to an ns of an unloaded file. While at it I added this to all places where we call `(in-ns ...)` and we will probably not see the funny errors like `str is not defined`, See: https://clojure.org/guides/repl/navigating_namespaces#_switching_to_an_existing_namespace_with_in_ns

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik