### PR TITLE
Don't `(refer-clojure)` in cljs sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Shadowcljs shows error when running calva.loadFile command](https://github.com/BetterThanTomorrow/calva/issues/1670)
 
 ## [2.0.263] - 2022-04-06
 - [Improve kondo configuration documentation](https://github.com/BetterThanTomorrow/calva/issues/1282)

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -93,7 +93,7 @@ async function evaluateCode(
     const err: string[] = [];
 
     if (outputWindow.getNs() !== ns) {
-      await session.eval(`(in-ns '${ns}) (clojure.core/refer-clojure)`, session.client.ns).value;
+      await session.switchNS(ns);
     }
 
     const context: NReplEvaluation = session.eval(code, ns, {
@@ -417,7 +417,7 @@ async function loadFile(
 
     outputWindow.append('; Evaluating file: ' + fileName);
 
-    await session.eval(`(in-ns '${ns}) (clojure.core/refer-clojure)`, session.client.ns).value;
+    await session.switchNS(ns);
 
     const res = session.loadFile(fileContents, {
       fileName,
@@ -474,7 +474,7 @@ async function requireREPLUtilitiesCommand() {
     if (session) {
       try {
         await namespace.createNamespaceFromDocumentIfNotExists(util.tryToGetDocument({}));
-        await session.eval(`(in-ns '${ns}) (clojure.core/refer-clojure)`, session.client.ns).value;
+        await session.switchNS(ns);
         await session.eval(form, ns).value;
         chan.appendLine(`REPL utilities are now available in namespace ${ns}.`);
       } catch (e) {
@@ -548,7 +548,7 @@ export async function evaluateInOutputWindow(
     const session = replSession.getSession(sessionType);
     replSession.updateReplSessionType();
     if (outputWindow.getNs() !== ns) {
-      await session.eval(`(in-ns '${ns}) (clojure.core/refer-clojure)`, session.client.ns).value;
+      await session.switchNS(ns);
       outputWindow.setSession(session, ns);
       if (options.evaluationSendCodeToOutputWindow !== false) {
         outputWindow.appendPrompt();

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -306,6 +306,14 @@ export class NReplSession {
     });
   }
 
+  async switchNS(ns: any) {
+    if (this.replType === 'clj') {
+      await this.eval(`(in-ns '${ns}) (clojure.core/refer-clojure)`, this.client.ns).value;
+    } else {
+      await this.eval(`(in-ns '${ns})`, this.client.ns).value;
+    }
+  }
+
   private _createEvalOperationMessage(code: string, ns: string, opts: any) {
     if (vscode.debug.activeDebugSession && this.replType === 'clj') {
       const debugResponse = getStateValue(debug.DEBUG_RESPONSE_KEY);

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -229,7 +229,7 @@ export async function setNamespaceFromCurrentFile() {
   const session = replSession.getSession();
   const ns = namespace.getNamespace(util.tryToGetDocument({}));
   if (getNs() !== ns && util.isDefined(ns)) {
-    await session.eval(`(in-ns '${ns}) (clojure.core/refer-clojure)`, session.client.ns).value;
+    await session.switchNS(ns);
   }
   setSession(session, ns);
   replSession.updateReplSessionType();
@@ -251,7 +251,7 @@ async function appendFormGrabbingSessionAndNS(topLevel: boolean) {
   }
   if (code != '') {
     if (getNs() !== ns) {
-      await session.eval(`(in-ns '${ns}) (clojure.core/refer-clojure)`, session.client.ns).value;
+      await session.switchNS(ns);
     }
     setSession(session, ns);
     append(code, (_) => revealResultsDoc(false));


### PR DESCRIPTION
## What has Changed?

shadow-cljs does not yet implement `refer-clojure`, so calling it throws an error and prints a huge map twice in the REPL.

Since the call is not needed in ClojureScript anyway, we skip doing it in `cljs` sessions.

Also refactored all these calls into a method `switchNS(ns)` on NReplSession instances.

Fixes #1670

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik