### PR TITLE
Fix file switching in workspace folders scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Jump between source/test does not work properly with multiple workspace folders](https://github.com/BetterThanTomorrow/calva/issues/1219)
 
 ## [2.0.264] - 2022-04-07
 - Fix: [Shadowcljs shows error when running calva.loadFile command](https://github.com/BetterThanTomorrow/calva/issues/1670)

--- a/src/file-switcher/file-switcher.ts
+++ b/src/file-switcher/file-switcher.ts
@@ -40,9 +40,9 @@ export async function toggleBetweenImplAndTest() {
   const openedFilename = activeFile.document.fileName;
   const projectRootPath = await projectRoot.findClosestProjectRootPath();
   const pathAfterRoot = openedFilename.replace(projectRootPath, '');
-  const fullFileName = pathAfterRoot.split(path.sep).slice(-1)[0];
-  const extension = '.' + fullFileName.split('.').pop();
-  const fileName = fullFileName.replace(extension, '');
+  const fullFileName = path.basename(openedFilename);
+  const extension = path.extname(fullFileName);
+  const fileName = fullFileName.substring(0, fullFileName.length - extension.length);
 
   const { success, message } = util.isFileValid(fullFileName, pathAfterRoot);
   if (!success) {
@@ -54,9 +54,9 @@ export async function toggleBetweenImplAndTest() {
   const newFilename = util.getNewFilename(fileName, extension);
 
   const filePath = path.join(projectRootPath, sourcePath, newFilename);
-  const fileToOpen = vscode.workspace.asRelativePath(filePath);
+  const fileToOpen = vscode.workspace.asRelativePath(filePath, false);
 
-  void vscode.workspace.findFiles(fileToOpen, '**/.calva/**').then((files) => {
+  void vscode.workspace.findFiles(fileToOpen, projectRoot.excludePattern()).then((files) => {
     if (!files.length) {
       void askToCreateANewFile(path.join(projectRootPath, sourcePath), newFilename);
     } else {

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -12,7 +12,7 @@ export async function findProjectRootPaths() {
     '.nrepl-port',
   ];
   const projectFilesGlob = `**/{${projectFileNames.join(',')}}`;
-  const excludeDirsGlob = `**/{${config.getConfig().projectRootsSearchExclude.join(',')}}`;
+  const excludeDirsGlob = excludePattern();
   const t0 = new Date().getTime();
   const rootPaths: string[] = [];
   if (vscode.workspace.workspaceFolders?.length > 0) {
@@ -25,6 +25,10 @@ export async function findProjectRootPaths() {
   rootPaths.push(...projectFilePaths);
   const candidatePaths = [...new Set(rootPaths)].sort();
   return candidatePaths;
+}
+
+export function excludePattern(moreExcludes: string[] = []) {
+  return `**/{${[...moreExcludes, ...config.getConfig().projectRootsSearchExclude].join(',')}}`;
 }
 
 export async function findClosestProjectRootPath(candidatePaths?: string[]) {


### PR DESCRIPTION
## What has Changed?

When there are Workspace Folders around `vscode.workspace.asRelativePah()`, defaulted to include the ws folder name. Now we're telling it not to, since we are using the result for a workspace glob.

Also simplified some code around constructing paths.

Fixes #1219

## My Calva PR Checklist

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik