### PR TITLE
Fixes #1660: Change Paredit navigation command labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Change paredit navigation command labels and paredit "Or Up" labels from [Issue #1660](https://github.com/BetterThanTomorrow/calva/issues/1660)
 
 ## [2.0.264] - 2022-04-07
 - Fix: [Shadowcljs shows error when running calva.loadFile command](https://github.com/BetterThanTomorrow/calva/issues/1670)

--- a/package.json
+++ b/package.json
@@ -1182,55 +1182,55 @@
       {
         "category": "Calva Paredit",
         "command": "paredit.forwardSexp",
-        "title": "Forward Sexp",
+        "title": "Move Cursor Forward Sexp/Form",
         "enablement": "editorLangId == clojure"
       },
       {
         "category": "Calva Paredit",
         "command": "paredit.backwardSexp",
-        "title": "Backward Sexp",
+        "title": "Move Cursor Backward Sexp/Form",
         "enablement": "editorLangId == clojure"
       },
       {
         "category": "Calva Paredit",
         "command": "paredit.forwardSexpOrUp",
-        "title": "Forward Sexp Or Up",
+        "title": "Move Cursor Forward or Up Sexp/Form",
         "enablement": "editorLangId == clojure"
       },
       {
         "category": "Calva Paredit",
         "command": "paredit.backwardSexpOrUp",
-        "title": "Backward Sexp Or Up",
+        "title": "Move Cursor Backward or Up Sexp/Form",
         "enablement": "editorLangId == clojure"
       },
       {
         "category": "Calva Paredit",
         "command": "paredit.forwardDownSexp",
-        "title": "Forward Down Sexp",
+        "title": "Move Cursor Forward Down Sexp/Form",
         "enablement": "editorLangId == clojure"
       },
       {
         "category": "Calva Paredit",
         "command": "paredit.backwardDownSexp",
-        "title": "Backward Down Sexp",
+        "title": "Move Cursor Backward Down Sexp/Form",
         "enablement": "editorLangId == clojure"
       },
       {
         "category": "Calva Paredit",
         "command": "paredit.backwardUpSexp",
-        "title": "Backward Up Sexp",
+        "title": "Move Cursor Backward Up Sexp/Form",
         "enablement": "editorLangId == clojure"
       },
       {
         "category": "Calva Paredit",
         "command": "paredit.forwardUpSexp",
-        "title": "Forward Up Sexp",
+        "title": "Move Cursor Forward Up Sexp/Form",
         "enablement": "editorLangId == clojure"
       },
       {
         "category": "Calva Paredit",
         "command": "paredit.closeList",
-        "title": "Forward to List End/Close",
+        "title": "Move Cursor Forward to List End/Close",
         "enablement": "editorLangId == clojure"
       },
       {
@@ -1278,13 +1278,13 @@
       {
         "category": "Calva Paredit",
         "command": "paredit.selectBackwardSexpOrUp",
-        "title": "Select Backward Sexp Or Up",
+        "title": "Select Backward Or Up Sexp",
         "enablement": "editorLangId == clojure"
       },
       {
         "category": "Calva Paredit",
         "command": "paredit.selectForwardSexpOrUp",
-        "title": "Select Forward Sexp Or Up",
+        "title": "Select Forward Or Up Sexp",
         "enablement": "editorLangId == clojure"
       },
       {


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- All cursor navigation commands were renamed to start with "Move Cursor..." and the word "Sexp" in each was suffixed with "/form"
- "Or Up" commands have been renamed to be grammatically correct
-

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1660

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik