### PR TITLE
Add format trimming command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- [Add command for formatting away multiple space between forms on the same line](https://github.com/BetterThanTomorrow/calva/issues/1677)
 
 ## [2.0.266] - 2022-04-11
 - Fix: [Jump between source/test does not work properly with multiple workspace folders](https://github.com/BetterThanTomorrow/calva/issues/1219)

--- a/docs/site/formatting.md
+++ b/docs/site/formatting.md
@@ -31,7 +31,35 @@ Calva's formatting is mostly about indenting, but it also (again, defaults):
     -   this also folds trailing brackets (a k a _the paren trail_) up on the same line
 -   inserts whitespace between forms
 
-Not a fan of some default setting? The formatter is quite configurable.
+Not a fan of some default setting? The formatter is quite [configurable](#configuration).
+
+## Format current form command variants
+
+There are two special commands for formatting the current form:
+
+### Format and Align Current Form
+
+Aligns associative structures and bindings in two columns. See more [below](#about-aligning-associative-forms).
+
+### Format Current Form and trim space between forms
+
+This formats the text, and trims consecutive, non-indent, whitespace on a line to just one space. Something like:
+
+```clojure
+(let [a    :b]
+(str "foo"     "bar" "baz"
+"a"    a))
+```
+
+Becomes:
+
+```clojure
+(let [a :b]
+  (str "foo" "bar" "baz"
+       "a" a))
+```
+
+Basically, it behaves like if `:remove-multiple-non-indenting-spaces? true` was added to the `cljfmt` config. Which, in fact, is what happens. Calva merges that onto your cljfmt config when this command is used.
 
 ## Configuration
 
@@ -54,7 +82,8 @@ If providing settings via a file, start changing the Calva formatting defaults b
 {:remove-surrounding-whitespace? true
  :remove-trailing-whitespace? true
  :remove-consecutive-blank-lines? false
- :insert-missing-whitespace? true}
+ :insert-missing-whitespace? true
+ :remove-multiple-non-indenting-spaces? false}
 ```
 
 Then set `calva.fmt.configPath` to the path to this file. The path should either be absolute, or relative to the project root directory. So, if you named the file `.cljfmt.edn` and saved it in the root of the project, then this setting should be `.cljfmt.edn`.

--- a/package.json
+++ b/package.json
@@ -1540,6 +1540,12 @@
         "enablement": "editorLangId == clojure"
       },
       {
+        "command": "calva-fmt.trimCurrentFormWhiteSpace",
+        "title": "Format Current Form and trim space between forms",
+        "category": "Calva Format",
+        "enablement": "editorLangId == clojure"
+      },
+      {
         "command": "calva-fmt.inferParens",
         "title": "Infer Parens (from the indentation)",
         "category": "Calva Format",

--- a/src/calva-fmt/src/extension.ts
+++ b/src/calva-fmt/src/extension.ts
@@ -46,6 +46,12 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   );
   context.subscriptions.push(
+    vscode.commands.registerTextEditorCommand(
+      'calva-fmt.trimCurrentFormWhiteSpace',
+      formatter.trimWhiteSpacePositionCommand
+    )
+  );
+  context.subscriptions.push(
     vscode.commands.registerTextEditorCommand('calva-fmt.inferParens', inferer.inferParensCommand)
   );
   context.subscriptions.push(

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -183,6 +183,10 @@ export function alignPositionCommand(editor: vscode.TextEditor) {
   void formatPosition(editor, true, { 'align-associative?': true });
 }
 
+export function trimWhiteSpacePositionCommand(editor: vscode.TextEditor) {
+  void formatPosition(editor, false, { 'remove-multiple-non-indenting-spaces?': true });
+}
+
 export async function formatCode(code: string, eol: number) {
   const d = {
     'range-text': code,

--- a/src/cljs-lib/src/calva/fmt/formatter.cljs
+++ b/src/cljs-lib/src/calva/fmt/formatter.cljs
@@ -37,12 +37,19 @@
     (catch js/Error e
       {:error (.-message e)})))
 
-(defn- reformat-string [range-text {:keys [align-associative?] :as config}]
-  (let [cljfmt-options (:cljfmt-options config)]
+(defn- reformat-string [range-text {:keys [align-associative?
+                                           remove-multiple-non-indenting-spaces?] :as config}]
+  (let [cljfmt-options (:cljfmt-options config)
+        trim-space-between? (or remove-multiple-non-indenting-spaces?
+                                (:remove-multiple-non-indenting-spaces? cljfmt-options))]
     (if (or align-associative?
             (:align-associative? cljfmt-options))
-      (pez-cljfmt/reformat-string range-text (assoc cljfmt-options :align-associative? true))
-      (cljfmt/reformat-string range-text cljfmt-options))))
+      (pez-cljfmt/reformat-string range-text (-> cljfmt-options
+                                                 (assoc :align-associative? true)
+                                                 (dissoc :remove-multiple-non-indenting-spaces?)))
+      (cljfmt/reformat-string range-text (-> cljfmt-options
+                                             (assoc :remove-multiple-non-indenting-spaces?
+                                                    trim-space-between?))))))
 
 (defn format-text
   [{:keys [range-text eol config] :as m}]

--- a/src/cljs-lib/test/calva/fmt/formatter_test.cljs
+++ b/src/cljs-lib/test/calva/fmt/formatter_test.cljs
@@ -30,7 +30,7 @@ baz)")
          (:range-text (sut/format-text-at-idx {:eol "\n" :all-text "(\n\n,)" :range [0 5] :idx 2})))))
 
 (def misaligned-text "(def foo
-(let[a b
+(let[a   b
 aa bb
 ccc {:a b :aa bb :ccc ccc}]
 ))")
@@ -46,16 +46,39 @@ ccc {:a b :aa bb :ccc ccc}]
            (:range-text (sut/format-text-at-idx {:eol      "\n"
                                                  :all-text misaligned-text
                                                  :config {:align-associative? true}
-                                                 :range    [0 54]
+                                                 :range    [0 56]
                                                  :idx      0})))))
+  
   (testing "Does not align associative structures when `:align-associative` is not `true`"
+    (is (= "(def foo
+  (let [a   b
+        aa bb
+        ccc {:a b :aa bb :ccc ccc}]))"
+           (:range-text (sut/format-text-at-idx {:eol      "\n"
+                                                 :all-text misaligned-text
+                                                 :range    [0 56]
+                                                 :idx      1}))))))
+
+(deftest format-trim-text-at-idx
+  (testing "Trims space between forms when `:remove-multiple-non-indenting-spaces?` is `true`"
     (is (= "(def foo
   (let [a b
         aa bb
         ccc {:a b :aa bb :ccc ccc}]))"
            (:range-text (sut/format-text-at-idx {:eol      "\n"
                                                  :all-text misaligned-text
-                                                 :range    [0 54]
+                                                 :config {:remove-multiple-non-indenting-spaces? true}
+                                                 :range    [0 56]
+                                                 :idx      0})))))
+  
+  (testing "Does not trim space between forms when `:remove-multiple-non-indenting-spaces?` is missing"
+    (is (= "(def foo
+  (let [a   b
+        aa bb
+        ccc {:a b :aa bb :ccc ccc}]))"
+           (:range-text (sut/format-text-at-idx {:eol      "\n"
+                                                 :all-text misaligned-text
+                                                 :range    [0 56]
                                                  :idx      1}))))))
 
 (def a-comment

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -21,5 +21,6 @@
     "titleBar.activeForeground": "#131722",
     "titleBar.inactiveBackground": "#90B4FEd5",
     "titleBar.inactiveForeground": "#13172299"
-  }
+  },
+  "calva.fmt.configPath": "projects/pirate-lang/.cljfmt.edn"
 }

--- a/test-data/projects/pirate-lang/.cljfmt.edn
+++ b/test-data/projects/pirate-lang/.cljfmt.edn
@@ -2,12 +2,13 @@
  :remove-trailing-whitespace? true
  :remove-consecutive-blank-lines? true
  :insert-missing-whitespace? true
+ :remove-multiple-non-indenting-spaces? false
  :align-associative? false
  :indents  {#"fooa?$" [[:inner 0]]
             #"bar" [[:block 0]]}
 
  :test (foob 1
              2
-             {:a a
+             {:a    a
               :aa a
               :bbb bbb})}


### PR DESCRIPTION
## What has Changed?

Added a command for formatting the current form, trimming space between forms. Good for when reverting from using aligned maps and bindings, for instance.

It's implemented similarly to the command for aligning maps and bindings. Though less of a burden here, because stock `cljfmt` has this option. We just merge it in before formatting.

Fixes #1677

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik