### PR TITLE
Create clojure-lsp drag commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 - Fix: [Toggle between implementation and test command should set editor focus](https://github.com/BetterThanTomorrow/calva/issues/1707)
 - Fix: [Hijacked shortcuts only works on strict](https://github.com/BetterThanTomorrow/calva/issues/1711)
+- [Enable users to bind keyboard shortcuts to clojure-lsp drag commands](https://github.com/BetterThanTomorrow/calva/issues/1697)
 
 ## [2.0.270] - 2022-05-02
 - Fix: [Downloaded clojure-lsp not working for static linux distros](https://github.com/BetterThanTomorrow/calva/issues/1692)

--- a/docs/site/clojure-lsp.md
+++ b/docs/site/clojure-lsp.md
@@ -114,3 +114,4 @@ See also:
 
 * [Connecting the REPL](connect.md)
 * [Refactoring](refactoring.md)
+* [Dragging forms](paredit.md#drag-bindings-forwardbackward)

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -135,6 +135,9 @@ And like so (wait for it):
 
 ![](images/paredit/drag-pairs-in-maps.gif)
 
+!!! Note
+    clojure-lsp also contributes commands for dragging forms backward and forward. You might prefer those, because they have better comment affinity—comments stay affiliated with clauses as they're dragged—and better contextual support—clauses within many common functions (e.g. assoc, case and cond) move intuitively. Note however that these commands won't work in the REPL and other places where clojure-lsp is unavailable. See [this PR](https://github.com/BetterThanTomorrow/calva/pull/1698) for more details. To use the clojure-lsp commands, search for "clojure-lsp drag" in the command palette or the keyboard shortcut preferences menu, or choose them from the _Quick Fix_ suggestion lightbulb.
+
 ## About the Keyboard Shortcuts
 
 Care has been put in to making the default keybindings somewhat logical, easy to use, and work with most keyboard layouts. Slurp and barf forward are extra accessible to go with the recommendation to learn using these two super handy editing commands.

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -136,7 +136,7 @@ And like so (wait for it):
 ![](images/paredit/drag-pairs-in-maps.gif)
 
 !!! Note
-    clojure-lsp also contributes commands for dragging forms backward and forward. You might prefer those, because they have better comment affinity—comments stay affiliated with clauses as they're dragged—and better contextual support—clauses within many common functions (e.g. assoc, case and cond) move intuitively. Note however that these commands won't work in the REPL and other places where clojure-lsp is unavailable. See [this PR](https://github.com/BetterThanTomorrow/calva/pull/1698) for more details. To use the clojure-lsp commands, search for "clojure-lsp drag" in the command palette or the keyboard shortcut preferences menu, or choose them from the _Quick Fix_ suggestion lightbulb.
+    clojure-lsp also contributes commands for dragging forms backward and forward. You might prefer those, because they have better comment affinity—comments stay affiliated with clauses as they're dragged—and better contextual support—clauses within many common functions (e.g. assoc, case and cond) move intuitively. Note however that these commands won't work in the REPL and other places where clojure-lsp is unavailable. Unlike Calva's drag commands, clojure-lsp's drag commands will not move words within strings. To use the clojure-lsp commands, search for "clojure-lsp drag" in the command palette or the keyboard shortcut preferences menu, or choose them from the _Quick Fix_ suggestion lightbulb. See [this PR](https://github.com/BetterThanTomorrow/calva/pull/1698) and its links for more discussion of this feature.
 
 ## About the Keyboard Shortcuts
 

--- a/docs/site/refactoring.md
+++ b/docs/site/refactoring.md
@@ -5,32 +5,32 @@ description: Powered by clojure-lsp, Calva comes with some quite nifty refactori
 
 # Refactoring
 
-There are two ”flavours” to refactoring support. Some (just a few) refactorings are made available as _Quick Fix_ suggestions (the light bulb), the rest are regular commands in the *Calva Refactoring* category.
+There are two ”flavours” to refactoring support. Some (just a few) refactorings are made available as _Quick Fix_ suggestions (the light bulb), the rest are regular commands in the *clojure-lsp Refactoring* category.
 
 ![](images/refactoring/quick-fix.png)
 
 You can enable or disable the _Quick Fix_ suggestion lightbulb using the VS Code setting `editor.lightbulb.enabled`.
 
-The refactoring commands do not have default keyboard shortcuts. You find them all by typing ”Calva Refactor” in the Command Palette.
+The refactoring commands do not have default keyboard shortcuts. You find them all by typing ”clojure-lsp Refactor” in the Command Palette.
 
 ## Commands
 
 Command Title | Command Key | Description
 ------------- | ----------- | -----------
-Clean NS Form | `calva.refactor.cleanNs` | ![](images/refactoring/cleanNs.gif)
-Add Missing Require | `calva.refactor.addMissingLibspec` | ![](images/refactoring/addMissingLibspec.gif)
-Extract to New Function | `calva.refactor.extractFunction` | ![](images/refactoring/extractFunction.gif)
-Cycle/Toggle Privacy | `calva.refactor.cyclePrivacy` | ![](images/refactoring/cyclePrivacy.gif)
-Inline Symbol | `calva.refactor.inlineSymbol` | ![](images/refactoring/inlineSymbol.gif)
-Introduce let | `calva.refactor.introduceLet` | Creates a new let box with the binding. Follow up with ”Expand let” to move it upwards.<br>![](images/refactoring/introduceLet.gif)
-Expand Let | `calva.refactor.expandLet` | ![](images/refactoring/expandLet.gif)
-Move to Previous let Box | `calva.refactor.moveToLet` | ![](images/refactoring/moveToLet.gif)
-Thread First | `calva.refactor.threadFirst` | ![](images/refactoring/threadFirst.gif)
-Thread First All | `calva.refactor.threadFirstAll` | ![](images/refactoring/threadFirstAll.gif)
-Thread Last | `calva.refactor.threadLast` | ![](images/refactoring/threadLast.gif)
-Thread Last All | `calva.refactor.threadLastAll` | ![](images/refactoring/threadLastAll.gif)
-Unwind All | `calva.refactor.unwindAll` | ![](images/refactoring/unwindAll.gif)
-Unwind Thread | `calva.refactor.unwindThread` | ![](images/refactoring/unwindThread.gif)
+Clean NS Form | `clojureLsp.refactor.cleanNs` | ![](images/refactoring/cleanNs.gif)
+Add Missing Require | `clojureLsp.refactor.addMissingLibspec` | ![](images/refactoring/addMissingLibspec.gif)
+Extract to New Function | `clojureLsp.refactor.extractFunction` | ![](images/refactoring/extractFunction.gif)
+Cycle/Toggle Privacy | `clojureLsp.refactor.cyclePrivacy` | ![](images/refactoring/cyclePrivacy.gif)
+Inline Symbol | `clojureLsp.refactor.inlineSymbol` | ![](images/refactoring/inlineSymbol.gif)
+Introduce let | `clojureLsp.refactor.introduceLet` | Creates a new let box with the binding. Follow up with ”Expand let” to move it upwards.<br>![](images/refactoring/introduceLet.gif)
+Expand Let | `clojureLsp.refactor.expandLet` | ![](images/refactoring/expandLet.gif)
+Move to Previous let Box | `clojureLsp.refactor.moveToLet` | ![](images/refactoring/moveToLet.gif)
+Thread First | `clojureLsp.refactor.threadFirst` | ![](images/refactoring/threadFirst.gif)
+Thread First All | `clojureLsp.refactor.threadFirstAll` | ![](images/refactoring/threadFirstAll.gif)
+Thread Last | `clojureLsp.refactor.threadLast` | ![](images/refactoring/threadLast.gif)
+Thread Last All | `clojureLsp.refactor.threadLastAll` | ![](images/refactoring/threadLastAll.gif)
+Unwind All | `clojureLsp.refactor.unwindAll` | ![](images/refactoring/unwindAll.gif)
+Unwind Thread | `clojureLsp.refactor.unwindThread` | ![](images/refactoring/unwindThread.gif)
 
 !!! Note "Formatting"
     The way that some of the refactorings are applied to the document, makes it difficult for Calva to format the results. So, sometimes you'll need to navigate the cursor to the enclosing form and hit `tab` to tidy up the formatting after a refactoring. See also [Formatting](formatting.md).

--- a/package.json
+++ b/package.json
@@ -1630,103 +1630,103 @@
         "category": "Calva"
       },
       {
-        "command": "calva.refactor.cleanNs",
+        "command": "clojureLsp.refactor.cleanNs",
         "title": "Clean NS Form",
         "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.addMissingLibspec",
+        "command": "clojureLsp.refactor.addMissingLibspec",
         "title": "Add Missing Require",
         "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.dragBackward",
+        "command": "clojureLsp.dragBackward",
         "title": "Drag Sexp Backward",
         "category": "clojure-lsp",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.dragForward",
+        "command": "clojureLsp.dragForward",
         "title": "Drag Sexp Forward",
         "category": "clojure-lsp",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.cyclePrivacy",
+        "command": "clojureLsp.refactor.cyclePrivacy",
         "title": "Cycle/Toggle Privacy",
         "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.expandLet",
+        "command": "clojureLsp.refactor.expandLet",
         "title": "Expand Let",
         "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.inlineSymbol",
+        "command": "clojureLsp.refactor.inlineSymbol",
         "title": "Inline Symbol",
         "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.threadFirst",
+        "command": "clojureLsp.refactor.threadFirst",
         "title": "Thread First",
         "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.threadFirstAll",
+        "command": "clojureLsp.refactor.threadFirstAll",
         "title": "Thread First All",
         "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.threadLast",
+        "command": "clojureLsp.refactor.threadLast",
         "title": "Thread Last",
         "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.threadLastAll",
+        "command": "clojureLsp.refactor.threadLastAll",
         "title": "Thread Last All",
         "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.unwindAll",
+        "command": "clojureLsp.refactor.unwindAll",
         "title": "Unwind All",
         "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.unwindThread",
+        "command": "clojureLsp.refactor.unwindThread",
         "title": "Unwind Thread",
         "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.introduceLet",
+        "command": "clojureLsp.refactor.introduceLet",
         "title": "Introduce let",
         "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.moveToLet",
+        "command": "clojureLsp.refactor.moveToLet",
         "title": "Move to Previous let Box",
         "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.refactor.extractFunction",
+        "command": "clojureLsp.refactor.extractFunction",
         "title": "Extract to New Function",
         "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
-        "command": "calva.diagnostics.clojureLspServerInfo",
+        "command": "clojureLsp.diagnostics.clojureLspServerInfo",
         "title": "Clojure-lsp Server Info",
         "category": "clojure-lsp Diagnostics",
         "enablement": "editorLangId == clojure && clojureLsp:active"

--- a/package.json
+++ b/package.json
@@ -1642,6 +1642,18 @@
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
+        "command": "calva.refactor.dragBackward",
+        "title": "Drag Sexp Backward",
+        "category": "Calva Refactor",
+        "enablement": "editorLangId == clojure && clojureLsp:active"
+      },
+      {
+        "command": "calva.refactor.dragForward",
+        "title": "Drag Sexp Forward",
+        "category": "Calva Refactor",
+        "enablement": "editorLangId == clojure && clojureLsp:active"
+      },
+      {
         "command": "calva.refactor.cyclePrivacy",
         "title": "Cycle/Toggle Privacy",
         "category": "Calva Refactor",

--- a/package.json
+++ b/package.json
@@ -1632,103 +1632,103 @@
       {
         "command": "calva.refactor.cleanNs",
         "title": "Clean NS Form",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.addMissingLibspec",
         "title": "Add Missing Require",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.dragBackward",
         "title": "Drag Sexp Backward",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.dragForward",
         "title": "Drag Sexp Forward",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.cyclePrivacy",
         "title": "Cycle/Toggle Privacy",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.expandLet",
         "title": "Expand Let",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.inlineSymbol",
         "title": "Inline Symbol",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.threadFirst",
         "title": "Thread First",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.threadFirstAll",
         "title": "Thread First All",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.threadLast",
         "title": "Thread Last",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.threadLastAll",
         "title": "Thread Last All",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.unwindAll",
         "title": "Unwind All",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.unwindThread",
         "title": "Unwind Thread",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.introduceLet",
         "title": "Introduce let",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.moveToLet",
         "title": "Move to Previous let Box",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.refactor.extractFunction",
         "title": "Extract to New Function",
-        "category": "Calva Refactor",
+        "category": "clojure-lsp Refactor",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
         "command": "calva.diagnostics.clojureLspServerInfo",
         "title": "Clojure-lsp Server Info",
-        "category": "Calva Diagnostics",
+        "category": "clojure-lsp Diagnostics",
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -201,6 +201,12 @@ const clojureLspCommands: ClojureLspCommand[] = [
     command: 'cycle-privacy',
   },
   {
+    command: 'drag-backward',
+  },
+  {
+    command: 'drag-forward',
+  },
+  {
     command: 'expand-let',
   },
   {

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -202,9 +202,11 @@ const clojureLspCommands: ClojureLspCommand[] = [
   },
   {
     command: 'drag-backward',
+    category: 'clojureLsp',
   },
   {
     command: 'drag-forward',
+    category: 'clojureLsp',
   },
   {
     command: 'expand-let',
@@ -259,7 +261,7 @@ function sendCommandRequest(command: string, args: (number | string)[]): void {
 }
 
 function registerLspCommand(command: ClojureLspCommand): vscode.Disposable {
-  const category = command.category ? command.category : 'calva.refactor';
+  const category = command.category ? command.category : 'clojureLsp.refactor';
   const vscodeCommand = `${category}.${command.command.replace(/-[a-z]/g, (m) =>
     m.substring(1).toUpperCase()
   )}`;


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

This is the start of exposing the clojure-lsp `drag-backward` and `drag-forward` commands as targets for keybindings. This was discussed in #1695.

These commands are similar to the built-in Calva commands `dragSexprForward` and `dragSexprBackward`. But users may want to use the clojure-lsp versions to take advantage of additional features that clojure-lsp offers:

- Better comment affinity. Comments stay affiliated with code blocks as they are dragged.
- Better contextual support. Clauses within many common forms (e.g. `case` and `cond`) move intuitively.

So far, I've been unable to test that this works as intended, probably because I'm new to Calva development.

The `drag-forward` and `drag-backward` commands appear in the keybindings menu, but:

1. They don't have any of the details defined in package.json. For example, I'd expect `drag-forward` to be named "Calva refactoring: Drag Sexpr Forward", but it isn't.
2. If I bind keys to these commands, the keys don't do anything. This may also be because the package.json info isn't picked up.

Even after we get the above solved, I'm a bit worried about whether the commands will work as intended. You can already invoke the commands from the clojure-lsp action menu, where they appear as 'Drag forward' or 'Drag backward'. When I do this, the code is edited as intended, but the cursor isn't moved to the correct location. Getting down into the LSP weeds, clojure-lsp sends a notification to the editor asking it to reposition the cursor after these edits. The notification is async... it happens not as part of the refactoring (in LSP terms, `workspace/executeCommand`) but later, after the refactoring has been completed (`window/showDocument`). It surprises me that this doesn't work, as I assume Calva is using the built-in LSP client tooling. Is there something special about Calva that would make it not respond to the `window/showDocument` notification?

When all of this is working, it will resolve #1697.

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - ~If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik