### PR TITLE
WIP: YASNCB (Yet Another Strict Null Checks Branch)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -216,7 +216,7 @@
     "editor.defaultFormatter": "vscode.json-language-features"
   },
   "[jsonc]": {
-    "editor.defaultFormatter": "vscode.json-language-features"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "peacock.color": "#e48141",
   "calva.replConnectSequences": [

--- a/src/clojuredocs.ts
+++ b/src/clojuredocs.ts
@@ -174,6 +174,7 @@ async function clojureDocsLookup(
   const symbol = util.getWordAtPosition(doc, position);
   const ns = namespace.getNamespace(doc);
   const session = replSession.getSession(util.getFileType(doc));
+
   const docsFromCider = await clojureDocsCiderNReplLookup(session, symbol, ns);
   if (docsFromCider) {
     return docsFromCider;

--- a/src/clojuredocs.ts
+++ b/src/clojuredocs.ts
@@ -174,6 +174,7 @@ async function clojureDocsLookup(
   const symbol = util.getWordAtPosition(doc, position);
   const ns = namespace.getNamespace(doc);
   const session = replSession.getSession(util.getFileType(doc));
+  util.assertIsDefined(session, 'Expected there to be a repl session!');
 
   const docsFromCider = await clojureDocsCiderNReplLookup(session, symbol, ns);
   if (docsFromCider) {

--- a/src/clojuredocs.ts
+++ b/src/clojuredocs.ts
@@ -174,8 +174,6 @@ async function clojureDocsLookup(
   const symbol = util.getWordAtPosition(doc, position);
   const ns = namespace.getNamespace(doc);
   const session = replSession.getSession(util.getFileType(doc));
-  util.assertIsDefined(session, 'Expected there to be a repl session!');
-
   const docsFromCider = await clojureDocsCiderNReplLookup(session, symbol, ns);
   if (docsFromCider) {
     return docsFromCider;

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ import { PrettyPrintingOptions } from './printer';
 import { parseEdn } from '../out/cljs-lib/cljs-lib';
 import * as state from './state';
 import _ = require('lodash');
-import { isDefined } from './utilities';
+import { isDefined } from './type-checks';
 
 const REPL_FILE_EXT = 'calva-repl';
 const KEYBINDINGS_ENABLED_CONFIG_KEY = 'calva.keybindingsEnabled';

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -704,9 +704,7 @@ export default {
     status.update();
 
     if (nClient) {
-      const projectRootUri = state.getProjectRootUri();
-
-      if (projectRootUri.scheme === 'vsls') {
+      if (state.getProjectRootUri().scheme === 'vsls') {
         nClient.disconnect();
       } else {
         // the connection may be ended before

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -80,9 +80,7 @@ async function connectToHost(hostname: string, port: number, connectSequence: Re
       host: hostname,
       port: +port,
       onError: (e) => {
-        const projectRootUri = state.getProjectRootUri();
-
-        const scheme = projectRootUri.scheme;
+        const scheme = state.getProjectRootUri().scheme;
         if (scheme === 'vsls') {
           outputWindow.append('; nREPL connection failed; did the host share the nREPL port?');
         }

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -652,7 +652,7 @@ export async function connect(
   return true;
 }
 
-async function standaloneConnect(connectSequence: ReplConnectSequence) {
+async function standaloneConnect(connectSequence: ReplConnectSequence | undefined) {
   await outputWindow.initResultsDoc();
   await outputWindow.openResultsDoc();
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -25,6 +25,7 @@ import * as clojureDocs from './clojuredocs';
 import * as jszip from 'jszip';
 import { addEdnConfig } from './config';
 import { getJarContents } from './utilities';
+import { assertIsDefined, isNonEmptyString } from './type-checks';
 
 async function readJarContent(uri: string) {
   try {
@@ -39,7 +40,7 @@ async function readJarContent(uri: string) {
 }
 
 async function readRuntimeConfigs() {
-  util.assertIsDefined(nClient, 'Expected there to be an nREPL client!');
+  assertIsDefined(nClient, 'Expected there to be an nREPL client!');
   const classpath = await nClient.session.classpath().catch((e) => {
     console.error('readRuntimeConfigs:', e);
   });
@@ -56,7 +57,7 @@ async function readRuntimeConfigs() {
 
     // maybe we don't need to keep uri -> edn association, but it would make showing errors easier later
     return files
-      .filter(([_, config]) => util.isNonEmptyString(config))
+      .filter(([_, config]) => isNonEmptyString(config))
       .map(([_, config]) => addEdnConfig(config));
   }
 }
@@ -114,7 +115,7 @@ async function connectToHost(hostname: string, port: number, connectSequence: Re
     if (connectSequence.afterCLJReplJackInCode) {
       outputWindow.append(`\n; Evaluating 'afterCLJReplJackInCode'`);
       const ns = outputWindow.getNs();
-      util.assertIsDefined(ns, 'Expected outputWindow to have a namespace!');
+      assertIsDefined(ns, 'Expected outputWindow to have a namespace!');
       await evaluateInOutputWindow(connectSequence.afterCLJReplJackInCode, 'clj', ns, {});
     }
 
@@ -379,7 +380,7 @@ function createCLJSReplType(
           const buildsForSelection = startedBuilds
             ? startedBuilds
             : await figwheelOrShadowBuilds(cljsTypeName);
-          util.assertIsDefined(
+          assertIsDefined(
             buildsForSelection,
             'Expected there to be figwheel or shadowcljs builds!'
           );
@@ -435,14 +436,14 @@ function createCLJSReplType(
     replType.start = async (session, name, checkFn) => {
       let startCode = cljsType.startCode;
       if (!hasStarted) {
-        util.assertIsDefined(startCode, 'Expected startCode to be defined!');
+        assertIsDefined(startCode, 'Expected startCode to be defined!');
         if (startCode.includes('%BUILDS')) {
           let builds: string[];
           if (menuSelections && menuSelections.cljsLaunchBuilds) {
             builds = menuSelections.cljsLaunchBuilds;
           } else {
             const allBuilds = await figwheelOrShadowBuilds(cljsTypeName);
-            util.assertIsDefined(allBuilds, 'Expected there to be figwheel or shadowcljs builds!');
+            assertIsDefined(allBuilds, 'Expected there to be figwheel or shadowcljs builds!');
 
             builds =
               allBuilds.length <= 1
@@ -529,7 +530,7 @@ async function makeCljsSessionClone(session, repl: ReplType, projectTypeName: st
       ';   The Calva Connection Log might have more connection progress information.'
     );
     if (repl.start !== undefined) {
-      util.assertIsDefined(repl.started, "Expected repl to have a 'started' check function!");
+      assertIsDefined(repl.started, "Expected repl to have a 'started' check function!");
       if (await repl.start(newCljsSession, repl.name, repl.started)) {
         state.analytics().logEvent('REPL', 'StartedCLJS', repl.name).send();
         outputWindow.append('; Cljs builds started');
@@ -543,7 +544,7 @@ async function makeCljsSessionClone(session, repl: ReplType, projectTypeName: st
       }
     }
 
-    util.assertIsDefined(repl.connect, 'Expected repl to have a connect function!');
+    assertIsDefined(repl.connect, 'Expected repl to have a connect function!');
 
     if (await repl.connect(newCljsSession, repl.name, repl.connected)) {
       state.analytics().logEvent('REPL', 'ConnectedCLJS', repl.name).send();

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -81,7 +81,6 @@ async function connectToHost(hostname: string, port: number, connectSequence: Re
       port: +port,
       onError: (e) => {
         const projectRootUri = state.getProjectRootUri();
-        util.assertIsDefined(projectRootUri, 'Expected a project root URI');
 
         const scheme = projectRootUri.scheme;
         if (scheme === 'vsls') {
@@ -190,8 +189,6 @@ function setUpCljsRepl(session, build) {
 
 async function getFigwheelMainBuilds() {
   const projectRootUri = state.getProjectRootUri();
-  util.assertIsDefined(projectRootUri, 'Expected a project root URI');
-
   const res = await vscode.workspace.fs.readDirectory(projectRootUri);
   const builds = res
     .filter(([name, type]) => type !== vscode.FileType.Directory && name.match(/\.cljs\.edn/))
@@ -383,7 +380,6 @@ function createCLJSReplType(
       } else {
         if (typeof initCode === 'object' || initCode.includes('%BUILD%')) {
           const projectRootUri = state.getProjectRootUri();
-          util.assertIsDefined(projectRootUri, 'Expected a project root URI');
 
           const buildsForSelection = startedBuilds
             ? startedBuilds
@@ -449,7 +445,6 @@ function createCLJSReplType(
             const allBuilds = await figwheelOrShadowBuilds(cljsTypeName);
             util.assertIsDefined(allBuilds, 'Expected there to be figwheel or shadowcljs builds!');
             const projectRootUri = state.getProjectRootUri();
-            util.assertIsDefined(projectRootUri, 'Expected a project root URI');
 
             builds =
               allBuilds.length <= 1
@@ -710,7 +705,6 @@ export default {
 
     if (nClient) {
       const projectRootUri = state.getProjectRootUri();
-      util.assertIsDefined(projectRootUri, 'Expected a project root URI');
 
       if (projectRootUri.scheme === 'vsls') {
         nClient.disconnect();

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -730,10 +730,10 @@ export default {
     let newSession: NReplSession | undefined;
 
     if (getStateValue('connected')) {
-      if (replSession.getSession('cljc') == replSession.getSession('cljs')) {
-        newSession = replSession.getSession('clj');
-      } else if (replSession.getSession('cljc') == replSession.getSession('clj')) {
-        newSession = replSession.getSession('cljs');
+      if (replSession.tryToGetSession('cljc') == replSession.tryToGetSession('cljs')) {
+        newSession = replSession.tryToGetSession('clj');
+      } else if (replSession.tryToGetSession('cljc') == replSession.tryToGetSession('clj')) {
+        newSession = replSession.tryToGetSession('cljs');
       }
       setStateValue('cljc', newSession);
       if (outputWindow.isResultsDoc(util.getActiveTextEditor().document)) {
@@ -745,7 +745,7 @@ export default {
     }
   },
   switchCljsBuild: async () => {
-    const cljSession = replSession.getSession('clj');
+    const cljSession = replSession.tryToGetSession('clj');
     const cljsTypeName: string | undefined =
         state.extensionContext.workspaceState.get('selectedCljsTypeName'),
       cljTypeName: string | undefined =

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as calvaLib from '../out/cljs-lib/cljs-lib';
+import { getActiveTextEditor } from './utilities';
 
 type Js2CljsResult = {
   result: string;
@@ -23,7 +24,7 @@ type Js2CljsInvalidResult = {
 const isJs2CljsResult = (input: any): input is Js2CljsResult => input.result !== undefined;
 
 export async function js2cljs() {
-  const editor = vscode.window.activeTextEditor;
+  const editor = getActiveTextEditor();
   const selection = editor.selection;
   const doc = editor.document;
   const js = doc.getText(

--- a/src/cursor-doc/clojure-lexer.ts
+++ b/src/cursor-doc/clojure-lexer.ts
@@ -43,7 +43,7 @@ export function validPair(open: string, close: string): boolean {
 }
 
 export interface Token extends LexerToken {
-  state: ScannerState;
+  state: ScannerState | null;
 }
 
 // whitespace, excluding newlines
@@ -174,7 +174,7 @@ export class Scanner {
     const tks: Token[] = [];
     this.state = state;
     let lex = (this.state.inString ? inString : toplevel).lex(line, this.maxLength);
-    let tk: LexerToken;
+    let tk: LexerToken | undefined;
     do {
       tk = lex.scan();
       if (tk) {

--- a/src/cursor-doc/indent.ts
+++ b/src/cursor-doc/indent.ts
@@ -66,11 +66,11 @@ export function collectIndents(
     const match = pattern.match(/^#"(.*)"$/);
 
     if (match) {
-      regexpMap.set(pattern, RegExp(match[1]));
+      regexpMap[pattern] = RegExp(match[1]);
     }
 
     return regexpMap;
-  }, new Map<string, RegExp>());
+  }, {} as Record<string, RegExp>);
 
   do {
     if (!cursor.backwardSexp()) {

--- a/src/cursor-doc/lexer.ts
+++ b/src/cursor-doc/lexer.ts
@@ -3,6 +3,8 @@
  * @module lexer
  */
 
+import { assertIsDefined } from '../utilities';
+
 /**
  * The base Token class. Contains the token type,
  * the raw string of the token, and the offset into the input line.
@@ -36,8 +38,8 @@ export class Lexer {
   constructor(public source: string, public rules: Rule[], private maxLength) {}
 
   /** Returns the next token in this lexer, or null if at the end. If the match fails, throws an Error. */
-  scan(): Token {
-    let token = null,
+  scan(): Token | undefined {
+    let token: Token | undefined,
       length = 0;
     if (this.position < this.source.length) {
       if (this.source !== undefined && this.source.length < this.maxLength) {
@@ -47,6 +49,7 @@ export class Lexer {
           const x = rule.r.exec(this.source);
           if (x && x[0].length > length && this.position + x[0].length == rule.r.lastIndex) {
             token = rule.fn(this, x);
+            assertIsDefined(token, 'Expected token!');
             token.offset = this.position;
             token.raw = x[0];
             length = x[0].length;
@@ -62,9 +65,9 @@ export class Lexer {
       }
     }
     this.position += length;
-    if (token == null) {
+    if (token === undefined) {
       if (this.position == this.source.length) {
-        return null;
+        return undefined;
       }
       throw new Error(
         'Unexpected character at ' + this.position + ': ' + JSON.stringify(this.source)

--- a/src/cursor-doc/lexer.ts
+++ b/src/cursor-doc/lexer.ts
@@ -3,7 +3,7 @@
  * @module lexer
  */
 
-import { assertIsDefined } from '../utilities';
+import { assertIsDefined } from '../type-checks';
 
 /**
  * The base Token class. Contains the token type,

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -155,12 +155,12 @@ export class LineInputModel implements EditableModel {
           }
           return x;
         })
-        .filter((x) => x !== null)
+        .filter((x) => x !== null) as number[]
     );
 
     this.insertedLines = new Set(
       Array.from(this.insertedLines)
-        .map((x): [number, number] => {
+        .map((x) => {
           const [a, b] = x;
           if (a > start && a < start + deleted) {
             return null;
@@ -170,12 +170,12 @@ export class LineInputModel implements EditableModel {
           }
           return [a, b];
         })
-        .filter((x) => x !== null)
+        .filter((x) => x !== null) as [number, number][]
     );
 
     this.deletedLines = new Set(
       Array.from(this.deletedLines)
-        .map((x): [number, number] => {
+        .map((x) => {
           const [a, b] = x;
           if (a > start && a < start + deleted) {
             return null;
@@ -185,7 +185,7 @@ export class LineInputModel implements EditableModel {
           }
           return [a, b];
         })
-        .filter((x) => x !== null)
+        .filter((x) => x !== null) as [number, number][]
     );
   }
 
@@ -224,7 +224,7 @@ export class LineInputModel implements EditableModel {
     const seen = new Set<number>();
     this.dirtyLines.sort();
     while (this.dirtyLines.length) {
-      let nextIdx = this.dirtyLines.shift();
+      let nextIdx = this.dirtyLines.shift() as number;
       if (seen.has(nextIdx)) {
         continue;
       } // already processed.

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -130,7 +130,7 @@ export function rangeForDefun(
   doc: EditableDocument,
   offset: number = doc.selection.active,
   commentCreatesTopLevel = true
-): [number, number] {
+): [number, number] | undefined {
   const cursor = doc.getTokenCursor(offset);
   return cursor.rangeForDefun(offset, commentCreatesTopLevel);
 }
@@ -992,7 +992,9 @@ export function raiseSexp(
   end = doc.selection.active
 ) {
   const cursor = doc.getTokenCursor(end);
-  const [formStart, formEnd] = cursor.rangeForCurrentForm(start);
+  const formRange = cursor.rangeForCurrentForm(start);
+  assertIsDefined(formRange, 'Expected to find a range for the current form!');
+  const [formStart, formEnd] = formRange;
   const isCaretTrailing = formEnd - start < start - formStart;
   const startCursor = doc.getTokenCursor(formStart);
   const endCursor = startCursor.clone();
@@ -1146,6 +1148,7 @@ function currentSexpsRange(
   usePairs = false
 ): [number, number] {
   const currentSingleRange = cursor.rangeForCurrentForm(offset);
+  assertIsDefined(currentSingleRange, 'Expected to find a range for the current form!');
   if (usePairs) {
     const ranges = cursor.rangesForSexpsInList();
     if (ranges.length > 1) {
@@ -1246,6 +1249,7 @@ export function collectWhitespaceInfo(
 ): WhitespaceInfo {
   const cursor = doc.getTokenCursor(p);
   const currentRange = cursor.rangeForCurrentForm(p);
+  assertIsDefined(currentRange, 'Expected to find a range for the current form!');
   const leftWsRight = currentRange[0];
   const leftWsCursor = doc.getTokenCursor(leftWsRight);
   const rightWsLeft = currentRange[1];
@@ -1275,6 +1279,7 @@ export function dragSexprBackwardUp(doc: EditableDocument, p = doc.selection.act
   const cursor = doc.getTokenCursor(p);
   const currentRange = cursor.rangeForCurrentForm(p);
   if (cursor.backwardList() && cursor.backwardUpList()) {
+    assertIsDefined(currentRange, 'Expected to find a range for the current form!');
     const listStart = cursor.offsetStart;
     const newPosOffset = p - currentRange[0];
     const newCursorPos = listStart + newPosOffset;
@@ -1314,6 +1319,7 @@ export function dragSexprBackwardUp(doc: EditableDocument, p = doc.selection.act
 export function dragSexprForwardDown(doc: EditableDocument, p = doc.selection.active) {
   const wsInfo = collectWhitespaceInfo(doc, p);
   const currentRange = doc.getTokenCursor(p).rangeForCurrentForm(p);
+  assertIsDefined(currentRange, 'Expected to find a range for the current form!');
   const newPosOffset = p - currentRange[0];
   const cursor = doc.getTokenCursor(currentRange[0]);
   while (cursor.forwardSexp()) {
@@ -1352,6 +1358,7 @@ export function dragSexprForwardUp(doc: EditableDocument, p = doc.selection.acti
   const cursor = doc.getTokenCursor(p);
   const currentRange = cursor.rangeForCurrentForm(p);
   if (cursor.forwardList() && cursor.upList()) {
+    assertIsDefined(currentRange, 'Expected to find a range for the current form!');
     const listEnd = cursor.offsetStart;
     const newPosOffset = p - currentRange[0];
     const listWsInfo = collectWhitespaceInfo(doc, listEnd);
@@ -1381,6 +1388,7 @@ export function dragSexprForwardUp(doc: EditableDocument, p = doc.selection.acti
 export function dragSexprBackwardDown(doc: EditableDocument, p = doc.selection.active) {
   const wsInfo = collectWhitespaceInfo(doc, p);
   const currentRange = doc.getTokenCursor(p).rangeForCurrentForm(p);
+  assertIsDefined(currentRange, 'Expected to find a range for the current form!');
   const newPosOffset = p - currentRange[0];
   const cursor = doc.getTokenCursor(currentRange[1]);
   while (cursor.backwardSexp()) {
@@ -1429,6 +1437,7 @@ export function addRichComment(doc: EditableDocument, p = doc.selection.active, 
   const richComment = `(comment\n  ${contents ? adaptContentsToRichComment(contents) : ''}\n  )`;
   let cursor = doc.getTokenCursor(p);
   const topLevelRange = rangeForDefun(doc, p, false);
+  assertIsDefined(topLevelRange, 'Expected to find a range for the current defun!');
   const isInsideForm = !(p <= topLevelRange[0] || p >= topLevelRange[1]);
   const checkIfAtStartCursor = doc.getTokenCursor(p);
   checkIfAtStartCursor.backwardWhitespace(true);

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1,4 +1,4 @@
-import { assertIsDefined } from '../utilities';
+import { assertIsDefined } from '../type-checks';
 import { validPair } from './clojure-lexer';
 import { ModelEdit, EditableDocument, ModelEditSelection } from './model';
 import { LispTokenCursor } from './token-cursor';

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -255,7 +255,7 @@ export class LispTokenCursor extends TokenCursor {
    */
   forwardSexp(skipComments = true, skipMetadata = false, skipIgnoredForms = false): boolean {
     // TODO: Consider using a proper bracket stack
-    const stack = [];
+    const stack: string[] = [];
     let isMetadata = false;
     this.forwardWhitespace(skipComments);
     if (this.getToken().type === 'close') {
@@ -297,7 +297,7 @@ export class LispTokenCursor extends TokenCursor {
           break;
         case 'close': {
           const close = token.raw;
-          let open: string;
+          let open: string | undefined;
           while ((open = stack.pop())) {
             if (validPair(open, close)) {
               this.next();
@@ -322,6 +322,8 @@ export class LispTokenCursor extends TokenCursor {
           break;
       }
     }
+
+    return false;
   }
 
   /**
@@ -339,7 +341,7 @@ export class LispTokenCursor extends TokenCursor {
     skipIgnoredForms = false,
     skipReaders = true
   ) {
-    const stack = [];
+    const stack: string[] = [];
     this.backwardWhitespace(skipComments);
     if (this.getPrevToken().type === 'open') {
       return false;
@@ -381,7 +383,7 @@ export class LispTokenCursor extends TokenCursor {
           break;
         case 'open': {
           const open = tk.raw;
-          let close: string;
+          let close: string | undefined;
           while ((close = stack.pop())) {
             if (validPair(open, close)) {
               break;
@@ -528,9 +530,9 @@ export class LispTokenCursor extends TokenCursor {
    * If you are particular about which type of list, supply the `openingBracket`.
    * @param openingBracket
    */
-  rangeForList(depth: number, openingBracket?: string): [number, number] {
+  rangeForList(depth: number, openingBracket?: string): [number, number] | undefined {
     const cursor = this.clone();
-    let range: [number, number] = undefined;
+    let range: [number, number] | undefined = undefined;
     for (let i = 0; i < depth; i++) {
       if (openingBracket === undefined) {
         if (!(cursor.backwardList() && cursor.backwardUpList())) {
@@ -648,8 +650,8 @@ export class LispTokenCursor extends TokenCursor {
    * 8. Else, return `undefined`.
    * @param offset the current cursor (caret) offset in the document
    */
-  rangeForCurrentForm(offset: number): [number, number] {
-    let afterCurrentFormOffset: number;
+  rangeForCurrentForm(offset: number): [number, number] | undefined {
+    let afterCurrentFormOffset: number | undefined;
     // console.log(-1, offset);
 
     // 0. If `offset` is within or before, a symbol, literal or keyword
@@ -782,9 +784,9 @@ export class LispTokenCursor extends TokenCursor {
     return [currentFormCursor.offsetStart, afterCurrentFormOffset];
   }
 
-  rangeForDefun(offset: number, commentCreatesTopLevel = true): [number, number] {
+  rangeForDefun(offset: number, commentCreatesTopLevel = true): [number, number] | undefined {
     const cursor = this.doc.getTokenCursor(offset);
-    let lastCandidateRange: [number, number] = cursor.rangeForCurrentForm(offset);
+    let lastCandidateRange: [number, number] | undefined = cursor.rangeForCurrentForm(offset);
     while (cursor.forwardList() && cursor.upList()) {
       const commentCursor = cursor.clone();
       commentCursor.backwardDownList();
@@ -915,7 +917,7 @@ export class LispTokenCursor extends TokenCursor {
    * @param levels how many levels of functions to dig up.
    * @returns the function name, or undefined if there is no function there.
    */
-  getFunctionName(levels: number = 0): string {
+  getFunctionName(levels: number = 0): string | undefined {
     const cursor = this.clone();
     if (cursor.backwardFunction(levels)) {
       cursor.forwardWhitespace();
@@ -931,7 +933,7 @@ export class LispTokenCursor extends TokenCursor {
    * @param levels how many levels of functions to dig up.
    * @returns the range of the function sexp/form, or undefined if there is no function there.
    */
-  getFunctionSexpRange(levels: number = 0): [number, number] {
+  getFunctionSexpRange(levels: number = 0): [number, number] | [undefined, undefined] {
     const cursor = this.clone();
     if (cursor.backwardFunction(levels)) {
       cursor.forwardWhitespace();

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -169,7 +169,7 @@ function _rangesForSexpsInList(
   if (useRowCol) {
     return collectRanges(cursor, 'rowCol', 'rowCol');
   } else {
-    return collectRanges(cursor, 'offsetStart', 'offsetEnd');
+    return collectRanges(cursor, 'offsetStart', 'offsetStart');
   }
 }
 

--- a/src/cursor-doc/undo.ts
+++ b/src/cursor-doc/undo.ts
@@ -114,8 +114,10 @@ export class UndoManager<T> {
   undo(c: T) {
     if (this.undos.length) {
       const step = this.undos.pop();
-      step.undo(c);
-      this.redos.push(step);
+      if (step) {
+        step.undo(c);
+        this.redos.push(step);
+      }
     }
   }
 
@@ -123,8 +125,10 @@ export class UndoManager<T> {
   redo(c: T) {
     if (this.redos.length) {
       const step = this.redos.pop();
-      step.redo(c);
-      this.undos.push(step);
+      if (step) {
+        step.redo(c);
+        this.undos.push(step);
+      }
     }
   }
 }

--- a/src/debugger/calva-debug.ts
+++ b/src/debugger/calva-debug.ts
@@ -439,8 +439,7 @@ function handleNeedDebugInput(response: any): void {
       void debug.startDebugging(undefined, CALVA_DEBUG_CONFIGURATION);
     }
   } else {
-    const cljSession = replSession.tryToGetSession(CLOJURE_SESSION_NAME);
-    util.assertIsDefined(cljSession, 'Expected there to be a repl session!');
+    const cljSession = replSession.getSession(CLOJURE_SESSION_NAME);
     void cljSession.sendDebugInput(':quit', response.id, response.key);
     void vscode.window.showInformationMessage(
       'Forms containing breakpoints that were not evaluated in the editor (such as if you evaluated a form in the REPL window) cannot be debugged. Evaluate the form in the editor in order to debug it.'

--- a/src/debugger/calva-debug.ts
+++ b/src/debugger/calva-debug.ts
@@ -35,8 +35,8 @@ import annotations from '../providers/annotations';
 import { NReplSession } from '../nrepl';
 import debugDecorations from './decorations';
 import { setStateValue, getStateValue } from '../../out/cljs-lib/cljs-lib';
-import * as util from '../utilities';
 import * as replSession from '../nrepl/repl-session';
+import { assertIsDefined } from '../type-checks';
 
 const CALVA_DEBUG_CONFIGURATION: DebugConfiguration = {
   type: 'clojure',
@@ -271,7 +271,7 @@ class CalvaDebugSession extends LoggingDebugSession {
     // Pass scheme in path argument to Source contructor so that if it's a jar file it's handled correctly
     const source = new Source(basename(debugResponse.file), debugResponse.file);
     const name = tokenCursor.getFunctionName();
-    util.assertIsDefined(name, 'Expected to find a function name!');
+    assertIsDefined(name, 'Expected to find a function name!');
     const stackFrames = [new StackFrame(0, name, source, line + 1, column + 1)];
 
     response.body = {

--- a/src/debugger/calva-debug.ts
+++ b/src/debugger/calva-debug.ts
@@ -100,7 +100,7 @@ class CalvaDebugSession extends LoggingDebugSession {
     response: DebugProtocol.AttachResponse,
     args: DebugProtocol.AttachRequestArguments
   ): void {
-    const cljSession = replSession.getSession(CLOJURE_SESSION_NAME);
+    const cljSession = replSession.tryToGetSession(CLOJURE_SESSION_NAME);
 
     this.sendResponse(response);
     state
@@ -114,7 +114,7 @@ class CalvaDebugSession extends LoggingDebugSession {
     args: DebugProtocol.ContinueArguments,
     request?: DebugProtocol.Request
   ): void {
-    const cljSession = replSession.getSession(CLOJURE_SESSION_NAME);
+    const cljSession = replSession.tryToGetSession(CLOJURE_SESSION_NAME);
 
     if (cljSession) {
       const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
@@ -146,7 +146,7 @@ class CalvaDebugSession extends LoggingDebugSession {
     args: DebugProtocol.NextArguments,
     request?: DebugProtocol.Request
   ): void {
-    const cljSession = replSession.getSession(CLOJURE_SESSION_NAME);
+    const cljSession = replSession.tryToGetSession(CLOJURE_SESSION_NAME);
 
     if (cljSession) {
       const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
@@ -169,7 +169,7 @@ class CalvaDebugSession extends LoggingDebugSession {
     args: DebugProtocol.StepInArguments,
     request?: DebugProtocol.Request
   ): void {
-    const cljSession = replSession.getSession(CLOJURE_SESSION_NAME);
+    const cljSession = replSession.tryToGetSession(CLOJURE_SESSION_NAME);
 
     if (cljSession) {
       const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
@@ -192,7 +192,7 @@ class CalvaDebugSession extends LoggingDebugSession {
     args: DebugProtocol.StepOutArguments,
     request?: DebugProtocol.Request
   ): void {
-    const cljSession = replSession.getSession(CLOJURE_SESSION_NAME);
+    const cljSession = replSession.tryToGetSession(CLOJURE_SESSION_NAME);
 
     if (cljSession) {
       const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
@@ -325,7 +325,7 @@ class CalvaDebugSession extends LoggingDebugSession {
     args: DebugProtocol.DisconnectArguments,
     request?: DebugProtocol.Request
   ): void {
-    const cljSession = replSession.getSession(CLOJURE_SESSION_NAME);
+    const cljSession = replSession.tryToGetSession(CLOJURE_SESSION_NAME);
 
     if (cljSession) {
       const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
@@ -439,7 +439,7 @@ function handleNeedDebugInput(response: any): void {
       void debug.startDebugging(undefined, CALVA_DEBUG_CONFIGURATION);
     }
   } else {
-    const cljSession = replSession.getSession(CLOJURE_SESSION_NAME);
+    const cljSession = replSession.tryToGetSession(CLOJURE_SESSION_NAME);
     util.assertIsDefined(cljSession, 'Expected there to be a repl session!');
     void cljSession.sendDebugInput(':quit', response.id, response.key);
     void vscode.window.showInformationMessage(

--- a/src/debugger/calva-debug.ts
+++ b/src/debugger/calva-debug.ts
@@ -84,8 +84,8 @@ class CalvaDebugSession extends LoggingDebugSession {
     response: DebugProtocol.InitializeResponse,
     args: DebugProtocol.InitializeRequestArguments
   ): void {
-    this.setDebuggerLinesStartAt1(args.linesStartAt1);
-    this.setDebuggerColumnsStartAt1(args.columnsStartAt1);
+    this.setDebuggerLinesStartAt1(!!args.linesStartAt1);
+    this.setDebuggerColumnsStartAt1(!!args.columnsStartAt1);
 
     // Build and return the capabilities of this debug adapter
     response.body = {
@@ -271,6 +271,7 @@ class CalvaDebugSession extends LoggingDebugSession {
     // Pass scheme in path argument to Source contructor so that if it's a jar file it's handled correctly
     const source = new Source(basename(debugResponse.file), debugResponse.file);
     const name = tokenCursor.getFunctionName();
+    util.assertIsDefined(name, 'Expected to find a function name!');
     const stackFrames = [new StackFrame(0, name, source, line + 1, column + 1)];
 
     response.body = {
@@ -439,6 +440,7 @@ function handleNeedDebugInput(response: any): void {
     }
   } else {
     const cljSession = replSession.getSession(CLOJURE_SESSION_NAME);
+    util.assertIsDefined(cljSession, 'Expected there to be a repl session!');
     void cljSession.sendDebugInput(':quit', response.id, response.key);
     void vscode.window.showInformationMessage(
       'Forms containing breakpoints that were not evaluated in the editor (such as if you evaluated a form in the REPL window) cannot be debugged. Evaluate the form in the editor in order to debug it.'

--- a/src/debugger/decorations.ts
+++ b/src/debugger/decorations.ts
@@ -33,7 +33,7 @@ const instrumentedSymbolDecorationType = vscode.window.createTextEditorDecoratio
 
 async function update(
   editor: vscode.TextEditor,
-  cljSession: NReplSession,
+  cljSession: NReplSession | undefined,
   lspClient: LanguageClient
 ): Promise<void> {
   if (/(\.clj)$/.test(editor.document.fileName)) {
@@ -49,6 +49,7 @@ async function update(
           const docUri = vscode.Uri.parse(namespacePath, true);
           const decodedDocUri = decodeURIComponent(docUri.toString());
           const docSymbols = (await lsp.getDocumentSymbols(lspClient, decodedDocUri))[0].children;
+          util.assertIsDefined(docSymbols, 'Expected to get document symbols from the LSP server!');
           const instrumentedDocSymbols = docSymbols.filter((s) =>
             instrumentedDefs.includes(s.name)
           );

--- a/src/debugger/decorations.ts
+++ b/src/debugger/decorations.ts
@@ -7,6 +7,7 @@ import * as util from '../utilities';
 import lsp from '../lsp/main';
 import { getStateValue } from '../../out/cljs-lib/cljs-lib';
 import * as replSession from '../nrepl/repl-session';
+import { assertIsDefined } from '../type-checks';
 
 let enabled = false;
 
@@ -49,7 +50,7 @@ async function update(
           const docUri = vscode.Uri.parse(namespacePath, true);
           const decodedDocUri = decodeURIComponent(docUri.toString());
           const docSymbols = (await lsp.getDocumentSymbols(lspClient, decodedDocUri))[0].children;
-          util.assertIsDefined(docSymbols, 'Expected to get document symbols from the LSP server!');
+          assertIsDefined(docSymbols, 'Expected to get document symbols from the LSP server!');
           const instrumentedDocSymbols = docSymbols.filter((s) =>
             instrumentedDefs.includes(s.name)
           );

--- a/src/debugger/decorations.ts
+++ b/src/debugger/decorations.ts
@@ -119,7 +119,7 @@ function triggerUpdateAndRenderDecorations() {
     const editor = util.tryToGetActiveTextEditor();
     if (editor) {
       timeout = setTimeout(() => {
-        const cljSession = replSession.getSession('clj');
+        const cljSession = replSession.tryToGetSession('clj');
         const lspClient = getStateValue(lsp.LSP_CLIENT_KEY);
         void update(editor, cljSession, lspClient).then(renderInAllVisibleEditors);
       }, 50);

--- a/src/debugger/util.ts
+++ b/src/debugger/util.ts
@@ -1,7 +1,10 @@
 import { LispTokenCursor } from '../cursor-doc/token-cursor';
+import { assertIsDefined } from '../utilities';
 
 function moveCursorPastStringInList(tokenCursor: LispTokenCursor, s: string): void {
-  const [listOffsetStart, listOffsetEnd] = tokenCursor.rangeForList(1);
+  const range = tokenCursor.rangeForList(1);
+  assertIsDefined(range, 'Expected range to be found!');
+  const [listOffsetStart, listOffsetEnd] = range;
   const text = tokenCursor.doc.getText(listOffsetStart, listOffsetEnd - 1);
 
   const stringIndexInList = text.indexOf(s);
@@ -22,7 +25,9 @@ function moveTokenCursorToBreakpoint(
   debugResponse: any
 ): LispTokenCursor {
   const errorMessage = 'Error finding position of breakpoint';
-  const [_, defunEnd] = tokenCursor.rangeForDefun(tokenCursor.offsetStart);
+  const range = tokenCursor.rangeForDefun(tokenCursor.offsetStart);
+  assertIsDefined(range, 'Expected range to be found!');
+  const [_, defunEnd] = range;
   let inSyntaxQuote = false;
 
   const coor = [...debugResponse.coor]; // Copy the array so we do not modify the one stored in state

--- a/src/debugger/util.ts
+++ b/src/debugger/util.ts
@@ -1,5 +1,5 @@
 import { LispTokenCursor } from '../cursor-doc/token-cursor';
-import { assertIsDefined } from '../utilities';
+import { assertIsDefined } from '../type-checks';
 
 function moveCursorPastStringInList(tokenCursor: LispTokenCursor, s: string): void {
   const range = tokenCursor.rangeForList(1);

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -169,18 +169,21 @@ export class MirroredDocument implements EditableDocument {
   }
 
   public delete(): Thenable<boolean> {
-    return vscode.commands.executeCommand('deleteRight');
+    return vscode.commands.executeCommand('deleteRight').then((v) => !!v);
   }
 
   public backspace(): Thenable<boolean> {
-    return vscode.commands.executeCommand('deleteLeft');
+    return vscode.commands.executeCommand('deleteLeft').then((v) => !!v);
   }
 }
 
 let registered = false;
 
 function processChanges(event: vscode.TextDocumentChangeEvent) {
-  const model = documents.get(event.document).model;
+  const mirrorDoc = documents.get(event.document);
+  utilities.assertIsDefined(mirrorDoc, 'Expected to find a mirror document!');
+  const model = mirrorDoc.model;
+
   for (const change of event.contentChanges) {
     // vscode may have a \r\n marker, so it's line offsets are all wrong.
     const myStartOffset =

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -12,6 +12,7 @@ import {
   ModelEditSelection,
 } from '../cursor-doc/model';
 import { isUndefined } from 'lodash';
+import { assertIsDefined } from '../type-checks';
 
 const documents = new Map<vscode.TextDocument, MirroredDocument>();
 
@@ -181,7 +182,7 @@ let registered = false;
 
 function processChanges(event: vscode.TextDocumentChangeEvent) {
   const mirrorDoc = documents.get(event.document);
-  utilities.assertIsDefined(mirrorDoc, 'Expected to find a mirror document!');
+  assertIsDefined(mirrorDoc, 'Expected to find a mirror document!');
   const model = mirrorDoc.model;
 
   for (const change of event.contentChanges) {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -153,6 +153,7 @@ async function evaluateCode(
           if (context.stacktrace) {
             outputWindow.saveStacktrace(context.stacktrace);
             outputWindow.append(errMsg, (_, afterResultLocation) => {
+              util.assertIsDefined(afterResultLocation, 'Expected there to be a location!');
               outputWindow.markLastStacktraceRange(afterResultLocation);
             });
           } else {
@@ -193,6 +194,7 @@ async function evaluateCode(
             }
           }
           if (context.stacktrace && context.stacktrace.stacktrace) {
+            util.assertIsDefined(afterResultLocation, 'Expected there to be a location!');
             outputWindow.markLastStacktraceRange(afterResultLocation);
           }
         });
@@ -409,6 +411,7 @@ async function loadFile(
 
   if (doc && doc.languageId == 'clojure' && fileType != 'edn' && getStateValue('connected')) {
     state.analytics().logEvent('Evaluation', 'LoadFile').send();
+    util.assertIsDefined(session, 'Expected there to be a repl session!');
     const docUri = outputWindow.isResultsDoc(doc)
       ? await namespace.getUriForNamespace(session, ns)
       : doc.uri;
@@ -489,6 +492,7 @@ async function requireREPLUtilitiesCommand() {
 async function copyLastResultCommand() {
   const chan = state.outputChannel();
   const session = replSession.getSession(util.getFileType(util.tryToGetDocument({})));
+  util.assertIsDefined(session, 'Expected there to be a repl session!');
 
   const value = await session.eval('*1', session.client.ns).value;
   if (value !== null) {
@@ -503,6 +507,7 @@ async function togglePrettyPrint() {
   const config = vscode.workspace.getConfiguration('calva'),
     pprintConfigKey = 'prettyPrintingOptions',
     pprintOptions = config.get<PrettyPrintingOptions>(pprintConfigKey);
+  util.assertIsDefined(pprintOptions, 'Expected there to be pprint options!');
   pprintOptions.enabled = !pprintOptions.enabled;
   if (pprintOptions.enabled && !(pprintOptions.printEngine || pprintOptions.printFn)) {
     pprintOptions.printEngine = 'pprint';
@@ -548,6 +553,7 @@ export async function evaluateInOutputWindow(
     const session = replSession.getSession(sessionType);
     replSession.updateReplSessionType();
     if (outputWindow.getNs() !== ns) {
+      util.assertIsDefined(session, 'Expected there to be a repl session!');
       await session.switchNS(ns);
       outputWindow.setSession(session, ns);
       if (options.evaluationSendCodeToOutputWindow !== false) {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -15,6 +15,7 @@ import { getStateValue } from '../out/cljs-lib/cljs-lib';
 import { getConfig } from './config';
 import * as replSession from './nrepl/repl-session';
 import * as getText from './util/get-text';
+import { assertIsDefined } from './type-checks';
 
 function interruptAllEvaluations() {
   if (util.getConnectedState()) {
@@ -86,7 +87,7 @@ async function evaluateCode(
 
   if (code.length > 0) {
     if (addToHistory) {
-      util.assertIsDefined(session.replType, 'Expected session to have a repl type!');
+      assertIsDefined(session.replType, 'Expected session to have a repl type!');
       replHistory.addToReplHistory(session.replType, code);
       replHistory.resetState();
     }
@@ -154,7 +155,7 @@ async function evaluateCode(
           if (context.stacktrace) {
             outputWindow.saveStacktrace(context.stacktrace);
             outputWindow.append(errMsg, (_, afterResultLocation) => {
-              util.assertIsDefined(afterResultLocation, 'Expected there to be a location!');
+              assertIsDefined(afterResultLocation, 'Expected there to be a location!');
               outputWindow.markLastStacktraceRange(afterResultLocation);
             });
           } else {
@@ -195,7 +196,7 @@ async function evaluateCode(
             }
           }
           if (context.stacktrace && context.stacktrace.stacktrace) {
-            util.assertIsDefined(afterResultLocation, 'Expected there to be a location!');
+            assertIsDefined(afterResultLocation, 'Expected there to be a location!');
             outputWindow.markLastStacktraceRange(afterResultLocation);
           }
         });
@@ -412,7 +413,8 @@ async function loadFile(
 
   if (doc && doc.languageId == 'clojure' && fileType != 'edn' && getStateValue('connected')) {
     state.analytics().logEvent('Evaluation', 'LoadFile').send();
-    util.assertIsDefined(session, 'Expected there to be a repl session!');
+    assertIsDefined(session, 'Expected there to be a repl session!');
+    assertIsDefined(ns, 'Expected there to be a namespace!');
     const docUri = outputWindow.isResultsDoc(doc)
       ? await namespace.getUriForNamespace(session, ns)
       : doc.uri;
@@ -478,6 +480,7 @@ async function requireREPLUtilitiesCommand() {
     if (session) {
       try {
         await namespace.createNamespaceFromDocumentIfNotExists(util.tryToGetDocument({}));
+        assertIsDefined(ns, 'Expected there to be a namespace!');
         await session.switchNS(ns);
         await session.eval(form, ns).value;
         chan.appendLine(`REPL utilities are now available in namespace ${ns}.`);
@@ -507,7 +510,7 @@ async function togglePrettyPrint() {
   const config = vscode.workspace.getConfiguration('calva'),
     pprintConfigKey = 'prettyPrintingOptions',
     pprintOptions = config.get<PrettyPrintingOptions>(pprintConfigKey);
-  util.assertIsDefined(pprintOptions, 'Expected there to be pprint options!');
+  assertIsDefined(pprintOptions, 'Expected there to be pprint options!');
   pprintOptions.enabled = !pprintOptions.enabled;
   if (pprintOptions.enabled && !(pprintOptions.printEngine || pprintOptions.printFn)) {
     pprintOptions.printEngine = 'pprint';
@@ -553,7 +556,7 @@ export async function evaluateInOutputWindow(
     const session = replSession.tryToGetSession(sessionType);
     replSession.updateReplSessionType();
     if (outputWindow.getNs() !== ns) {
-      util.assertIsDefined(session, 'Expected there to be a repl session!');
+      assertIsDefined(session, 'Expected there to be a repl session!');
       await session.switchNS(ns);
       outputWindow.setSession(session, ns);
       if (options.evaluationSendCodeToOutputWindow !== false) {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -492,8 +492,7 @@ async function requireREPLUtilitiesCommand() {
 
 async function copyLastResultCommand() {
   const chan = state.outputChannel();
-  const session = replSession.tryToGetSession(util.getFileType(util.tryToGetDocument({})));
-  util.assertIsDefined(session, 'Expected there to be a repl session!');
+  const session = replSession.getSession(util.getFileType(util.tryToGetDocument({})));
 
   const value = await session.eval('*1', session.client.ns).value;
   if (value !== null) {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -86,6 +86,7 @@ async function evaluateCode(
 
   if (code.length > 0) {
     if (addToHistory) {
+      util.assertIsDefined(session.replType, 'Expected session to have a repl type!');
       replHistory.addToReplHistory(session.replType, code);
       replHistory.resetState();
     }

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -228,7 +228,7 @@ async function evaluateSelection(document = {}, options) {
     const line = codeSelection.start.line;
     const column = codeSelection.start.character;
     const filePath = doc.fileName;
-    const session = replSession.getSession(util.getFileType(doc));
+    const session = replSession.tryToGetSession(util.getFileType(doc));
 
     if (code.length > 0) {
       if (options.debug) {
@@ -408,7 +408,7 @@ async function loadFile(
   const doc = util.tryToGetDocument(document);
   const fileType = util.getFileType(doc);
   const ns = namespace.getNamespace(doc);
-  const session = replSession.getSession(util.getFileType(doc));
+  const session = replSession.tryToGetSession(util.getFileType(doc));
 
   if (doc && doc.languageId == 'clojure' && fileType != 'edn' && getStateValue('connected')) {
     state.analytics().logEvent('Evaluation', 'LoadFile').send();
@@ -451,7 +451,7 @@ async function loadFile(
 
 async function evaluateUser(code: string) {
   const fileType = util.getFileType(util.tryToGetDocument({})),
-    session = replSession.getSession(fileType);
+    session = replSession.tryToGetSession(fileType);
   if (session) {
     try {
       await session.eval(code, session.client.ns).value;
@@ -473,7 +473,7 @@ async function requireREPLUtilitiesCommand() {
       sessionType = replSession.getReplSessionTypeFromState(),
       form = sessionType == 'cljs' ? CLJS_FORM : CLJ_FORM,
       fileType = util.getFileType(util.tryToGetDocument({})),
-      session = replSession.getSession(fileType);
+      session = replSession.tryToGetSession(fileType);
 
     if (session) {
       try {
@@ -492,7 +492,7 @@ async function requireREPLUtilitiesCommand() {
 
 async function copyLastResultCommand() {
   const chan = state.outputChannel();
-  const session = replSession.getSession(util.getFileType(util.tryToGetDocument({})));
+  const session = replSession.tryToGetSession(util.getFileType(util.tryToGetDocument({})));
   util.assertIsDefined(session, 'Expected there to be a repl session!');
 
   const value = await session.eval('*1', session.client.ns).value;
@@ -551,7 +551,7 @@ export async function evaluateInOutputWindow(
   const outputDocument = await outputWindow.openResultsDoc();
   const evalPos = outputDocument.positionAt(outputDocument.getText().length);
   try {
-    const session = replSession.getSession(sessionType);
+    const session = replSession.tryToGetSession(sessionType);
     replSession.updateReplSessionType();
     if (outputWindow.getNs() !== ns) {
       util.assertIsDefined(session, 'Expected there to be a repl session!');

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -574,6 +574,7 @@ export type customREPLCommandSnippet = {
   snippet: string;
   repl?: string;
   ns?: string;
+  evaluationSendCodeToOutputWindow?: boolean;
 };
 
 export default {

--- a/src/extension-test/unit/common/text-notation.ts
+++ b/src/extension-test/unit/common/text-notation.ts
@@ -12,7 +12,9 @@ import * as model from '../../../cursor-doc/model';
  *   * Selections with direction left->right are denoted with `|<|` at the range boundaries
  */
 
-function textNotationToTextAndSelection(s: string): [string, { anchor: number; active: number }] {
+function textNotationToTextAndSelection(
+  s: string
+): [string, { anchor: number; active: number | undefined }] {
   const text = s.replace(/•/g, '\n').replace(/\|?[<>]?\|/g, '');
   let anchor: undefined | number = undefined;
   let active: undefined | number = undefined;

--- a/src/extension-test/unit/cursor-doc/clojure-lexer-test.ts
+++ b/src/extension-test/unit/cursor-doc/clojure-lexer-test.ts
@@ -677,7 +677,7 @@ describe('Scanner', () => {
         if (!['reader', 'junk'].includes(rule.name)) {
           expect(x).toBeNull();
         } else {
-          expect(x.length).toBe(1);
+          expect(x?.length).toBe(1);
         }
       });
     });

--- a/src/extension-test/unit/results-output/util-test.ts
+++ b/src/extension-test/unit/results-output/util-test.ts
@@ -25,7 +25,7 @@ describe('addToHistory', () => {
   });
   it('should not push null to history array', () => {
     const history = [];
-    const newHistory = util.addToHistory(history, null);
+    const newHistory = util.addToHistory(history, undefined);
     expect(newHistory.length).toBe(history.length);
   });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,7 @@ import * as nreplLogging from './nrepl/logging';
 import * as converters from './converters';
 
 import * as clojureDocs from './clojuredocs';
+import { assertIsDefined } from './type-checks';
 async function onDidSave(testController: vscode.TestController, document: vscode.TextDocument) {
   const { evaluate, test } = config.getConfig();
 
@@ -50,7 +51,7 @@ async function onDidSave(testController: vscode.TestController, document: vscode
   } else if (evaluate) {
     if (!outputWindow.isResultsDoc(document)) {
       const pprintOptions = config.getConfig().prettyPrintingOptions;
-      util.assertIsDefined(pprintOptions, 'Expected there to be pprint options!');
+      assertIsDefined(pprintOptions, 'Expected there to be pprint options!');
       await eval.loadFile(document, pprintOptions);
       outputWindow.appendPrompt();
       state.analytics().logEvent('Calva', 'OnSaveLoad').send();
@@ -111,7 +112,7 @@ async function activate(context: vscode.ExtensionContext) {
   const maxTokenizationLineLength = vscode.workspace
     .getConfiguration('editor')
     .get<number>('maxTokenizationLineLength');
-  util.assertIsDefined(
+  assertIsDefined(
     maxTokenizationLineLength,
     'Expected there to be a maxTokenizationLineLength set in the editor config'
   );
@@ -127,7 +128,7 @@ async function activate(context: vscode.ExtensionContext) {
   const clojureExtension = vscode.extensions.getExtension('avli.clojure');
   const customCljsRepl = config.getConfig().customCljsRepl;
   const replConnectSequences = config.getConfig().replConnectSequences;
-  util.assertIsDefined(
+  assertIsDefined(
     replConnectSequences,
     'Expected there to be a repl connect sequence in the config!'
   );
@@ -245,7 +246,7 @@ async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('calva.loadFile', async () => {
       const pprintOptions = config.getConfig().prettyPrintingOptions;
-      util.assertIsDefined(pprintOptions, 'Expected pprint options in the config!');
+      assertIsDefined(pprintOptions, 'Expected pprint options in the config!');
       await eval.loadFile({}, pprintOptions);
       return new Promise((resolve) => {
         outputWindow.appendPrompt(resolve);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,9 @@ async function onDidSave(testController: vscode.TestController, document: vscode
     state.analytics().logEvent('Calva', 'OnSaveTest').send();
   } else if (evaluate) {
     if (!outputWindow.isResultsDoc(document)) {
-      await eval.loadFile(document, config.getConfig().prettyPrintingOptions);
+      const pprintOptions = config.getConfig().prettyPrintingOptions;
+      util.assertIsDefined(pprintOptions, 'Expected there to be pprint options!');
+      await eval.loadFile(document, pprintOptions);
       outputWindow.appendPrompt();
       state.analytics().logEvent('Calva', 'OnSaveLoad').send();
     }
@@ -62,7 +64,7 @@ function onDidOpen(document) {
   }
 }
 
-function onDidChangeEditorOrSelection(editor: vscode.TextEditor) {
+function onDidChangeEditorOrSelection(editor: vscode.TextEditor | undefined) {
   replHistory.setReplHistoryCommandsActiveContext(editor);
   whenContexts.setCursorContextIfChanged(editor);
 }
@@ -106,7 +108,14 @@ async function activate(context: vscode.ExtensionContext) {
   setStateValue('analytics', new Analytics(context));
   state.analytics().logPath('/start').logEvent('LifeCycle', 'Started').send();
 
-  model.initScanner(vscode.workspace.getConfiguration('editor').get('maxTokenizationLineLength'));
+  const maxTokenizationLineLength = vscode.workspace
+    .getConfiguration('editor')
+    .get<number>('maxTokenizationLineLength');
+  util.assertIsDefined(
+    maxTokenizationLineLength,
+    'Expected there to be a maxTokenizationLineLength set in the editor config'
+  );
+  model.initScanner(maxTokenizationLineLength);
 
   const chan = state.outputChannel();
 
@@ -118,6 +127,10 @@ async function activate(context: vscode.ExtensionContext) {
   const clojureExtension = vscode.extensions.getExtension('avli.clojure');
   const customCljsRepl = config.getConfig().customCljsRepl;
   const replConnectSequences = config.getConfig().replConnectSequences;
+  util.assertIsDefined(
+    replConnectSequences,
+    'Expected there to be a repl connect sequence in the config!'
+  );
   const BUTTON_GOTO_DOC = 'Open the docs';
   const BUTTON_OK = 'Got it';
   const VIM_DOC_URL = 'https://calva.io/vim/';
@@ -231,7 +244,9 @@ async function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(
     vscode.commands.registerCommand('calva.loadFile', async () => {
-      await eval.loadFile({}, config.getConfig().prettyPrintingOptions);
+      const pprintOptions = config.getConfig().prettyPrintingOptions;
+      util.assertIsDefined(pprintOptions, 'Expected pprint options in the config!');
+      await eval.loadFile({}, pprintOptions);
       return new Promise((resolve) => {
         outputWindow.appendPrompt(resolve);
       });

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -4,7 +4,8 @@ import * as isEqual from 'lodash.isequal';
 import * as docMirror from '../../doc-mirror/index';
 import { Token, validPair } from '../../cursor-doc/clojure-lexer';
 import { LispTokenCursor } from '../../cursor-doc/token-cursor';
-import { tryToGetActiveTextEditor, getActiveTextEditor, assertIsDefined } from '../../utilities';
+import { tryToGetActiveTextEditor, getActiveTextEditor } from '../../utilities';
+import { assertIsDefined } from '../../type-checks';
 
 type StackItem = {
   char: string;

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -1,17 +1,16 @@
 import * as vscode from 'vscode';
 import { Position, Range } from 'vscode';
 import * as isEqual from 'lodash.isequal';
-import { isArray } from 'util';
 import * as docMirror from '../../doc-mirror/index';
 import { Token, validPair } from '../../cursor-doc/clojure-lexer';
 import { LispTokenCursor } from '../../cursor-doc/token-cursor';
-import { tryToGetActiveTextEditor, getActiveTextEditor } from '../../utilities';
+import { tryToGetActiveTextEditor, getActiveTextEditor, assertIsDefined } from '../../utilities';
 
 type StackItem = {
   char: string;
   start: Position;
   end: Position;
-  pair_idx: number;
+  pair_idx: number | undefined;
   opens_comment_form?: boolean;
 };
 
@@ -23,7 +22,12 @@ function is_clojure(editor) {
 }
 
 // Exported for integration testing purposes
-export let activeEditor: vscode.TextEditor;
+export let activeEditor: vscode.TextEditor | undefined;
+
+const definedActiveEditor = () => {
+  assertIsDefined(activeEditor, 'Expected there to be an active text editor set!');
+  return activeEditor;
+};
 
 let lastHighlightedEditor,
   rainbowColors,
@@ -45,8 +49,8 @@ let lastHighlightedEditor,
   pairsBack: Map<string, [Range, Range]> = new Map(),
   pairsForward: Map<string, [Range, Range]> = new Map(),
   placedGuidesColor: Map<string, number> = new Map(),
-  rainbowTimer = undefined,
-  matchTimer = undefined,
+  rainbowTimer: NodeJS.Timeout | undefined = undefined,
+  matchTimer: NodeJS.Timeout | undefined = undefined,
   dirty = false;
 
 reloadConfig();
@@ -57,7 +61,7 @@ function decorationType(opts) {
 }
 
 function colorDecorationType(color) {
-  if (isArray(color)) {
+  if (Array.isArray(color)) {
     return decorationType({
       light: { color: color[0] },
       dark: { color: color[1] },
@@ -68,7 +72,7 @@ function colorDecorationType(color) {
 }
 
 function guidesDecorationType_(color, isActive: boolean): vscode.TextEditorDecorationType {
-  if (isArray(color)) {
+  if (Array.isArray(color)) {
     return decorationType({
       light: {
         borderWidth: `0; border-right-width: ${
@@ -105,23 +109,26 @@ function activeGuidesDecorationType(color): vscode.TextEditorDecorationType {
 }
 
 function reset_styles() {
+  const editor = activeEditor;
+  assertIsDefined(editor, 'Expected there to be an active text editor!');
+
   if (rainbowTypes) {
-    rainbowTypes.forEach((type) => activeEditor.setDecorations(type, []));
+    rainbowTypes.forEach((type) => editor.setDecorations(type, []));
   }
   rainbowTypes = rainbowColors.map(colorDecorationType);
 
   if (rainbowGuidesTypes) {
-    rainbowGuidesTypes.forEach((type) => activeEditor.setDecorations(type, []));
+    rainbowGuidesTypes.forEach((type) => editor.setDecorations(type, []));
   }
   rainbowGuidesTypes = rainbowColors.map(guidesDecorationType);
 
   if (activeGuidesTypes) {
-    activeGuidesTypes.forEach((type) => activeEditor.setDecorations(type, []));
+    activeGuidesTypes.forEach((type) => editor.setDecorations(type, []));
   }
   activeGuidesTypes = rainbowColors.map(activeGuidesDecorationType);
 
   if (misplacedType) {
-    activeEditor.setDecorations(misplacedType, []);
+    editor.setDecorations(misplacedType, []);
   }
   misplacedType = decorationType(
     misplacedBracketStyle || {
@@ -133,7 +140,7 @@ function reset_styles() {
   );
 
   if (matchedType) {
-    activeEditor.setDecorations(matchedType, []);
+    editor.setDecorations(matchedType, []);
   }
   matchedType = decorationType(
     matchedBracketStyle || {
@@ -143,12 +150,12 @@ function reset_styles() {
   );
 
   if (commentFormType) {
-    activeEditor.setDecorations(commentFormType, []);
+    editor.setDecorations(commentFormType, []);
   }
   commentFormType = decorationType(commentFormStyle || { fontStyle: 'italic' });
 
   if (ignoredFormType) {
-    activeEditor.setDecorations(ignoredFormType, []);
+    editor.setDecorations(ignoredFormType, []);
   }
   ignoredFormType = decorationType(ignoredFormStyle || { textDecoration: 'none; opacity: 0.5' });
 
@@ -231,13 +238,16 @@ function updateRainbowBrackets() {
     reset_styles();
   }
 
-  const doc = activeEditor.document,
+  const editor = activeEditor;
+  assertIsDefined(editor, 'Expected there to be an active text editor!');
+
+  const doc = editor.document,
     mirrorDoc = docMirror.getDocument(doc),
-    rainbow = rainbowTypes.map(() => []),
+    rainbow = rainbowTypes.map(() => [] as { range: Range }[]),
     rainbowGuides = rainbowTypes.map(() => []),
-    misplaced = [],
-    comment_forms = [],
-    ignores = [],
+    misplaced: { range: Range }[] = [],
+    comment_forms: Range[] = [],
+    ignores: Range[] = [],
     len = rainbowTypes.length,
     colorsEnabled = enableBracketColors && len > 0,
     guideColorsEnabled = useRainbowIndentGuides && len > 0,
@@ -250,7 +260,7 @@ function updateRainbowBrackets() {
   pairsBack = new Map();
   pairsForward = new Map();
   placedGuidesColor = new Map();
-  activeEditor.visibleRanges.forEach((range) => {
+  editor.visibleRanges.forEach((range) => {
     // Find the visible forms
     const startOffset = doc.offsetAt(range.start),
       endOffset = doc.offsetAt(range.end),
@@ -289,7 +299,7 @@ function updateRainbowBrackets() {
         } else if (token.type === 'ignore') {
           const ignoreCursor = cursor.clone();
           let ignore_counter = 0;
-          const ignore_start = activeEditor.document.positionAt(ignoreCursor.offsetStart);
+          const ignore_start = editor.document.positionAt(ignoreCursor.offsetStart);
           while (ignoreCursor.getToken().type === 'ignore') {
             ignore_counter++;
             ignoreCursor.next();
@@ -298,7 +308,7 @@ function updateRainbowBrackets() {
           for (let i = 0; i < ignore_counter; i++) {
             ignoreCursor.forwardSexp(true, true, true);
           }
-          const ignore_end = activeEditor.document.positionAt(ignoreCursor.offsetStart);
+          const ignore_end = editor.document.positionAt(ignoreCursor.offsetStart);
           ignores.push(new Range(ignore_start, ignore_end));
         }
       }
@@ -318,10 +328,11 @@ function updateRainbowBrackets() {
       if (token.type === 'open') {
         const readerCursor = cursor.clone();
         readerCursor.backwardThroughAnyReader();
-        const start = activeEditor.document.positionAt(readerCursor.offsetStart),
-          end = activeEditor.document.positionAt(cursor.offsetEnd),
+
+        const start = editor.document.positionAt(readerCursor.offsetStart),
+          end = editor.document.positionAt(cursor.offsetEnd),
           openRange = new Range(start, end),
-          openString = activeEditor.document.getText(openRange);
+          openString = editor.document.getText(openRange);
         if (colorsEnabled) {
           const decoration = { range: openRange };
           rainbow[colorIndex(stack_depth)].push(decoration);
@@ -336,11 +347,12 @@ function updateRainbowBrackets() {
         });
         continue;
       } else if (token.type === 'close') {
-        const pos = activeEditor.document.positionAt(cursor.offsetStart),
+        const pos = editor.document.positionAt(cursor.offsetStart),
           decoration = { range: new Range(pos, pos.translate(0, 1)) };
         let pair_idx = stack.length - 1;
-        while (pair_idx >= 0 && stack[pair_idx].pair_idx !== undefined) {
-          pair_idx = stack[pair_idx].pair_idx - 1;
+        const stackPairIdx = stack[pair_idx];
+        while (pair_idx >= 0 && stackPairIdx.pair_idx !== undefined) {
+          pair_idx = stackPairIdx.pair_idx - 1;
         }
         if (pair_idx === undefined || pair_idx < 0 || !validPair(stack[pair_idx].char, char)) {
           misplaced.push(decoration);
@@ -359,9 +371,9 @@ function updateRainbowBrackets() {
             pair_idx: pair_idx,
           });
           pairsBack.set(position_str(pos), [opening, closing]);
-          const startOffset = activeEditor.document.offsetAt(pair.start);
+          const startOffset = editor.document.offsetAt(pair.start);
           for (let i = 0; i < pair.char.length; ++i) {
-            pairsForward.set(position_str(activeEditor.document.positionAt(startOffset + i)), [
+            pairsForward.set(position_str(editor.document.positionAt(startOffset + i)), [
               opening,
               closing,
             ]);
@@ -373,6 +385,7 @@ function updateRainbowBrackets() {
           if (guideColorsEnabled || activeGuideEnabled) {
             const matchPos = pos.translate(0, 1);
             const openSelection = matchBefore(new vscode.Selection(matchPos, matchPos));
+            assertIsDefined(openSelection, 'Expected openSelection to be defined!');
             const openSelectionPos = openSelection[0].start;
             const guideLength = decorateGuide(
               doc,
@@ -391,14 +404,14 @@ function updateRainbowBrackets() {
   });
 
   for (let i = 0; i < rainbowTypes.length; ++i) {
-    activeEditor.setDecorations(rainbowTypes[i], rainbow[i]);
+    editor.setDecorations(rainbowTypes[i], rainbow[i]);
     if (guideColorsEnabled) {
-      activeEditor.setDecorations(rainbowGuidesTypes[i], rainbowGuides[i]);
+      editor.setDecorations(rainbowGuidesTypes[i], rainbowGuides[i]);
     }
   }
-  activeEditor.setDecorations(misplacedType, misplaced);
-  activeEditor.setDecorations(commentFormType, comment_forms);
-  activeEditor.setDecorations(ignoredFormType, ignores);
+  editor.setDecorations(misplacedType, misplaced);
+  editor.setDecorations(commentFormType, comment_forms);
+  editor.setDecorations(ignoredFormType, ignores);
   matchPairs();
   if (activeGuideEnabled) {
     decorateActiveGuides();
@@ -428,8 +441,11 @@ function matchPairs() {
     return;
   }
 
+  const editor = activeEditor;
+  assertIsDefined(editor, 'Expected there to be an active text editor!');
+
   const matches: { range: vscode.Range }[] = [];
-  activeEditor.selections.forEach((selection) => {
+  editor.selections.forEach((selection) => {
     const match_before = matchBefore(selection),
       match_after = matchAfter(selection);
     if (match_before) {
@@ -441,7 +457,7 @@ function matchPairs() {
       matches.push({ range: match_after[1] });
     }
   });
-  activeEditor.setDecorations(matchedType, matches);
+  editor.setDecorations(matchedType, matches);
 }
 
 function decorateGuide(
@@ -453,7 +469,8 @@ function decorateGuide(
   let guideLength = 0;
   for (let lineDelta = 1; lineDelta <= endPos.line - startPos.line; lineDelta++) {
     const guidePos = startPos.translate(lineDelta, 0);
-    if (doc.lineAt(guidePos).text.match(/^ */)[0].length >= startPos.character) {
+    const leadingSpacesMatch = doc.lineAt(guidePos).text.match(/^ */);
+    if (leadingSpacesMatch && leadingSpacesMatch[0].length >= startPos.character) {
       const guidesDecoration = { range: new Range(guidePos, guidePos) };
       guides.push(guidesDecoration);
       guideLength++;
@@ -464,12 +481,13 @@ function decorateGuide(
 
 function decorateActiveGuides() {
   const activeGuides = [];
-  activeEditor = getActiveTextEditor();
+  const editor = getActiveTextEditor();
+  activeEditor = editor;
   if (activeGuidesTypes) {
-    activeGuidesTypes.forEach((type) => activeEditor.setDecorations(type, []));
+    activeGuidesTypes.forEach((type) => editor.setDecorations(type, []));
   }
-  activeEditor.selections.forEach((selection) => {
-    const doc = activeEditor.document;
+  editor.selections.forEach((selection) => {
+    const doc = editor.document;
     const mirrorDoc = docMirror.getDocument(doc);
     const cursor = mirrorDoc.getTokenCursor(doc.offsetAt(selection.start));
     const visitedEndPositions = [selection.start];
@@ -490,7 +508,7 @@ function decorateActiveGuides() {
         if (colorIndex !== undefined) {
           if (guideRange.contains(selection)) {
             decorateGuide(doc, startPos, endPos, activeGuides);
-            activeEditor.setDecorations(activeGuidesTypes[colorIndex], activeGuides);
+            editor.setDecorations(activeGuidesTypes[colorIndex], activeGuides);
           }
           break;
         }
@@ -539,7 +557,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   vscode.workspace.onDidChangeTextDocument(
     (event) => {
-      if (is_clojure(activeEditor) && event.document === activeEditor.document) {
+      if (is_clojure(activeEditor) && event.document === activeEditor?.document) {
         scheduleRainbowBrackets();
       }
     },

--- a/src/live-share.ts
+++ b/src/live-share.ts
@@ -3,12 +3,12 @@ import * as vsls from 'vsls';
 import * as config from './config';
 
 // Keeps hold of the LiveShare API instance, so that it is requested only once.
-let liveShare: vsls.LiveShare = null;
+let liveShare: vsls.LiveShare | null = null;
 
 // Keeps hold of the LiveShare listener, to prevent it from being disposed immediately.
-let liveShareListener: Disposable = null;
+let liveShareListener: Disposable | null = null;
 
-let connectedPort: number = null;
+let connectedPort: number | null = null;
 let jackedIn = false;
 const sharedPorts: Map<number, Disposable> = new Map();
 

--- a/src/lsp/download.ts
+++ b/src/lsp/download.ts
@@ -18,12 +18,25 @@ async function getLatestVersion(): Promise<string> {
   }
 }
 
+const zipFileNames = {
+  darwin: 'clojure-lsp-native-macos-amd64.zip',
+  linux: 'clojure-lsp-native-static-linux-amd64.zip',
+  win32: 'clojure-lsp-native-windows-amd64.zip',
+};
+
+const validPlatforms = Object.keys(zipFileNames);
+type ValidPlatform = keyof typeof zipFileNames;
+
+function assertValidPlatform(platform: string): asserts platform is ValidPlatform {
+  if (!validPlatforms.includes(platform)) {
+    throw new Error(`Expected a valid clojure-lsp platform but got ${platform}`);
+  }
+}
+
 function getZipFileName(platform: string): string {
-  return {
-    darwin: 'clojure-lsp-native-macos-amd64.zip',
-    linux: 'clojure-lsp-native-static-linux-amd64.zip',
-    win32: 'clojure-lsp-native-windows-amd64.zip',
-  }[platform];
+  assertValidPlatform(platform);
+
+  return zipFileNames[platform];
 }
 
 function getZipFilePath(extensionPath: string, platform: string): string {

--- a/src/lsp/download.ts
+++ b/src/lsp/download.ts
@@ -101,6 +101,7 @@ async function unzipFile(zipFilePath: string, extensionPath: string): Promise<vo
 }
 
 async function downloadClojureLsp(extensionPath: string, version: string): Promise<string> {
+  console.log({ extensionPath, version, platform: process.platform });
   const zipFileName = getZipFileName(process.platform);
   const urlPath = `/clojure-lsp/clojure-lsp/releases/download/${version}/${zipFileName}`;
   const zipFilePath = getZipFilePath(extensionPath, process.platform);

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -32,7 +32,7 @@ const SERVER_NOT_RUNNING_OR_INITIALIZED_MESSAGE =
 const lspStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
 let serverVersion: string;
 let extensionContext: vscode.ExtensionContext;
-let clojureLspPath: string;
+let clojureLspPath: string | undefined;
 let testTreeHandler: TestTreeHandler;
 let lspCommandsRegistered = false;
 
@@ -124,7 +124,11 @@ function createClient(clojureLspPath: string, fallbackFolder: FallbackFolder): L
         provideCodeActions(document, range, context, token, next) {
           return next(document, range, context, token);
         },
-        provideCodeLenses: async (document, token, next): Promise<vscode.CodeLens[]> => {
+        provideCodeLenses: async (
+          document,
+          token,
+          next
+        ): Promise<vscode.CodeLens[] | null | undefined> => {
           if (config.getConfig().referencesCodeLensEnabled) {
             return await next(document, token);
           }
@@ -137,7 +141,7 @@ function createClient(clojureLspPath: string, fallbackFolder: FallbackFolder): L
           return null;
         },
         async provideHover(document, position, token, next) {
-          let hover: vscode.Hover;
+          let hover: vscode.Hover | null | undefined;
           try {
             hover = await provideHover(document, position);
           } catch {
@@ -266,7 +270,7 @@ function registerLspCommand(command: ClojureLspCommand): vscode.Disposable {
       const docUri = `${document.uri.scheme}://${document.uri.path}`;
       const params = [docUri, line, column];
       const extraParam = command.extraParamFn ? await command.extraParamFn() : undefined;
-      if (!command.extraParamFn || (command.extraParamFn && extraParam)) {
+      if (!command.extraParamFn || extraParam) {
         sendCommandRequest(command.command, extraParam ? [...params, extraParam] : params);
       }
     }
@@ -360,10 +364,12 @@ enum FolderType {
   FROM_NO_CLOJURE_FILE = 3,
 }
 
-type FallbackFolder = {
-  uri: vscode.Uri;
-  type: FolderType;
-};
+type FallbackFolder =
+  | { uri: undefined; type: FolderType.VSCODE }
+  | {
+      uri: vscode.Uri;
+      type: FolderType;
+    };
 
 /**
  * Figures out a ”best fit” rootUri for use when starting the clojure-lsp
@@ -382,8 +388,8 @@ async function getFallbackFolder(): Promise<FallbackFolder> {
   }
 
   const activeEditor = vscode.window.activeTextEditor;
-  let clojureFilePath: string;
-  let folderType: FolderType;
+  let clojureFilePath: string | undefined;
+  let folderType: FolderType | undefined;
   if (activeEditor && activeEditor.document?.languageId === 'clojure') {
     folderType = activeEditor.document.isUntitled
       ? FolderType.FROM_UNTITLED_FILE
@@ -394,8 +400,10 @@ async function getFallbackFolder(): Promise<FallbackFolder> {
   } else {
     for (const document of vscode.workspace.textDocuments) {
       if (document.languageId === 'clojure') {
-        folderType = document.isUntitled ? FolderType.FROM_UNTITLED_FILE : FolderType.FROM_FS_FILE;
-        if (!document.isUntitled) {
+        if (document.isUntitled) {
+          folderType = FolderType.FROM_UNTITLED_FILE;
+        } else {
+          folderType = FolderType.FROM_FS_FILE;
           clojureFilePath = document.uri.fsPath;
         }
       }
@@ -421,6 +429,8 @@ async function getFallbackFolder(): Promise<FallbackFolder> {
       await util.writeTextToFile(vscode.Uri.file(depsFilePath), '{}');
     }
   }
+
+  util.assertIsDefined(folderType, 'Expected there to be a folderType at this point!');
 
   return {
     uri: fallbackFolder,
@@ -477,6 +487,7 @@ async function startClient(fallbackFolder: FallbackFolder): Promise<boolean> {
     });
   }
   setStateValue(LSP_CLIENT_KEY, undefined);
+  util.assertIsDefined(clojureLspPath, 'Expected there to be a clojure LSP path!');
   const client = createClient(clojureLspPath, fallbackFolder);
   console.log('Starting clojure-lsp at', clojureLspPath);
 
@@ -515,11 +526,14 @@ async function startClient(fallbackFolder: FallbackFolder): Promise<boolean> {
 
 // A quickPick that expects the same input as showInformationMessage does
 // TODO: How do we make it satisfy the messageFunc interface above?
-function quickPick(message: string, actions: { title: string }[]): Promise<{ title: string }> {
+function quickPick(
+  message: string,
+  actions: { title: string }[]
+): Promise<{ title: string } | undefined> {
   const qp = vscode.window.createQuickPick();
   qp.items = actions.map((item) => ({ label: item.title }));
   qp.title = message;
-  return new Promise<{ title: string }>((resolve, _reject) => {
+  return new Promise<{ title: string } | undefined>((resolve, _reject) => {
     qp.show();
     qp.onDidAccept(() => {
       if (qp.selectedItems.length > 0) {
@@ -649,7 +663,7 @@ async function activate(context: vscode.ExtensionContext, handler: TestTreeHandl
   }
 }
 
-async function maybeDownloadLspServer(forceDownLoad = false): Promise<string> {
+async function maybeDownloadLspServer(forceDownLoad = false): Promise<string | undefined> {
   const userConfiguredClojureLspPath = config.getConfig().clojureLspPath;
   if (userConfiguredClojureLspPath !== '') {
     clojureLspPath = userConfiguredClojureLspPath;
@@ -672,11 +686,12 @@ async function downloadLSPServerCommand() {
 
 async function ensureServerDownloaded(forceDownLoad = false): Promise<string> {
   const currentVersion = readVersionFile(extensionContext.extensionPath);
-  const configuredVersion: string = config.getConfig().clojureLspVersion;
+  const configuredVersion: string | undefined = config.getConfig().clojureLspVersion;
   clojureLspPath = getClojureLspPath(extensionContext.extensionPath, util.isWindows);
-  const downloadVersion = ['', 'latest'].includes(configuredVersion)
-    ? await getLatestVersion()
-    : configuredVersion;
+  const downloadVersion =
+    configuredVersion === undefined || ['', 'latest'].includes(configuredVersion)
+      ? await getLatestVersion()
+      : configuredVersion;
   if (
     (currentVersion !== downloadVersion && downloadVersion !== '') ||
     forceDownLoad ||
@@ -787,7 +802,7 @@ export async function getCljFmtConfig(): Promise<string | undefined> {
 
 function showMenu(items: vscode.QuickPickItem[], commands: Record<string, string>) {
   void vscode.window.showQuickPick(items, { title: 'clojure-lsp' }).then((v) => {
-    if (commands[v.label]) {
+    if (v && commands[v.label]) {
       void vscode.commands.executeCommand(commands[v.label]);
     }
   });

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -23,6 +23,7 @@ import { provideHover } from '../providers/hover';
 import { provideSignatureHelp } from '../providers/signature';
 import { isResultsDoc } from '../results-output/results-doc';
 import { MessageItem } from 'vscode';
+import { assertIsDefined } from '../type-checks';
 
 const LSP_CLIENT_KEY = 'lspClient';
 const LSP_CLIENT_KEY_ERROR = 'lspClientError';
@@ -430,7 +431,7 @@ async function getFallbackFolder(): Promise<FallbackFolder> {
     }
   }
 
-  util.assertIsDefined(folderType, 'Expected there to be a folderType at this point!');
+  assertIsDefined(folderType, 'Expected there to be a folderType at this point!');
 
   return {
     uri: fallbackFolder,
@@ -487,7 +488,7 @@ async function startClient(fallbackFolder: FallbackFolder): Promise<boolean> {
     });
   }
   setStateValue(LSP_CLIENT_KEY, undefined);
-  util.assertIsDefined(clojureLspPath, 'Expected there to be a clojure LSP path!');
+  assertIsDefined(clojureLspPath, 'Expected there to be a clojure LSP path!');
   const client = createClient(clojureLspPath, fallbackFolder);
   console.log('Starting clojure-lsp at', clojureLspPath);
 

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -72,7 +72,7 @@ export async function createNamespaceFromDocumentIfNotExists(doc) {
     const document = utilities.tryToGetDocument(doc);
     if (document) {
       const ns = getNamespace(document);
-      const client = replSession.getSession(utilities.getFileType(document));
+      const client = replSession.tryToGetSession(utilities.getFileType(document));
       if (client) {
         const nsList = await client.listNamespaces([]);
         if (nsList['ns-list'] && nsList['ns-list'].includes(ns)) {

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -7,11 +7,12 @@ import * as outputWindow from './results-output/results-doc';
 import * as utilities from './utilities';
 import * as replSession from './nrepl/repl-session';
 import { NReplSession } from './nrepl';
+import { assertIsDefined } from './type-checks';
 
 export function getNamespace(doc?: vscode.TextDocument) {
   if (outputWindow.isResultsDoc(doc)) {
     const outputWindowNs = outputWindow.getNs();
-    utilities.assertIsDefined(outputWindowNs, 'Expected output window to have a namespace!');
+    assertIsDefined(outputWindowNs, 'Expected output window to have a namespace!');
     return outputWindowNs;
   }
   let ns = 'user';

--- a/src/nrepl/bencode.ts
+++ b/src/nrepl/bencode.ts
@@ -5,7 +5,7 @@
  */
 import * as stream from 'stream';
 import { Buffer } from 'buffer';
-import { assertIsDefined } from '../utilities';
+import { assertIsDefined } from '../type-checks';
 
 /** Bencode the given JSON object */
 const bencode = (value) => {

--- a/src/nrepl/bencode.ts
+++ b/src/nrepl/bencode.ts
@@ -5,6 +5,7 @@
  */
 import * as stream from 'stream';
 import { Buffer } from 'buffer';
+import { assertIsDefined } from '../utilities';
 
 /** Bencode the given JSON object */
 const bencode = (value) => {
@@ -103,8 +104,9 @@ class BIncrementalDecoder {
   stack: State[] = [];
 
   private complete(data: any) {
-    if (this.stack.length) {
-      this.state = this.stack.pop();
+    const state = this.stack.pop();
+    if (state) {
+      this.state = state;
       if (this.state.id == 'list') {
         this.state.accum.push(data);
         this.stack.push(this.state);
@@ -127,6 +129,7 @@ class BIncrementalDecoder {
 
   write(byte: number) {
     const ch = String.fromCharCode(byte);
+    let state: State | undefined;
     if (this.state.id == 'ready') {
       switch (ch) {
         case 'i':
@@ -139,10 +142,9 @@ class BIncrementalDecoder {
           this.stack.push({ id: 'list', accum: [] });
           break;
         case 'e':
-          if (!this.stack.length) {
-            throw 'unexpected end';
-          }
-          this.state = this.stack.pop();
+          state = this.stack.pop();
+          assertIsDefined(state, 'Expected there to be states on the stack!');
+          this.state = state;
           if (this.state.id == 'dict') {
             if (this.state.key !== null) {
               throw 'Missing value in dict';

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as state from '../state';
 import * as utilities from '../utilities';
 import { getConfig } from '../config';
+import { assertIsDefined } from '../type-checks';
 
 enum ProjectTypes {
   'Leiningen' = 'Leiningen',
@@ -253,7 +254,7 @@ const defaultCljsTypes: { [id: string]: CljsTypeConfig } = {
 /** Retrieve the replConnectSequences from the config */
 function getCustomConnectSequences(): ReplConnectSequence[] {
   const sequences: ReplConnectSequence[] | undefined = getConfig().replConnectSequences;
-  utilities.assertIsDefined(sequences, 'Expected there to be repl connect sequences!');
+  assertIsDefined(sequences, 'Expected there to be repl connect sequences!');
 
   for (const sequence of sequences) {
     if (
@@ -327,7 +328,7 @@ async function askForConnectSequence(
     return;
   }
   const sequence = sequences.find((seq) => seq.name === projectConnectSequenceName);
-  utilities.assertIsDefined(sequence, 'Expected to find a sequence!');
+  assertIsDefined(sequence, 'Expected to find a sequence!');
   void state.extensionContext.workspaceState.update('selectedCljTypeName', sequence.projectType);
   return sequence;
 }

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -252,7 +252,8 @@ const defaultCljsTypes: { [id: string]: CljsTypeConfig } = {
 
 /** Retrieve the replConnectSequences from the config */
 function getCustomConnectSequences(): ReplConnectSequence[] {
-  const sequences: ReplConnectSequence[] = getConfig().replConnectSequences || [];
+  const sequences: ReplConnectSequence[] | undefined = getConfig().replConnectSequences;
+  utilities.assertIsDefined(sequences, 'Expected there to be repl connect sequences!');
 
   for (const sequence of sequences) {
     if (

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -252,7 +252,7 @@ const defaultCljsTypes: { [id: string]: CljsTypeConfig } = {
 
 /** Retrieve the replConnectSequences from the config */
 function getCustomConnectSequences(): ReplConnectSequence[] {
-  const sequences: ReplConnectSequence[] = getConfig().replConnectSequences;
+  const sequences: ReplConnectSequence[] = getConfig().replConnectSequences || [];
 
   for (const sequence of sequences) {
     if (
@@ -283,7 +283,7 @@ function getConnectSequences(projectTypes: string[]): ReplConnectSequence[] {
   const customSequences = getCustomConnectSequences();
   const defSequences = projectTypes.reduce(
     (seqs, projectType) => seqs.concat(defaultSequences[projectType]),
-    []
+    [] as ReplConnectSequence[]
   );
   const defSequenceProjectTypes = [...new Set(defSequences.map((s) => s.projectType))];
   const sequences = customSequences
@@ -306,7 +306,7 @@ async function askForConnectSequence(
   cljTypes: string[],
   saveAs: string,
   logLabel: string
-): Promise<ReplConnectSequence> {
+): Promise<ReplConnectSequence | undefined> {
   // figure out what possible kinds of project we're in
   const sequences: ReplConnectSequence[] = getConnectSequences(cljTypes);
   const projectRootUri = state.getProjectRootUri();
@@ -326,6 +326,7 @@ async function askForConnectSequence(
     return;
   }
   const sequence = sequences.find((seq) => seq.name === projectConnectSequenceName);
+  utilities.assertIsDefined(sequence, 'Expected to find a sequence!');
   void state.extensionContext.workspaceState.update('selectedCljTypeName', sequence.projectType);
   return sequence;
 }

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -309,7 +309,7 @@ async function askForConnectSequence(
 ): Promise<ReplConnectSequence | undefined> {
   // figure out what possible kinds of project we're in
   const sequences: ReplConnectSequence[] = getConnectSequences(cljTypes);
-  const projectRootUri = state.getProjectRootUri();
+  const projectRootUri = state.tryToGetProjectRootUri();
   const saveAsFull = projectRootUri ? `${projectRootUri.toString()}/${saveAs}` : saveAs;
   void state.extensionContext.workspaceState.update('askForConnectSequenceQuickPick', true);
   const projectConnectSequenceName = await utilities.quickPickSingle({

--- a/src/nrepl/jack-in-terminal.ts
+++ b/src/nrepl/jack-in-terminal.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as child from 'child_process';
 import * as kill from 'tree-kill';
 import * as outputWindow from '../results-output/results-doc';
-import { assertIsDefined } from '../utilities';
+import { assertIsDefined } from '../type-checks';
 
 export interface JackInTerminalOptions extends vscode.TerminalOptions {
   name: string;

--- a/src/nrepl/jack-in-terminal.ts
+++ b/src/nrepl/jack-in-terminal.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as child from 'child_process';
 import * as kill from 'tree-kill';
 import * as outputWindow from '../results-output/results-doc';
+import { assertIsDefined } from '../utilities';
 
 export interface JackInTerminalOptions extends vscode.TerminalOptions {
   name: string;
@@ -80,7 +81,7 @@ export class JackInTerminal implements vscode.Pseudoterminal {
       this.process.on('exit', (status) => {
         this.writeEmitter.fire(`Jack-in process exited. Status: ${status}\r\n`);
       });
-      this.process.stdout.on('data', (data) => {
+      this.process.stdout?.on('data', (data) => {
         const msg = this.dataToString(data);
         this.writeEmitter.fire(`${msg}\r\n`);
         // Started nREPL server at 127.0.0.1:1337
@@ -89,9 +90,14 @@ export class JackInTerminal implements vscode.Pseudoterminal {
         // nbb - nRepl server started on port %d . nrepl-cljs-sci version %s 1337 TODO
         // TODO: Remove nbb WIP match
         if (msg.match(/Started nREPL server|nREPL server started/i)) {
-          const [_, port1, host1, host2, port2, port3] = msg.match(
+          const connectionInfo = msg.match(
             /(?:Started nREPL server|nREPL server started)[^\r\n]+?(?:(?:on port (\d+)(?: on host (\S+))?)|([^\s/]+):(\d+))|.*?(\d+) TODO/
           );
+          assertIsDefined(
+            connectionInfo,
+            'Expected to find connection info in repl started messages!'
+          );
+          const [_, port1, host1, host2, port2, port3] = connectionInfo;
           this.whenREPLStarted(
             this.process,
             host1 ? host1 : host2 ? host2 : 'localhost',
@@ -99,7 +105,7 @@ export class JackInTerminal implements vscode.Pseudoterminal {
           );
         }
       });
-      this.process.stderr.on('data', (data) => {
+      this.process.stderr?.on('data', (data) => {
         const msg = this.dataToString(data);
         this.writeEmitter.fire(`${msg}\r\n`);
       });
@@ -111,8 +117,9 @@ export class JackInTerminal implements vscode.Pseudoterminal {
     if (this.process && !this.process.killed) {
       console.log('Closing any ongoing stdin event');
       this.writeEmitter.fire('Killing the Jack-in process\r\n');
-      this.process.stdin.end(() => {
+      this.process.stdin?.end(() => {
         console.log('Killing the Jack-in process');
+        assertIsDefined(this.process.pid, 'Expected child process to have a pid!');
         kill(this.process.pid);
       });
     } else if (this.process && this.process.killed) {

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -13,6 +13,7 @@ import * as outputWindow from '../results-output/results-doc';
 import { JackInTerminal, JackInTerminalOptions, createCommandLine } from './jack-in-terminal';
 import * as liveShareSupport from '../live-share';
 import { getConfig } from '../config';
+import { assertIsDefined } from '../type-checks';
 
 let jackInPTY: JackInTerminal | undefined = undefined;
 let jackInTerminal: vscode.Terminal | undefined = undefined;
@@ -172,7 +173,7 @@ async function getJackInTerminalOptions(
   }
 
   const projectType = projectTypes.getProjectTypeForName(projectTypeName);
-  utilities.assertIsDefined(projectType, 'Expected to find a project type!');
+  assertIsDefined(projectType, 'Expected to find a project type!');
 
   const projectRootLocal = state.getProjectRootLocal();
 

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -242,7 +242,6 @@ export async function jackIn(connectSequence: ReplConnectSequence | undefined, c
     console.error('An error occurred while setting up Live Share listener.', e);
   }
   const projectRootUri = state.getProjectRootUri();
-  utilities.assertIsDefined(projectRootUri, 'Expected to find a project root URI!');
   if (projectRootUri.scheme === 'vsls') {
     outputWindow.append("; Aborting Jack-in, since you're the guest of a live share session.");
     outputWindow.append(

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -175,7 +175,6 @@ async function getJackInTerminalOptions(
   utilities.assertIsDefined(projectType, 'Expected to find a project type!');
 
   const projectRootLocal = state.getProjectRootLocal();
-  utilities.assertIsDefined(projectRootLocal, 'Expected to find a local project root!');
 
   let args: string[] = await projectType.commandLine(projectConnectSequence, selectedCljsType);
   let cmd: string[];

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -50,7 +50,7 @@ function nreplPortFileRelativePath(connectSequence: ReplConnectSequence): string
  */
 export function nreplPortFileLocalPath(connectSequence: ReplConnectSequence): string {
   const relativePath = nreplPortFileRelativePath(connectSequence);
-  const projectRoot = state.getProjectRootLocal();
+  const projectRoot = state.tryToGetProjectRootLocal();
   if (projectRoot) {
     try {
       return path.resolve(projectRoot, relativePath);

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -168,7 +168,7 @@ async function leinProfilesAndAlias(
           leinAlias = menuSelections ? menuSelections.leinAlias : undefined;
         if (leinAlias) {
           alias = unKeywordize(leinAlias);
-        } else if (leinAlias === null) {
+        } else if (leinAlias === undefined) {
           alias = undefined;
         } else {
           let aliases: string[] = [];

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -20,7 +20,7 @@ export type ProjectType = {
   resolveBundledPathUnix?: () => string;
   processShellWin: boolean;
   processShellUnix: boolean;
-  commandLine: (connectSequence: ReplConnectSequence, cljsType: CljsTypes) => any;
+  commandLine: (connectSequence: ReplConnectSequence, cljsType: CljsTypes | undefined) => any;
   useWhenExists: string | undefined;
   nReplPortFile: string[];
 };
@@ -471,7 +471,10 @@ const projectTypes: { [id: string]: ProjectType } = {
   },
 };
 
-async function cljCommandLine(connectSequence: ReplConnectSequence, cljsType: CljsTypes) {
+async function cljCommandLine(
+  connectSequence: ReplConnectSequence,
+  cljsType: CljsTypes | undefined
+) {
   const out: string[] = [];
   let depsUri: vscode.Uri;
 
@@ -582,7 +585,7 @@ async function cljCommandLine(connectSequence: ReplConnectSequence, cljsType: Cl
 
 async function leinCommandLine(
   command: string[],
-  cljsType: CljsTypes,
+  cljsType: CljsTypes | undefined,
   connectSequence: ReplConnectSequence
 ) {
   const out: string[] = [];

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -8,6 +8,7 @@ import { getConfig } from '../config';
 import { keywordize, unKeywordize } from '../util/string';
 import { CljsTypes, ReplConnectSequence } from './connectSequence';
 import { parseForms, parseEdn } from '../../out/cljs-lib/cljs-lib';
+import { assertIsDefined } from '../type-checks';
 
 export const isWin = /^win/.test(process.platform);
 
@@ -32,7 +33,7 @@ function nreplPortFileRelativePath(connectSequence: ReplConnectSequence): string
   } else {
     const projectTypeName: ProjectType | string = connectSequence.projectType;
     const projectType = getProjectTypeForName(projectTypeName);
-    utilities.assertIsDefined(
+    assertIsDefined(
       projectType,
       `Expected a project type given project type name of ${projectTypeName}`
     );
@@ -121,7 +122,7 @@ async function selectShadowBuilds(
   if (menuSelections) {
     selectedBuilds = menuSelections.cljsLaunchBuilds;
   } else {
-    utilities.assertIsDefined(foundBuilds, 'Expected to have foundBuilds when using the picker!');
+    assertIsDefined(foundBuilds, 'Expected to have foundBuilds when using the picker!');
     selectedBuilds = await utilities.quickPickMulti({
       values: foundBuilds.filter((x) => x[0] == ':'),
       placeHolder: 'Select builds to start',
@@ -222,7 +223,7 @@ export enum JackInDependency {
 }
 
 const jackInDependencyVersions = getConfig().jackInDependencyVersions;
-utilities.assertIsDefined(
+assertIsDefined(
   jackInDependencyVersions,
   'Expected jackInDependencyVersions to be set in the config!'
 );
@@ -641,7 +642,7 @@ export async function detectProjectTypes(): Promise<string[]> {
     if (projectTypes[clj].useWhenExists) {
       try {
         const projectFileName = projectTypes[clj].useWhenExists;
-        utilities.assertIsDefined(projectFileName, 'Expected there to be a project filename!');
+        assertIsDefined(projectFileName, 'Expected there to be a project filename!');
         const uri = vscode.Uri.joinPath(state.getProjectRootUri(), projectFileName);
         await vscode.workspace.fs.readFile(uri);
         cljProjTypes.push(clj);

--- a/src/nrepl/repl-session.ts
+++ b/src/nrepl/repl-session.ts
@@ -1,9 +1,9 @@
 import { NReplSession } from '.';
-import { cljsLib, tryToGetDocument, getFileType } from '../utilities';
+import { cljsLib, tryToGetDocument, getFileType, assertIsDefined } from '../utilities';
 import * as outputWindow from '../results-output/results-doc';
 import { isUndefined } from 'lodash';
 
-function getSession(fileType?: string): NReplSession | undefined {
+function tryToGetSession(fileType?: string): NReplSession | undefined {
   const doc = tryToGetDocument({});
 
   if (isUndefined(fileType)) {
@@ -20,6 +20,14 @@ function getSession(fileType?: string): NReplSession | undefined {
   }
 }
 
+function getSession(fileType?: string): NReplSession {
+  const session = tryToGetSession(fileType);
+
+  assertIsDefined(session, 'Expected to be able to get an nrepl session!');
+
+  return session;
+}
+
 function getReplSessionType(connected: boolean): string | undefined {
   const doc = tryToGetDocument({});
   const fileType = getFileType(doc);
@@ -28,12 +36,12 @@ function getReplSessionType(connected: boolean): string | undefined {
   if (connected) {
     if (outputWindow.isResultsDoc(doc)) {
       sessionType = outputWindow.getSessionType();
-    } else if (fileType == 'cljs' && getSession('cljs') !== null) {
+    } else if (fileType == 'cljs' && tryToGetSession('cljs') !== undefined) {
       sessionType = 'cljs';
-    } else if (fileType == 'clj' && getSession('clj') !== null) {
+    } else if (fileType == 'clj' && tryToGetSession('clj') !== undefined) {
       sessionType = 'clj';
-    } else if (getSession('cljc') !== null) {
-      sessionType = getSession('cljc') == getSession('clj') ? 'clj' : 'cljs';
+    } else if (tryToGetSession('cljc') !== undefined) {
+      sessionType = tryToGetSession('cljc') == tryToGetSession('clj') ? 'clj' : 'cljs';
     } else {
       sessionType = 'clj';
     }
@@ -52,4 +60,10 @@ function getReplSessionTypeFromState(): string | undefined {
   return cljsLib.getStateValue('current-session-type');
 }
 
-export { getSession, getReplSessionType, updateReplSessionType, getReplSessionTypeFromState };
+export {
+  tryToGetSession,
+  getSession,
+  getReplSessionType,
+  updateReplSessionType,
+  getReplSessionTypeFromState,
+};

--- a/src/nrepl/repl-session.ts
+++ b/src/nrepl/repl-session.ts
@@ -3,7 +3,7 @@ import { cljsLib, tryToGetDocument, getFileType } from '../utilities';
 import * as outputWindow from '../results-output/results-doc';
 import { isUndefined } from 'lodash';
 
-function getSession(fileType?: string): NReplSession {
+function getSession(fileType?: string): NReplSession | undefined {
   const doc = tryToGetDocument({});
 
   if (isUndefined(fileType)) {
@@ -48,7 +48,7 @@ function updateReplSessionType() {
   cljsLib.setStateValue('current-session-type', replSessionType);
 }
 
-function getReplSessionTypeFromState() {
+function getReplSessionTypeFromState(): string | undefined {
   return cljsLib.getStateValue('current-session-type');
 }
 

--- a/src/nrepl/repl-session.ts
+++ b/src/nrepl/repl-session.ts
@@ -1,7 +1,8 @@
 import { NReplSession } from '.';
-import { cljsLib, tryToGetDocument, getFileType, assertIsDefined } from '../utilities';
+import { cljsLib, tryToGetDocument, getFileType } from '../utilities';
 import * as outputWindow from '../results-output/results-doc';
 import { isUndefined } from 'lodash';
+import { assertIsDefined } from '../type-checks';
 
 function tryToGetSession(fileType?: string): NReplSession | undefined {
   const doc = tryToGetDocument({});

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -12,6 +12,7 @@ import * as cljsLib from '../../out/cljs-lib/cljs-lib';
 import { ReplConnectSequence } from './connectSequence';
 import * as clojureLsp from '../lsp/main';
 import * as calvaConfig from '../config';
+import { assertIsDefined } from '../type-checks';
 
 const TEMPLATES_SUB_DIR = 'bundled';
 const DRAM_BASE_URL = 'https://raw.githubusercontent.com/BetterThanTomorrow/dram';
@@ -168,7 +169,7 @@ export async function startStandaloneRepl(
   }
 
   const main = await openStoredDoc(storageUri, tempDirUri, config.files[0]);
-  utilities.assertIsDefined(main, 'Expected to be able to open the stored doc!');
+  assertIsDefined(main, 'Expected to be able to open the stored doc!');
   const [mainDoc, mainEditor] = main;
   for (const file of config.files.slice(1)) {
     await openStoredDoc(storageUri, tempDirUri, file);
@@ -189,10 +190,7 @@ export async function startStandaloneRepl(
       preserveFocus: false,
     });
     const pprintOptions = getConfig().prettyPrintingOptions;
-    utilities.assertIsDefined(
-      pprintOptions,
-      'Expected there to be pretty printing options configured!'
-    );
+    assertIsDefined(pprintOptions, 'Expected there to be pretty printing options configured!');
     await eval.loadFile({}, pprintOptions);
     outputWindow.appendPrompt();
   });

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -191,7 +191,7 @@ export async function startStandaloneRepl(
     const pprintOptions = getConfig().prettyPrintingOptions;
     utilities.assertIsDefined(
       pprintOptions,
-      'Expected there to be pretty printing options configured'
+      'Expected there to be pretty printing options configured!'
     );
     await eval.loadFile({}, pprintOptions);
     outputWindow.appendPrompt();

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -249,7 +249,7 @@ export function startOrConnectRepl() {
     commands[START_HELLO_CLJS_NODE_OPTION] = START_HELLO_CLJS_NODE_COMMAND;
   } else {
     commands[DISCONNECT_OPTION] = DISCONNECT_COMMAND;
-    if (replSession.getSession('clj')) {
+    if (replSession.tryToGetSession('clj')) {
       commands[OPEN_WINDOW_OPTION] = OPEN_WINDOW_COMMAND;
     }
   }

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -61,7 +61,7 @@ async function fetchConfig(configName: string): Promise<DramConfig> {
 
 async function downloadDram(storageUri: vscode.Uri, configPath: string, filePath: string) {
   const calva = vscode.extensions.getExtension('betterthantomorrow.calva');
-  const calvaVersion = calva.packageJSON.version;
+  const calvaVersion = calva?.packageJSON.version;
   const isDebug = process.env['IS_DEBUG'] === 'true';
   const branch = isDebug || calvaVersion.match(/-.+$/) ? 'dev' : 'published';
   const dramBaseUrl = `${DRAM_BASE_URL}/${branch}/drams`;
@@ -167,7 +167,9 @@ export async function startStandaloneRepl(
     void clojureLsp.startClientCommand();
   }
 
-  const [mainDoc, mainEditor] = await openStoredDoc(storageUri, tempDirUri, config.files[0]);
+  const main = await openStoredDoc(storageUri, tempDirUri, config.files[0]);
+  utilities.assertIsDefined(main, 'Expected to be able to open the stored doc!');
+  const [mainDoc, mainEditor] = main;
   for (const file of config.files.slice(1)) {
     await openStoredDoc(storageUri, tempDirUri, file);
   }
@@ -186,7 +188,12 @@ export async function startStandaloneRepl(
       viewColumn: vscode.ViewColumn.One,
       preserveFocus: false,
     });
-    await eval.loadFile({}, getConfig().prettyPrintingOptions);
+    const pprintOptions = getConfig().prettyPrintingOptions;
+    utilities.assertIsDefined(
+      pprintOptions,
+      'Expected there to be pretty printing options configured'
+    );
+    await eval.loadFile({}, pprintOptions);
     outputWindow.appendPrompt();
   });
 }

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -109,7 +109,9 @@ const pareditCommands: PareditCommand[] = [
   {
     command: 'paredit.rangeForDefun',
     handler: (doc: EditableDocument) => {
-      paredit.selectRange(doc, paredit.rangeForDefun(doc));
+      const range = paredit.rangeForDefun(doc);
+      assertIsDefined(range, 'Expected to find a range for the current defun!');
+      paredit.selectRange(doc, range);
     },
   },
   {

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -13,7 +13,7 @@ import {
 import * as paredit from '../cursor-doc/paredit';
 import * as docMirror from '../doc-mirror/index';
 import { EditableDocument } from '../cursor-doc/model';
-import { assertIsDefined } from '../utilities';
+import { assertIsDefined } from '../type-checks';
 
 const onPareditKeyMapChangedEmitter = new EventEmitter<string>();
 

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1,5 +1,5 @@
 import { getConfig } from './config';
-import { assertIsDefined } from './utilities';
+import { assertIsDefined } from './type-checks';
 
 export type PrintFnOptions = {
   name: string;

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -15,8 +15,9 @@ export async function findProjectRootPaths() {
   const excludeDirsGlob = excludePattern();
   const t0 = new Date().getTime();
   const rootPaths: string[] = [];
-  if (vscode.workspace.workspaceFolders?.length > 0) {
-    const wsRootPaths = vscode.workspace.workspaceFolders.map((f) => f.uri.fsPath);
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (workspaceFolders && workspaceFolders.length > 0) {
+    const wsRootPaths = workspaceFolders.map((f) => f.uri.fsPath);
     rootPaths.push(...wsRootPaths);
   }
   const candidateUris = await vscode.workspace.findFiles(projectFilesGlob, excludeDirsGlob, 10000);

--- a/src/providers/annotations.ts
+++ b/src/providers/annotations.ts
@@ -27,7 +27,7 @@ const evalResultsDecorationType = vscode.window.createTextEditorDecorationType({
   rangeBehavior: vscode.DecorationRangeBehavior.ClosedOpen,
 });
 
-let resultsLocations: [vscode.Range, vscode.Position, vscode.Location][] = [];
+let resultsLocations: [vscode.Range, vscode.Position | undefined, vscode.Location][] = [];
 
 function getResultsLocation(pos: vscode.Position): vscode.Location | undefined {
   for (const [range, _evaluatePosition, location] of resultsLocations) {
@@ -141,7 +141,7 @@ function decorateSelection(
   resultString: string,
   codeSelection: vscode.Selection,
   editor: vscode.TextEditor,
-  evaluatePosition: vscode.Position,
+  evaluatePosition: vscode.Position | undefined,
   resultsLocation,
   status: AnnotationStatus
 ) {

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -102,7 +102,7 @@ export default class CalvaCompletionItemProvider implements CompletionItemProvid
 
       util.assertIsDefined(activeTextEditor, 'Expected window to have activeTextEditor defined!');
 
-      const client = replSession.getSession(util.getFileType(activeTextEditor.document));
+      const client = replSession.tryToGetSession(util.getFileType(activeTextEditor.document));
       if (client) {
         await namespace.createNamespaceFromDocumentIfNotExists(activeTextEditor.document);
         const ns = namespace.getDocumentNamespace();
@@ -176,7 +176,7 @@ async function replCompletions(
     replContext = `${contextStart}__prefix__${contextEnd}`,
     toplevelIsValidForm = toplevelStartCursor.withinValidList() && replContext != '__prefix__',
     ns = namespace.getNamespace(document),
-    client = replSession.getSession(util.getFileType(document));
+    client = replSession.tryToGetSession(util.getFileType(document));
 
   util.assertIsDefined(client, 'Expected there to be a repl client!');
 

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -176,8 +176,11 @@ async function replCompletions(
     replContext = `${contextStart}__prefix__${contextEnd}`,
     toplevelIsValidForm = toplevelStartCursor.withinValidList() && replContext != '__prefix__',
     ns = namespace.getNamespace(document),
-    client = replSession.getSession(util.getFileType(document)),
-    res = await client.complete(ns, text, toplevelIsValidForm ? replContext : undefined),
+    client = replSession.getSession(util.getFileType(document));
+
+  util.assertIsDefined(client, 'Expected there to be a repl client!');
+
+  const res = await client.complete(ns, text, toplevelIsValidForm ? replContext : undefined),
     results = res.completions || [];
 
   results.forEach((element) => {

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -20,6 +20,7 @@ import { getClient } from '../lsp/main';
 import { CompletionRequest, CompletionResolveRequest } from 'vscode-languageserver-protocol';
 import { createConverter } from 'vscode-languageclient/lib/common/protocolConverter';
 import { CompletionItem as LSPCompletionItem } from 'vscode-languageclient';
+import { assertIsDefined } from '../type-checks';
 
 const mappings = {
   nil: CompletionItemKind.Value,
@@ -100,7 +101,7 @@ export default class CalvaCompletionItemProvider implements CompletionItemProvid
     if (util.getConnectedState() && item['data']?.provider === 'repl') {
       const activeTextEditor = window.activeTextEditor;
 
-      util.assertIsDefined(activeTextEditor, 'Expected window to have activeTextEditor defined!');
+      assertIsDefined(activeTextEditor, 'Expected window to have activeTextEditor defined!');
 
       const client = replSession.tryToGetSession(util.getFileType(activeTextEditor.document));
       if (client) {
@@ -160,14 +161,14 @@ async function replCompletions(
 
   const toplevelSelection = select.getFormSelection(document, position, true);
 
-  util.assertIsDefined(toplevelSelection, 'Expected a topLevelSelection!');
+  assertIsDefined(toplevelSelection, 'Expected a topLevelSelection!');
 
   const toplevel = document.getText(toplevelSelection),
     toplevelStartOffset = document.offsetAt(toplevelSelection.start),
     toplevelStartCursor = docMirror.getDocument(document).getTokenCursor(toplevelStartOffset + 1),
     wordRange = document.getWordRangeAtPosition(position);
 
-  util.assertIsDefined(wordRange, 'Expected a wordRange!');
+  assertIsDefined(wordRange, 'Expected a wordRange!');
 
   const wordStartLocalOffset = document.offsetAt(wordRange.start) - toplevelStartOffset,
     wordEndLocalOffset = document.offsetAt(wordRange.end) - toplevelStartOffset,
@@ -178,7 +179,7 @@ async function replCompletions(
     ns = namespace.getNamespace(document),
     client = replSession.tryToGetSession(util.getFileType(document));
 
-  util.assertIsDefined(client, 'Expected there to be a repl client!');
+  assertIsDefined(client, 'Expected there to be a repl client!');
 
   const res = await client.complete(ns, text, toplevelIsValidForm ? replContext : undefined),
     results = res.completions || [];

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -21,6 +21,7 @@ async function provideClojureDefinition(document, position: vscode.Position, _to
   if (util.getConnectedState() && !posIsEvalPos) {
     const text = util.getWordAtPosition(document, position);
     const client = replSession.getSession(util.getFileType(document));
+    util.assertIsDefined(client, 'Expected there to be a repl client!');
     const info = await client.info(namespace.getNamespace(document), text);
     if (info.file && info.file.length > 0) {
       const pos = new vscode.Position(info.line - 1, info.column || 0);

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -20,8 +20,7 @@ async function provideClojureDefinition(document, position: vscode.Position, _to
   const posIsEvalPos = evalPos && position.isEqual(evalPos);
   if (util.getConnectedState() && !posIsEvalPos) {
     const text = util.getWordAtPosition(document, position);
-    const client = replSession.tryToGetSession(util.getFileType(document));
-    util.assertIsDefined(client, 'Expected there to be a repl client!');
+    const client = replSession.getSession(util.getFileType(document));
     const info = await client.info(namespace.getNamespace(document), text);
     if (info.file && info.file.length > 0) {
       const pos = new vscode.Position(info.line - 1, info.column || 0);

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -20,7 +20,7 @@ async function provideClojureDefinition(document, position: vscode.Position, _to
   const posIsEvalPos = evalPos && position.isEqual(evalPos);
   if (util.getConnectedState() && !posIsEvalPos) {
     const text = util.getWordAtPosition(document, position);
-    const client = replSession.getSession(util.getFileType(document));
+    const client = replSession.tryToGetSession(util.getFileType(document));
     util.assertIsDefined(client, 'Expected there to be a repl client!');
     const info = await client.info(namespace.getNamespace(document), text);
     if (info.file && info.file.length > 0) {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -13,7 +13,7 @@ export async function provideHover(document: vscode.TextDocument, position: vsco
   if (util.getConnectedState()) {
     const text = util.getWordAtPosition(document, position);
     const ns = namespace.getNamespace(document);
-    const client = replSession.getSession(util.getFileType(document));
+    const client = replSession.tryToGetSession(util.getFileType(document));
     if (client) {
       await namespace.createNamespaceFromDocumentIfNotExists(document);
       const res = await client.info(ns, text);

--- a/src/providers/infoparser.ts
+++ b/src/providers/infoparser.ts
@@ -170,7 +170,7 @@ export class REPLInfoParser {
         const signatures = argListStrings.map((argList) => {
           const signature = new SignatureInformation(`(${symbol} ${argList})`);
           // Skip parameter help on special forms and forms with optional arguments, for now
-          if (this._arglist && !argList.match(/\?/)) {
+          if (this._arglist && !argList.includes('?')) {
             const parameters = this.getParameters(symbol, argList);
 
             if (parameters) {

--- a/src/providers/infoparser.ts
+++ b/src/providers/infoparser.ts
@@ -1,6 +1,7 @@
 import { SignatureInformation, ParameterInformation, MarkdownString } from 'vscode';
 import * as tokenCursor from '../cursor-doc/token-cursor';
 import { getConfig } from '../config';
+import { isString } from 'lodash';
 
 export type Completion =
   | [string, string]
@@ -10,8 +11,16 @@ export type Completion =
 export class REPLInfoParser {
   private _name: string | undefined = undefined;
 
+  /*
+   * Different arities of arglists for a symbol.
+   * e.g. "[]" or "[xs]" or "[s re]\n[s re limit]"
+   */
   private _arglist: string | undefined = undefined;
 
+  /*
+   * Different forms a special form can take.
+   * e.g. "(do exprs*)" or "(Classname. args*)\n(new Classname args*)"
+   */
   private _formsString: string | undefined = undefined;
 
   private _docString: string | undefined = undefined;
@@ -99,7 +108,7 @@ export class REPLInfoParser {
 
   getHover(): MarkdownString {
     const hover = new MarkdownString();
-    if (this._name !== '') {
+    if (isString(this._name) && this._name !== '') {
       if (!this._specialForm || this._isMacro) {
         hover.appendCodeblock(this._name, 'clojure');
         if (this._arglist) {
@@ -117,7 +126,10 @@ export class REPLInfoParser {
       } else {
         hover.appendText('\n');
       }
-      hover.appendMarkdown(this._docString);
+
+      if (isString(this._docString)) {
+        hover.appendMarkdown(this._docString);
+      }
     }
     return hover;
   }
@@ -145,27 +157,33 @@ export class REPLInfoParser {
   }
 
   getSignatures(symbol: string): SignatureInformation[] | undefined {
-    if (this._name !== '') {
+    if (isString(this._name) && this._name !== '') {
       const argLists = this._arglist ? this._arglist : this._formsString;
-      if (argLists) {
-        return argLists
+      if (isString(argLists) && argLists !== '') {
+        // Break down arglist or formsString into the different arglists/arities,
+        // removing empty strings since those make no sense as arglists.
+        const argListStrings = argLists
           .split('\n')
-          .map((argList) => argList.trim())
-          .map((argList) => {
-            if (argList !== '') {
-              const signature = new SignatureInformation(`(${symbol} ${argList})`);
-              // Skip parameter help on special forms and forms with optional arguments, for now
-              if (this._arglist && !argList.match(/\?/)) {
-                signature.parameters = this.getParameters(symbol, argList);
-              }
-              if (this._docString && getConfig().showDocstringInParameterHelp) {
-                signature.documentation = new MarkdownString(this._docString);
-              }
-              return signature;
-            } else {
-              return undefined;
+          .map((a) => a.trim())
+          .filter((a) => a !== '');
+
+        const signatures = argListStrings.map((argList) => {
+          const signature = new SignatureInformation(`(${symbol} ${argList})`);
+          // Skip parameter help on special forms and forms with optional arguments, for now
+          if (this._arglist && !argList.match(/\?/)) {
+            const parameters = this.getParameters(symbol, argList);
+
+            if (parameters) {
+              signature.parameters = parameters;
             }
-          });
+          }
+          if (this._docString && getConfig().showDocstringInParameterHelp) {
+            signature.documentation = new MarkdownString(this._docString);
+          }
+          return signature;
+        });
+
+        return signatures;
       }
     }
     return undefined;

--- a/src/providers/signature.ts
+++ b/src/providers/signature.ts
@@ -13,6 +13,7 @@ import { LispTokenCursor } from '../cursor-doc/token-cursor';
 import * as docMirror from '../doc-mirror/index';
 import * as namespace from '../namespace';
 import * as replSession from '../nrepl/repl-session';
+import { assertIsDefined } from '../type-checks';
 
 export class CalvaSignatureHelpProvider implements SignatureHelpProvider {
   async provideSignatureHelp(
@@ -42,13 +43,13 @@ export async function provideSignatureHelp(
         if (signatures) {
           const help = new SignatureHelp(),
             currentArgsRanges = getCurrentArgsRanges(document, idx);
-          util.assertIsDefined(currentArgsRanges, 'Expected to find the current args ranges!');
+          assertIsDefined(currentArgsRanges, 'Expected to find the current args ranges!');
           help.signatures = signatures;
           help.activeSignature = getActiveSignatureIdx(signatures, currentArgsRanges.length);
           if (signatures[help.activeSignature].parameters !== undefined) {
             const currentArgIdx = currentArgsRanges.findIndex((range) => range.contains(position)),
               activeSignature = signatures[help.activeSignature];
-            util.assertIsDefined(activeSignature, 'Expected activeSignature to be defined!');
+            assertIsDefined(activeSignature, 'Expected activeSignature to be defined!');
             help.activeParameter =
               activeSignature.label.match(/&/) !== null
                 ? Math.min(currentArgIdx, activeSignature.parameters.length - 1)

--- a/src/providers/signature.ts
+++ b/src/providers/signature.ts
@@ -34,7 +34,7 @@ export async function provideSignatureHelp(
       idx = document.offsetAt(position),
       symbol = getSymbol(document, idx);
     if (symbol) {
-      const client = replSession.getSession(util.getFileType(document));
+      const client = replSession.tryToGetSession(util.getFileType(document));
       if (client) {
         await namespace.createNamespaceFromDocumentIfNotExists(document);
         const res = await client.info(ns, symbol),

--- a/src/providers/signature.ts
+++ b/src/providers/signature.ts
@@ -42,6 +42,7 @@ export async function provideSignatureHelp(
         if (signatures) {
           const help = new SignatureHelp(),
             currentArgsRanges = getCurrentArgsRanges(document, idx);
+          util.assertIsDefined(currentArgsRanges, 'Expected to find the current args ranges!');
           help.signatures = signatures;
           help.activeSignature = getActiveSignatureIdx(signatures, currentArgsRanges.length);
           if (signatures[help.activeSignature].parameters !== undefined) {
@@ -68,7 +69,7 @@ function getCurrentArgsRanges(document: TextDocument, idx: number): Range[] | un
   // Are we in a function that gets a threaded first parameter?
   const { previousRangeIndex, previousFunction } = getPreviousRangeIndexAndFunction(document, idx);
   const isInThreadFirst: boolean =
-    (previousRangeIndex > 1 && ['->', 'some->'].includes(previousFunction)) ||
+    (previousRangeIndex > 1 && previousFunction && ['->', 'some->'].includes(previousFunction)) ||
     (previousRangeIndex > 1 && previousRangeIndex % 2 !== 0 && previousFunction === 'cond->');
 
   if (allRanges !== undefined) {
@@ -83,7 +84,7 @@ function getActiveSignatureIdx(signatures: SignatureInformation[], currentArgsCo
   return activeSignatureIdx !== -1 ? activeSignatureIdx : signatures.length - 1;
 }
 
-function getSymbol(document: TextDocument, idx: number): string {
+function getSymbol(document: TextDocument, idx: number): string | undefined {
   const cursor: LispTokenCursor = docMirror.getDocument(document).getTokenCursor(idx);
   return cursor.getFunctionName();
 }

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -22,7 +22,7 @@ function report(res, chan: vscode.OutputChannel) {
 
 function refresh(document = {}) {
   const doc = util.tryToGetDocument(document),
-    client: NReplSession | undefined = replSession.getSession(util.getFileType(doc)),
+    client: NReplSession | undefined = replSession.tryToGetSession(util.getFileType(doc)),
     chan: vscode.OutputChannel = state.outputChannel();
 
   if (client !== undefined) {
@@ -37,7 +37,7 @@ function refresh(document = {}) {
 
 function refreshAll(document = {}) {
   const doc = util.tryToGetDocument(document),
-    client: NReplSession | undefined = replSession.getSession(util.getFileType(doc)),
+    client: NReplSession | undefined = replSession.tryToGetSession(util.getFileType(doc)),
     chan: vscode.OutputChannel = state.outputChannel();
 
   if (client !== undefined) {

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -22,10 +22,10 @@ function report(res, chan: vscode.OutputChannel) {
 
 function refresh(document = {}) {
   const doc = util.tryToGetDocument(document),
-    client: NReplSession = replSession.getSession(util.getFileType(doc)),
+    client: NReplSession | undefined = replSession.getSession(util.getFileType(doc)),
     chan: vscode.OutputChannel = state.outputChannel();
 
-  if (client != undefined) {
+  if (client !== undefined) {
     chan.appendLine('Reloading...');
     void client.refresh().then((res) => {
       report(res, chan);
@@ -37,10 +37,10 @@ function refresh(document = {}) {
 
 function refreshAll(document = {}) {
   const doc = util.tryToGetDocument(document),
-    client: NReplSession = replSession.getSession(util.getFileType(doc)),
+    client: NReplSession | undefined = replSession.getSession(util.getFileType(doc)),
     chan: vscode.OutputChannel = state.outputChannel();
 
-  if (client != undefined) {
+  if (client !== undefined) {
     chan.appendLine('Reloading all the things...');
     void client.refreshAll().then((res) => {
       report(res, chan);

--- a/src/results-output/repl-history.ts
+++ b/src/results-output/repl-history.ts
@@ -14,7 +14,7 @@ const replHistoryCommandsActiveContext = 'calva:replHistoryCommandsActive';
 let historyIndex: number | undefined = undefined;
 let lastTextAtPrompt: string | undefined = undefined;
 
-function setReplHistoryCommandsActiveContext(editor: vscode.TextEditor): void {
+function setReplHistoryCommandsActiveContext(editor: vscode.TextEditor | undefined): void {
   if (editor && util.getConnectedState() && isResultsDoc(editor.document)) {
     const document = editor.document;
     const selection = editor.selection;

--- a/src/results-output/repl-history.ts
+++ b/src/results-output/repl-history.ts
@@ -9,6 +9,7 @@ import type { ReplSessionType } from '../config';
 import { isResultsDoc, getSessionType, getPrompt, append } from './results-doc';
 import { addToHistory } from './util';
 import { isUndefined } from 'lodash';
+import { assertIsDefined } from '../type-checks';
 
 const replHistoryCommandsActiveContext = 'calva:replHistoryCommandsActive';
 let historyIndex: number | undefined = undefined;
@@ -113,7 +114,7 @@ function showPreviousReplHistoryEntry(): void {
     historyIndex = history.length;
     lastTextAtPrompt = textAtPrompt;
   } else {
-    util.assertIsDefined(textAtPrompt, 'Expected to find text at the prompt!');
+    assertIsDefined(textAtPrompt, 'Expected to find text at the prompt!');
     updateReplHistory(replSessionType, history, textAtPrompt, historyIndex);
   }
   historyIndex--;
@@ -133,8 +134,8 @@ function showNextReplHistoryEntry(): void {
     showReplHistoryEntry(lastTextAtPrompt, editor);
   } else {
     const textAtPrompt = getTextAfterLastOccurrenceOfSubstring(doc.getText(), getPrompt());
-    util.assertIsDefined(textAtPrompt, 'Expected to find text at the prompt!');
-    util.assertIsDefined(historyIndex, 'Expected a value for historyIndex!');
+    assertIsDefined(textAtPrompt, 'Expected to find text at the prompt!');
+    assertIsDefined(historyIndex, 'Expected a value for historyIndex!');
     updateReplHistory(replSessionType, history, textAtPrompt, historyIndex);
     historyIndex++;
     const nextHistoryEntry = history[historyIndex];

--- a/src/results-output/repl-history.ts
+++ b/src/results-output/repl-history.ts
@@ -126,7 +126,7 @@ function showNextReplHistoryEntry(): void {
   const doc = editor.document;
   const replSessionType = getSessionType();
   const history = getHistory(replSessionType);
-  if (!isResultsDoc(doc) || historyIndex === null) {
+  if (!isResultsDoc(doc) || historyIndex === undefined) {
     return;
   }
   if (historyIndex === history.length - 1) {

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -88,7 +88,7 @@ export function getSession(): NReplSession | undefined {
   return _sessionInfo[_sessionType].session;
 }
 
-export function setSession(session: NReplSession, newNs?: string): void {
+export function setSession(session: NReplSession | undefined, newNs?: string): void {
   if (session) {
     if (session.replType) {
       _sessionType = session.replType;

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -225,8 +225,7 @@ export async function revealDocForCurrentNS(preserveFocus: boolean = true) {
 }
 
 export async function setNamespaceFromCurrentFile() {
-  const session = replSession.tryToGetSession();
-  util.assertIsDefined(session, 'Expected there to be a session!');
+  const session = replSession.getSession();
   const ns = namespace.getNamespace(util.tryToGetDocument({}));
   if (getNs() !== ns && util.isDefined(ns)) {
     await session.switchNS(ns);
@@ -237,8 +236,7 @@ export async function setNamespaceFromCurrentFile() {
 }
 
 async function appendFormGrabbingSessionAndNS(topLevel: boolean) {
-  const session = replSession.tryToGetSession();
-  util.assertIsDefined(session, 'Expected there to be a session!');
+  const session = replSession.getSession();
   const ns = namespace.getNamespace(util.tryToGetDocument({}));
   const editor = util.getActiveTextEditor();
   const doc = editor.document;

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -14,6 +14,7 @@ import * as docMirror from '../doc-mirror/index';
 import { PrintStackTraceCodelensProvider } from '../providers/codelense';
 import * as replSession from '../nrepl/repl-session';
 import { splitEditQueueForTextBatching } from './util';
+import { assertIsDefined, isDefined } from '../type-checks';
 
 const RESULTS_DOC_NAME = `output.${config.REPL_FILE_EXT}`;
 
@@ -227,7 +228,7 @@ export async function revealDocForCurrentNS(preserveFocus: boolean = true) {
 export async function setNamespaceFromCurrentFile() {
   const session = replSession.getSession();
   const ns = namespace.getNamespace(util.tryToGetDocument({}));
-  if (getNs() !== ns && util.isDefined(ns)) {
+  if (getNs() !== ns && isDefined(ns)) {
     await session.switchNS(ns);
   }
   setSession(session, ns);
@@ -434,8 +435,8 @@ export function appendPrompt(onAppended?: OnAppendedCallback) {
 
 function getUriForCurrentNamespace(): Promise<vscode.Uri> {
   const session = getSession();
-  util.assertIsDefined(session, 'Expected there to be a current session!');
+  assertIsDefined(session, 'Expected there to be a current session!');
   const ns = getNs();
-  util.assertIsDefined(ns, 'Expected there to be a current namespace!');
+  assertIsDefined(ns, 'Expected there to be a current namespace!');
   return namespace.getUriForNamespace(session, ns);
 }

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -226,7 +226,7 @@ export async function revealDocForCurrentNS(preserveFocus: boolean = true) {
 }
 
 export async function setNamespaceFromCurrentFile() {
-  const session = replSession.getSession();
+  const session = replSession.tryToGetSession();
   util.assertIsDefined(session, 'Expected there to be a session!');
   const ns = namespace.getNamespace(util.tryToGetDocument({}));
   if (getNs() !== ns && util.isDefined(ns)) {
@@ -238,7 +238,7 @@ export async function setNamespaceFromCurrentFile() {
 }
 
 async function appendFormGrabbingSessionAndNS(topLevel: boolean) {
-  const session = replSession.getSession();
+  const session = replSession.tryToGetSession();
   util.assertIsDefined(session, 'Expected there to be a session!');
   const ns = namespace.getNamespace(util.tryToGetDocument({}));
   const editor = util.getActiveTextEditor();

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -42,7 +42,6 @@ export const CLJS_CONNECT_GREETINGS =
 
 function outputFileDir() {
   const projectRoot = state.getProjectRootUri();
-  util.assertIsDefined(projectRoot, 'Expected there to be a project root!');
   try {
     return vscode.Uri.joinPath(projectRoot, '.calva', 'output-window');
   } catch {

--- a/src/state.ts
+++ b/src/state.ts
@@ -46,11 +46,19 @@ const PROJECT_DIR_KEY = 'connect.projectDir';
 const PROJECT_DIR_URI_KEY = 'connect.projectDirNew';
 const PROJECT_CONFIG_MAP = 'config';
 
-export function getProjectRootLocal(useCache = true): string | undefined {
+export function tryToGetProjectRootLocal(useCache = true): string | undefined {
   if (useCache) {
     return getStateValue(PROJECT_DIR_KEY);
   }
 }
+
+export const getProjectRootLocal = (useCache = true): string => {
+  const projectRootLocal = tryToGetProjectRootLocal(useCache);
+
+  util.assertIsDefined(projectRootLocal, 'Expected to find a local project root!');
+
+  return projectRootLocal;
+};
 
 export function getProjectConfig(useCache = true) {
   if (useCache) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -62,10 +62,17 @@ export function setProjectConfig(config) {
   return setStateValue(PROJECT_CONFIG_MAP, config);
 }
 
-export function getProjectRootUri(useCache = true): vscode.Uri | undefined {
+export function tryToGetProjectRootUri(useCache = true): vscode.Uri | undefined {
   if (useCache) {
     return getStateValue(PROJECT_DIR_URI_KEY);
   }
+}
+export function getProjectRootUri(useCache = true): vscode.Uri {
+  const projectRootUri = tryToGetProjectRootUri(useCache);
+
+  util.assertIsDefined(projectRootUri, 'Expected to find project root URI!');
+
+  return projectRootUri;
 }
 
 const NON_PROJECT_DIR_KEY = 'calva.connect.nonProjectDir';
@@ -104,7 +111,7 @@ export async function setOrCreateNonProjectRoot(
 ): Promise<vscode.Uri> {
   let root: vscode.Uri | undefined = undefined;
   if (preferProjectDir) {
-    root = getProjectRootUri();
+    root = tryToGetProjectRootUri();
   }
   if (!root) {
     root = await getNonProjectRootDir(context);

--- a/src/state.ts
+++ b/src/state.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { getStateValue, setStateValue } from '../out/cljs-lib/cljs-lib';
 import * as projectRoot from './project-root';
+import { assertIsDefined } from './type-checks';
 
 let extensionContext: vscode.ExtensionContext;
 export function setExtensionContext(context: vscode.ExtensionContext) {
@@ -55,7 +56,7 @@ export function tryToGetProjectRootLocal(useCache = true): string | undefined {
 export const getProjectRootLocal = (useCache = true): string => {
   const projectRootLocal = tryToGetProjectRootLocal(useCache);
 
-  util.assertIsDefined(projectRootLocal, 'Expected to find a local project root!');
+  assertIsDefined(projectRootLocal, 'Expected to find a local project root!');
 
   return projectRootLocal;
 };
@@ -78,7 +79,7 @@ export function tryToGetProjectRootUri(useCache = true): vscode.Uri | undefined 
 export function getProjectRootUri(useCache = true): vscode.Uri {
   const projectRootUri = tryToGetProjectRootUri(useCache);
 
-  util.assertIsDefined(projectRootUri, 'Expected to find project root URI!');
+  assertIsDefined(projectRootUri, 'Expected to find project root URI!');
 
   return projectRootUri;
 }

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -83,7 +83,7 @@ function update(context = state.extensionContext) {
     connectionStatus.command = 'calva.startOrConnectRepl';
     typeStatus.color = colorValue('typeStatusColor', currentConf);
     const replType = getReplSessionTypeFromState();
-    if (replType !== null) {
+    if (replType !== undefined) {
       typeStatus.text = ['cljc', config.REPL_FILE_EXT].includes(fileType)
         ? `cljc/${replType}`
         : replType;

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -4,7 +4,7 @@ import * as util from './utilities';
 import * as config from './config';
 import status from './status';
 import { getStateValue } from '../out/cljs-lib/cljs-lib';
-import { getSession, getReplSessionTypeFromState } from './nrepl/repl-session';
+import { tryToGetSession, getReplSessionTypeFromState } from './nrepl/repl-session';
 
 const connectionStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1);
 const typeStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1);
@@ -87,7 +87,7 @@ function update(context = state.extensionContext) {
       typeStatus.text = ['cljc', config.REPL_FILE_EXT].includes(fileType)
         ? `cljc/${replType}`
         : replType;
-      if (getSession('clj') !== null && getSession('cljs') !== null) {
+      if (tryToGetSession('clj') !== null && tryToGetSession('cljs') !== null) {
         typeStatus.command = 'calva.toggleCLJCSession';
         typeStatus.tooltip = `Click to use ${replType === 'clj' ? 'cljs' : 'clj'} REPL for cljc`;
       } else {

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -87,7 +87,7 @@ function update(context = state.extensionContext) {
       typeStatus.text = ['cljc', config.REPL_FILE_EXT].includes(fileType)
         ? `cljc/${replType}`
         : replType;
-      if (tryToGetSession('clj') !== null && tryToGetSession('cljs') !== null) {
+      if (tryToGetSession('clj') !== undefined && tryToGetSession('cljs') !== undefined) {
         typeStatus.command = 'calva.toggleCLJCSession';
         typeStatus.tooltip = `Click to use ${replType === 'clj' ? 'cljs' : 'clj'} REPL for cljc`;
       } else {

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -5,6 +5,7 @@ import * as config from './config';
 import status from './status';
 import { getStateValue } from '../out/cljs-lib/cljs-lib';
 import { tryToGetSession, getReplSessionTypeFromState } from './nrepl/repl-session';
+import { assertIsDefined } from './type-checks';
 
 const connectionStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1);
 const typeStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1);
@@ -24,7 +25,7 @@ const color = {
 function colorValue(section: string, currentConf: vscode.WorkspaceConfiguration): string {
   const configSection = currentConf.inspect<string>(section);
 
-  util.assertIsDefined(configSection, () => `Expected config section "${section}" to be defined!`);
+  assertIsDefined(configSection, () => `Expected config section "${section}" to be defined!`);
 
   const { defaultValue, globalValue, workspaceFolderValue, workspaceValue } = configSection;
 

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -7,7 +7,7 @@ import { NReplSession } from './nrepl';
 import * as cider from './nrepl/cider';
 import * as lsp from './lsp/types';
 import * as namespace from './namespace';
-import { getSession, tryToGetSession, updateReplSessionType } from './nrepl/repl-session';
+import { getSession, updateReplSessionType } from './nrepl/repl-session';
 import * as getText from './util/get-text';
 
 const diagnosticCollection = vscode.languages.createDiagnosticCollection('calva');

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -7,7 +7,7 @@ import { NReplSession } from './nrepl';
 import * as cider from './nrepl/cider';
 import * as lsp from './lsp/types';
 import * as namespace from './namespace';
-import { getSession, updateReplSessionType } from './nrepl/repl-session';
+import { tryToGetSession, updateReplSessionType } from './nrepl/repl-session';
 import * as getText from './util/get-text';
 
 const diagnosticCollection = vscode.languages.createDiagnosticCollection('calva');
@@ -236,7 +236,7 @@ function reportTests(
 
 // FIXME: use cljs session where necessary
 async function runAllTests(controller: vscode.TestController, document = {}) {
-  const session = getSession(util.getFileType(document));
+  const session = tryToGetSession(util.getFileType(document));
   util.assertIsDefined(session, 'Expected there to be a current session!');
   outputWindow.append('; Running all project tests…');
   try {
@@ -293,7 +293,7 @@ async function runNamespaceTestsImpl(
     return;
   }
 
-  const session = getSession(util.getFileType(document));
+  const session = tryToGetSession(util.getFileType(document));
   util.assertIsDefined(session, 'Expected there to be a current session!');
 
   // TODO.marc: Should we be passing the `document` argument to `loadFile`?
@@ -319,7 +319,7 @@ async function runNamespaceTests(controller: vscode.TestController, document: vs
   if (outputWindow.isResultsDoc(doc)) {
     return;
   }
-  const session = getSession(util.getFileType(document));
+  const session = tryToGetSession(util.getFileType(document));
   util.assertIsDefined(session, 'Expected there to be a current session!');
   const ns = namespace.getNamespace(doc);
   const nss = await considerTestNS(ns, session);
@@ -335,7 +335,7 @@ function getTestUnderCursor() {
 
 async function runTestUnderCursor(controller: vscode.TestController) {
   const doc = util.tryToGetDocument({});
-  const session = getSession(util.getFileType(doc));
+  const session = tryToGetSession(util.getFileType(doc));
   util.assertIsDefined(session, 'Expected there to be a current session!');
   const ns = namespace.getNamespace(doc);
   const test = getTestUnderCursor();
@@ -379,7 +379,7 @@ function runNamespaceTestsCommand(controller: vscode.TestController) {
 }
 
 async function rerunTests(controller: vscode.TestController, document = {}) {
-  const session = getSession(util.getFileType(document));
+  const session = tryToGetSession(util.getFileType(document));
   util.assertIsDefined(session, 'Expected there to be a current session!');
   await evaluate.loadFile({}, disabledPrettyPrinter);
   outputWindow.append('; Running previously failed tests…');

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -9,6 +9,7 @@ import * as lsp from './lsp/types';
 import * as namespace from './namespace';
 import { getSession, updateReplSessionType } from './nrepl/repl-session';
 import * as getText from './util/get-text';
+import { assertIsDefined, isNonEmptyString } from './type-checks';
 
 const diagnosticCollection = vscode.languages.createDiagnosticCollection('calva');
 
@@ -68,7 +69,7 @@ function upsertTest(
 // Cider 0.26 and 0.27 have an issue where context can be an empty array.
 // https://github.com/clojure-emacs/cider-nrepl/issues/728#issuecomment-996002988
 export function assertionName(result: cider.TestResult): string {
-  if (util.isNonEmptyString(result.context)) {
+  if (isNonEmptyString(result.context)) {
     return result.context;
   }
   return 'assertion';
@@ -181,9 +182,9 @@ function reportTests(
   diagnosticCollection.clear();
 
   const recordDiagnostic = (result: cider.TestResult) => {
-    util.assertIsDefined(result.line, 'Expected cider test result to have a line!');
+    assertIsDefined(result.line, 'Expected cider test result to have a line!');
 
-    util.assertIsDefined(result.file, 'Expected cider test result to have a file!');
+    assertIsDefined(result.file, 'Expected cider test result to have a file!');
 
     const msg = cider.diagnosticMessage(result);
 

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -237,6 +237,7 @@ function reportTests(
 // FIXME: use cljs session where necessary
 async function runAllTests(controller: vscode.TestController, document = {}) {
   const session = getSession(util.getFileType(document));
+  util.assertIsDefined(session, 'Expected there to be a current session!');
   outputWindow.append('; Running all project tests…');
   try {
     reportTests(controller, session, [await session.testAll()]);
@@ -293,6 +294,7 @@ async function runNamespaceTestsImpl(
   }
 
   const session = getSession(util.getFileType(document));
+  util.assertIsDefined(session, 'Expected there to be a current session!');
 
   // TODO.marc: Should we be passing the `document` argument to `loadFile`?
   await evaluate.loadFile({}, disabledPrettyPrinter);
@@ -318,6 +320,7 @@ async function runNamespaceTests(controller: vscode.TestController, document: vs
     return;
   }
   const session = getSession(util.getFileType(document));
+  util.assertIsDefined(session, 'Expected there to be a current session!');
   const ns = namespace.getNamespace(doc);
   const nss = await considerTestNS(ns, session);
   void runNamespaceTestsImpl(controller, document, nss);
@@ -333,6 +336,7 @@ function getTestUnderCursor() {
 async function runTestUnderCursor(controller: vscode.TestController) {
   const doc = util.tryToGetDocument({});
   const session = getSession(util.getFileType(doc));
+  util.assertIsDefined(session, 'Expected there to be a current session!');
   const ns = namespace.getNamespace(doc);
   const test = getTestUnderCursor();
 
@@ -376,6 +380,7 @@ function runNamespaceTestsCommand(controller: vscode.TestController) {
 
 async function rerunTests(controller: vscode.TestController, document = {}) {
   const session = getSession(util.getFileType(document));
+  util.assertIsDefined(session, 'Expected there to be a current session!');
   await evaluate.loadFile({}, disabledPrettyPrinter);
   outputWindow.append('; Running previously failed tests…');
 

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -7,7 +7,7 @@ import { NReplSession } from './nrepl';
 import * as cider from './nrepl/cider';
 import * as lsp from './lsp/types';
 import * as namespace from './namespace';
-import { tryToGetSession, updateReplSessionType } from './nrepl/repl-session';
+import { getSession, tryToGetSession, updateReplSessionType } from './nrepl/repl-session';
 import * as getText from './util/get-text';
 
 const diagnosticCollection = vscode.languages.createDiagnosticCollection('calva');
@@ -236,8 +236,7 @@ function reportTests(
 
 // FIXME: use cljs session where necessary
 async function runAllTests(controller: vscode.TestController, document = {}) {
-  const session = tryToGetSession(util.getFileType(document));
-  util.assertIsDefined(session, 'Expected there to be a current session!');
+  const session = getSession(util.getFileType(document));
   outputWindow.append('; Running all project tests…');
   try {
     reportTests(controller, session, [await session.testAll()]);
@@ -293,8 +292,7 @@ async function runNamespaceTestsImpl(
     return;
   }
 
-  const session = tryToGetSession(util.getFileType(document));
-  util.assertIsDefined(session, 'Expected there to be a current session!');
+  const session = getSession(util.getFileType(document));
 
   // TODO.marc: Should we be passing the `document` argument to `loadFile`?
   await evaluate.loadFile({}, disabledPrettyPrinter);
@@ -319,8 +317,7 @@ async function runNamespaceTests(controller: vscode.TestController, document: vs
   if (outputWindow.isResultsDoc(doc)) {
     return;
   }
-  const session = tryToGetSession(util.getFileType(document));
-  util.assertIsDefined(session, 'Expected there to be a current session!');
+  const session = getSession(util.getFileType(document));
   const ns = namespace.getNamespace(doc);
   const nss = await considerTestNS(ns, session);
   void runNamespaceTestsImpl(controller, document, nss);
@@ -335,8 +332,7 @@ function getTestUnderCursor() {
 
 async function runTestUnderCursor(controller: vscode.TestController) {
   const doc = util.tryToGetDocument({});
-  const session = tryToGetSession(util.getFileType(doc));
-  util.assertIsDefined(session, 'Expected there to be a current session!');
+  const session = getSession(util.getFileType(doc));
   const ns = namespace.getNamespace(doc);
   const test = getTestUnderCursor();
 
@@ -379,8 +375,7 @@ function runNamespaceTestsCommand(controller: vscode.TestController) {
 }
 
 async function rerunTests(controller: vscode.TestController, document = {}) {
-  const session = tryToGetSession(util.getFileType(document));
-  util.assertIsDefined(session, 'Expected there to be a current session!');
+  const session = getSession(util.getFileType(document));
   await evaluate.loadFile({}, disabledPrettyPrinter);
   outputWindow.append('; Running previously failed tests…');
 

--- a/src/type-checks.ts
+++ b/src/type-checks.ts
@@ -1,0 +1,21 @@
+const isNonEmptyString = (value: any): boolean => typeof value == 'string' && value.length > 0;
+
+const isNullOrUndefined = (object: unknown): object is null | undefined =>
+  object === null || object === undefined;
+
+const isDefined = <T>(value: T | undefined | null): value is T => {
+  return !isNullOrUndefined(value);
+};
+
+// This needs to be a function and not an arrow function
+// because assertion types are special.
+function assertIsDefined<T>(
+  value: T | undefined | null,
+  message: string | (() => string)
+): asserts value is T {
+  if (isNullOrUndefined(value)) {
+    throw new Error(typeof message === 'string' ? message : message());
+  }
+}
+
+export { isNonEmptyString, isNullOrUndefined, isDefined, assertIsDefined };

--- a/src/type-checks.ts
+++ b/src/type-checks.ts
@@ -14,6 +14,7 @@ function assertIsDefined<T>(
   message: string | (() => string)
 ): asserts value is T {
   if (isNullOrUndefined(value)) {
+    console.trace({ value, message });
     throw new Error(typeof message === 'string' ? message : message());
   }
 }

--- a/src/util/cursor-get-text.ts
+++ b/src/util/cursor-get-text.ts
@@ -3,7 +3,7 @@
  */
 
 import { EditableDocument } from '../cursor-doc/model';
-import { assertIsDefined } from '../utilities';
+import { assertIsDefined } from '../type-checks';
 
 export type RangeAndText = [[number, number], string] | [undefined, ''];
 

--- a/src/util/cursor-get-text.ts
+++ b/src/util/cursor-get-text.ts
@@ -3,6 +3,7 @@
  */
 
 import { EditableDocument } from '../cursor-doc/model';
+import { assertIsDefined } from '../utilities';
 
 export type RangeAndText = [[number, number], string] | [undefined, ''];
 
@@ -11,7 +12,10 @@ export function currentTopLevelFunction(
   active: number = doc.selection.active
 ): RangeAndText {
   const defunCursor = doc.getTokenCursor(active);
-  const defunStart = defunCursor.rangeForDefun(active)[0];
+  assertIsDefined(defunCursor, 'Expected a token cursor!');
+  const defunRange = defunCursor.rangeForDefun(active);
+  assertIsDefined(defunRange, 'Expected a range representing the current defun!');
+  const defunStart = defunRange[0];
   const cursor = doc.getTokenCursor(defunStart);
   while (cursor.downList()) {
     cursor.forwardWhitespace();
@@ -41,7 +45,7 @@ export function currentTopLevelForm(doc: EditableDocument): RangeAndText {
 
 function rangeOrStartOfFileToCursor(
   doc: EditableDocument,
-  foldRange: [number, number],
+  foldRange: [number, number] | undefined,
   startFrom: number
 ): RangeAndText {
   if (foldRange) {
@@ -65,12 +69,17 @@ function rangeOrStartOfFileToCursor(
 export function currentEnclosingFormToCursor(doc: EditableDocument): RangeAndText {
   const cursor = doc.getTokenCursor(doc.selection.active);
   const enclosingRange = cursor.rangeForList(1);
+  assertIsDefined(enclosingRange, 'Expected to get the range that encloses the current form!');
   return rangeOrStartOfFileToCursor(doc, enclosingRange, enclosingRange[0]);
 }
 
 export function currentTopLevelFormToCursor(doc: EditableDocument): RangeAndText {
   const cursor = doc.getTokenCursor(doc.selection.active);
   const defunRange = cursor.rangeForDefun(doc.selection.active);
+  assertIsDefined(
+    defunRange,
+    'Expected to get the range that encloses the current top-level form!'
+  );
   return rangeOrStartOfFileToCursor(doc, defunRange, defunRange[0]);
 }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -10,7 +10,6 @@ import * as outputWindow from './results-output/results-doc';
 import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as url from 'url';
 import { isUndefined } from 'lodash';
-import { isNullOrUndefined } from 'util';
 
 const specialWords = ['-', '+', '/', '*']; //TODO: Add more here
 const syntaxQuoteSymbol = '`';
@@ -22,6 +21,9 @@ export function stripAnsi(str: string) {
     ''
   );
 }
+
+export const isNullOrUndefined = (object: unknown): object is null | undefined =>
+  object === null || object === undefined;
 
 export const isDefined = <T>(value: T | undefined | null): value is T => {
   return !isNullOrUndefined(value);

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -90,7 +90,7 @@ async function quickPickMulti(opts: { values: string[]; saveAs: string; placeHol
 
 // Testing facility.
 // Recreated every time we create a new quickPick
-let quickPickActive: Promise<void>;
+let quickPickActive: Promise<void> | undefined;
 
 function quickPick(
   itemsToPick: string[],

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -9,7 +9,6 @@ import * as JSZip from 'jszip';
 import * as outputWindow from './results-output/results-doc';
 import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as url from 'url';
-import { isUndefined } from 'lodash';
 
 const specialWords = ['-', '+', '/', '*']; //TODO: Add more here
 const syntaxQuoteSymbol = '`';
@@ -22,30 +21,8 @@ export function stripAnsi(str: string) {
   );
 }
 
-export const isNullOrUndefined = (object: unknown): object is null | undefined =>
-  object === null || object === undefined;
-
-export const isDefined = <T>(value: T | undefined | null): value is T => {
-  return !isNullOrUndefined(value);
-};
-
-// This needs to be a function and not an arrow function
-// because assertion types are special.
-export function assertIsDefined<T>(
-  value: T | undefined | null,
-  message: string | (() => string)
-): asserts value is T {
-  if (isNullOrUndefined(value)) {
-    throw new Error(typeof message === 'string' ? message : message());
-  }
-}
-
 export function escapeStringRegexp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-export function isNonEmptyString(value: any): boolean {
-  return typeof value == 'string' && value.length > 0;
 }
 
 async function quickPickSingle(opts: {
@@ -200,7 +177,7 @@ function tryToGetDocument(
 function getDocument(document: vscode.TextDocument | Record<string, never>): vscode.TextDocument {
   const doc = tryToGetDocument(document);
 
-  if (isUndefined(doc)) {
+  if (doc === undefined) {
     throw new Error('Expected an activeTextEditor with a document!');
   }
 
@@ -532,7 +509,7 @@ function tryToGetActiveTextEditor(): vscode.TextEditor | undefined {
 function getActiveTextEditor(): vscode.TextEditor {
   const editor = tryToGetActiveTextEditor();
 
-  if (isUndefined(editor)) {
+  if (editor === undefined) {
     throw new Error('Expected active text editor!');
   }
 

--- a/src/when-contexts.ts
+++ b/src/when-contexts.ts
@@ -6,7 +6,7 @@ import * as util from './utilities';
 
 let lastContexts: context.CursorContext[] = [];
 
-export function setCursorContextIfChanged(editor: vscode.TextEditor) {
+export function setCursorContextIfChanged(editor: vscode.TextEditor | undefined) {
   if (
     !editor ||
     !editor.document ||

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     "strict": false /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    "strictNullChecks": true, /* Enable strict null checks. */
+    "strictNullChecks": true /* Enable strict null checks. */,
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
@@ -18,17 +18,9 @@
     "module": "commonjs",
     "target": "es6",
     "outDir": "out",
-    "lib": [
-      "es2020",
-      "dom"
-    ],
+    "lib": ["es2020", "dom"],
     "sourceMap": true,
     "rootDir": "src"
   },
-  "exclude": [
-    "node_modules",
-    "src/webview",
-    "src/webview.ts",
-    ".vscode-test"
-  ]
+  "exclude": ["node_modules", "src/webview", "src/webview.ts", ".vscode-test"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,17 +18,9 @@
     "module": "commonjs",
     "target": "es6",
     "outDir": "out",
-    "lib": [
-      "es2020",
-      "dom"
-    ],
+    "lib": ["es2020", "dom"],
     "sourceMap": true,
     "rootDir": "src"
   },
-  "exclude": [
-    "node_modules",
-    "src/webview",
-    "src/webview.ts",
-    ".vscode-test"
-  ]
+  "exclude": ["node_modules", "src/webview", "src/webview.ts", ".vscode-test"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
     "incremental": true,
     "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     "strict": false /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     "strictNullChecks": true /* Enable strict null checks. */,
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
@@ -18,9 +18,17 @@
     "module": "commonjs",
     "target": "es6",
     "outDir": "out",
-    "lib": ["es2020", "dom"],
+    "lib": [
+      "es2020",
+      "dom"
+    ],
     "sourceMap": true,
     "rootDir": "src"
   },
-  "exclude": ["node_modules", "src/webview", "src/webview.ts", ".vscode-test"]
+  "exclude": [
+    "node_modules",
+    "src/webview",
+    "src/webview.ts",
+    ".vscode-test"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     "strict": false /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
+    "strictNullChecks": true, /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
@@ -18,9 +18,17 @@
     "module": "commonjs",
     "target": "es6",
     "outDir": "out",
-    "lib": ["es2020", "dom"],
+    "lib": [
+      "es2020",
+      "dom"
+    ],
     "sourceMap": true,
     "rootDir": "src"
   },
-  "exclude": ["node_modules", "src/webview", "src/webview.ts", ".vscode-test"]
+  "exclude": [
+    "node_modules",
+    "src/webview",
+    "src/webview.ts",
+    ".vscode-test"
+  ]
 }


### PR DESCRIPTION
## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

This turns on `strictNullChecks` in TypeScript and fixes all the remaining issues in the codebase that were preventing us from turning this setting on.

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [~] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [~] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [~] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [~] Created the issue I am fixing/addressing, if it was not present.
- [~] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [~] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik