### PR TITLE
Don't eval in output window when suggestions are active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Pressing "enter" in the REPL window while editor suggestions are active evaluates whatever's typed without applying the suggestion](https://github.com/BetterThanTomorrow/calva/issues/1696#issuecomment-1121829584)
 
 ## [2.0.272] - 2022-05-07
 - [Add Joyride REPL server start and connect, a.k.a. Jack-in](https://github.com/BetterThanTomorrow/calva/issues/1714)

--- a/package.json
+++ b/package.json
@@ -1843,7 +1843,7 @@
       {
         "command": "calva.evaluateOutputWindowForm",
         "key": "enter",
-        "when": "calva:keybindingsEnabled && calva:outputWindowActive && calva:outputWindowSubmitOnEnter && editorTextFocus"
+        "when": "calva:keybindingsEnabled && calva:outputWindowActive && calva:outputWindowSubmitOnEnter && editorTextFocus && !suggestWidgetVisible"
       },
       {
         "command": "calva.evaluateSelectionReplace",


### PR DESCRIPTION
## What has Changed?
When the cursor is in the output window and outside of a form, pressing enter should evaluate the form. However when the suggestions widget is active, instead of eval'ing whatever's currently in the output window, instead the selected suggestion should be applied. Previously this was not the case.

Fixes #1696
Discussed in https://clojurians.slack.com/archives/CBE668G4R/p1651249114664639

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] ~Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- [ ] ~Added to or updated docs in this branch, if appropriate~
- [ ] ~Tests~
     - [ ] ~Tested the particular change~
     - [ ] ~Figured if the change might have some side effects and tested those as well.~
     - [ ] ~Smoke tested the extension as such.~
     - [ ] ~Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.~
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [ ] ~If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [x] Created the issue I am fixing/addressing, if it was not present.
- [ ] ~Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)~
- [ ] ~Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).~