### PR TITLE
Prioritize prject root if there is a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 Changes to Calva.
 
 ## [Unreleased]
-- Fix: [Pressing "enter" in the REPL window while editor suggestions are active evaluates whatever's typed without applying the suggestion](https://github.com/BetterThanTomorrow/calva/issues/1696#issuecomment-1121829584)
+- Fix: [Pressing "enter" in the REPL window while editor suggestions are active evaluates whatever's typed without applying the suggestion](https://github.com/BetterThanTomorrow/calva/issues/1696)
+- Fix: [Calva fails finding project root if a file from outside the workspace is the active editor](https://github.com/BetterThanTomorrow/calva/issues/1721)
 
 ## [2.0.272] - 2022-05-07
 - [Add Joyride REPL server start and connect, a.k.a. Jack-in](https://github.com/BetterThanTomorrow/calva/issues/1714)

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "onCommand:calva.startStandaloneHelloRepl",
     "onCommand:calva.startStandaloneCljsBrowserRepl",
     "onCommand:calva.startStandaloneCljsNodeRepl",
+    "onCommand:calva.calva.startJoyrideReplAndConnect",
     "onCommand:calva.jackIn",
     "onCommand:calva.startOrConnectRepl",
     "onCommand:calva.connect",

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -41,23 +41,27 @@ export async function findClosestProjectRootPath(candidatePaths?: string[]) {
         .sort()
         .reverse()[0]
     : candidatePaths[0];
-  return closestRootPath;
+  return closestRootPath ?? (candidatePaths && candidatePaths.length) > 0
+    ? candidatePaths[0]
+    : undefined;
 }
 
 export async function pickProjectRootPath(candidatePaths: string[], closestRootPath: string) {
-  const pickedRootPath =
-    candidatePaths.length < 2
-      ? undefined
-      : await util.quickPickSingle({
-          title: 'Project root',
-          values: candidatePaths,
-          default: closestRootPath,
-          placeHolder: 'Multiple Clojure projects found. Please pick the one you want to use.',
-          saveAs: `projectRoot`,
-          autoSelect: true,
-        });
-  const projectRootPath = candidatePaths.includes(pickedRootPath)
-    ? pickedRootPath
-    : closestRootPath;
-  return projectRootPath;
+  if (closestRootPath !== undefined) {
+    const pickedRootPath =
+      candidatePaths.length < 2
+        ? undefined
+        : await util.quickPickSingle({
+            title: 'Project root',
+            values: candidatePaths,
+            default: closestRootPath,
+            placeHolder: 'Multiple Clojure projects found. Please pick the one you want to use.',
+            saveAs: `projectRoot`,
+            autoSelect: true,
+          });
+    const projectRootPath = candidatePaths.includes(pickedRootPath)
+      ? pickedRootPath
+      : closestRootPath;
+    return projectRootPath;
+  }
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -144,8 +144,12 @@ export async function initProjectDir(uri?: vscode.Uri): Promise<void> {
     const candidatePaths = await projectRoot.findProjectRootPaths();
     const closestRootPath = await projectRoot.findClosestProjectRootPath(candidatePaths);
     const projectRootPath = await projectRoot.pickProjectRootPath(candidatePaths, closestRootPath);
-    setStateValue(PROJECT_DIR_KEY, projectRootPath);
-    setStateValue(PROJECT_DIR_URI_KEY, vscode.Uri.file(projectRootPath));
+    if (projectRootPath !== undefined) {
+      setStateValue(PROJECT_DIR_KEY, projectRootPath);
+      setStateValue(PROJECT_DIR_URI_KEY, vscode.Uri.file(projectRootPath));
+    } else {
+      await setOrCreateNonProjectRoot(extensionContext, true);
+    }
   }
 }
 


### PR DESCRIPTION
## What has Changed?

- When there is a project and a file from outside it is active, we still initialize the project root to be in the project.
- In case no project is opened, we use a temp directory as the root

It still fails if no folder and no Clojure file is open, but that's for later.

Fixes #1721

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
"fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik