### PR TITLE
Fix for toggle impl test regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [**Toggle between implementation and test** doesn't work in multi-root workspaces](https://github.com/BetterThanTomorrow/calva/issues/1725)
+
 ## [2.0.273] - 2022-05-11
-- Fix: [Pressing "enter" in the REPL window while editor suggestions are active evaluates whatever's typed without applying the suggestion](https://github.com/BetterThanTomorrow/calva/issues/1696)
 - Fix: [Calva fails finding project root if a file from outside the workspace is the active editor](https://github.com/BetterThanTomorrow/calva/issues/1721)
 
 ## [2.0.272] - 2022-05-07

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -41,9 +41,11 @@ export async function findClosestProjectRootPath(candidatePaths?: string[]) {
         .sort()
         .reverse()[0]
     : candidatePaths[0];
-  return closestRootPath ?? (candidatePaths && candidatePaths.length) > 0
-    ? candidatePaths[0]
-    : undefined;
+  if (closestRootPath) {
+    return closestRootPath;
+  } else if (candidatePaths && candidatePaths.length > 0) {
+    return candidatePaths[0];
+  }
 }
 
 export async function pickProjectRootPath(candidatePaths: string[], closestRootPath: string) {


### PR DESCRIPTION
## What has Changed?

I introduced a bug in how we find closest root path that made it so that even though the function had found the correct one, I returned the wrong one...

I had actually just placed a closing paren wrong, but I simplified/clarified the decision making in what should be returned, instead of just slurping.

Fixes #1725

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik