### PR TITLE
1733 paredit awaitable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Enable awaiting Calva Paredit commands when using `vscode.commands.executeCommand()`](https://github.com/BetterThanTomorrow/calva/issues/1733)
+
 ## [2.0.275] - 2022-05-18
 
 - Addressing: [Better REPL feedback while waiting for evaluation](https://github.com/BetterThanTomorrow/calva/issues/1543)

--- a/src/calva-fmt/src/providers/ontype_formatter.ts
+++ b/src/calva-fmt/src/providers/ontype_formatter.ts
@@ -22,8 +22,8 @@ export class FormatOnTypeEditProvider implements vscode.OnTypeFormattingEditProv
         if (tokenCursor.withinComment()) {
           return undefined;
         }
-        return paredit.backspace(mDoc).then((fulfilled) => {
-          paredit.close(mDoc, ch);
+        return paredit.backspace(mDoc).then(async (fulfilled) => {
+          await paredit.close(mDoc, ch);
           return undefined;
         });
       } else {

--- a/src/calva-fmt/src/providers/ontype_formatter.ts
+++ b/src/calva-fmt/src/providers/ontype_formatter.ts
@@ -22,6 +22,9 @@ export class FormatOnTypeEditProvider implements vscode.OnTypeFormattingEditProv
         if (tokenCursor.withinComment()) {
           return undefined;
         }
+        // TODO: We should make a function in/for the MirrorDoc that can return
+        // edits instead of performing them. It is not awesome to perform edits
+        // here, since we are expected to return them.
         await paredit.backspace(mDoc);
         await paredit.close(mDoc, ch);
       } else {

--- a/src/calva-fmt/src/providers/ontype_formatter.ts
+++ b/src/calva-fmt/src/providers/ontype_formatter.ts
@@ -22,10 +22,8 @@ export class FormatOnTypeEditProvider implements vscode.OnTypeFormattingEditProv
         if (tokenCursor.withinComment()) {
           return undefined;
         }
-        return paredit.backspace(mDoc).then((fulfilled) => {
-          paredit.close(mDoc, ch);
-          return undefined;
-        });
+        await paredit.backspace(mDoc);
+        await paredit.close(mDoc, ch);
       } else {
         return undefined;
       }

--- a/src/clojuredocs.ts
+++ b/src/clojuredocs.ts
@@ -53,18 +53,18 @@ export async function printClojureDocsToRichComment() {
   if (!docs) {
     return;
   } else {
-    printTextToRichComment(docsEntry2ClojureCode(docs));
+    await printTextToRichComment(docsEntry2ClojureCode(docs));
   }
 }
 
-export function printTextToRichCommentCommand(args: { [x: string]: string }) {
-  printTextToRichComment(args['text'], Number.parseInt(args['position']));
+export async function printTextToRichCommentCommand(args: { [x: string]: string }) {
+  await printTextToRichComment(args['text'], Number.parseInt(args['position']));
 }
 
-function printTextToRichComment(text: string, position?: number) {
+async function printTextToRichComment(text: string, position?: number) {
   const doc = util.getDocument({});
   const mirrorDoc = docMirror.getDocument(doc);
-  paredit.addRichComment(mirrorDoc, position ? position : mirrorDoc.selection.active, text);
+  await paredit.addRichComment(mirrorDoc, position ? position : mirrorDoc.selection.active, text);
 }
 
 export async function getExamplesHover(

--- a/src/clojuredocs.ts
+++ b/src/clojuredocs.ts
@@ -53,18 +53,18 @@ export async function printClojureDocsToRichComment() {
   if (!docs) {
     return;
   } else {
-    printTextToRichComment(docsEntry2ClojureCode(docs));
+    return printTextToRichComment(docsEntry2ClojureCode(docs));
   }
 }
 
 export function printTextToRichCommentCommand(args: { [x: string]: string }) {
-  printTextToRichComment(args['text'], Number.parseInt(args['position']));
+  return printTextToRichComment(args['text'], Number.parseInt(args['position']));
 }
 
 function printTextToRichComment(text: string, position?: number) {
   const doc = util.getDocument({});
   const mirrorDoc = docMirror.getDocument(doc);
-  paredit.addRichComment(mirrorDoc, position ? position : mirrorDoc.selection.active, text);
+  return paredit.addRichComment(mirrorDoc, position ? position : mirrorDoc.selection.active, text);
 }
 
 export async function getExamplesHover(

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -12,14 +12,14 @@ import { LispTokenCursor } from './token-cursor';
 //       Example: paredit.moveToRangeRight(this.readline, paredit.forwardSexpRange(this.readline))
 //                => paredit.moveForwardSexp(this.readline)
 
-export function killRange(
+export async function killRange(
   doc: EditableDocument,
   range: [number, number],
   start = doc.selection.anchor,
   end = doc.selection.active
 ) {
   const [left, right] = [Math.min(...range), Math.max(...range)];
-  void doc.model.edit([new ModelEdit('deleteRange', [left, right - left, [start, end]])], {
+  await doc.model.edit([new ModelEdit('deleteRange', [left, right - left, [start, end]])], {
     selection: new ModelEditSelection(left),
   });
 }
@@ -431,14 +431,14 @@ export function rangeToBackwardList(
   }
 }
 
-export function wrapSexpr(
+export async function wrapSexpr(
   doc: EditableDocument,
   open: string,
   close: string,
   start: number = doc.selection.anchor,
   end: number = doc.selection.active,
   options = { skipFormat: false }
-): Thenable<boolean> {
+): Promise<Thenable<boolean>> {
   const cursor = doc.getTokenCursor(end);
   if (cursor.withinString() && open == '"') {
     open = close = '\\"';
@@ -448,7 +448,7 @@ export function wrapSexpr(
     const currentFormRange = cursor.rangeForCurrentForm(start);
     if (currentFormRange) {
       const range = currentFormRange;
-      return doc.model.edit(
+      return await doc.model.edit(
         [
           new ModelEdit('insertString', [range[1], close]),
           new ModelEdit('insertString', [
@@ -467,7 +467,7 @@ export function wrapSexpr(
   } else {
     // there is a selection
     const range = [Math.min(start, end), Math.max(start, end)];
-    return doc.model.edit(
+    return await doc.model.edit(
       [
         new ModelEdit('insertString', [range[1], close]),
         new ModelEdit('insertString', [range[0], open]),
@@ -480,13 +480,13 @@ export function wrapSexpr(
   }
 }
 
-export function rewrapSexpr(
+export async function rewrapSexpr(
   doc: EditableDocument,
   open: string,
   close: string,
   start: number = doc.selection.anchor,
   end: number = doc.selection.active
-): Thenable<boolean> {
+): Promise<Thenable<boolean>> {
   const cursor = doc.getTokenCursor(end);
   if (cursor.backwardList()) {
     const openStart = cursor.offsetStart - 1,
@@ -494,7 +494,7 @@ export function rewrapSexpr(
     if (cursor.forwardList()) {
       const closeStart = cursor.offsetStart,
         closeEnd = cursor.offsetEnd;
-      return doc.model.edit(
+      return await doc.model.edit(
         [
           new ModelEdit('changeRange', [closeStart, closeEnd, close]),
           new ModelEdit('changeRange', [openStart, openEnd, open]),
@@ -505,7 +505,7 @@ export function rewrapSexpr(
   }
 }
 
-export function splitSexp(doc: EditableDocument, start: number = doc.selection.active) {
+export async function splitSexp(doc: EditableDocument, start: number = doc.selection.active) {
   const cursor = doc.getTokenCursor(start);
   if (!cursor.withinString() && !(cursor.isWhiteSpace() || cursor.previousIsWhiteSpace())) {
     cursor.forwardWhitespace();
@@ -515,9 +515,12 @@ export function splitSexp(doc: EditableDocument, start: number = doc.selection.a
     const open = cursor.getPrevToken().raw;
     if (cursor.forwardList()) {
       const close = cursor.getToken().raw;
-      void doc.model.edit([new ModelEdit('changeRange', [splitPos, splitPos, `${close}${open}`])], {
-        selection: new ModelEditSelection(splitPos + 1),
-      });
+      await doc.model.edit(
+        [new ModelEdit('changeRange', [splitPos, splitPos, `${close}${open}`])],
+        {
+          selection: new ModelEditSelection(splitPos + 1),
+        }
+      );
     }
   }
 }
@@ -527,10 +530,10 @@ export function splitSexp(doc: EditableDocument, start: number = doc.selection.a
  * @param doc
  * @param start
  */
-export function joinSexp(
+export async function joinSexp(
   doc: EditableDocument,
   start: number = doc.selection.active
-): Thenable<boolean> {
+): Promise<Thenable<boolean>> {
   const cursor = doc.getTokenCursor(start);
   cursor.backwardWhitespace();
   const prevToken = cursor.getPrevToken(),
@@ -540,7 +543,7 @@ export function joinSexp(
     const nextToken = cursor.getToken(),
       nextStart = cursor.offsetStart;
     if (validPair(nextToken.raw[0], prevToken.raw[prevToken.raw.length - 1])) {
-      return doc.model.edit(
+      return await doc.model.edit(
         [
           new ModelEdit('changeRange', [
             prevEnd - 1,
@@ -556,11 +559,11 @@ export function joinSexp(
   }
 }
 
-export function spliceSexp(
+export async function spliceSexp(
   doc: EditableDocument,
   start: number = doc.selection.active,
   undoStopBefore = true
-): Thenable<boolean> {
+): Promise<Thenable<boolean>> {
   const cursor = doc.getTokenCursor(start);
   // TODO: this should unwrap the string, not the enclosing list.
 
@@ -572,7 +575,7 @@ export function spliceSexp(
     const close = cursor.getToken();
     const end = cursor.offsetStart;
     if (close.type == 'close' && validPair(open.raw, close.raw)) {
-      return doc.model.edit(
+      return await doc.model.edit(
         [
           new ModelEdit('changeRange', [end, end + close.raw.length, '']),
           new ModelEdit('changeRange', [beginning - open.raw.length, beginning, '']),
@@ -583,11 +586,11 @@ export function spliceSexp(
   }
 }
 
-export function killBackwardList(
+export async function killBackwardList(
   doc: EditableDocument,
   [start, end]: [number, number]
-): Thenable<boolean> {
-  return doc.model.edit(
+): Promise<Thenable<boolean>> {
+  return await doc.model.edit(
     [new ModelEdit('changeRange', [start, end, '', [end, end], [start, start]])],
     {
       selection: new ModelEditSelection(start),
@@ -595,15 +598,15 @@ export function killBackwardList(
   );
 }
 
-export function killForwardList(
+export async function killForwardList(
   doc: EditableDocument,
   [start, end]: [number, number]
-): Thenable<boolean> {
+): Promise<Thenable<boolean>> {
   const cursor = doc.getTokenCursor(start);
   const inComment =
     (cursor.getToken().type == 'comment' && start > cursor.offsetStart) ||
     cursor.getPrevToken().type == 'comment';
-  return doc.model.edit(
+  return await doc.model.edit(
     [
       new ModelEdit('changeRange', [
         start,
@@ -617,7 +620,7 @@ export function killForwardList(
   );
 }
 
-export function forwardSlurpSexp(
+export async function forwardSlurpSexp(
   doc: EditableDocument,
   start: number = doc.selection.active,
   extraOpts = { formatDepth: 1 }
@@ -641,7 +644,7 @@ export function forwardSlurpSexp(
         replacedText.indexOf('\n') >= 0
           ? [currentCloseOffset, currentCloseOffset + close.length, '']
           : [wsStartOffset, wsEndOffset, ' '];
-      void doc.model.edit(
+      await doc.model.edit(
         [
           new ModelEdit('insertString', [newCloseOffset, close]),
           new ModelEdit('changeRange', changeArgs),
@@ -655,14 +658,14 @@ export function forwardSlurpSexp(
       );
     } else {
       const formatDepth = extraOpts['formatDepth'] ? extraOpts['formatDepth'] : 1;
-      forwardSlurpSexp(doc, cursor.offsetStart, {
+      await forwardSlurpSexp(doc, cursor.offsetStart, {
         formatDepth: formatDepth + 1,
       });
     }
   }
 }
 
-export function backwardSlurpSexp(
+export async function backwardSlurpSexp(
   doc: EditableDocument,
   start: number = doc.selection.active,
   extraOpts = {}
@@ -677,7 +680,7 @@ export function backwardSlurpSexp(
     cursor.backwardSexp(true, true);
     cursor.forwardWhitespace(false);
     if (offset !== cursor.offsetStart) {
-      void doc.model.edit(
+      await doc.model.edit(
         [
           new ModelEdit('deleteRange', [offset, tk.raw.length]),
           new ModelEdit('changeRange', [cursor.offsetStart, cursor.offsetStart, open]),
@@ -691,14 +694,14 @@ export function backwardSlurpSexp(
       );
     } else {
       const formatDepth = extraOpts['formatDepth'] ? extraOpts['formatDepth'] : 1;
-      backwardSlurpSexp(doc, cursor.offsetStart, {
+      await backwardSlurpSexp(doc, cursor.offsetStart, {
         formatDepth: formatDepth + 1,
       });
     }
   }
 }
 
-export function forwardBarfSexp(doc: EditableDocument, start: number = doc.selection.active) {
+export async function forwardBarfSexp(doc: EditableDocument, start: number = doc.selection.active) {
   const cursor = doc.getTokenCursor(start);
   cursor.forwardList();
   if (cursor.getToken().type == 'close') {
@@ -706,7 +709,7 @@ export function forwardBarfSexp(doc: EditableDocument, start: number = doc.selec
       close = cursor.getToken().raw;
     cursor.backwardSexp(true, true);
     cursor.backwardWhitespace();
-    void doc.model.edit(
+    await doc.model.edit(
       [
         new ModelEdit('deleteRange', [offset, close.length]),
         new ModelEdit('insertString', [cursor.offsetStart, close]),
@@ -721,7 +724,10 @@ export function forwardBarfSexp(doc: EditableDocument, start: number = doc.selec
   }
 }
 
-export function backwardBarfSexp(doc: EditableDocument, start: number = doc.selection.active) {
+export async function backwardBarfSexp(
+  doc: EditableDocument,
+  start: number = doc.selection.active
+) {
   const cursor = doc.getTokenCursor(start);
   cursor.backwardList();
   const tk = cursor.getPrevToken();
@@ -732,7 +738,7 @@ export function backwardBarfSexp(doc: EditableDocument, start: number = doc.sele
     cursor.next();
     cursor.forwardSexp(true, true);
     cursor.forwardWhitespace(false);
-    void doc.model.edit(
+    await doc.model.edit(
       [
         new ModelEdit('changeRange', [cursor.offsetStart, cursor.offsetStart, close]),
         new ModelEdit('deleteRange', [offset, tk.raw.length]),
@@ -771,7 +777,11 @@ function docIsBalanced(doc: EditableDocument, start: number = doc.selection.acti
   return cursor.atEnd();
 }
 
-export function close(doc: EditableDocument, close: string, start: number = doc.selection.active) {
+export async function close(
+  doc: EditableDocument,
+  close: string,
+  start: number = doc.selection.active
+) {
   const cursor = doc.getTokenCursor(start);
   const inString = cursor.withinString();
   cursor.forwardWhitespace(false);
@@ -781,18 +791,18 @@ export function close(doc: EditableDocument, close: string, start: number = doc.
     if (!inString && docIsBalanced(doc)) {
       // Do nothing when there is balance
     } else {
-      void doc.model.edit([new ModelEdit('insertString', [start, close])], {
+      await doc.model.edit([new ModelEdit('insertString', [start, close])], {
         selection: new ModelEditSelection(start + close.length),
       });
     }
   }
 }
 
-export function backspace(
+export async function backspace(
   doc: EditableDocument,
   start: number = doc.selection.anchor,
   end: number = doc.selection.active
-): Thenable<boolean> {
+): Promise<Thenable<boolean>> {
   if (start != end) {
     return doc.backspace();
   } else {
@@ -804,15 +814,15 @@ export function backspace(
         ? nextToken
         : cursor.getPrevToken();
     if (prevToken.type == 'prompt') {
-      return new Promise<boolean>((resolve) => resolve(true));
+      return await new Promise<boolean>((resolve) => resolve(true));
     } else if (nextToken.type == 'prompt') {
-      return new Promise<boolean>((resolve) => resolve(true));
+      return await new Promise<boolean>((resolve) => resolve(true));
     } else if (doc.model.getText(p - 2, p, true) == '\\"') {
-      return doc.model.edit([new ModelEdit('deleteRange', [p - 2, 2])], {
+      return await doc.model.edit([new ModelEdit('deleteRange', [p - 2, 2])], {
         selection: new ModelEditSelection(p - 2),
       });
     } else if (prevToken.type === 'open' && nextToken.type === 'close') {
-      return doc.model.edit(
+      return await doc.model.edit(
         [new ModelEdit('deleteRange', [p - prevToken.raw.length, prevToken.raw.length + 1])],
         {
           selection: new ModelEditSelection(p - prevToken.raw.length),
@@ -821,32 +831,32 @@ export function backspace(
     } else {
       if (['open', 'close'].includes(prevToken.type) && docIsBalanced(doc)) {
         doc.selection = new ModelEditSelection(p - prevToken.raw.length);
-        return new Promise<boolean>((resolve) => resolve(true));
+        return await new Promise<boolean>((resolve) => resolve(true));
       } else {
-        return doc.backspace();
+        return await doc.backspace();
       }
     }
   }
 }
 
-export function deleteForward(
+export async function deleteForward(
   doc: EditableDocument,
   start: number = doc.selection.anchor,
   end: number = doc.selection.active
 ) {
   if (start != end) {
-    void doc.delete();
+    await doc.delete();
   } else {
     const cursor = doc.getTokenCursor(start);
     const prevToken = cursor.getPrevToken();
     const nextToken = cursor.getToken();
     const p = start;
     if (doc.model.getText(p, p + 2, true) == '\\"') {
-      return doc.model.edit([new ModelEdit('deleteRange', [p, 2])], {
+      return await doc.model.edit([new ModelEdit('deleteRange', [p, 2])], {
         selection: new ModelEditSelection(p),
       });
     } else if (prevToken.type === 'open' && nextToken.type === 'close') {
-      void doc.model.edit(
+      await doc.model.edit(
         [new ModelEdit('deleteRange', [p - prevToken.raw.length, prevToken.raw.length + 1])],
         {
           selection: new ModelEditSelection(p - prevToken.raw.length),
@@ -857,13 +867,13 @@ export function deleteForward(
         doc.selection = new ModelEditSelection(p + 1);
         return new Promise<boolean>((resolve) => resolve(true));
       } else {
-        return doc.delete();
+        return await doc.delete();
       }
     }
   }
 }
 
-export function stringQuote(
+export async function stringQuote(
   doc: EditableDocument,
   start: number = doc.selection.anchor,
   end: number = doc.selection.active
@@ -876,25 +886,25 @@ export function stringQuote(
       // inside a string, let's be clever
       if (cursor.getToken().type == 'close') {
         if (doc.model.getText(0, start).endsWith('\\')) {
-          void doc.model.edit([new ModelEdit('changeRange', [start, start, '"'])], {
+          await doc.model.edit([new ModelEdit('changeRange', [start, start, '"'])], {
             selection: new ModelEditSelection(start + 1),
           });
         } else {
-          close(doc, '"', start);
+          await close(doc, '"', start);
         }
       } else {
         if (doc.model.getText(0, start).endsWith('\\')) {
-          void doc.model.edit([new ModelEdit('changeRange', [start, start, '"'])], {
+          await doc.model.edit([new ModelEdit('changeRange', [start, start, '"'])], {
             selection: new ModelEditSelection(start + 1),
           });
         } else {
-          void doc.model.edit([new ModelEdit('changeRange', [start, start, '\\"'])], {
+          await doc.model.edit([new ModelEdit('changeRange', [start, start, '\\"'])], {
             selection: new ModelEditSelection(start + 2),
           });
         }
       }
     } else {
-      void doc.model.edit([new ModelEdit('changeRange', [start, start, '""'])], {
+      await doc.model.edit([new ModelEdit('changeRange', [start, start, '""'])], {
         selection: new ModelEditSelection(start + 1),
       });
     }
@@ -982,7 +992,7 @@ export function setSelectionStack(doc: EditableDocument, selection = doc.selecti
   doc.selectionStack = [selection];
 }
 
-export function raiseSexp(
+export async function raiseSexp(
   doc: EditableDocument,
   start = doc.selection.anchor,
   end = doc.selection.active
@@ -999,7 +1009,7 @@ export function raiseSexp(
     if (startCursor.getPrevToken().type == 'open') {
       startCursor.previous();
       if (endCursor.getToken().type == 'close') {
-        void doc.model.edit(
+        await doc.model.edit(
           [new ModelEdit('changeRange', [startCursor.offsetStart, endCursor.offsetEnd, raised])],
           {
             selection: new ModelEditSelection(
@@ -1012,7 +1022,7 @@ export function raiseSexp(
   }
 }
 
-export function convolute(
+export async function convolute(
   doc: EditableDocument,
   start = doc.selection.anchor,
   end = doc.selection.active
@@ -1031,7 +1041,7 @@ export function convolute(
           if (headStart.backwardList() && headStart.backwardUpList()) {
             const headEnd = cursorStart.clone();
             if (headEnd.forwardList() && cursorEnd.getToken().type == 'close') {
-              void doc.model.edit(
+              await doc.model.edit(
                 [
                   new ModelEdit('changeRange', [headEnd.offsetEnd, headEnd.offsetEnd, ')']),
                   new ModelEdit('changeRange', [cursorEnd.offsetStart, cursorEnd.offsetEnd, '']),
@@ -1052,7 +1062,7 @@ export function convolute(
   }
 }
 
-export function transpose(
+export async function transpose(
   doc: EditableDocument,
   left = doc.selection.anchor,
   right = doc.selection.active,
@@ -1084,7 +1094,7 @@ export function transpose(
         } else if (newPosOffset.fromRight != undefined) {
           newCursorPos = rightEnd - newPosOffset.fromRight;
         }
-        void doc.model.edit(
+        await doc.model.edit(
           [
             new ModelEdit('changeRange', [rightStart, rightEnd, leftText]),
             new ModelEdit('changeRange', [
@@ -1162,7 +1172,7 @@ function currentSexpsRange(
   return currentSingleRange;
 }
 
-export function dragSexprBackward(
+export async function dragSexprBackward(
   doc: EditableDocument,
   pairForms = bindingForms,
   left = doc.selection.anchor,
@@ -1179,7 +1189,7 @@ export function dragSexprBackward(
     // there is a sexp to the left
     const leftText = doc.model.getText(backRange[0], backRange[1]);
     const currentText = doc.model.getText(currentRange[0], currentRange[1]);
-    void doc.model.edit(
+    await doc.model.edit(
       [
         new ModelEdit('changeRange', [currentRange[0], currentRange[1], leftText]),
         new ModelEdit('changeRange', [backRange[0], backRange[1], currentText]),
@@ -1189,7 +1199,7 @@ export function dragSexprBackward(
   }
 }
 
-export function dragSexprForward(
+export async function dragSexprForward(
   doc: EditableDocument,
   pairForms = bindingForms,
   left = doc.selection.anchor,
@@ -1206,7 +1216,7 @@ export function dragSexprForward(
     // there is a sexp to the right
     const rightText = doc.model.getText(forwardRange[0], forwardRange[1]);
     const currentText = doc.model.getText(currentRange[0], currentRange[1]);
-    void doc.model.edit(
+    await doc.model.edit(
       [
         new ModelEdit('changeRange', [forwardRange[0], forwardRange[1], currentText]),
         new ModelEdit('changeRange', [currentRange[0], currentRange[1], rightText]),
@@ -1266,7 +1276,7 @@ export function collectWhitespaceInfo(
   };
 }
 
-export function dragSexprBackwardUp(doc: EditableDocument, p = doc.selection.active) {
+export async function dragSexprBackwardUp(doc: EditableDocument, p = doc.selection.active) {
   const wsInfo = collectWhitespaceInfo(doc, p);
   const cursor = doc.getTokenCursor(p);
   const currentRange = cursor.rangeForCurrentForm(p);
@@ -1293,7 +1303,7 @@ export function dragSexprBackwardUp(doc: EditableDocument, p = doc.selection.act
         wsInfo.rightWsRange[1] - currentRange[0],
       ]);
     }
-    void doc.model.edit(
+    await doc.model.edit(
       [
         deleteEdit,
         new ModelEdit('insertString', [listStart, dragText, [p, p], [newCursorPos, newCursorPos]]),
@@ -1307,7 +1317,7 @@ export function dragSexprBackwardUp(doc: EditableDocument, p = doc.selection.act
   }
 }
 
-export function dragSexprForwardDown(doc: EditableDocument, p = doc.selection.active) {
+export async function dragSexprForwardDown(doc: EditableDocument, p = doc.selection.active) {
   const wsInfo = collectWhitespaceInfo(doc, p);
   const currentRange = doc.getTokenCursor(p).rangeForCurrentForm(p);
   const newPosOffset = p - currentRange[0];
@@ -1322,7 +1332,7 @@ export function dragSexprForwardDown(doc: EditableDocument, p = doc.selection.ac
       const newCursorPos = insertStart - deleteLength + newPosOffset;
       const insertText =
         doc.model.getText(...currentRange) + (wsInfo.rightWsHasNewline ? '\n' : ' ');
-      void doc.model.edit(
+      await doc.model.edit(
         [
           new ModelEdit('insertString', [
             insertStart,
@@ -1343,7 +1353,7 @@ export function dragSexprForwardDown(doc: EditableDocument, p = doc.selection.ac
   }
 }
 
-export function dragSexprForwardUp(doc: EditableDocument, p = doc.selection.active) {
+export async function dragSexprForwardUp(doc: EditableDocument, p = doc.selection.active) {
   const wsInfo = collectWhitespaceInfo(doc, p);
   const cursor = doc.getTokenCursor(p);
   const currentRange = cursor.rangeForCurrentForm(p);
@@ -1360,7 +1370,7 @@ export function dragSexprForwardUp(doc: EditableDocument, p = doc.selection.acti
       deleteLength = wsInfo.rightWsRange[1] - deleteStart;
     }
     const newCursorPos = listEnd + newPosOffset + 1 - deleteLength;
-    void doc.model.edit(
+    await doc.model.edit(
       [
         new ModelEdit('insertString', [listEnd, dragText, [p, p], [newCursorPos, newCursorPos]]),
         new ModelEdit('deleteRange', [deleteStart, deleteLength]),
@@ -1374,7 +1384,7 @@ export function dragSexprForwardUp(doc: EditableDocument, p = doc.selection.acti
   }
 }
 
-export function dragSexprBackwardDown(doc: EditableDocument, p = doc.selection.active) {
+export async function dragSexprBackwardDown(doc: EditableDocument, p = doc.selection.active) {
   const wsInfo = collectWhitespaceInfo(doc, p);
   const currentRange = doc.getTokenCursor(p).rangeForCurrentForm(p);
   const newPosOffset = p - currentRange[0];
@@ -1392,7 +1402,7 @@ export function dragSexprBackwardDown(doc: EditableDocument, p = doc.selection.a
       const newCursorPos = insertStart + newPosOffset + 1;
       let insertText = doc.model.getText(...currentRange);
       insertText = (siblingWsInfo.leftWsHasNewline ? '\n' : ' ') + insertText;
-      void doc.model.edit(
+      await doc.model.edit(
         [
           new ModelEdit('deleteRange', [wsInfo.leftWsRange[0], deleteLength]),
           new ModelEdit('insertString', [
@@ -1421,7 +1431,11 @@ function adaptContentsToRichComment(contents: string): string {
     .trim();
 }
 
-export function addRichComment(doc: EditableDocument, p = doc.selection.active, contents?: string) {
+export async function addRichComment(
+  doc: EditableDocument,
+  p = doc.selection.active,
+  contents?: string
+) {
   const richComment = `(comment\n  ${contents ? adaptContentsToRichComment(contents) : ''}\n  )`;
   let cursor = doc.getTokenCursor(p);
   const topLevelRange = rangeForDefun(doc, p, false);
@@ -1448,7 +1462,7 @@ export function addRichComment(doc: EditableDocument, p = doc.selection.active, 
       checkIfRichCommentExistsCursor.forwardWhitespace(false);
       // insert nothing, just place cursor
       const newCursorPos = checkIfRichCommentExistsCursor.offsetStart;
-      void doc.model.edit(
+      await doc.model.edit(
         [
           new ModelEdit('insertString', [
             newCursorPos,
@@ -1476,7 +1490,7 @@ export function addRichComment(doc: EditableDocument, p = doc.selection.active, 
   const append = '\n'.repeat(numAppendNls);
   const insertText = `${prepend}${richComment}${append}`;
   const newCursorPos = insertStart + 11 + numPrependNls * doc.model.lineEndingLength;
-  void doc.model.edit(
+  await doc.model.edit(
     [
       new ModelEdit('insertString', [
         insertStart,

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -448,7 +448,7 @@ export async function wrapSexpr(
     const currentFormRange = cursor.rangeForCurrentForm(start);
     if (currentFormRange) {
       const range = currentFormRange;
-      return await doc.model.edit(
+      return doc.model.edit(
         [
           new ModelEdit('insertString', [range[1], close]),
           new ModelEdit('insertString', [
@@ -467,7 +467,7 @@ export async function wrapSexpr(
   } else {
     // there is a selection
     const range = [Math.min(start, end), Math.max(start, end)];
-    return await doc.model.edit(
+    return doc.model.edit(
       [
         new ModelEdit('insertString', [range[1], close]),
         new ModelEdit('insertString', [range[0], open]),
@@ -494,7 +494,7 @@ export async function rewrapSexpr(
     if (cursor.forwardList()) {
       const closeStart = cursor.offsetStart,
         closeEnd = cursor.offsetEnd;
-      return await doc.model.edit(
+      return doc.model.edit(
         [
           new ModelEdit('changeRange', [closeStart, closeEnd, close]),
           new ModelEdit('changeRange', [openStart, openEnd, open]),
@@ -543,7 +543,7 @@ export async function joinSexp(
     const nextToken = cursor.getToken(),
       nextStart = cursor.offsetStart;
     if (validPair(nextToken.raw[0], prevToken.raw[prevToken.raw.length - 1])) {
-      return await doc.model.edit(
+      return doc.model.edit(
         [
           new ModelEdit('changeRange', [
             prevEnd - 1,
@@ -575,7 +575,7 @@ export async function spliceSexp(
     const close = cursor.getToken();
     const end = cursor.offsetStart;
     if (close.type == 'close' && validPair(open.raw, close.raw)) {
-      return await doc.model.edit(
+      return doc.model.edit(
         [
           new ModelEdit('changeRange', [end, end + close.raw.length, '']),
           new ModelEdit('changeRange', [beginning - open.raw.length, beginning, '']),
@@ -600,7 +600,7 @@ export async function killForwardList(doc: EditableDocument, [start, end]: [numb
   const inComment =
     (cursor.getToken().type == 'comment' && start > cursor.offsetStart) ||
     cursor.getPrevToken().type == 'comment';
-  return await doc.model.edit(
+  return doc.model.edit(
     [
       new ModelEdit('changeRange', [
         start,
@@ -808,15 +808,15 @@ export async function backspace(
         ? nextToken
         : cursor.getPrevToken();
     if (prevToken.type == 'prompt') {
-      return await new Promise<boolean>((resolve) => resolve(true));
+      return new Promise<boolean>((resolve) => resolve(true));
     } else if (nextToken.type == 'prompt') {
-      return await new Promise<boolean>((resolve) => resolve(true));
+      return new Promise<boolean>((resolve) => resolve(true));
     } else if (doc.model.getText(p - 2, p, true) == '\\"') {
-      return await doc.model.edit([new ModelEdit('deleteRange', [p - 2, 2])], {
+      return doc.model.edit([new ModelEdit('deleteRange', [p - 2, 2])], {
         selection: new ModelEditSelection(p - 2),
       });
     } else if (prevToken.type === 'open' && nextToken.type === 'close') {
-      return await doc.model.edit(
+      return doc.model.edit(
         [new ModelEdit('deleteRange', [p - prevToken.raw.length, prevToken.raw.length + 1])],
         {
           selection: new ModelEditSelection(p - prevToken.raw.length),
@@ -825,9 +825,9 @@ export async function backspace(
     } else {
       if (['open', 'close'].includes(prevToken.type) && docIsBalanced(doc)) {
         doc.selection = new ModelEditSelection(p - prevToken.raw.length);
-        return await new Promise<boolean>((resolve) => resolve(true));
+        return new Promise<boolean>((resolve) => resolve(true));
       } else {
-        return await doc.backspace();
+        return doc.backspace();
       }
     }
   }
@@ -846,7 +846,7 @@ export async function deleteForward(
     const nextToken = cursor.getToken();
     const p = start;
     if (doc.model.getText(p, p + 2, true) == '\\"') {
-      return await doc.model.edit([new ModelEdit('deleteRange', [p, 2])], {
+      return doc.model.edit([new ModelEdit('deleteRange', [p, 2])], {
         selection: new ModelEditSelection(p),
       });
     } else if (prevToken.type === 'open' && nextToken.type === 'close') {
@@ -861,7 +861,7 @@ export async function deleteForward(
         doc.selection = new ModelEditSelection(p + 1);
         return new Promise<boolean>((resolve) => resolve(true));
       } else {
-        return await doc.delete();
+        return doc.delete();
       }
     }
   }

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -12,14 +12,14 @@ import { LispTokenCursor } from './token-cursor';
 //       Example: paredit.moveToRangeRight(this.readline, paredit.forwardSexpRange(this.readline))
 //                => paredit.moveForwardSexp(this.readline)
 
-export function killRange(
+export async function killRange(
   doc: EditableDocument,
   range: [number, number],
   start = doc.selection.anchor,
   end = doc.selection.active
 ) {
   const [left, right] = [Math.min(...range), Math.max(...range)];
-  void doc.model.edit([new ModelEdit('deleteRange', [left, right - left, [start, end]])], {
+  return doc.model.edit([new ModelEdit('deleteRange', [left, right - left, [start, end]])], {
     selection: new ModelEditSelection(left),
   });
 }
@@ -431,14 +431,14 @@ export function rangeToBackwardList(
   }
 }
 
-export function wrapSexpr(
+export async function wrapSexpr(
   doc: EditableDocument,
   open: string,
   close: string,
   start: number = doc.selection.anchor,
   end: number = doc.selection.active,
   options = { skipFormat: false }
-): Thenable<boolean> {
+) {
   const cursor = doc.getTokenCursor(end);
   if (cursor.withinString() && open == '"') {
     open = close = '\\"';
@@ -515,9 +515,12 @@ export function splitSexp(doc: EditableDocument, start: number = doc.selection.a
     const open = cursor.getPrevToken().raw;
     if (cursor.forwardList()) {
       const close = cursor.getToken().raw;
-      void doc.model.edit([new ModelEdit('changeRange', [splitPos, splitPos, `${close}${open}`])], {
-        selection: new ModelEditSelection(splitPos + 1),
-      });
+      return doc.model.edit(
+        [new ModelEdit('changeRange', [splitPos, splitPos, `${close}${open}`])],
+        {
+          selection: new ModelEditSelection(splitPos + 1),
+        }
+      );
     }
   }
 }
@@ -583,10 +586,7 @@ export function spliceSexp(
   }
 }
 
-export function killBackwardList(
-  doc: EditableDocument,
-  [start, end]: [number, number]
-): Thenable<boolean> {
+export async function killBackwardList(doc: EditableDocument, [start, end]: [number, number]) {
   return doc.model.edit(
     [new ModelEdit('changeRange', [start, end, '', [end, end], [start, start]])],
     {
@@ -595,10 +595,7 @@ export function killBackwardList(
   );
 }
 
-export function killForwardList(
-  doc: EditableDocument,
-  [start, end]: [number, number]
-): Thenable<boolean> {
+export async function killForwardList(doc: EditableDocument, [start, end]: [number, number]) {
   const cursor = doc.getTokenCursor(start);
   const inComment =
     (cursor.getToken().type == 'comment' && start > cursor.offsetStart) ||
@@ -641,7 +638,7 @@ export function forwardSlurpSexp(
         replacedText.indexOf('\n') >= 0
           ? [currentCloseOffset, currentCloseOffset + close.length, '']
           : [wsStartOffset, wsEndOffset, ' '];
-      void doc.model.edit(
+      return doc.model.edit(
         [
           new ModelEdit('insertString', [newCloseOffset, close]),
           new ModelEdit('changeRange', changeArgs),
@@ -655,7 +652,7 @@ export function forwardSlurpSexp(
       );
     } else {
       const formatDepth = extraOpts['formatDepth'] ? extraOpts['formatDepth'] : 1;
-      forwardSlurpSexp(doc, cursor.offsetStart, {
+      return forwardSlurpSexp(doc, cursor.offsetStart, {
         formatDepth: formatDepth + 1,
       });
     }
@@ -677,7 +674,7 @@ export function backwardSlurpSexp(
     cursor.backwardSexp(true, true);
     cursor.forwardWhitespace(false);
     if (offset !== cursor.offsetStart) {
-      void doc.model.edit(
+      return doc.model.edit(
         [
           new ModelEdit('deleteRange', [offset, tk.raw.length]),
           new ModelEdit('changeRange', [cursor.offsetStart, cursor.offsetStart, open]),
@@ -691,7 +688,7 @@ export function backwardSlurpSexp(
       );
     } else {
       const formatDepth = extraOpts['formatDepth'] ? extraOpts['formatDepth'] : 1;
-      backwardSlurpSexp(doc, cursor.offsetStart, {
+      return backwardSlurpSexp(doc, cursor.offsetStart, {
         formatDepth: formatDepth + 1,
       });
     }
@@ -706,7 +703,7 @@ export function forwardBarfSexp(doc: EditableDocument, start: number = doc.selec
       close = cursor.getToken().raw;
     cursor.backwardSexp(true, true);
     cursor.backwardWhitespace();
-    void doc.model.edit(
+    return doc.model.edit(
       [
         new ModelEdit('deleteRange', [offset, close.length]),
         new ModelEdit('insertString', [cursor.offsetStart, close]),
@@ -732,7 +729,7 @@ export function backwardBarfSexp(doc: EditableDocument, start: number = doc.sele
     cursor.next();
     cursor.forwardSexp(true, true);
     cursor.forwardWhitespace(false);
-    void doc.model.edit(
+    return doc.model.edit(
       [
         new ModelEdit('changeRange', [cursor.offsetStart, cursor.offsetStart, close]),
         new ModelEdit('deleteRange', [offset, tk.raw.length]),
@@ -781,18 +778,18 @@ export function close(doc: EditableDocument, close: string, start: number = doc.
     if (!inString && docIsBalanced(doc)) {
       // Do nothing when there is balance
     } else {
-      void doc.model.edit([new ModelEdit('insertString', [start, close])], {
+      return doc.model.edit([new ModelEdit('insertString', [start, close])], {
         selection: new ModelEditSelection(start + close.length),
       });
     }
   }
 }
 
-export function backspace(
+export async function backspace(
   doc: EditableDocument,
   start: number = doc.selection.anchor,
   end: number = doc.selection.active
-): Thenable<boolean> {
+): Promise<boolean> {
   if (start != end) {
     return doc.backspace();
   } else {
@@ -829,7 +826,7 @@ export function backspace(
   }
 }
 
-export function deleteForward(
+export async function deleteForward(
   doc: EditableDocument,
   start: number = doc.selection.anchor,
   end: number = doc.selection.active
@@ -846,7 +843,7 @@ export function deleteForward(
         selection: new ModelEditSelection(p),
       });
     } else if (prevToken.type === 'open' && nextToken.type === 'close') {
-      void doc.model.edit(
+      return doc.model.edit(
         [new ModelEdit('deleteRange', [p - prevToken.raw.length, prevToken.raw.length + 1])],
         {
           selection: new ModelEditSelection(p - prevToken.raw.length),
@@ -876,25 +873,25 @@ export function stringQuote(
       // inside a string, let's be clever
       if (cursor.getToken().type == 'close') {
         if (doc.model.getText(0, start).endsWith('\\')) {
-          void doc.model.edit([new ModelEdit('changeRange', [start, start, '"'])], {
+          return doc.model.edit([new ModelEdit('changeRange', [start, start, '"'])], {
             selection: new ModelEditSelection(start + 1),
           });
         } else {
-          close(doc, '"', start);
+          return close(doc, '"', start);
         }
       } else {
         if (doc.model.getText(0, start).endsWith('\\')) {
-          void doc.model.edit([new ModelEdit('changeRange', [start, start, '"'])], {
+          return doc.model.edit([new ModelEdit('changeRange', [start, start, '"'])], {
             selection: new ModelEditSelection(start + 1),
           });
         } else {
-          void doc.model.edit([new ModelEdit('changeRange', [start, start, '\\"'])], {
+          return doc.model.edit([new ModelEdit('changeRange', [start, start, '\\"'])], {
             selection: new ModelEditSelection(start + 2),
           });
         }
       }
     } else {
-      void doc.model.edit([new ModelEdit('changeRange', [start, start, '""'])], {
+      return doc.model.edit([new ModelEdit('changeRange', [start, start, '""'])], {
         selection: new ModelEditSelection(start + 1),
       });
     }
@@ -999,7 +996,7 @@ export function raiseSexp(
     if (startCursor.getPrevToken().type == 'open') {
       startCursor.previous();
       if (endCursor.getToken().type == 'close') {
-        void doc.model.edit(
+        return doc.model.edit(
           [new ModelEdit('changeRange', [startCursor.offsetStart, endCursor.offsetEnd, raised])],
           {
             selection: new ModelEditSelection(
@@ -1012,7 +1009,7 @@ export function raiseSexp(
   }
 }
 
-export function convolute(
+export async function convolute(
   doc: EditableDocument,
   start = doc.selection.anchor,
   end = doc.selection.active
@@ -1031,7 +1028,7 @@ export function convolute(
           if (headStart.backwardList() && headStart.backwardUpList()) {
             const headEnd = cursorStart.clone();
             if (headEnd.forwardList() && cursorEnd.getToken().type == 'close') {
-              void doc.model.edit(
+              return doc.model.edit(
                 [
                   new ModelEdit('changeRange', [headEnd.offsetEnd, headEnd.offsetEnd, ')']),
                   new ModelEdit('changeRange', [cursorEnd.offsetStart, cursorEnd.offsetEnd, '']),
@@ -1052,7 +1049,7 @@ export function convolute(
   }
 }
 
-export function transpose(
+export async function transpose(
   doc: EditableDocument,
   left = doc.selection.anchor,
   right = doc.selection.active,
@@ -1084,7 +1081,7 @@ export function transpose(
         } else if (newPosOffset.fromRight != undefined) {
           newCursorPos = rightEnd - newPosOffset.fromRight;
         }
-        void doc.model.edit(
+        return doc.model.edit(
           [
             new ModelEdit('changeRange', [rightStart, rightEnd, leftText]),
             new ModelEdit('changeRange', [
@@ -1162,7 +1159,7 @@ function currentSexpsRange(
   return currentSingleRange;
 }
 
-export function dragSexprBackward(
+export async function dragSexprBackward(
   doc: EditableDocument,
   pairForms = bindingForms,
   left = doc.selection.anchor,
@@ -1179,7 +1176,7 @@ export function dragSexprBackward(
     // there is a sexp to the left
     const leftText = doc.model.getText(backRange[0], backRange[1]);
     const currentText = doc.model.getText(currentRange[0], currentRange[1]);
-    void doc.model.edit(
+    return doc.model.edit(
       [
         new ModelEdit('changeRange', [currentRange[0], currentRange[1], leftText]),
         new ModelEdit('changeRange', [backRange[0], backRange[1], currentText]),
@@ -1189,7 +1186,7 @@ export function dragSexprBackward(
   }
 }
 
-export function dragSexprForward(
+export async function dragSexprForward(
   doc: EditableDocument,
   pairForms = bindingForms,
   left = doc.selection.anchor,
@@ -1206,7 +1203,7 @@ export function dragSexprForward(
     // there is a sexp to the right
     const rightText = doc.model.getText(forwardRange[0], forwardRange[1]);
     const currentText = doc.model.getText(currentRange[0], currentRange[1]);
-    void doc.model.edit(
+    return doc.model.edit(
       [
         new ModelEdit('changeRange', [forwardRange[0], forwardRange[1], currentText]),
         new ModelEdit('changeRange', [currentRange[0], currentRange[1], rightText]),
@@ -1266,7 +1263,7 @@ export function collectWhitespaceInfo(
   };
 }
 
-export function dragSexprBackwardUp(doc: EditableDocument, p = doc.selection.active) {
+export async function dragSexprBackwardUp(doc: EditableDocument, p = doc.selection.active) {
   const wsInfo = collectWhitespaceInfo(doc, p);
   const cursor = doc.getTokenCursor(p);
   const currentRange = cursor.rangeForCurrentForm(p);
@@ -1293,7 +1290,7 @@ export function dragSexprBackwardUp(doc: EditableDocument, p = doc.selection.act
         wsInfo.rightWsRange[1] - currentRange[0],
       ]);
     }
-    void doc.model.edit(
+    return doc.model.edit(
       [
         deleteEdit,
         new ModelEdit('insertString', [listStart, dragText, [p, p], [newCursorPos, newCursorPos]]),
@@ -1307,7 +1304,7 @@ export function dragSexprBackwardUp(doc: EditableDocument, p = doc.selection.act
   }
 }
 
-export function dragSexprForwardDown(doc: EditableDocument, p = doc.selection.active) {
+export async function dragSexprForwardDown(doc: EditableDocument, p = doc.selection.active) {
   const wsInfo = collectWhitespaceInfo(doc, p);
   const currentRange = doc.getTokenCursor(p).rangeForCurrentForm(p);
   const newPosOffset = p - currentRange[0];
@@ -1322,7 +1319,7 @@ export function dragSexprForwardDown(doc: EditableDocument, p = doc.selection.ac
       const newCursorPos = insertStart - deleteLength + newPosOffset;
       const insertText =
         doc.model.getText(...currentRange) + (wsInfo.rightWsHasNewline ? '\n' : ' ');
-      void doc.model.edit(
+      return doc.model.edit(
         [
           new ModelEdit('insertString', [
             insertStart,
@@ -1338,12 +1335,11 @@ export function dragSexprForwardDown(doc: EditableDocument, p = doc.selection.ac
           undoStopBefore: true,
         }
       );
-      break;
     }
   }
 }
 
-export function dragSexprForwardUp(doc: EditableDocument, p = doc.selection.active) {
+export async function dragSexprForwardUp(doc: EditableDocument, p = doc.selection.active) {
   const wsInfo = collectWhitespaceInfo(doc, p);
   const cursor = doc.getTokenCursor(p);
   const currentRange = cursor.rangeForCurrentForm(p);
@@ -1360,7 +1356,7 @@ export function dragSexprForwardUp(doc: EditableDocument, p = doc.selection.acti
       deleteLength = wsInfo.rightWsRange[1] - deleteStart;
     }
     const newCursorPos = listEnd + newPosOffset + 1 - deleteLength;
-    void doc.model.edit(
+    return doc.model.edit(
       [
         new ModelEdit('insertString', [listEnd, dragText, [p, p], [newCursorPos, newCursorPos]]),
         new ModelEdit('deleteRange', [deleteStart, deleteLength]),
@@ -1374,7 +1370,7 @@ export function dragSexprForwardUp(doc: EditableDocument, p = doc.selection.acti
   }
 }
 
-export function dragSexprBackwardDown(doc: EditableDocument, p = doc.selection.active) {
+export async function dragSexprBackwardDown(doc: EditableDocument, p = doc.selection.active) {
   const wsInfo = collectWhitespaceInfo(doc, p);
   const currentRange = doc.getTokenCursor(p).rangeForCurrentForm(p);
   const newPosOffset = p - currentRange[0];
@@ -1392,7 +1388,7 @@ export function dragSexprBackwardDown(doc: EditableDocument, p = doc.selection.a
       const newCursorPos = insertStart + newPosOffset + 1;
       let insertText = doc.model.getText(...currentRange);
       insertText = (siblingWsInfo.leftWsHasNewline ? '\n' : ' ') + insertText;
-      void doc.model.edit(
+      return doc.model.edit(
         [
           new ModelEdit('deleteRange', [wsInfo.leftWsRange[0], deleteLength]),
           new ModelEdit('insertString', [
@@ -1421,7 +1417,11 @@ function adaptContentsToRichComment(contents: string): string {
     .trim();
 }
 
-export function addRichComment(doc: EditableDocument, p = doc.selection.active, contents?: string) {
+export async function addRichComment(
+  doc: EditableDocument,
+  p = doc.selection.active,
+  contents?: string
+) {
   const richComment = `(comment\n  ${contents ? adaptContentsToRichComment(contents) : ''}\n  )`;
   let cursor = doc.getTokenCursor(p);
   const topLevelRange = rangeForDefun(doc, p, false);
@@ -1448,7 +1448,7 @@ export function addRichComment(doc: EditableDocument, p = doc.selection.active, 
       checkIfRichCommentExistsCursor.forwardWhitespace(false);
       // insert nothing, just place cursor
       const newCursorPos = checkIfRichCommentExistsCursor.offsetStart;
-      void doc.model.edit(
+      return doc.model.edit(
         [
           new ModelEdit('insertString', [
             newCursorPos,
@@ -1463,7 +1463,6 @@ export function addRichComment(doc: EditableDocument, p = doc.selection.active, 
           undoStopBefore: false,
         }
       );
-      return;
     }
   }
   cursor.backwardWhitespace(false);
@@ -1476,7 +1475,7 @@ export function addRichComment(doc: EditableDocument, p = doc.selection.active, 
   const append = '\n'.repeat(numAppendNls);
   const insertText = `${prepend}${richComment}${append}`;
   const newCursorPos = insertStart + 11 + numPrependNls * doc.model.lineEndingLength;
-  void doc.model.edit(
+  return doc.model.edit(
     [
       new ModelEdit('insertString', [
         insertStart,

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -581,16 +581,16 @@ describe('paredit', () => {
   });
 
   describe('Reader tags', () => {
-    it('dragSexprBackward', () => {
+    it('dragSexprBackward', async () => {
       const a = docFromTextNotation('(a(b(c•#f•|(#b •[:f :b :z])•#z•1)))');
       const b = docFromTextNotation('(a(b(#f•|(#b •[:f :b :z])•c•#z•1)))');
-      paredit.dragSexprBackward(a);
+      await paredit.dragSexprBackward(a);
       expect(textAndSelection(a)).toEqual(textAndSelection(b));
     });
-    it('dragSexprForward', () => {
+    it('dragSexprForward', async () => {
       const a = docFromTextNotation('(a(b(c•#f•|(#b •[:f :b :z])•#z•1)))');
       const b = docFromTextNotation('(a(b(c•#z•1•#f•|(#b •[:f :b :z]))))');
-      paredit.dragSexprForward(a);
+      await paredit.dragSexprForward(a);
       expect(textAndSelection(a)).toEqual(textAndSelection(b));
     });
     describe('Stacked readers', () => {
@@ -600,16 +600,16 @@ describe('paredit', () => {
       beforeEach(() => {
         doc = new model.StringDocument(docText);
       });
-      it('dragSexprBackward', () => {
+      it('dragSexprBackward', async () => {
         const a = docFromTextNotation('(c•#f•(#b •[:f :b :z])•#x•#y•|1)');
         const b = docFromTextNotation('(c•#x•#y•|1•#f•(#b •[:f :b :z]))');
-        paredit.dragSexprBackward(a);
+        await paredit.dragSexprBackward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('dragSexprForward', () => {
+      it('dragSexprForward', async () => {
         const a = docFromTextNotation('(c•#f•|(#b •[:f :b :z])•#x•#y•1)');
         const b = docFromTextNotation('(c•#x•#y•1•#f•|(#b •[:f :b :z]))');
-        paredit.dragSexprForward(a);
+        await paredit.dragSexprForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
@@ -621,20 +621,20 @@ describe('paredit', () => {
       beforeEach(() => {
         doc = new model.StringDocument(docText);
       });
-      it('dragSexprBackward: #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö => #x•#y•1•#f•(#b •[:f :b :z])•#å#ä#ö', () => {
+      it('dragSexprBackward: #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö => #x•#y•1•#f•(#b •[:f :b :z])•#å#ä#ö', async () => {
         doc.selection = new ModelEditSelection(26, 26);
-        paredit.dragSexprBackward(doc);
+        await paredit.dragSexprBackward(doc);
         expect(doc.model.getText(0, Infinity)).toBe('#x\n#y\n1\n#f\n(#b \n[:f :b :z])\n#å#ä#ö');
       });
-      it('dragSexprForward: #f•|(#b •[:f :b :z])•#x•#y•1#å#ä#ö => #x•#y•1•#f•|(#b •[:f :b :z])•#å#ä#ö', () => {
+      it('dragSexprForward: #f•|(#b •[:f :b :z])•#x•#y•1#å#ä#ö => #x•#y•1•#f•|(#b •[:f :b :z])•#å#ä#ö', async () => {
         doc.selection = new ModelEditSelection(3, 3);
-        paredit.dragSexprForward(doc);
+        await paredit.dragSexprForward(doc);
         expect(doc.model.getText(0, Infinity)).toBe('#x\n#y\n1\n#f\n(#b \n[:f :b :z])\n#å#ä#ö');
         expect(doc.selection).toEqual(new ModelEditSelection(11));
       });
-      it('dragSexprForward: #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö => #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö', () => {
+      it('dragSexprForward: #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö => #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö', async () => {
         doc.selection = new ModelEditSelection(26, 26);
-        paredit.dragSexprForward(doc);
+        await paredit.dragSexprForward(doc);
         expect(doc.model.getText(0, Infinity)).toBe('#f\n(#b \n[:f :b :z])\n#x\n#y\n1\n#å#ä#ö');
         expect(doc.selection).toEqual(new ModelEditSelection(26));
       });
@@ -732,316 +732,316 @@ describe('paredit', () => {
         doc = new model.StringDocument(docText);
       });
 
-      it('drags forward in regular lists', () => {
+      it('drags forward in regular lists', async () => {
         const a = docFromTextNotation(`(c• [:|f '(0 "t")•   "b" :s]•)`);
         const b = docFromTextNotation(`(c• ['(0 "t") :|f•   "b" :s]•)`);
-        paredit.dragSexprForward(a);
+        await paredit.dragSexprForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('drags backward in regular lists', () => {
+      it('drags backward in regular lists', async () => {
         const a = docFromTextNotation(`(c• [:f '(0 "t")•   "b"| :s]•)`);
         const b = docFromTextNotation(`(c• [:f "b"|•   '(0 "t") :s]•)`);
-        paredit.dragSexprBackward(a);
+        await paredit.dragSexprBackward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('does not drag forward when sexpr is last in regular lists', () => {
+      it('does not drag forward when sexpr is last in regular lists', async () => {
         const dotText = `(c• [:f '(0 "t")•   "b" |:s ]•)`;
         const a = docFromTextNotation(dotText);
         const b = docFromTextNotation(dotText);
-        paredit.dragSexprForward(a);
+        await paredit.dragSexprForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('does not drag backward when sexpr is last in regular lists', () => {
+      it('does not drag backward when sexpr is last in regular lists', async () => {
         const dotText = `(c• [ :|f '(0 "t")•   "b" :s ]•)`;
         const a = docFromTextNotation(dotText);
         const b = docFromTextNotation(dotText);
-        paredit.dragSexprBackward(a);
+        await paredit.dragSexprBackward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('drags pair forward in maps', () => {
+      it('drags pair forward in maps', async () => {
         const a = docFromTextNotation(
           `(c• {:|e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`
         );
         const b = docFromTextNotation(
           `(c• {3 {:w? 'w}•   :|e '(e o ea)•   :t '(t i o im)•   :b 'b}•)`
         );
-        paredit.dragSexprForward(a);
+        await paredit.dragSexprForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('drags pair backwards in maps', () => {
+      it('drags pair backwards in maps', async () => {
         const a = docFromTextNotation(
           `(c• {:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)|•   :b 'b}•)`
         );
         const b = docFromTextNotation(
           `(c• {:e '(e o ea)•   :t '(t i o im)|•   3 {:w? 'w}•   :b 'b}•)`
         );
-        paredit.dragSexprBackward(a);
+        await paredit.dragSexprBackward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('drags pair backwards in meta-data maps', () => {
+      it('drags pair backwards in meta-data maps', async () => {
         const a = docFromTextNotation(
           `(c• ^{:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)|•   :b 'b}•)`
         );
         const b = docFromTextNotation(
           `(c• ^{:e '(e o ea)•   :t '(t i o im)|•   3 {:w? 'w}•   :b 'b}•)`
         );
-        paredit.dragSexprBackward(a);
+        await paredit.dragSexprBackward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('drags single sexpr forward in sets', () => {
+      it('drags single sexpr forward in sets', async () => {
         const a = docFromTextNotation(
           `(c• #{:|e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`
         );
         const b = docFromTextNotation(
           `(c• #{'(e o ea) :|e•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`
         );
-        paredit.dragSexprForward(a);
+        await paredit.dragSexprForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('drags pair in binding box', () => {
+      it('drags pair in binding box', async () => {
         const b = docFromTextNotation(
           `(c• [:e '(e o ea)•   3 {:w? 'w}•   :t |'(t i o im)•   :b 'b]•)`
         );
         const a = docFromTextNotation(
           `(c• [:e '(e o ea)•   3 {:w? 'w}•   :b 'b•   :t |'(t i o im)]•)`
         );
-        paredit.dragSexprForward(b, ['c']);
+        await paredit.dragSexprForward(b, ['c']);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
     });
 
     describe('backwardUp - one line', () => {
-      it('Drags up from start of vector', () => {
+      it('Drags up from start of vector', async () => {
         const b = docFromTextNotation(`(def foo [:|foo :bar :baz])`);
         const a = docFromTextNotation(`(def foo :|foo [:bar :baz])`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up from middle of vector', () => {
+      it('Drags up from middle of vector', async () => {
         const b = docFromTextNotation(`(def foo [:foo |:bar :baz])`);
         const a = docFromTextNotation(`(def foo |:bar [:foo :baz])`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up from end of vector', () => {
+      it('Drags up from end of vector', async () => {
         const b = docFromTextNotation(`(def foo [:foo :bar :baz|])`);
         const a = docFromTextNotation(`(def foo :baz| [:foo :bar])`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up from start of list', () => {
+      it('Drags up from start of list', async () => {
         const b = docFromTextNotation(`(d|e|f foo [:foo :bar :baz])`);
         const a = docFromTextNotation(`de|f (foo [:foo :bar :baz])`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up without killing preceding line comments', () => {
+      it('Drags up without killing preceding line comments', async () => {
         const b = docFromTextNotation(`(;;foo•de|f foo [:foo :bar :baz])`);
         const a = docFromTextNotation(`de|f•(;;foo• foo [:foo :bar :baz])`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up without killing preceding line comments or trailing parens', () => {
+      it('Drags up without killing preceding line comments or trailing parens', async () => {
         const b = docFromTextNotation(`(def ;; foo•  |:foo)`);
         const a = docFromTextNotation(`|:foo•(def ;; foo•)`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
     });
     describe('backwardUp - multi-line', () => {
-      it('Drags up from indented vector', () => {
+      it('Drags up from indented vector', async () => {
         const b = docFromTextNotation(`((fn foo•  [x]•  [|:foo•   :bar•   :baz])• 1)`);
         const a = docFromTextNotation(`((fn foo•  [x]•  |:foo•  [:bar•   :baz])• 1)`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up from indented list', () => {
+      it('Drags up from indented list', async () => {
         const b = docFromTextNotation(`(|(fn foo•  [x]•  [:foo•   :bar•   :baz])• 1)`);
         const a = docFromTextNotation(`|(fn foo•  [x]•  [:foo•   :bar•   :baz])•(1)`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up from end of indented list', () => {
+      it('Drags up from end of indented list', async () => {
         const b = docFromTextNotation(`((fn foo•  [x]•  [:foo•   :bar•   :baz])• |1)`);
         const a = docFromTextNotation(`|1•((fn foo•  [x]•  [:foo•   :bar•   :baz]))`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up from indented vector w/o killing preceding comment', () => {
+      it('Drags up from indented vector w/o killing preceding comment', async () => {
         const b = docFromTextNotation(`((fn foo•  [x]•  [:foo•   ;; foo•   :b|ar•   :baz])• 1)`);
         const a = docFromTextNotation(`((fn foo•  [x]•  :b|ar•  [:foo•   ;; foo••   :baz])• 1)`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
     });
     describe('forwardDown - one line', () => {
-      it('Drags down into vector', () => {
+      it('Drags down into vector', async () => {
         const b = docFromTextNotation(`(def f|oo [:foo :bar :baz])`);
         const a = docFromTextNotation(`(def [f|oo :foo :bar :baz])`);
-        paredit.dragSexprForwardDown(b);
+        await paredit.dragSexprForwardDown(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags down into vector past sexpression on the same level', () => {
+      it('Drags down into vector past sexpression on the same level', async () => {
         const b = docFromTextNotation(`(d|ef| foo [:foo :bar :baz])`);
         const a = docFromTextNotation(`(foo [def| :foo :bar :baz])`);
-        paredit.dragSexprForwardDown(b);
+        await paredit.dragSexprForwardDown(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags down into vector w/o killing line comments on the way', () => {
+      it('Drags down into vector w/o killing line comments on the way', async () => {
         const b = docFromTextNotation(`(d|ef ;; foo• [:foo :bar :baz])`);
         const a = docFromTextNotation(`(;; foo• [d|ef :foo :bar :baz])`);
-        paredit.dragSexprForwardDown(b);
+        await paredit.dragSexprForwardDown(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
     });
     describe('forwardUp', () => {
-      it('Drags forward out of vector', () => {
+      it('Drags forward out of vector', async () => {
         const b = docFromTextNotation(`((fn foo [x] [:foo :b|ar])) :baz`);
         const a = docFromTextNotation(`((fn foo [x] [:foo] :b|ar)) :baz`);
-        paredit.dragSexprForwardUp(b);
+        await paredit.dragSexprForwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags forward out of vector w/o killing line comments on the way', () => {
+      it('Drags forward out of vector w/o killing line comments on the way', async () => {
         const b = docFromTextNotation(`((fn foo [x] [:foo :b|ar ;; bar•])) :baz`);
         const a = docFromTextNotation(`((fn foo [x] [:foo ;; bar•] :b|ar)) :baz`);
-        paredit.dragSexprForwardUp(b);
+        await paredit.dragSexprForwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
     });
     describe('backwardDown', () => {
-      it('Drags backward down into list', () => {
+      it('Drags backward down into list', async () => {
         const b = docFromTextNotation(`((fn foo [x] [:foo :bar])) :b|az`);
         const a = docFromTextNotation(`((fn foo [x] [:foo :bar]) :b|az)`);
-        paredit.dragSexprBackwardDown(b);
+        await paredit.dragSexprBackwardDown(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags backward down into list w/o killing line comments on the way', () => {
+      it('Drags backward down into list w/o killing line comments on the way', async () => {
         const b = docFromTextNotation(`((fn foo [x] [:foo :bar])) ;; baz•:b|az`);
         const a = docFromTextNotation(`((fn foo [x] [:foo :bar]) :b|az) ;; baz`);
-        paredit.dragSexprBackwardDown(b);
+        await paredit.dragSexprBackwardDown(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it("Does not drag when can't drag down", () => {
+      it("Does not drag when can't drag down", async () => {
         const b = docFromTextNotation(`((fn foo [x] [:foo :b|ar])) :baz`);
         const a = docFromTextNotation(`((fn foo [x] [:foo :b|ar])) :baz`);
-        paredit.dragSexprBackwardDown(b);
+        await paredit.dragSexprBackwardDown(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
     });
   });
   describe('edits', () => {
     describe('Close lists', () => {
-      it('Advances cursor if at end of list of the same type', () => {
+      it('Advances cursor if at end of list of the same type', async () => {
         const a = docFromTextNotation('(str "foo"|)');
         const b = docFromTextNotation('(str "foo")|');
-        paredit.close(a, ')');
+        await paredit.close(a, ')');
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Does not enter new closing parens in balanced doc', () => {
+      it('Does not enter new closing parens in balanced doc', async () => {
         const a = docFromTextNotation('(str |"foo")');
         const b = docFromTextNotation('(str |"foo")');
-        paredit.close(a, ')');
+        await paredit.close(a, ')');
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      xit('Enter new closing parens in unbalanced doc', () => {
+      xit('Enter new closing parens in unbalanced doc', async () => {
         // TODO: Reinstall this test once the corresponding cursor test works
         //       (The extension actually behaves correctly.)
         const a = docFromTextNotation('(str |"foo"');
         const b = docFromTextNotation('(str )|"foo"');
-        paredit.close(a, ')');
+        await paredit.close(a, ')');
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Enter new closing parens in string', () => {
+      it('Enter new closing parens in string', async () => {
         const a = docFromTextNotation('(str "|foo"');
         const b = docFromTextNotation('(str ")|foo"');
-        paredit.close(a, ')');
+        await paredit.close(a, ')');
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
     describe('String quoting', () => {
-      it('Closes quote at end of string', () => {
+      it('Closes quote at end of string', async () => {
         const a = docFromTextNotation('(str "foo|")');
         const b = docFromTextNotation('(str "foo"|)');
-        paredit.stringQuote(a);
+        await paredit.stringQuote(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
 
     describe('Slurping', () => {
       describe('Slurping forwards', () => {
-        it('slurps form after list', () => {
+        it('slurps form after list', async () => {
           const a = docFromTextNotation('(str|) "foo"');
           const b = docFromTextNotation('(str| "foo")');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps, in multiline document', () => {
+        it('slurps, in multiline document', async () => {
           const a = docFromTextNotation('(foo• (str| ) "foo")');
           const b = docFromTextNotation('(foo• (str| "foo"))');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps and adds leading space', () => {
+        it('slurps and adds leading space', async () => {
           const a = docFromTextNotation('(s|tr)#(foo)');
           const b = docFromTextNotation('(s|tr #(foo))');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps without adding a space', () => {
+        it('slurps without adding a space', async () => {
           const a = docFromTextNotation('(s|tr )#(foo)');
           const b = docFromTextNotation('(s|tr #(foo))');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps, trimming inside whitespace', () => {
+        it('slurps, trimming inside whitespace', async () => {
           const a = docFromTextNotation('(str|   )"foo"');
           const b = docFromTextNotation('(str| "foo")');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps, trimming outside whitespace', () => {
+        it('slurps, trimming outside whitespace', async () => {
           const a = docFromTextNotation('(str|)   "foo"');
           const b = docFromTextNotation('(str| "foo")');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps, trimming inside and outside whitespace', () => {
+        it('slurps, trimming inside and outside whitespace', async () => {
           const a = docFromTextNotation('(str|   )   "foo"');
           const b = docFromTextNotation('(str| "foo")');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps form after empty list', () => {
+        it('slurps form after empty list', async () => {
           const a = docFromTextNotation('(|) "foo"');
           const b = docFromTextNotation('(| "foo")');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('leaves newlines when slurp', () => {
+        it('leaves newlines when slurp', async () => {
           const a = docFromTextNotation('(fo|o•)  bar');
           const b = docFromTextNotation('(fo|o•  bar)');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps properly when closing paren is on new line', () => {
+        it('slurps properly when closing paren is on new line', async () => {
           // https://github.com/BetterThanTomorrow/calva/issues/1171
           const a = docFromTextNotation('(def foo•  (str|•   )•  42)');
           const b = docFromTextNotation('(def foo•  (str|•   •  42))');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps form including meta and readers', () => {
+        it('slurps form including meta and readers', async () => {
           const a = docFromTextNotation('(|) ^{:a b} #c ^d "foo"');
           const b = docFromTextNotation('(| ^{:a b} #c ^d "foo")');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
       });
@@ -1049,24 +1049,24 @@ describe('paredit', () => {
       describe('Slurping backwards', () => {
         // TODO: Figure out why this test makes the following test fail
         //       It's something with in-string navigation...
-        it.skip('slurps form before string', () => {
+        it.skip('slurps form before string', async () => {
           const a = docFromTextNotation('(str) "fo|o"');
           const b = docFromTextNotation('"(str) fo|o"');
-          paredit.backwardSlurpSexp(a);
+          await paredit.backwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps form before list', () => {
+        it('slurps form before list', async () => {
           const a = docFromTextNotation('(str) (fo|o)');
           const b = docFromTextNotation('((str) fo|o)');
-          paredit.backwardSlurpSexp(a);
+          await paredit.backwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps form before list including meta and readers', () => {
+        it('slurps form before list including meta and readers', async () => {
           const a = docFromTextNotation('^{:a b} #c ^d "foo" (|)');
           // TODO: Figure out how to test result after format
           //       (Because that last space is then removed)
           const b = docFromTextNotation('(^{:a b} #c ^d "foo" |)');
-          paredit.backwardSlurpSexp(a);
+          await paredit.backwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
       });
@@ -1074,365 +1074,365 @@ describe('paredit', () => {
 
     describe('Barfing', () => {
       describe('Barfing forwards', () => {
-        it('barfs last form in list', () => {
+        it('barfs last form in list', async () => {
           const a = docFromTextNotation('(str| "foo")');
           const b = docFromTextNotation('(str|) "foo"');
-          paredit.forwardBarfSexp(a);
+          await paredit.forwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('leaves newlines when slurp', () => {
+        it('leaves newlines when slurp', async () => {
           const a = docFromTextNotation('(fo|o•  bar)');
           const b = docFromTextNotation('(fo|o)•  bar');
-          paredit.forwardBarfSexp(a);
+          await paredit.forwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('barfs form including meta and readers', () => {
+        it('barfs form including meta and readers', async () => {
           const a = docFromTextNotation('(| ^{:a b} #c ^d "foo")');
           const b = docFromTextNotation('(|) ^{:a b} #c ^d "foo"');
-          paredit.forwardBarfSexp(a);
+          await paredit.forwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('barfs form from balanced list, when inside unclosed list', () => {
+        it('barfs form from balanced list, when inside unclosed list', async () => {
           // Trying to expose:
           // https://github.com/BetterThanTomorrow/calva/issues/1585
           const a = docFromTextNotation('(let [a| a)');
           const b = docFromTextNotation('(let [a|) a');
-          paredit.forwardBarfSexp(a);
+          await paredit.forwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
       });
 
       describe('Barfing backwards', () => {
-        it('barfs first form in list', () => {
+        it('barfs first form in list', async () => {
           const a = docFromTextNotation('((str) fo|o)');
           const b = docFromTextNotation('(str) (fo|o)');
-          paredit.backwardBarfSexp(a);
+          await paredit.backwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('barfs first form in list including meta and readers', () => {
+        it('barfs first form in list including meta and readers', async () => {
           const a = docFromTextNotation('(^{:a b} #c ^d "foo"|)');
           const b = docFromTextNotation('^{:a b} #c ^d "foo"(|)');
-          paredit.backwardBarfSexp(a);
+          await paredit.backwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
       });
     });
 
     describe('Raise', () => {
-      it('raises the current form when cursor is preceding', () => {
+      it('raises the current form when cursor is preceding', async () => {
         const a = docFromTextNotation('(comment•  (str |#(foo)))');
         const b = docFromTextNotation('(comment•  |#(foo))');
-        paredit.raiseSexp(a);
+        await paredit.raiseSexp(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('raises the current form when cursor is trailing', () => {
+      it('raises the current form when cursor is trailing', async () => {
         const a = docFromTextNotation('(comment•  (str #(foo)|))');
         const b = docFromTextNotation('(comment•  #(foo)|)');
-        paredit.raiseSexp(a);
+        await paredit.raiseSexp(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
 
     describe('Kill character backwards (backspace)', () => {
-      it('Leaves closing paren of empty list alone', () => {
+      it('Leaves closing paren of empty list alone', async () => {
         const a = docFromTextNotation('{::foo ()|• ::bar :foo}');
         const b = docFromTextNotation('{::foo (|)• ::bar :foo}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes closing paren if unbalance', () => {
+      it('Deletes closing paren if unbalance', async () => {
         const a = docFromTextNotation('{::foo )|• ::bar :foo}');
         const b = docFromTextNotation('{::foo |• ::bar :foo}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Leaves opening paren of non-empty list alone', () => {
+      it('Leaves opening paren of non-empty list alone', async () => {
         const a = docFromTextNotation('{::foo (|a)• ::bar :foo}');
         const b = docFromTextNotation('{::foo |(a)• ::bar :foo}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Leaves opening quote of non-empty string alone', () => {
+      it('Leaves opening quote of non-empty string alone', async () => {
         const a = docFromTextNotation('{::foo "|a"• ::bar :foo}');
         const b = docFromTextNotation('{::foo |"a"• ::bar :foo}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Leaves closing quote of non-empty string alone', () => {
+      it('Leaves closing quote of non-empty string alone', async () => {
         const a = docFromTextNotation('{::foo "a"|• ::bar :foo}');
         const b = docFromTextNotation('{::foo "a|"• ::bar :foo}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes contents in strings', () => {
+      it('Deletes contents in strings', async () => {
         const a = docFromTextNotation('{::foo "a|"• ::bar :foo}');
         const b = docFromTextNotation('{::foo "|"• ::bar :foo}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes contents in strings 2', () => {
+      it('Deletes contents in strings 2', async () => {
         const a = docFromTextNotation('{::foo "a|a"• ::bar :foo}');
         const b = docFromTextNotation('{::foo "|a"• ::bar :foo}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes contents in strings 3', () => {
+      it('Deletes contents in strings 3', async () => {
         const a = docFromTextNotation('{::foo "aa|"• ::bar :foo}');
         const b = docFromTextNotation('{::foo "a|"• ::bar :foo}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes quoted quote', () => {
+      it('Deletes quoted quote', async () => {
         const a = docFromTextNotation('{::foo \\"|• ::bar :foo}');
         const b = docFromTextNotation('{::foo |• ::bar :foo}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes quoted quote in string', () => {
+      it('Deletes quoted quote in string', async () => {
         const a = docFromTextNotation('{::foo "\\"|"• ::bar :foo}');
         const b = docFromTextNotation('{::foo "|"• ::bar :foo}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes contents in list', () => {
+      it('Deletes contents in list', async () => {
         const a = docFromTextNotation('{::foo (a|)• ::bar :foo}');
         const b = docFromTextNotation('{::foo (|)• ::bar :foo}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes empty list function', () => {
+      it('Deletes empty list function', async () => {
         const a = docFromTextNotation('{::foo (|)• ::bar :foo}');
         const b = docFromTextNotation('{::foo |• ::bar :foo}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes empty set', () => {
+      it('Deletes empty set', async () => {
         const a = docFromTextNotation('#{|}');
         const b = docFromTextNotation('|');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes empty literal function with trailing newline', () => {
+      it('Deletes empty literal function with trailing newline', async () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1079
         const a = docFromTextNotation('{::foo #(|)• ::bar :foo}');
         const b = docFromTextNotation('{::foo |• ::bar :foo}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes open paren prefix characters', () => {
+      it('Deletes open paren prefix characters', async () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1122
         const a = docFromTextNotation('#|(foo)');
         const b = docFromTextNotation('|(foo)');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes open map curly prefix/ns characters', () => {
+      it('Deletes open map curly prefix/ns characters', async () => {
         const a = docFromTextNotation('#:same|{:thing :here}');
         const b = docFromTextNotation('#:sam|{:thing :here}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes open set hash characters', () => {
+      it('Deletes open set hash characters', async () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1122
         const a = docFromTextNotation('#|{:thing :here}');
         const b = docFromTextNotation('|{:thing :here}');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Moves cursor past entire open paren, including prefix characters', () => {
+      it('Moves cursor past entire open paren, including prefix characters', async () => {
         const a = docFromTextNotation('#(|foo)');
         const b = docFromTextNotation('|#(foo)');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes unbalanced bracket', () => {
+      it('Deletes unbalanced bracket', async () => {
         // This hangs the structural editing in the real editor
         // https://github.com/BetterThanTomorrow/calva/issues/1573
         const a = docFromTextNotation('([{|)');
         const b = docFromTextNotation('([|');
-        void paredit.backspace(a);
+        await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
 
     describe('Kill character forwards (delete)', () => {
-      it('Leaves closing paren of empty list alone', () => {
+      it('Leaves closing paren of empty list alone', async () => {
         const a = docFromTextNotation('{::foo |()• ::bar :foo}');
         const b = docFromTextNotation('{::foo (|)• ::bar :foo}');
-        void paredit.deleteForward(a);
+        await paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes closing paren if unbalance', () => {
+      it('Deletes closing paren if unbalance', async () => {
         const a = docFromTextNotation('{::foo |)• ::bar :foo}');
         const b = docFromTextNotation('{::foo |• ::bar :foo}');
-        void paredit.deleteForward(a);
+        await paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Leaves opening paren of non-empty list alone', () => {
+      it('Leaves opening paren of non-empty list alone', async () => {
         const a = docFromTextNotation('{::foo |(a)• ::bar :foo}');
         const b = docFromTextNotation('{::foo (|a)• ::bar :foo}');
-        void paredit.deleteForward(a);
+        await paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Leaves opening quote of non-empty string alone', () => {
+      it('Leaves opening quote of non-empty string alone', async () => {
         const a = docFromTextNotation('{::foo |"a"• ::bar :foo}');
         const b = docFromTextNotation('{::foo "|a"• ::bar :foo}');
-        void paredit.deleteForward(a);
+        await paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Leaves closing quote of non-empty string alone', () => {
+      it('Leaves closing quote of non-empty string alone', async () => {
         const a = docFromTextNotation('{::foo "a|"• ::bar :foo}');
         const b = docFromTextNotation('{::foo "a"|• ::bar :foo}');
-        void paredit.deleteForward(a);
+        await paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes contents in strings', () => {
+      it('Deletes contents in strings', async () => {
         const a = docFromTextNotation('{::foo "|a"• ::bar :foo}');
         const b = docFromTextNotation('{::foo "|"• ::bar :foo}');
-        void paredit.deleteForward(a);
+        await paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes contents in strings 2', () => {
+      it('Deletes contents in strings 2', async () => {
         const a = docFromTextNotation('{::foo "|aa"• ::bar :foo}');
         const b = docFromTextNotation('{::foo "|a"• ::bar :foo}');
-        void paredit.deleteForward(a);
+        await paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes quoted quote', () => {
+      it('Deletes quoted quote', async () => {
         const a = docFromTextNotation('{::foo |\\"• ::bar :foo}');
         const b = docFromTextNotation('{::foo |• ::bar :foo}');
-        void paredit.deleteForward(a);
+        await paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes quoted quote in string', () => {
+      it('Deletes quoted quote in string', async () => {
         const a = docFromTextNotation('{::foo "|\\""• ::bar :foo}');
         const b = docFromTextNotation('{::foo "|"• ::bar :foo}');
-        void paredit.deleteForward(a);
+        await paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes contents in list', () => {
+      it('Deletes contents in list', async () => {
         const a = docFromTextNotation('{::foo (|a)• ::bar :foo}');
         const b = docFromTextNotation('{::foo (|)• ::bar :foo}');
-        void paredit.deleteForward(a);
+        await paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes empty list function', () => {
+      it('Deletes empty list function', async () => {
         const a = docFromTextNotation('{::foo (|)• ::bar :foo}');
         const b = docFromTextNotation('{::foo |• ::bar :foo}');
-        void paredit.deleteForward(a);
+        await paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes empty set', () => {
+      it('Deletes empty set', async () => {
         const a = docFromTextNotation('#{|}');
         const b = docFromTextNotation('|');
-        void paredit.deleteForward(a);
+        await paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Deletes empty literal function with trailing newline', () => {
+      it('Deletes empty literal function with trailing newline', async () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1079
         const a = docFromTextNotation('{::foo #(|)• ::bar :foo}');
         const b = docFromTextNotation('{::foo |• ::bar :foo}');
-        void paredit.deleteForward(a);
+        await paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
     describe('addRichComment', () => {
-      it('Adds Rich Comment after Top Level form', () => {
+      it('Adds Rich Comment after Top Level form', async () => {
         const a = docFromTextNotation('(fo|o)••(bar)');
         const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
-        paredit.addRichComment(a);
+        await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Inserts Rich Comment between Top Levels', () => {
+      it('Inserts Rich Comment between Top Levels', async () => {
         const a = docFromTextNotation('(foo)•|•(bar)');
         const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
-        paredit.addRichComment(a);
+        await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Inserts Rich Comment between Top Levels, before Top Level form', () => {
+      it('Inserts Rich Comment between Top Levels, before Top Level form', async () => {
         const a = docFromTextNotation('(foo)••|(bar)');
         const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
-        paredit.addRichComment(a);
+        await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Inserts Rich Comment between Top Levels, after Top Level form', () => {
+      it('Inserts Rich Comment between Top Levels, after Top Level form', async () => {
         const a = docFromTextNotation('(foo)|••(bar)');
         const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
-        paredit.addRichComment(a);
+        await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Inserts Rich Comment between Top Levels, in comment', () => {
+      it('Inserts Rich Comment between Top Levels, in comment', async () => {
         const a = docFromTextNotation('(foo)•;foo| bar•(bar)');
         const b = docFromTextNotation('(foo)•;foo bar••(comment•  |•  )••(bar)');
-        paredit.addRichComment(a);
+        await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Moves to Rich Comment below, if any', () => {
+      it('Moves to Rich Comment below, if any', async () => {
         const a = docFromTextNotation('(foo|)••(comment••bar••baz)');
         const b = docFromTextNotation('(foo)••(comment••|bar••baz)');
-        paredit.addRichComment(a);
+        await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Moves to Rich Comment below, if any, looking behind line comments', () => {
+      it('Moves to Rich Comment below, if any, looking behind line comments', async () => {
         const a = docFromTextNotation('(foo|)••;;line comment••(comment••bar••baz)');
         const b = docFromTextNotation('(foo)••;;line comment••(comment••|bar••baz)');
-        paredit.addRichComment(a);
+        await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
 
     describe('splice sexp', () => {
-      it('splice empty', () => {
+      it('splice empty', async () => {
         const a = docFromTextNotation('|');
         const b = docFromTextNotation('|');
-        void paredit.spliceSexp(a);
+        await paredit.spliceSexp(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('splice list', () => {
+      it('splice list', async () => {
         const a = docFromTextNotation('(a|a b c)');
         const b = docFromTextNotation('a|a b c');
-        void paredit.spliceSexp(a);
+        await paredit.spliceSexp(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('splice list also when forms have meta and readers', () => {
+      it('splice list also when forms have meta and readers', async () => {
         const a = docFromTextNotation('(^{:d e} #a|a b c)');
         const b = docFromTextNotation('^{:d e} #a|a b c');
-        void paredit.spliceSexp(a);
+        await paredit.spliceSexp(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('splice vector', () => {
+      it('splice vector', async () => {
         const a = docFromTextNotation('[a| b c]');
         const b = docFromTextNotation('a| b c');
-        void paredit.spliceSexp(a);
+        await paredit.spliceSexp(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('splice map', () => {
+      it('splice map', async () => {
         const a = docFromTextNotation('{a| b}');
         const b = docFromTextNotation('a| b');
-        void paredit.spliceSexp(a);
+        await paredit.spliceSexp(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('splice nested', () => {
+      it('splice nested', async () => {
         const a = docFromTextNotation('[1 {ab| cd} 2]');
         const b = docFromTextNotation('[1 ab| cd 2]');
-        void paredit.spliceSexp(a);
+        await paredit.spliceSexp(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('splice set', () => {
+      it('splice set', async () => {
         // TODO: Figure out why the cursor gets misplaced
         const a = docFromTextNotation('#{a| b}');
         const b = docFromTextNotation('a |b');
-        void paredit.spliceSexp(a);
+        await paredit.spliceSexp(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
       // NB: enabling this breaks bunch of other tests.
       //     Not sure why, but it can be run successfully by itself.
-      it.skip('splice string', () => {
+      it.skip('splice string', async () => {
         const a = docFromTextNotation('"h|ello"');
-        void paredit.spliceSexp(a);
+        await paredit.spliceSexp(a);
         expect(text(a)).toEqual('hello');
       });
     });

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1135,7 +1135,7 @@ describe('paredit', () => {
 
     describe('Kill character backwards (backspace)', () => {
       // TODO: Change to await instead of void
-      it('Leaves closing paren of empty list alone', () => {
+      it('Leaves closing paren of empty list alone', async () => {
         const a = docFromTextNotation('{::foo ()|• ::bar :foo}');
         const b = docFromTextNotation('{::foo (|)• ::bar :foo}');
         await paredit.backspace(a);

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -7,7 +7,7 @@ import { ModelEditSelection } from '../../../cursor-doc/model';
 model.initScanner(20000);
 
 /**
- * TODO: Use text-notation for these tests
+ * TODO: Use await instead of void on edit operations
  */
 
 describe('paredit', () => {
@@ -581,16 +581,16 @@ describe('paredit', () => {
   });
 
   describe('Reader tags', () => {
-    it('dragSexprBackward', () => {
+    it('dragSexprBackward', async () => {
       const a = docFromTextNotation('(a(b(c•#f•|(#b •[:f :b :z])•#z•1)))');
       const b = docFromTextNotation('(a(b(#f•|(#b •[:f :b :z])•c•#z•1)))');
-      paredit.dragSexprBackward(a);
+      await paredit.dragSexprBackward(a);
       expect(textAndSelection(a)).toEqual(textAndSelection(b));
     });
-    it('dragSexprForward', () => {
+    it('dragSexprForward', async () => {
       const a = docFromTextNotation('(a(b(c•#f•|(#b •[:f :b :z])•#z•1)))');
       const b = docFromTextNotation('(a(b(c•#z•1•#f•|(#b •[:f :b :z]))))');
-      paredit.dragSexprForward(a);
+      await paredit.dragSexprForward(a);
       expect(textAndSelection(a)).toEqual(textAndSelection(b));
     });
     describe('Stacked readers', () => {
@@ -600,16 +600,16 @@ describe('paredit', () => {
       beforeEach(() => {
         doc = new model.StringDocument(docText);
       });
-      it('dragSexprBackward', () => {
+      it('dragSexprBackward', async () => {
         const a = docFromTextNotation('(c•#f•(#b •[:f :b :z])•#x•#y•|1)');
         const b = docFromTextNotation('(c•#x•#y•|1•#f•(#b •[:f :b :z]))');
-        paredit.dragSexprBackward(a);
+        await paredit.dragSexprBackward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('dragSexprForward', () => {
         const a = docFromTextNotation('(c•#f•|(#b •[:f :b :z])•#x•#y•1)');
         const b = docFromTextNotation('(c•#x•#y•1•#f•|(#b •[:f :b :z]))');
-        paredit.dragSexprForward(a);
+        return paredit.dragSexprForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
@@ -621,20 +621,20 @@ describe('paredit', () => {
       beforeEach(() => {
         doc = new model.StringDocument(docText);
       });
-      it('dragSexprBackward: #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö => #x•#y•1•#f•(#b •[:f :b :z])•#å#ä#ö', () => {
+      it('dragSexprBackward: #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö => #x•#y•1•#f•(#b •[:f :b :z])•#å#ä#ö', async () => {
         doc.selection = new ModelEditSelection(26, 26);
-        paredit.dragSexprBackward(doc);
+        await paredit.dragSexprBackward(doc);
         expect(doc.model.getText(0, Infinity)).toBe('#x\n#y\n1\n#f\n(#b \n[:f :b :z])\n#å#ä#ö');
       });
-      it('dragSexprForward: #f•|(#b •[:f :b :z])•#x•#y•1#å#ä#ö => #x•#y•1•#f•|(#b •[:f :b :z])•#å#ä#ö', () => {
+      it('dragSexprForward: #f•|(#b •[:f :b :z])•#x•#y•1#å#ä#ö => #x•#y•1•#f•|(#b •[:f :b :z])•#å#ä#ö', async () => {
         doc.selection = new ModelEditSelection(3, 3);
-        paredit.dragSexprForward(doc);
+        await paredit.dragSexprForward(doc);
         expect(doc.model.getText(0, Infinity)).toBe('#x\n#y\n1\n#f\n(#b \n[:f :b :z])\n#å#ä#ö');
         expect(doc.selection).toEqual(new ModelEditSelection(11));
       });
-      it('dragSexprForward: #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö => #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö', () => {
+      it('dragSexprForward: #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö => #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö', async () => {
         doc.selection = new ModelEditSelection(26, 26);
-        paredit.dragSexprForward(doc);
+        await paredit.dragSexprForward(doc);
         expect(doc.model.getText(0, Infinity)).toBe('#f\n(#b \n[:f :b :z])\n#x\n#y\n1\n#å#ä#ö');
         expect(doc.selection).toEqual(new ModelEditSelection(26));
       });
@@ -732,316 +732,316 @@ describe('paredit', () => {
         doc = new model.StringDocument(docText);
       });
 
-      it('drags forward in regular lists', () => {
+      it('drags forward in regular lists', async () => {
         const a = docFromTextNotation(`(c• [:|f '(0 "t")•   "b" :s]•)`);
         const b = docFromTextNotation(`(c• ['(0 "t") :|f•   "b" :s]•)`);
-        paredit.dragSexprForward(a);
+        await paredit.dragSexprForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('drags backward in regular lists', () => {
+      it('drags backward in regular lists', async () => {
         const a = docFromTextNotation(`(c• [:f '(0 "t")•   "b"| :s]•)`);
         const b = docFromTextNotation(`(c• [:f "b"|•   '(0 "t") :s]•)`);
-        paredit.dragSexprBackward(a);
+        await paredit.dragSexprBackward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('does not drag forward when sexpr is last in regular lists', () => {
+      it('does not drag forward when sexpr is last in regular lists', async () => {
         const dotText = `(c• [:f '(0 "t")•   "b" |:s ]•)`;
         const a = docFromTextNotation(dotText);
         const b = docFromTextNotation(dotText);
-        paredit.dragSexprForward(a);
+        await paredit.dragSexprForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('does not drag backward when sexpr is last in regular lists', () => {
+      it('does not drag backward when sexpr is last in regular lists', async () => {
         const dotText = `(c• [ :|f '(0 "t")•   "b" :s ]•)`;
         const a = docFromTextNotation(dotText);
         const b = docFromTextNotation(dotText);
-        paredit.dragSexprBackward(a);
+        await paredit.dragSexprBackward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('drags pair forward in maps', () => {
+      it('drags pair forward in maps', async () => {
         const a = docFromTextNotation(
           `(c• {:|e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`
         );
         const b = docFromTextNotation(
           `(c• {3 {:w? 'w}•   :|e '(e o ea)•   :t '(t i o im)•   :b 'b}•)`
         );
-        paredit.dragSexprForward(a);
+        await paredit.dragSexprForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('drags pair backwards in maps', () => {
+      it('drags pair backwards in maps', async () => {
         const a = docFromTextNotation(
           `(c• {:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)|•   :b 'b}•)`
         );
         const b = docFromTextNotation(
           `(c• {:e '(e o ea)•   :t '(t i o im)|•   3 {:w? 'w}•   :b 'b}•)`
         );
-        paredit.dragSexprBackward(a);
+        await paredit.dragSexprBackward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('drags pair backwards in meta-data maps', () => {
+      it('drags pair backwards in meta-data maps', async () => {
         const a = docFromTextNotation(
           `(c• ^{:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)|•   :b 'b}•)`
         );
         const b = docFromTextNotation(
           `(c• ^{:e '(e o ea)•   :t '(t i o im)|•   3 {:w? 'w}•   :b 'b}•)`
         );
-        paredit.dragSexprBackward(a);
+        await paredit.dragSexprBackward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('drags single sexpr forward in sets', () => {
+      it('drags single sexpr forward in sets', async () => {
         const a = docFromTextNotation(
           `(c• #{:|e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`
         );
         const b = docFromTextNotation(
           `(c• #{'(e o ea) :|e•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`
         );
-        paredit.dragSexprForward(a);
+        await paredit.dragSexprForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
 
-      it('drags pair in binding box', () => {
+      it('drags pair in binding box', async () => {
         const b = docFromTextNotation(
           `(c• [:e '(e o ea)•   3 {:w? 'w}•   :t |'(t i o im)•   :b 'b]•)`
         );
         const a = docFromTextNotation(
           `(c• [:e '(e o ea)•   3 {:w? 'w}•   :b 'b•   :t |'(t i o im)]•)`
         );
-        paredit.dragSexprForward(b, ['c']);
+        await paredit.dragSexprForward(b, ['c']);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
     });
 
     describe('backwardUp - one line', () => {
-      it('Drags up from start of vector', () => {
+      it('Drags up from start of vector', async () => {
         const b = docFromTextNotation(`(def foo [:|foo :bar :baz])`);
         const a = docFromTextNotation(`(def foo :|foo [:bar :baz])`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up from middle of vector', () => {
+      it('Drags up from middle of vector', async () => {
         const b = docFromTextNotation(`(def foo [:foo |:bar :baz])`);
         const a = docFromTextNotation(`(def foo |:bar [:foo :baz])`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up from end of vector', () => {
+      it('Drags up from end of vector', async () => {
         const b = docFromTextNotation(`(def foo [:foo :bar :baz|])`);
         const a = docFromTextNotation(`(def foo :baz| [:foo :bar])`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up from start of list', () => {
+      it('Drags up from start of list', async () => {
         const b = docFromTextNotation(`(d|e|f foo [:foo :bar :baz])`);
         const a = docFromTextNotation(`de|f (foo [:foo :bar :baz])`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up without killing preceding line comments', () => {
+      it('Drags up without killing preceding line comments', async () => {
         const b = docFromTextNotation(`(;;foo•de|f foo [:foo :bar :baz])`);
         const a = docFromTextNotation(`de|f•(;;foo• foo [:foo :bar :baz])`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up without killing preceding line comments or trailing parens', () => {
+      it('Drags up without killing preceding line comments or trailing parens', async () => {
         const b = docFromTextNotation(`(def ;; foo•  |:foo)`);
         const a = docFromTextNotation(`|:foo•(def ;; foo•)`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
     });
     describe('backwardUp - multi-line', () => {
-      it('Drags up from indented vector', () => {
+      it('Drags up from indented vector', async () => {
         const b = docFromTextNotation(`((fn foo•  [x]•  [|:foo•   :bar•   :baz])• 1)`);
         const a = docFromTextNotation(`((fn foo•  [x]•  |:foo•  [:bar•   :baz])• 1)`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up from indented list', () => {
+      it('Drags up from indented list', async () => {
         const b = docFromTextNotation(`(|(fn foo•  [x]•  [:foo•   :bar•   :baz])• 1)`);
         const a = docFromTextNotation(`|(fn foo•  [x]•  [:foo•   :bar•   :baz])•(1)`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up from end of indented list', () => {
+      it('Drags up from end of indented list', async () => {
         const b = docFromTextNotation(`((fn foo•  [x]•  [:foo•   :bar•   :baz])• |1)`);
         const a = docFromTextNotation(`|1•((fn foo•  [x]•  [:foo•   :bar•   :baz]))`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags up from indented vector w/o killing preceding comment', () => {
+      it('Drags up from indented vector w/o killing preceding comment', async () => {
         const b = docFromTextNotation(`((fn foo•  [x]•  [:foo•   ;; foo•   :b|ar•   :baz])• 1)`);
         const a = docFromTextNotation(`((fn foo•  [x]•  :b|ar•  [:foo•   ;; foo••   :baz])• 1)`);
-        paredit.dragSexprBackwardUp(b);
+        await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
     });
     describe('forwardDown - one line', () => {
-      it('Drags down into vector', () => {
+      it('Drags down into vector', async () => {
         const b = docFromTextNotation(`(def f|oo [:foo :bar :baz])`);
         const a = docFromTextNotation(`(def [f|oo :foo :bar :baz])`);
-        paredit.dragSexprForwardDown(b);
+        await paredit.dragSexprForwardDown(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags down into vector past sexpression on the same level', () => {
+      it('Drags down into vector past sexpression on the same level', async () => {
         const b = docFromTextNotation(`(d|ef| foo [:foo :bar :baz])`);
         const a = docFromTextNotation(`(foo [def| :foo :bar :baz])`);
-        paredit.dragSexprForwardDown(b);
+        await paredit.dragSexprForwardDown(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags down into vector w/o killing line comments on the way', () => {
+      it('Drags down into vector w/o killing line comments on the way', async () => {
         const b = docFromTextNotation(`(d|ef ;; foo• [:foo :bar :baz])`);
         const a = docFromTextNotation(`(;; foo• [d|ef :foo :bar :baz])`);
-        paredit.dragSexprForwardDown(b);
+        await paredit.dragSexprForwardDown(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
     });
     describe('forwardUp', () => {
-      it('Drags forward out of vector', () => {
+      it('Drags forward out of vector', async () => {
         const b = docFromTextNotation(`((fn foo [x] [:foo :b|ar])) :baz`);
         const a = docFromTextNotation(`((fn foo [x] [:foo] :b|ar)) :baz`);
-        paredit.dragSexprForwardUp(b);
+        await paredit.dragSexprForwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags forward out of vector w/o killing line comments on the way', () => {
+      it('Drags forward out of vector w/o killing line comments on the way', async () => {
         const b = docFromTextNotation(`((fn foo [x] [:foo :b|ar ;; bar•])) :baz`);
         const a = docFromTextNotation(`((fn foo [x] [:foo ;; bar•] :b|ar)) :baz`);
-        paredit.dragSexprForwardUp(b);
+        await paredit.dragSexprForwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
     });
     describe('backwardDown', () => {
-      it('Drags backward down into list', () => {
+      it('Drags backward down into list', async () => {
         const b = docFromTextNotation(`((fn foo [x] [:foo :bar])) :b|az`);
         const a = docFromTextNotation(`((fn foo [x] [:foo :bar]) :b|az)`);
-        paredit.dragSexprBackwardDown(b);
+        await paredit.dragSexprBackwardDown(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it('Drags backward down into list w/o killing line comments on the way', () => {
+      it('Drags backward down into list w/o killing line comments on the way', async () => {
         const b = docFromTextNotation(`((fn foo [x] [:foo :bar])) ;; baz•:b|az`);
         const a = docFromTextNotation(`((fn foo [x] [:foo :bar]) :b|az) ;; baz`);
-        paredit.dragSexprBackwardDown(b);
+        await paredit.dragSexprBackwardDown(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
-      it("Does not drag when can't drag down", () => {
+      it("Does not drag when can't drag down", async () => {
         const b = docFromTextNotation(`((fn foo [x] [:foo :b|ar])) :baz`);
         const a = docFromTextNotation(`((fn foo [x] [:foo :b|ar])) :baz`);
-        paredit.dragSexprBackwardDown(b);
+        await paredit.dragSexprBackwardDown(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
     });
   });
   describe('edits', () => {
     describe('Close lists', () => {
-      it('Advances cursor if at end of list of the same type', () => {
+      it('Advances cursor if at end of list of the same type', async () => {
         const a = docFromTextNotation('(str "foo"|)');
         const b = docFromTextNotation('(str "foo")|');
-        paredit.close(a, ')');
+        await paredit.close(a, ')');
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Does not enter new closing parens in balanced doc', () => {
+      it('Does not enter new closing parens in balanced doc', async () => {
         const a = docFromTextNotation('(str |"foo")');
         const b = docFromTextNotation('(str |"foo")');
-        paredit.close(a, ')');
+        await paredit.close(a, ')');
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      xit('Enter new closing parens in unbalanced doc', () => {
+      xit('Enter new closing parens in unbalanced doc', async () => {
         // TODO: Reinstall this test once the corresponding cursor test works
         //       (The extension actually behaves correctly.)
         const a = docFromTextNotation('(str |"foo"');
         const b = docFromTextNotation('(str )|"foo"');
-        paredit.close(a, ')');
+        await paredit.close(a, ')');
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Enter new closing parens in string', () => {
+      it('Enter new closing parens in string', async () => {
         const a = docFromTextNotation('(str "|foo"');
         const b = docFromTextNotation('(str ")|foo"');
-        paredit.close(a, ')');
+        await paredit.close(a, ')');
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
     describe('String quoting', () => {
-      it('Closes quote at end of string', () => {
+      it('Closes quote at end of string', async () => {
         const a = docFromTextNotation('(str "foo|")');
         const b = docFromTextNotation('(str "foo"|)');
-        paredit.stringQuote(a);
+        await paredit.stringQuote(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
 
     describe('Slurping', () => {
       describe('Slurping forwards', () => {
-        it('slurps form after list', () => {
+        it('slurps form after list', async () => {
           const a = docFromTextNotation('(str|) "foo"');
           const b = docFromTextNotation('(str| "foo")');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps, in multiline document', () => {
+        it('slurps, in multiline document', async () => {
           const a = docFromTextNotation('(foo• (str| ) "foo")');
           const b = docFromTextNotation('(foo• (str| "foo"))');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps and adds leading space', () => {
+        it('slurps and adds leading space', async () => {
           const a = docFromTextNotation('(s|tr)#(foo)');
           const b = docFromTextNotation('(s|tr #(foo))');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps without adding a space', () => {
+        it('slurps without adding a space', async () => {
           const a = docFromTextNotation('(s|tr )#(foo)');
           const b = docFromTextNotation('(s|tr #(foo))');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps, trimming inside whitespace', () => {
+        it('slurps, trimming inside whitespace', async () => {
           const a = docFromTextNotation('(str|   )"foo"');
           const b = docFromTextNotation('(str| "foo")');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps, trimming outside whitespace', () => {
+        it('slurps, trimming outside whitespace', async () => {
           const a = docFromTextNotation('(str|)   "foo"');
           const b = docFromTextNotation('(str| "foo")');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps, trimming inside and outside whitespace', () => {
+        it('slurps, trimming inside and outside whitespace', async () => {
           const a = docFromTextNotation('(str|   )   "foo"');
           const b = docFromTextNotation('(str| "foo")');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps form after empty list', () => {
+        it('slurps form after empty list', async () => {
           const a = docFromTextNotation('(|) "foo"');
           const b = docFromTextNotation('(| "foo")');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('leaves newlines when slurp', () => {
+        it('leaves newlines when slurp', async () => {
           const a = docFromTextNotation('(fo|o•)  bar');
           const b = docFromTextNotation('(fo|o•  bar)');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps properly when closing paren is on new line', () => {
+        it('slurps properly when closing paren is on new line', async () => {
           // https://github.com/BetterThanTomorrow/calva/issues/1171
           const a = docFromTextNotation('(def foo•  (str|•   )•  42)');
           const b = docFromTextNotation('(def foo•  (str|•   •  42))');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps form including meta and readers', () => {
+        it('slurps form including meta and readers', async () => {
           const a = docFromTextNotation('(|) ^{:a b} #c ^d "foo"');
           const b = docFromTextNotation('(| ^{:a b} #c ^d "foo")');
-          paredit.forwardSlurpSexp(a);
+          await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
       });
@@ -1049,24 +1049,24 @@ describe('paredit', () => {
       describe('Slurping backwards', () => {
         // TODO: Figure out why this test makes the following test fail
         //       It's something with in-string navigation...
-        it.skip('slurps form before string', () => {
+        it.skip('slurps form before string', async () => {
           const a = docFromTextNotation('(str) "fo|o"');
           const b = docFromTextNotation('"(str) fo|o"');
-          paredit.backwardSlurpSexp(a);
+          await paredit.backwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps form before list', () => {
+        it('slurps form before list', async () => {
           const a = docFromTextNotation('(str) (fo|o)');
           const b = docFromTextNotation('((str) fo|o)');
-          paredit.backwardSlurpSexp(a);
+          await paredit.backwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('slurps form before list including meta and readers', () => {
+        it('slurps form before list including meta and readers', async () => {
           const a = docFromTextNotation('^{:a b} #c ^d "foo" (|)');
           // TODO: Figure out how to test result after format
           //       (Because that last space is then removed)
           const b = docFromTextNotation('(^{:a b} #c ^d "foo" |)');
-          paredit.backwardSlurpSexp(a);
+          await paredit.backwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
       });
@@ -1074,66 +1074,67 @@ describe('paredit', () => {
 
     describe('Barfing', () => {
       describe('Barfing forwards', () => {
-        it('barfs last form in list', () => {
+        it('barfs last form in list', async () => {
           const a = docFromTextNotation('(str| "foo")');
           const b = docFromTextNotation('(str|) "foo"');
-          paredit.forwardBarfSexp(a);
+          await paredit.forwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('leaves newlines when slurp', () => {
+        it('leaves newlines when slurp', async () => {
           const a = docFromTextNotation('(fo|o•  bar)');
           const b = docFromTextNotation('(fo|o)•  bar');
-          paredit.forwardBarfSexp(a);
+          await paredit.forwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('barfs form including meta and readers', () => {
+        it('barfs form including meta and readers', async () => {
           const a = docFromTextNotation('(| ^{:a b} #c ^d "foo")');
           const b = docFromTextNotation('(|) ^{:a b} #c ^d "foo"');
-          paredit.forwardBarfSexp(a);
+          await paredit.forwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('barfs form from balanced list, when inside unclosed list', () => {
+        it('barfs form from balanced list, when inside unclosed list', async () => {
           // Trying to expose:
           // https://github.com/BetterThanTomorrow/calva/issues/1585
           const a = docFromTextNotation('(let [a| a)');
           const b = docFromTextNotation('(let [a|) a');
-          paredit.forwardBarfSexp(a);
+          await paredit.forwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
       });
 
       describe('Barfing backwards', () => {
-        it('barfs first form in list', () => {
+        it('barfs first form in list', async () => {
           const a = docFromTextNotation('((str) fo|o)');
           const b = docFromTextNotation('(str) (fo|o)');
-          paredit.backwardBarfSexp(a);
+          await paredit.backwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('barfs first form in list including meta and readers', () => {
+        it('barfs first form in list including meta and readers', async () => {
           const a = docFromTextNotation('(^{:a b} #c ^d "foo"|)');
           const b = docFromTextNotation('^{:a b} #c ^d "foo"(|)');
-          paredit.backwardBarfSexp(a);
+          await paredit.backwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
       });
     });
 
     describe('Raise', () => {
-      it('raises the current form when cursor is preceding', () => {
+      it('raises the current form when cursor is preceding', async () => {
         const a = docFromTextNotation('(comment•  (str |#(foo)))');
         const b = docFromTextNotation('(comment•  |#(foo))');
-        paredit.raiseSexp(a);
+        await paredit.raiseSexp(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('raises the current form when cursor is trailing', () => {
+      it('raises the current form when cursor is trailing', async () => {
         const a = docFromTextNotation('(comment•  (str #(foo)|))');
         const b = docFromTextNotation('(comment•  #(foo)|)');
-        paredit.raiseSexp(a);
+        await paredit.raiseSexp(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
 
     describe('Kill character backwards (backspace)', () => {
+      // TODO: Change to await instead of void
       it('Leaves closing paren of empty list alone', () => {
         const a = docFromTextNotation('{::foo ()|• ::bar :foo}');
         const b = docFromTextNotation('{::foo (|)• ::bar :foo}');
@@ -1337,46 +1338,46 @@ describe('paredit', () => {
       });
     });
     describe('addRichComment', () => {
-      it('Adds Rich Comment after Top Level form', () => {
+      it('Adds Rich Comment after Top Level form', async () => {
         const a = docFromTextNotation('(fo|o)••(bar)');
         const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
-        paredit.addRichComment(a);
+        await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Inserts Rich Comment between Top Levels', () => {
+      it('Inserts Rich Comment between Top Levels', async () => {
         const a = docFromTextNotation('(foo)•|•(bar)');
         const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
-        paredit.addRichComment(a);
+        await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Inserts Rich Comment between Top Levels, before Top Level form', () => {
+      it('Inserts Rich Comment between Top Levels, before Top Level form', async () => {
         const a = docFromTextNotation('(foo)••|(bar)');
         const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
-        paredit.addRichComment(a);
+        await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Inserts Rich Comment between Top Levels, after Top Level form', () => {
+      it('Inserts Rich Comment between Top Levels, after Top Level form', async () => {
         const a = docFromTextNotation('(foo)|••(bar)');
         const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
-        paredit.addRichComment(a);
+        await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Inserts Rich Comment between Top Levels, in comment', () => {
+      it('Inserts Rich Comment between Top Levels, in comment', async () => {
         const a = docFromTextNotation('(foo)•;foo| bar•(bar)');
         const b = docFromTextNotation('(foo)•;foo bar••(comment•  |•  )••(bar)');
-        paredit.addRichComment(a);
+        await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Moves to Rich Comment below, if any', () => {
+      it('Moves to Rich Comment below, if any', async () => {
         const a = docFromTextNotation('(foo|)••(comment••bar••baz)');
         const b = docFromTextNotation('(foo)••(comment••|bar••baz)');
-        paredit.addRichComment(a);
+        await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      it('Moves to Rich Comment below, if any, looking behind line comments', () => {
+      it('Moves to Rich Comment below, if any, looking behind line comments', async () => {
         const a = docFromTextNotation('(foo|)••;;line comment••(comment••bar••baz)');
         const b = docFromTextNotation('(foo)••;;line comment••(comment••|bar••baz)');
-        paredit.addRichComment(a);
+        await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -25,9 +25,9 @@ const enabled = true;
  * @param doc
  * @param range
  */
-function copyRangeToClipboard(doc: EditableDocument, [start, end]) {
+async function copyRangeToClipboard(doc: EditableDocument, [start, end]) {
   const text = doc.model.getText(start, end);
-  void vscode.env.clipboard.writeText(text);
+  await vscode.env.clipboard.writeText(text);
 }
 
 /**
@@ -40,7 +40,7 @@ function shouldKillAlsoCutToClipboard() {
 
 type PareditCommand = {
   command: string;
-  handler: (doc: EditableDocument) => void | Promise<void>;
+  handler: (doc: EditableDocument) => void | Promise<any>;
 };
 const pareditCommands: PareditCommand[] = [
   // NAVIGATING
@@ -234,154 +234,160 @@ const pareditCommands: PareditCommand[] = [
   },
   {
     command: 'paredit.killRight',
-    handler: (doc: EditableDocument) => {
+    handler: async (doc: EditableDocument) => {
       const range = paredit.forwardHybridSexpRange(doc);
       if (shouldKillAlsoCutToClipboard()) {
-        copyRangeToClipboard(doc, range);
+        await copyRangeToClipboard(doc, range);
       }
-      paredit.killRange(doc, range);
+      await paredit.killRange(doc, range);
     },
   },
   {
     command: 'paredit.killSexpForward',
-    handler: (doc: EditableDocument) => {
+    handler: async (doc: EditableDocument) => {
       const range = paredit.forwardSexpRange(doc);
       if (shouldKillAlsoCutToClipboard()) {
-        copyRangeToClipboard(doc, range);
+        await copyRangeToClipboard(doc, range);
       }
-      paredit.killRange(doc, range);
+      await paredit.killRange(doc, range);
     },
   },
   {
     command: 'paredit.killSexpBackward',
-    handler: (doc: EditableDocument) => {
+    handler: async (doc: EditableDocument) => {
       const range = paredit.backwardSexpRange(doc);
       if (shouldKillAlsoCutToClipboard()) {
-        copyRangeToClipboard(doc, range);
+        await copyRangeToClipboard(doc, range);
       }
-      paredit.killRange(doc, range);
+      await paredit.killRange(doc, range);
     },
   },
   {
     command: 'paredit.killListForward',
-    handler: (doc: EditableDocument) => {
+    handler: async (doc: EditableDocument) => {
       const range = paredit.forwardListRange(doc);
       if (shouldKillAlsoCutToClipboard()) {
-        copyRangeToClipboard(doc, range);
+        await copyRangeToClipboard(doc, range);
       }
-      return paredit.killForwardList(doc, range);
+      return await paredit.killForwardList(doc, range);
     },
   }, // TODO: Implement with killRange
   {
     command: 'paredit.killListBackward',
-    handler: (doc: EditableDocument) => {
+    handler: async (doc: EditableDocument) => {
       const range = paredit.backwardListRange(doc);
       if (shouldKillAlsoCutToClipboard()) {
-        copyRangeToClipboard(doc, range);
+        await copyRangeToClipboard(doc, range);
       }
-      return paredit.killBackwardList(doc, range);
+      return await paredit.killBackwardList(doc, range);
     },
   }, // TODO: Implement with killRange
   {
     command: 'paredit.spliceSexpKillForward',
-    handler: (doc: EditableDocument) => {
+    handler: async (doc: EditableDocument) => {
       const range = paredit.forwardListRange(doc);
       if (shouldKillAlsoCutToClipboard()) {
-        copyRangeToClipboard(doc, range);
+        await copyRangeToClipboard(doc, range);
       }
-      void paredit.killForwardList(doc, range).then((isFulfilled) => {
+      await paredit.killForwardList(doc, range).then((isFulfilled) => {
         return paredit.spliceSexp(doc, doc.selection.active, false);
       });
     },
   },
   {
     command: 'paredit.spliceSexpKillBackward',
-    handler: (doc: EditableDocument) => {
+    handler: async (doc: EditableDocument) => {
       const range = paredit.backwardListRange(doc);
       if (shouldKillAlsoCutToClipboard()) {
-        copyRangeToClipboard(doc, range);
+        await copyRangeToClipboard(doc, range);
       }
-      void paredit.killBackwardList(doc, range).then((isFulfilled) => {
+      await paredit.killBackwardList(doc, range).then((isFulfilled) => {
         return paredit.spliceSexp(doc, doc.selection.active, false);
       });
     },
   },
   {
     command: 'paredit.wrapAroundParens',
-    handler: (doc: EditableDocument) => {
-      void paredit.wrapSexpr(doc, '(', ')');
+    handler: async (doc: EditableDocument) => {
+      await paredit.wrapSexpr(doc, '(', ')');
     },
   },
   {
     command: 'paredit.wrapAroundSquare',
-    handler: (doc: EditableDocument) => {
-      void paredit.wrapSexpr(doc, '[', ']');
+    handler: async (doc: EditableDocument) => {
+      await paredit.wrapSexpr(doc, '[', ']');
     },
   },
   {
     command: 'paredit.wrapAroundCurly',
-    handler: (doc: EditableDocument) => {
-      void paredit.wrapSexpr(doc, '{', '}');
+    handler: async (doc: EditableDocument) => {
+      await paredit.wrapSexpr(doc, '{', '}');
     },
   },
   {
     command: 'paredit.wrapAroundQuote',
-    handler: (doc: EditableDocument) => {
-      void paredit.wrapSexpr(doc, '"', '"');
+    handler: async (doc: EditableDocument) => {
+      await paredit.wrapSexpr(doc, '"', '"');
     },
   },
   {
     command: 'paredit.rewrapParens',
-    handler: (doc: EditableDocument) => {
-      void paredit.rewrapSexpr(doc, '(', ')');
+    handler: async (doc: EditableDocument) => {
+      await paredit.rewrapSexpr(doc, '(', ')');
     },
   },
   {
     command: 'paredit.rewrapSquare',
-    handler: (doc: EditableDocument) => {
-      void paredit.rewrapSexpr(doc, '[', ']');
+    handler: async (doc: EditableDocument) => {
+      await paredit.rewrapSexpr(doc, '[', ']');
     },
   },
   {
     command: 'paredit.rewrapCurly',
-    handler: (doc: EditableDocument) => {
-      void paredit.rewrapSexpr(doc, '{', '}');
+    handler: async (doc: EditableDocument) => {
+      await paredit.rewrapSexpr(doc, '{', '}');
     },
   },
   {
     command: 'paredit.rewrapQuote',
-    handler: (doc: EditableDocument) => {
-      void paredit.rewrapSexpr(doc, '"', '"');
+    handler: async (doc: EditableDocument) => {
+      await paredit.rewrapSexpr(doc, '"', '"');
     },
   },
   {
     command: 'paredit.deleteForward',
-    handler: paredit.deleteForward,
+    handler: async (doc: EditableDocument) => {
+      await paredit.deleteForward(doc);
+    },
   },
   {
     command: 'paredit.deleteBackward',
-    handler: paredit.backspace,
+    handler: async (doc: EditableDocument) => {
+      await paredit.backspace(doc);
+    },
   },
   {
     command: 'paredit.forceDeleteForward',
-    handler: () => {
-      void vscode.commands.executeCommand('deleteRight');
+    handler: async () => {
+      await vscode.commands.executeCommand('deleteRight');
     },
   },
   {
     command: 'paredit.forceDeleteBackward',
-    handler: () => {
-      void vscode.commands.executeCommand('deleteLeft');
+    handler: async () => {
+      await vscode.commands.executeCommand('deleteLeft');
     },
   },
   {
     command: 'paredit.addRichComment',
-    handler: paredit.addRichComment,
+    handler: async (doc: EditableDocument) => {
+      await paredit.addRichComment(doc);
+    },
   },
 ];
 
 function wrapPareditCommand(command: PareditCommand) {
-  return () => {
+  return async () => {
     try {
       const textEditor = window.activeTextEditor;
 
@@ -391,7 +397,7 @@ function wrapPareditCommand(command: PareditCommand) {
       if (!enabled || !languages.has(textEditor.document.languageId)) {
         return;
       }
-      void command.handler(mDoc);
+      await command.handler(mDoc);
     } catch (e) {
       console.error(e.message);
     }

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -40,7 +40,7 @@ function shouldKillAlsoCutToClipboard() {
 
 type PareditCommand = {
   command: string;
-  handler: (doc: EditableDocument) => void | Promise<void>;
+  handler: (doc: EditableDocument) => void | Promise<any>;
 };
 const pareditCommands: PareditCommand[] = [
   // NAVIGATING
@@ -239,7 +239,7 @@ const pareditCommands: PareditCommand[] = [
       if (shouldKillAlsoCutToClipboard()) {
         copyRangeToClipboard(doc, range);
       }
-      paredit.killRange(doc, range);
+      return paredit.killRange(doc, range);
     },
   },
   {
@@ -249,7 +249,7 @@ const pareditCommands: PareditCommand[] = [
       if (shouldKillAlsoCutToClipboard()) {
         copyRangeToClipboard(doc, range);
       }
-      paredit.killRange(doc, range);
+      return paredit.killRange(doc, range);
     },
   },
   {
@@ -259,7 +259,7 @@ const pareditCommands: PareditCommand[] = [
       if (shouldKillAlsoCutToClipboard()) {
         copyRangeToClipboard(doc, range);
       }
-      paredit.killRange(doc, range);
+      return paredit.killRange(doc, range);
     },
   },
   {
@@ -309,49 +309,49 @@ const pareditCommands: PareditCommand[] = [
   {
     command: 'paredit.wrapAroundParens',
     handler: (doc: EditableDocument) => {
-      void paredit.wrapSexpr(doc, '(', ')');
+      return paredit.wrapSexpr(doc, '(', ')');
     },
   },
   {
     command: 'paredit.wrapAroundSquare',
     handler: (doc: EditableDocument) => {
-      void paredit.wrapSexpr(doc, '[', ']');
+      return paredit.wrapSexpr(doc, '[', ']');
     },
   },
   {
     command: 'paredit.wrapAroundCurly',
     handler: (doc: EditableDocument) => {
-      void paredit.wrapSexpr(doc, '{', '}');
+      return paredit.wrapSexpr(doc, '{', '}');
     },
   },
   {
     command: 'paredit.wrapAroundQuote',
     handler: (doc: EditableDocument) => {
-      void paredit.wrapSexpr(doc, '"', '"');
+      return paredit.wrapSexpr(doc, '"', '"');
     },
   },
   {
     command: 'paredit.rewrapParens',
     handler: (doc: EditableDocument) => {
-      void paredit.rewrapSexpr(doc, '(', ')');
+      return paredit.rewrapSexpr(doc, '(', ')');
     },
   },
   {
     command: 'paredit.rewrapSquare',
     handler: (doc: EditableDocument) => {
-      void paredit.rewrapSexpr(doc, '[', ']');
+      return paredit.rewrapSexpr(doc, '[', ']');
     },
   },
   {
     command: 'paredit.rewrapCurly',
     handler: (doc: EditableDocument) => {
-      void paredit.rewrapSexpr(doc, '{', '}');
+      return paredit.rewrapSexpr(doc, '{', '}');
     },
   },
   {
     command: 'paredit.rewrapQuote',
     handler: (doc: EditableDocument) => {
-      void paredit.rewrapSexpr(doc, '"', '"');
+      return paredit.rewrapSexpr(doc, '"', '"');
     },
   },
   {
@@ -365,13 +365,13 @@ const pareditCommands: PareditCommand[] = [
   {
     command: 'paredit.forceDeleteForward',
     handler: () => {
-      void vscode.commands.executeCommand('deleteRight');
+      return vscode.commands.executeCommand('deleteRight');
     },
   },
   {
     command: 'paredit.forceDeleteBackward',
     handler: () => {
-      void vscode.commands.executeCommand('deleteLeft');
+      return vscode.commands.executeCommand('deleteLeft');
     },
   },
   {
@@ -391,7 +391,7 @@ function wrapPareditCommand(command: PareditCommand) {
       if (!enabled || !languages.has(textEditor.document.languageId)) {
         return;
       }
-      void command.handler(mDoc);
+      return command.handler(mDoc);
     } catch (e) {
       console.error(e.message);
     }


### PR DESCRIPTION
## What has Changed?

Changed a lot of paredit code to stop using `void` on the edit promises and instead return them. At some places we were doing `return await`, and there I removed the await.

Also changed the Paredit extension command handlers to always return the promise to whoever is using the commands. E.g, a Joyrider:

![joyride-paredit](https://user-images.githubusercontent.com/30010/169695279-2ec63ae1-5276-4e90-b078-c61fc2dc2089.gif)

Fixes #1733 

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
     - [x] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik