### PR TITLE
Align behavior of backspace in paredit with other editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ Changes to Calva.
 - [Extension API for retrieving the current REPL session key](https://github.com/BetterThanTomorrow/calva/issues/1747)
 - [Extension API for some common ranges, like current form and top level form](https://github.com/BetterThanTomorrow/calva/issues/1748)
 
-
 ## [2.0.277] - 2022-05-26
 
 - [Extension API: Evaluate via Calva's REPL connection](https://github.com/BetterThanTomorrow/calva/issues/1719)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Align behavior of backspace in paredit with other editors (Cursive, Emacs)](https://github.com/BetterThanTomorrow/calva/issues/1741)
+
 ## [2.0.277] - 2022-05-26
 
 - [Extension API: Evaluate via Calva's REPL connection](https://github.com/BetterThanTomorrow/calva/issues/1719)

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -812,7 +812,7 @@ function backspaceOnWhitespaceEdit(doc: EditableDocument, cursor: LispTokenCurso
     start = cursor.offsetEnd;
   }
   cursor.previous();
-  let prevToken = cursor.getToken();
+  const prevToken = cursor.getToken();
   if (prevToken.type === 'ws' && start === cursor.offsetEnd) {
     token = prevToken;
   }

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -805,6 +805,7 @@ function onlyWhitespaceLeftOfCursor(doc: EditableDocument, cursor: LispTokenCurs
 
 function backspaceOnWhitespaceEdit(doc: EditableDocument, cursor: LispTokenCursor) {
   const origIndent = getIndent(doc.model, cursor.offsetStart);
+  const onCloseToken = cursor.getToken().type === 'close';
   let start = doc.selection.anchor;
   let token = cursor.getToken();
   if (token.type === 'ws') {
@@ -832,7 +833,7 @@ function backspaceOnWhitespaceEdit(doc: EditableDocument, cursor: LispTokenCurso
 
   const destTokenType = cursor.getToken().type;
   let indent = destTokenType === 'eol' ? origIndent : 1;
-  if (destTokenType === 'open') {
+  if (destTokenType === 'open' || onCloseToken) {
     indent = 0;
   }
   const changeArgs = [start, end, ' '.repeat(indent)];

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1271,17 +1271,25 @@ describe('paredit', () => {
       it('Deletes whitespace to the left of the cursor', async () => {
         const a = docFromTextNotation(
           `
-(defn nil-if-blank [s]
-  (if (str/blank? s) 
-    |nil s))
+(if false nil
+  |true)
         `.trim()
         );
-        const b = docFromTextNotation(
-          `
-(defn nil-if-blank [s]
-  (if (str/blank? s) |nil s))
-        `.trim()
-        );
+        const b = docFromTextNotation(`(if false nil |true)`.trim());
+        await paredit.backspace(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('Deletes whitespace to the left of the cursor without crossing multiple lines', async () => {
+        const a = docFromTextNotation('[•• |::foo]');
+        const b = docFromTextNotation('[• |::foo]');
+        await paredit.backspace(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('Deletes whitespace to the left and right of the cursor when inside whitespace', async () => {
+        const a = docFromTextNotation('[• | ::foo]');
+        const b = docFromTextNotation('[|::foo]');
         await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1268,6 +1268,23 @@ describe('paredit', () => {
         await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
+      it('Deletes whitespace to the left of the cursor', async () => {
+        const a = docFromTextNotation(
+          `
+(defn nil-if-blank [s]
+  (if (str/blank? s) 
+    |nil s))
+        `.trim()
+        );
+        const b = docFromTextNotation(
+          `
+(defn nil-if-blank [s]
+  (if (str/blank? s) |nil s))
+        `.trim()
+        );
+        await paredit.backspace(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
     });
 
     describe('Kill character forwards (delete)', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1293,6 +1293,27 @@ describe('paredit', () => {
         await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
+
+      it('Deletes whitespace to the left and inserts a space when arriving at the end of a line', async () => {
+        const a = docFromTextNotation('(if :foo•  |:bar   :baz)');
+        const b = docFromTextNotation('(if :foo |:bar   :baz)');
+        await paredit.backspace(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('Deletes whitespace to the left and inserts a single space when ending up on a line with trailing whitespace', async () => {
+        const a = docFromTextNotation('(if :foo    •  |:bar   :baz)');
+        const b = docFromTextNotation('(if :foo |:bar   :baz)');
+        await paredit.backspace(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('Deletes whitespace to the left and avoids inserting a space if on a close token', async () => {
+        const a = docFromTextNotation('(if :foo•    |)');
+        const b = docFromTextNotation('(if :foo|)');
+        await paredit.backspace(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
     });
 
     describe('Kill character forwards (delete)', () => {


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

This PR brings Calva paredit backspace more in alignement with other editors like Cursive and Emacs.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1741

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Tests
     - [x] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->