### PR TITLE
1747 1748 moar api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Extension API: Fix Javascript examples & align them with their ClojureScript versions](https://github.com/BetterThanTomorrow/calva/issues/1742)
+- [Extension API for retrieving the current REPL session key](https://github.com/BetterThanTomorrow/calva/issues/1747)
+- [Extension API for some common ranges, like current form and top level form](https://github.com/BetterThanTomorrow/calva/issues/1748)
 
 ## [2.0.277] - 2022-05-26
 

--- a/docs/site/api.md
+++ b/docs/site/api.md
@@ -159,36 +159,51 @@ All functions in this module have the following TypeScript signature:
 (editor = vscode.window.activeTextEditor, position = editor?.selection?.active) => [vscode.Range, string];
 ```
 
-I.e. they expect a [vscode.TextEditor]() – defaulting to the currently active editor – and a [vscode.Position]() – defaulting to the current active position in the editor (or the first active position if multiple selections/positions exist, and will return a tuple with the range, and the text for the piece of interest requested.
+I.e. they expect a [vscode.TextEditor](https://code.visualstudio.com/api/references/vscode-api#TextEditor) – defaulting to the currently active editor – and a [vscode.Position](https://code.visualstudio.com/api/references/vscode-api#Position) – defaulting to the current active position in the editor (or the first active position if multiple selections/positions exist, and will return a tuple with the range, and the text for the piece of interest requested.
+
+!!! Note "Custom REPL Commands"
+    The `ranges` function have corresponding [REPL Snippets/Commands](custom-commands.md) substitution variables. It is the same implementation functions used in both cases.
 
 The functions available are:
 
 ### `ranges.currentForm()`
 
-Retrieves information about the current form, as determined from the editor and position. See about Calva's [Current Form]() on YouTube.
+Retrieves information about the current form, as determined from the editor and position.
+
+_Corresponding [REPL Snippet](custom-commands.md) variable: `$current-form`._
+
+See also about Calva's [Current Form](https://www.youtube.com/watch?v=8ygw7LLLU1w) on YouTube.
 
 ### `ranges.currentEnclosingForm()`
 
 The list/vector/etcetera form comtaining the current form.
 
+_Corresponding [REPL Snippet](custom-commands.md) variable: `$enclosing-form`._
+
 ### `ranges.currentTopLevelForm()`
 
 The current top level form. Outside `(comment ...)` (Rich comments) forms this is most often (`(def ...), (defgn ...)`, etcetera. Inside Rich comments it will be the current immediate child to the `(comment ...)` form.
+
+_Corresponding [REPL Snippet](custom-commands.md) variable: `$top-level-form`._
 
 ### `ranges.currentFunction()`
 
 The current function, i.e. the form in ”call position” of the closest enclosing list.
 
+_Corresponding [REPL Snippet](custom-commands.md) variable: `$current-fn`._
+
 ### `ranges.currentTopLevelDef()`
 
 The symbol being defined by the current top level form. NB: Will stupidly assume it is the second form. I.e. it does not check that it is an actual definition, and will often return nonsense if used in Rich comments.
+
+_Corresponding [REPL Snippet](custom-commands.md) variable: `$top-level-defined-symbol`._
 
 ### Example: `ranges.currentTopLevelForm()`
 
 === "ClojureScript"
 
     ```clojure
-    (def top-level-form (get-in [:repl :currentTopLevelForm] calvaApi))
+    (def top-level-form (get-in [:ranges :currentTopLevelForm] calvaApi))
     (def text (-> (top-level-form)
                   second))
     ```
@@ -196,7 +211,7 @@ The symbol being defined by the current top level form. NB: Will stupidly assume
 === "JavaScript"
 
     ```javascript
-    const text = repl.currentTopLevelForm()[1];
+    const text = ranges.currentTopLevelForm()[1];
     ```
 
 ## Feedback Welcome

--- a/docs/site/api.md
+++ b/docs/site/api.md
@@ -7,7 +7,7 @@ search:
 
 # The Calva Extension API
 
-Calva exposes an API for use from other VS Code extensions (such as [Joyride](./joyride.md)). The API is rather small for now, consisting of only one function. It is also in an experimental state, while we are figuring out what is a good shape for this API.
+Calva exposes an API for use from other VS Code extensions (such as [Joyride](./joyride.md)). The API is in an experimental state, while we are figuring out what is a good shape for this API. It is also rather small, and will grow to expose more of Calva's functionality.
 
 ## Accessing
 
@@ -32,13 +32,33 @@ To access the API the Calva extension needs to be [activated](https://code.visua
     const calvaApi = calva.exports.v0;
     ```
 
-## `evaluateCode()`
+## `repl`
+
+The `repl` module contains provides access to Calva's REPL connection.
+
+### `repl.currentSessionKey()`
+
+Use `repl.currentSessionKey()` find out which REPL/session Calva's REPL is currently connected to (depends on the active file). Returns either `"clj"`, or `"cljs"`, or `nil` if no REPL is connected.
+
+=== "ClojureScript"
+
+    ```clojure
+    (def session-key ((get-in [:repl :currentSessionKey] calvaApi)))
+    ```
+
+=== "JavaScript"
+
+    ```javascript
+    const sessionKey = calvaApi.repl.evaluateCode()
+    ```
+
+### `repl.evaluateCode()`
 
 This function lets you evaluate Clojure code through Calva's nREPL connection. Calling it returns a promise that resolves to a `Result` object. It's signature looks like so (TypeScript):
 
 ```typescript
 export async function evaluateCode(
-  sessionKey: 'clj' | 'cljs',
+  sessionKey: 'clj' | 'cljs' | 'cljc' | undefined,
   code: string,
   output?: {
     stdout: (m: string) => void;
@@ -58,14 +78,14 @@ type Result = {
 };
 ```
 
-As you can see, the required arguments to the function are `sessionKey` and `code`. `sessionKey` should be either `clj` or `cljs` depending on which of Calva's REPL sessions/connections that should be used. It will depend on your project, and how you connect to it, if both or only one of them is valid.
+As you can see, the required arguments to the function are `sessionKey` and `code`. `sessionKey` should be `"clj"`, `"cljs"`, `"cljc"`, or `undefined` depending on which of Calva's REPL sessions/connections that should be used. It will depend on your project, and how you connect to it, which session keys are valid. Use `cljc` to request whatever REPL session `"cljc"` files are connected to. Use `undefined` to use the current REPL connection Calva would use (depends on which file is active).
 
 An example:
 
 === "ClojureScript"
 
     ```clojure
-    (def evaluate (:evaluateCode calvaApi))
+    (def evaluate (get-in [:repl :evaluateCode] calvaApi))
     (-> (p/let [evaluation (evaluate "clj" "(+ 2 40)")]
           (println (.-result evaluation)))
         (p/catch (fn [e]
@@ -76,14 +96,14 @@ An example:
 
     ```javascript
     try {
-      const evaluation = await calvaApi.evaluateCode("clj", "(+ 2 40)");
+      const evaluation = await calvaApi.repl.evaluateCode("clj", "(+ 2 40)");
       console.log(evaluation.result);
     } catch (e) {
       console.error("Evaluation error:", e);
     }
     ```
 
-### Handling Output
+#### Handling Output
 
 The `output` member on the `Result` object will have any output produced during evaluation. (The `errorOutput` member should contain error output produced, but currently some Calva bug makes this not work.) By default the stdout and stderr output is not printed anywhere.
 
@@ -96,7 +116,7 @@ An example:
     ```clojure
     (def oc (joyride.core/output-channel)) ;; Assuming Joyride is used
     (def evaluate (fn [code]
-                    ((:evaluateCode calvaApi)
+                    ((get-in [:repl :evaluateCode] calvaApi)
                      "clj"
                      code
                      #js {:stdout #(.append oc %)
@@ -112,7 +132,7 @@ An example:
 
     ```javascript
     const evaluate = (code) =>
-      calvaApi.evaluateCode("clj", code, {
+      calvaApi.repl.evaluateCode("clj", code, {
         stdout: (s) => {
           console.log(s);
         },
@@ -127,6 +147,56 @@ An example:
     } catch (e) {
       console.error("Evaluation error:", e);
     }
+    ```
+
+## `ranges`
+
+The `ranges` module contains functions for retreiving [vscode.Range](https://code.visualstudio.com/api/references/vscode-api#Range)s and text for pieces of interest in a Clojure document.
+
+All functions in this module have the following TypeScript signature:
+
+```typescript
+(editor = vscode.window.activeTextEditor, position = editor?.selection?.active) => [vscode.Range, string];
+```
+
+I.e. they expect a [vscode.TextEditor]() – defaulting to the currently active editor – and a [vscode.Position]() – defaulting to the current active position in the editor (or the first active position if multiple selections/positions exist, and will return a tuple with the range, and the text for the piece of interest requested.
+
+The functions available are:
+
+### `ranges.currentForm()`
+
+Retrieves information about the current form, as determined from the editor and position. See about Calva's [Current Form]() on YouTube.
+
+### `ranges.currentEnclosingForm()`
+
+The list/vector/etcetera form comtaining the current form.
+
+### `ranges.currentTopLevelForm()`
+
+The current top level form. Outside `(comment ...)` (Rich comments) forms this is most often (`(def ...), (defgn ...)`, etcetera. Inside Rich comments it will be the current immediate child to the `(comment ...)` form.
+
+### `ranges.currentFunction()`
+
+The current function, i.e. the form in ”call position” of the closest enclosing list.
+
+### `ranges.currentTopLevelDef()`
+
+The symbol being defined by the current top level form. NB: Will stupidly assume it is the second form. I.e. it does not check that it is an actual definition, and will often return nonsense if used in Rich comments.
+
+### Example: `ranges.currentTopLevelForm()`
+
+=== "ClojureScript"
+
+    ```clojure
+    (def top-level-form (get-in [:repl :currentTopLevelForm] calvaApi))
+    (def text (-> (top-level-form)
+                  second))
+    ```
+
+=== "JavaScript"
+
+    ```javascript
+    const text = repl.currentTopLevelForm()[1];
     ```
 
 ## Feedback Welcome

--- a/docs/site/custom-commands.md
+++ b/docs/site/custom-commands.md
@@ -9,6 +9,9 @@ search:
 
 Calva supports configuration of custom command snippets that you can evaluate in the REPL at will. If your workflow has you repeatedly evaluate a particular piece of code, you can use the setting `calva.customREPLCommandSnippets` to configure it. Then either bind keyboard shortcuts to them or use the command **Run Custom REPL Command** to access it. The command will give you a menu with the snippets you have configured.
 
+!!! Note "Joyride"
+    For some use cases you might be better served by/want to combine these with using the [VS Code Extension API](https://code.visualstudio.com/api/references/vscode-ap), and [that of Calva](api.md), or any other extension, through [Joyride](joyride.md).
+
 The `calva.customREPLCommandSnippets` is an array of objects with the following fields (required fields in **bold**):
 
 * **`name`**: The name of the snippet as it will appear in the picker menu
@@ -137,7 +140,5 @@ A new experimental feature lets library authors ship snippets inside their jar f
  [{:name "edn hover"
    :snippet "(str \"$hover-tex\")"}
   {:name "edn hover show val"
-   :snippet "(str \"### EDN show val\n```clojure\n\" (pr-str (eval (symbol (str \"$ns\" \"/\" \"$hover-top-level-defined-symbol\")))) \"\n```\")"}
- ]
- }
+   :snippet "(str \"### EDN show val\n```clojure\n\" (pr-str (eval (symbol (str \"$ns\" \"/\" \"$hover-top-level-defined-symbol\")))) \"\n```\")"}]}
 ```

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,12 +1,14 @@
-import * as evaluate from './evaluate-code';
-
+import * as repl from './repl';
+import * as ranges from './ranges';
 export function getApi() {
   return {
     // If we can avoid it we don't want to ever break our callers.
     // This first version of the API is a draft though, so signaling
     // potential removal of this version of the API with the `0`.
     v0: {
-      evaluateCode: evaluate.evaluateCode,
+      evaluateCode: repl.evaluateCode, // backward compatible
+      repl,
+      ranges,
     },
   };
 }

--- a/src/api/ranges.ts
+++ b/src/api/ranges.ts
@@ -1,0 +1,20 @@
+import * as vscode from 'vscode';
+import * as getText from '../util/get-text';
+
+const wrapSelectionAndTextFunction = (
+  f: (document: vscode.TextDocument, position: vscode.Position) => [vscode.Range, string]
+) => {
+  return (editor = vscode.window.activeTextEditor, position = editor?.selection?.active) => {
+    if (editor && position && editor.document && editor.document.languageId === 'clojure') {
+      return f(editor.document, position);
+    } else {
+      return [undefined, undefined];
+    }
+  };
+};
+
+export const currentForm = wrapSelectionAndTextFunction(getText.currentFormText);
+export const currentEnclosingForm = wrapSelectionAndTextFunction(getText.currentEnclosingFormText);
+export const currentTopLevelForm = wrapSelectionAndTextFunction(getText.currentTopLevelFormText);
+export const currentFunction = wrapSelectionAndTextFunction(getText.currentFunction);
+export const currentTopLevelDef = wrapSelectionAndTextFunction(getText.currentTopLevelFunction);

--- a/src/api/repl.ts
+++ b/src/api/repl.ts
@@ -1,6 +1,6 @@
 import * as printer from '../printer';
-import * as state from '../state';
 import * as replSession from '../nrepl/repl-session';
+import { cljsLib } from '../utilities';
 
 type Result = {
   result: string;
@@ -9,26 +9,26 @@ type Result = {
   errorOutput: string;
 };
 
-export async function evaluateCode(
-  sessionKey: 'clj' | 'cljs',
+export const evaluateCode = async (
+  sessionKey: 'clj' | 'cljs' | 'cljc' | undefined,
   code: string,
   output?: {
     stdout: (m: string) => void;
     stderr: (m: string) => void;
   }
-): Promise<Result> {
-  const session = replSession.getSession(sessionKey);
+): Promise<Result> => {
+  const session = replSession.getSession(sessionKey || undefined);
   if (!session) {
     throw new Error(`Can't retrieve REPL session for session key: ${sessionKey}.`);
   }
   const stdout = output
     ? output.stdout
-    : (m: string) => {
+    : (_m: string) => {
         // Do nothing
       };
   const stderr = output
     ? output.stdout
-    : (m: string) => {
+    : (_m: string) => {
         // Do nothing
       };
   const evaluation = session.eval(code, undefined, {
@@ -42,4 +42,8 @@ export async function evaluateCode(
     output: evaluation.outPut,
     errorOutput: evaluation.errorOutput,
   };
-}
+};
+
+export const currentSessionKey = () => {
+  return replSession.getReplSessionType(cljsLib.getStateValue('connected'));
+};

--- a/test-data/.joyride/scripts/calva_api_scratch.cljs
+++ b/test-data/.joyride/scripts/calva_api_scratch.cljs
@@ -1,0 +1,118 @@
+(ns calva-api-scratch
+  (:require ["vscode" :as vscode]
+            [joyride.core :as joyride]
+            [promesa.core :as p]
+            [z-joylib.editor-utils :as util]))
+
+(def oc (joyride.core/output-channel))
+(def calva (vscode/extensions.getExtension "betterthantomorrow.calva"))
+(def calvaApi (-> calva
+                  .-exports
+                  .-v0
+                  (js->clj :keywordize-keys true)))
+
+(def evaluate (fn [code]
+                ((get-in [:repl :evaluateCode] calvaApi)
+                 "clj"
+                 code
+                 #js {:stdout #(.append oc %)
+                      :stderr #(.append oc (str "Error: " %))})))
+
+(defn top-level-form-text []
+  #_(p/let [_ (vscode/commands.executeCommand "paredit.rangeForDefun")
+            selection vscode/window.activeTextEditor.selection
+            document vscode/window.activeTextEditor.document
+            code (.getText document selection)]
+      (vscode/commands.executeCommand "cursorUndo")
+      code)
+  (second ((get-in calvaApi [:ranges :currentTopLevelForm]))))
+
+(defn evaluate-selection []
+  (p/let [selection vscode/window.activeTextEditor.selection
+          document vscode/window.activeTextEditor.document
+          code (.getText document selection)
+          result (.-result (evaluate code))]
+    result))
+
+(defn evaluate-top-level-form []
+  (p/let [code (top-level-form-text)
+          result (.-result (evaluate code))]
+    result))
+
+(defn paredit-sandbox []
+  (p/do!
+   (vscode/commands.executeCommand "paredit.dragSexprBackward")
+   (vscode/commands.executeCommand "paredit.dragSexprBackward")
+   (vscode/commands.executeCommand "paredit.dragSexprForward")
+   (vscode/commands.executeCommand "paredit.wrapAroundParens")
+   (vscode/commands.executeCommand "paredit.slurpSexpForward")
+   (vscode/commands.executeCommand "paredit.backwardUpSexp")
+   (vscode/commands.executeCommand "paredit.dragSexprBackwardUp")
+   (util/insert-text!+ "#_")
+   (vscode/commands.executeCommand "paredit.forwardSexp")
+   (vscode/commands.executeCommand "paredit.forwardDownSexp")))
+
+(comment
+  {:foo 1234
+   :bar
+   {:foo 4321
+    :bar :baz
+    42 :question
+    :answer 42}}
+  (evaluate-top-level-form))
+
+(comment
+  (def eval1 (partial (get-in [:repl :evaluateCode] calvaApi) "clj"))
+
+  (def evaluate (fn [code]
+                  ((get-in [:repl :evaluateCode] calvaApi)
+                   "clj"
+                   code
+                   #js {:stdout #(.append oc %)
+                        :stderr #(.append oc (str "Error: " %))})))
+
+  #_(def evaluate (get-in [:repl :evaluateCode] calvaApi))
+
+  (-> (p/let [evaluation (evaluate "(println :foo) (+ 2 40)")]
+        (.appendLine oc (str "=> " (.-result evaluation))))
+      (p/catch (fn [e]
+                 (.appendLine oc (str "Evaluation error: " e)))))
+  #_(-> (p/let [evaluation (eval1 "[(println :forty-two) #_(in-ns 'some-ns) (println (str *ns* foo)) 42]")]
+          (println "evaluation" evaluation)
+          (println "ns" (.-ns evaluation))
+          (println "output" (.-output evaluation))
+          (println "result" (.-result evaluation))
+          (def ev evaluation)
+          evaluation
+          #_(p/let [#_#_result (.-value evaluation)]
+              #_(println result)
+              evaluation))
+        (p/catch (fn [e]
+                   (.appendLine oc (str "Evaluation error: " e))))))
+
+(comment
+  ev
+  (.-ns ev)
+  (js-keys ev)
+  (p/do! (println "ev.value" (.-value ev))))
+
+(def gtlf (get-in calvaApi [:ranges :currentTopLevelForm]))
+(def gcf (get-in calvaApi [:ranges :currentForm]))
+
+;(def ate vscode/window.activeTextEditor)
+;(def p vscode/window.activeTextEditor.selection.active)
+{:ranges {:currentTopLevelForm (second (gtlf))
+          :currentFormText (second (gcf))
+          :currentFunction (second ((get-in calvaApi [:ranges :currentFunction])))
+          :currentEnclosingForm (second ((get-in calvaApi [:ranges :currentEnclosingForm])))
+          :currentTopLevelDef (second ((get-in calvaApi [:ranges :currentTopLevelDef])))
+          :currentSessionKey ((get-in calvaApi [:repl :currentSessionKey]))}
+ :repl {:evaluatedCode (-> ((get-in calvaApi [:repl :evaluateCode]) "cljc" "43")
+                           (p/then (fn [result]
+                                     (def result result)
+                                     (.appendLine oc (str "Result: " (.-result result)))
+                                     (.appendLine oc (str "ns: " (.-ns result)))))
+                           (p/catch (fn [error]
+                                      (.appendLine oc (str "Error evaluating: " error)))))
+        :currentSessionKey ((get-in calvaApi [:repl :currentSessionKey]))}}
+;(second (gtlf ate, p))

--- a/test-data/.joyride/scripts/clojure_file.clj
+++ b/test-data/.joyride/scripts/clojure_file.clj
@@ -1,0 +1,3 @@
+(ns clojure-file)
+
+{:foo "bar"}


### PR DESCRIPTION
## What has Changed?

- New `ranges` API module, with five functions for getting information about the current form, etcetera.
- `repl` API module introduced
  - `repl.currentSessionKey()`
  - `repl.evaluateCode()` (This function also still exist at the root of the `v0` API.)

Fixes #1747
Fixes #1748

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik