### PR TITLE
Api register document symbol provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Expose Calva's `registerSymbolProvider` function in the extension API](https://github.com/BetterThanTomorrow/calva/issues/1752)
+
 ## [2.0.278] - 2022-05-29
 
 - [Extension API: Fix Javascript examples & align them with their ClojureScript versions](https://github.com/BetterThanTomorrow/calva/issues/1742)

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,6 @@
 import * as repl from './repl';
 import * as ranges from './ranges';
+import * as calvaVsCode from './vscode';
 export function getApi() {
   return {
     // If we can avoid it we don't want to ever break our callers.
@@ -9,6 +10,7 @@ export function getApi() {
       evaluateCode: repl.evaluateCode, // backward compatible
       repl,
       ranges,
+      vscode: calvaVsCode,
     },
   };
 }

--- a/src/api/vscode.ts
+++ b/src/api/vscode.ts
@@ -1,0 +1,3 @@
+import * as vscode from 'vscode';
+
+export const registerDocumentSymbolProvider = vscode.languages.registerDocumentSymbolProvider;


### PR DESCRIPTION
## What has Changed?

Adding a module `vscode` to Calva's extension API. Right now with only one member: `registerSymbolProvider` which is s reference to Calva's `vscode/languages.registerSymbolProvider`.

Fixes #1752

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik