### PR TITLE
Symbols provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Provide document symbols via Calva's provider](https://github.com/BetterThanTomorrow/calva/issues/1755)
+
 ## [2.0.279] - 2022-05-30
 
 - [Expose Calva's `registerSymbolProvider` function in the extension API](https://github.com/BetterThanTomorrow/calva/issues/1752)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,7 @@ import * as joyride from './joyride';
 import * as api from './api/index';
 
 import * as clojureDocs from './clojuredocs';
+import { CalvaDocumentSymbolsProvider } from './providers/symbols';
 async function onDidSave(testController: vscode.TestController, document: vscode.TextDocument) {
   const { evaluate, test } = config.getConfig();
 
@@ -517,6 +518,12 @@ async function activate(context: vscode.ExtensionContext) {
       new CalvaSignatureHelpProvider(),
       ' ',
       ' '
+    )
+  );
+  context.subscriptions.push(
+    vscode.languages.registerDocumentSymbolProvider(
+      config.documentSelector,
+      new CalvaDocumentSymbolsProvider()
     )
   );
 

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -3,7 +3,6 @@ import {
   LanguageClient,
   ServerOptions,
   LanguageClientOptions,
-  DocumentSymbol,
   Position,
   StaticFeature,
   ClientCapabilities,
@@ -113,6 +112,9 @@ function createClient(clojureLspPath: string, fallbackFolder: FallbackFolder): L
           return next(change);
         },
         provideLinkedEditingRange: (_document, _position, _token, _next): null => {
+          return null;
+        },
+        provideDocumentSymbols(_document, _token, _next) {
           return null;
         },
         handleDiagnostics(uri, diagnostics, next) {
@@ -721,15 +723,18 @@ async function getReferences(
   return result;
 }
 
-async function getDocumentSymbols(
+function getDocumentSymbols(
   lspClient: LanguageClient,
   uri: string
-): Promise<DocumentSymbol[]> {
-  const result: DocumentSymbol[] = await lspClient.sendRequest('textDocument/documentSymbol', {
-    textDocument: {
-      uri,
-    },
-  });
+): Promise<vscode.DocumentSymbol[]> {
+  const result: Promise<vscode.DocumentSymbol[]> = lspClient.sendRequest(
+    'textDocument/documentSymbol',
+    {
+      textDocument: {
+        uri,
+      },
+    }
+  );
   return result;
 }
 

--- a/src/providers/symbols.ts
+++ b/src/providers/symbols.ts
@@ -1,0 +1,15 @@
+import * as vscode from 'vscode';
+import lsp from '../lsp/main';
+import * as util from '../utilities';
+
+export class CalvaDocumentSymbolsProvider implements vscode.DocumentSymbolProvider {
+  provideDocumentSymbols(
+    document: vscode.TextDocument,
+    _token: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
+    return lsp.getDocumentSymbols(
+      util.cljsLib.getStateValue(lsp.LSP_CLIENT_KEY),
+      decodeURIComponent(document.uri.toString())
+    );
+  }
+}


### PR DESCRIPTION
## What has Changed?

Implementing a document symbols provider by using clojure-lsp for it, and disabling the ”automatic” provider in lsp client middleware.

It doesn't work yet. I don't understand why. I'm merely passing on the promise and the function in the clojure-lsp main.ts file clearly works.

Fixes #1755

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [ ] Created the issue I am fixing/addressing, if it was not present.
- [ ] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [ ] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik