### PR TITLE
Use document.uri instead of nrepl.nsPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Debugger decorations are not working properly](https://github.com/BetterThanTomorrow/calva/issues/1165)
+
 ## [2.0.279] - 2022-05-30
 
 - [Expose Calva's `registerSymbolProvider` function in the extension API](https://github.com/BetterThanTomorrow/calva/issues/1752)

--- a/src/debugger/decorations.ts
+++ b/src/debugger/decorations.ts
@@ -45,10 +45,10 @@ async function update(
           iSymbolRefLocations: Promise<InstrumentedSymbolReferenceLocations>,
           [namespace, ...instrumentedDefs]: string[]
         ) => {
-          const namespacePath = (await cljSession.nsPath(namespace)).path;
-          const docUri = vscode.Uri.parse(namespacePath, true);
+          const docUri = editor.document.uri; //vscode.Uri.parse(namespacePath, true);
           const decodedDocUri = decodeURIComponent(docUri.toString());
-          const docSymbols = (await lsp.getDocumentSymbols(lspClient, decodedDocUri))[0].children;
+          const docSymbols = (await lsp.getDocumentSymbols(lspClient, editor.document.uri))[0]
+            .children;
           const instrumentedDocSymbols = docSymbols.filter((s) =>
             instrumentedDefs.includes(s.name)
           );
@@ -58,7 +58,7 @@ async function update(
                 line: s.selectionRange.start.line,
                 character: s.selectionRange.start.character,
               };
-              return lsp.getReferences(lspClient, decodedDocUri, position);
+              return lsp.getReferences(lspClient, editor.document.uri, position);
             })
           );
           const currentNsSymbolsReferenceLocations = instrumentedDocSymbols.reduce(

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -705,13 +705,13 @@ function deactivate(): Promise<void> {
 
 async function getReferences(
   lspClient: LanguageClient,
-  uri: string,
+  documentUri: vscode.Uri,
   position: Position,
   includeDeclaration: boolean = true
 ): Promise<Location[] | null> {
   const result: Location[] = await lspClient.sendRequest('textDocument/references', {
     textDocument: {
-      uri,
+      uri: documentUri.toString(),
     },
     position,
     context: {
@@ -723,11 +723,11 @@ async function getReferences(
 
 async function getDocumentSymbols(
   lspClient: LanguageClient,
-  uri: string
+  documentUri: vscode.Uri
 ): Promise<DocumentSymbol[]> {
   const result: DocumentSymbol[] = await lspClient.sendRequest('textDocument/documentSymbol', {
     textDocument: {
-      uri,
+      uri: documentUri.toString(),
     },
   });
   return result;


### PR DESCRIPTION
## What has Changed?

It seems the ns-path op on nrepl at some point stopped working as expected by the debugger symbol decorator. Here it's changed to use the vscode document uri instead. Works for the cases I've tried.

Fixes #1165

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik