### PR TITLE
Use platform & architecture to locate clojure-lsp native binary w/ fallback to standalone JAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- clojure-lsp changes:
-  - Use OS and architecture to identify native binary to download
-  - Fall back to `clojure-lsp-standalone.jar` for environments with no native binary
-  - Use system Java to execute clojure-lsp if a JAR file is provided
-  - Fix: [Calva downloads the wrong clojure-lsp when running in devcontainer
-](https://github.com/BetterThanTomorrow/calva/issues/1598)
-  - Fix: [start clojure-lsp client failed](https://github.com/BetterThanTomorrow/calva/issues/1590)
+- [Updates to how we choose clojure-lsp executable for different platforms](https://github.com/BetterThanTomorrow/calva/pull/1758), fixes: [#1590](https://github.com/BetterThanTomorrow/calva/issues/1590), and [#1598](https://github.com/BetterThanTomorrow/calva/issues/1598)
 
 ## [2.0.280] - 2022-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- clojure-lsp changes:
+  - Use OS and architecture to identify native binary to download
+  - Fall back to `clojure-lsp-standalone.jar` for environments with no native binary
+  - Use system Java to execute clojure-lsp if a JAR file is provided
+  - Fix: [Calva downloads the wrong clojure-lsp when running in devcontainer
+](https://github.com/BetterThanTomorrow/calva/issues/1598)
+  - Fix: [start clojure-lsp client failed](https://github.com/BetterThanTomorrow/calva/issues/1590)
+
 ## [2.0.280] - 2022-05-31
 
 - Fix: [Debugger decorations are not working properly](https://github.com/BetterThanTomorrow/calva/issues/1165)

--- a/docs/site/clojure-lsp.md
+++ b/docs/site/clojure-lsp.md
@@ -84,9 +84,9 @@ Example:
     * `latest`: Will download and use the latest stable build of clojure-lsp, when one becomes available. This is the default
     * `nightly`: Will always download and use the latest nightly build, _whether there is a new version available or not_.
 
-### Using a Custom Clojure-lsp Native Binary
+### Using a Custom Clojure-lsp
 
-You can set a path to a clojure-lsp binary to be used by Calva by setting the `calva.clojureLspPath` setting. This should be an absolute path. The binary at this path will then be used.
+You can set a path to a custom clojure-lsp to be used by Calva by configuring the `calva.clojureLspPath` setting. This should be an absolute path to a native binary or JAR file.
 
 Example:
 

--- a/src/lsp/download.ts
+++ b/src/lsp/download.ts
@@ -80,7 +80,9 @@ async function downloadClojureLsp(extensionPath: string, version: string): Promi
       : `https://nightly.link/clojure-lsp/clojure-lsp/workflows/nightly/master/${artifactName}`;
   const downloadPath = path.join(extensionPath, artifactName);
   const clojureLspPath = lspUtil.getClojureLspPath(extensionPath);
-  const backupPath = fs.existsSync(clojureLspPath) ? backupExistingFile(clojureLspPath) : clojureLspPath;
+  const backupPath = fs.existsSync(clojureLspPath)
+    ? backupExistingFile(clojureLspPath)
+    : clojureLspPath;
   try {
     await downloadArtifact(url, downloadPath);
     if (path.extname(downloadPath) === '.zip') {

--- a/src/lsp/main.ts
+++ b/src/lsp/main.ts
@@ -58,7 +58,7 @@ class TestTreeFeature implements StaticFeature {
 
 function createClient(clojureLspPath: string, fallbackFolder: FallbackFolder): LanguageClient {
   // Run JARs with system Java; anything else execute directly
-  const serverOptions : ServerOptions =
+  const serverOptions: ServerOptions =
     path.extname(clojureLspPath) === '.jar'
       ? {
           command: path.join(process.env.JAVA_HOME, 'bin', 'java'),

--- a/src/lsp/utilities.ts
+++ b/src/lsp/utilities.ts
@@ -1,11 +1,41 @@
 import * as path from 'path';
 import * as fs from 'fs';
+import * as process from 'process';
 
 const versionFileName = 'clojure-lsp-version';
 
-function getClojureLspPath(extensionPath: string, isWindows: boolean): string {
-  const fileExtension = isWindows ? '.exe' : '';
-  return path.join(extensionPath, `clojure-lsp${fileExtension}`);
+const artifacts = {
+  darwin: {
+    x64: 'clojure-lsp-native-macos-amd64.zip',
+    // Should M1 Macs use emulated native binary or native standalone jar until M1 native available?
+    // arm64: 'clojure-lsp-native-macos-amd64.zip',
+  },
+  linux: {
+    x64: 'clojure-lsp-native-static-linux-amd64.zip',
+    arm64: 'clojure-lsp-native-linux-aarch64.zip',
+  },
+  win32: {
+    x64: 'clojure-lsp-native-windows-amd64.zip',
+  },
+};
+
+function getArtifactDownloadName(
+  platform: string = process.platform,
+  arch: string = process.arch
+): string {
+  return artifacts[platform]?.[arch] ?? 'clojure-lsp-standalone.jar';
+}
+
+function getClojureLspPath(
+  extensionPath: string,
+  platform: string = process.platform,
+  arch: string = process.arch
+): string {
+  let name = getArtifactDownloadName(platform, arch);
+  if (path.extname(name).toLowerCase() !== '.jar') {
+    name = arch === 'win32' ? 'clojure-lsp.exe' : 'clojure-lsp';
+  }
+  return path.join(extensionPath, name);
 }
 
 function getVersionFilePath(extensionPath: string): string {
@@ -23,4 +53,4 @@ function readVersionFile(extensionPath: string): string {
   }
 }
 
-export { getClojureLspPath, getVersionFilePath, readVersionFile };
+export { getArtifactDownloadName, getClojureLspPath, getVersionFilePath, readVersionFile };


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

Changes the clojure-lsp download logic to use the OS and architecture to find native binary to download and fall back to `clojure-lsp-standalone.jar` for environments with no native binary. 

Adds support for running clojure-lsp from JAR file.

Tested on linux-amd64, linux-aarch64 (Calva 2.0.280 downloads wrong native binary), windows-aarch64 (no native binary available) and using WSL and SSH remotes.

This PR as-is will change current Calva behavior on M1 Macs by downloading the JAR instead of the native binary which would run under emulation if enabled.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1590, #1598

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
     - [x] Tested the particular change
     - [x] Figured if the change might have some side effects and tested those as well.
     - [x] Smoke tested the extension as such.
     - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik