### PR TITLE
Allow backspace to delete a char when inside leftmost token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Fix a problem when using paredit backspace on the leftmost token](https://github.com/BetterThanTomorrow/calva/pull/1768)
+
 ## [2.0.283] - 2022-06-10
 
 - [Add a Dart->ClojureDart converter](https://github.com/BetterThanTomorrow/calva/pull/1763)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- [Fix a problem when using paredit backspace on the leftmost token](https://github.com/BetterThanTomorrow/calva/pull/1768)
+- Fix: [Paredit strict backspace in the leftmost symbol/keyword/thing inserts a space instead](https://github.com/BetterThanTomorrow/calva/pull/1771)
 
 ## [2.0.284] - 2022-06-11
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -797,6 +797,8 @@ function onlyWhitespaceLeftOfCursor(doc: EditableDocument, cursor: LispTokenCurs
   const token = cursor.getToken();
   if (token.type === 'ws') {
     return token.offset === 0;
+  } else if (doc.selection.anchor > cursor.offsetStart) {
+    return false;
   }
   const prevToken = cursor.getPrevToken();
 

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1314,6 +1314,13 @@ describe('paredit', () => {
         await paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
+
+      it('Deletes a character when inside a token on a blank line', async () => {
+        const a = docFromTextNotation('(if• :|foo)');
+        const b = docFromTextNotation('(if• |foo)');
+        await paredit.backspace(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
     });
 
     describe('Kill character forwards (delete)', () => {


### PR DESCRIPTION
## What has Changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

[This PR](https://github.com/BetterThanTomorrow/calva/pull/1745) had a bug. This is a follow-up fix.

Briefly, the problem is that when you press backspace in this form:

```
(if• :|foo)
```

It would insert a space between `:` and `f`, instead of just deleting the `:`. This is because the `onlyWhitespaceLeftOfCursor` that was being used to guard the new backspace on whitespace behavior function didn't verify that you were not deeply inside the current token (as opposed to just touching the left edge).

Fixes this the problem shown in this comment: https://github.com/BetterThanTomorrow/calva/pull/1745#issuecomment-1152613501

And this Slack thread:
https://clojurians.slack.com/archives/CBE668G4R/p1654897313506689

#1741

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

If this PR involves code changes, I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
