### PR TITLE
Hide stacktrace behind codelens for errors from load file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Error reporting for load file differs from evaluate code](https://github.com/BetterThanTomorrow/calva/issues/1774)
+
 ## [2.0.286] - 2022-06-13
 
 - [Add option in clojure-lsp quick pick to restart clojure-lsp](https://github.com/BetterThanTomorrow/calva/issues/1770)

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -438,12 +438,15 @@ async function loadFile(
         outputWindow.append('; No results from file evaluation.');
       }
     } catch (e) {
-      if (res.stacktrace) {
-        outputWindow.saveStacktrace(res.stacktrace.stacktrace);
-      }
-      outputWindow.append(`; Evaluation of file ${fileName} failed: ${e}`, (_location, nextLocation) => {
-        outputWindow.markLastStacktraceRange(nextLocation);
-      });
+      outputWindow.append(
+        `; Evaluation of file ${fileName} failed: ${e}`,
+        (_location, nextLocation) => {
+          if (res.stacktrace) {
+            outputWindow.saveStacktrace(res.stacktrace.stacktrace);
+            outputWindow.markLastStacktraceRange(nextLocation);
+          }
+        }
+      );
     }
     outputWindow.setSession(session, res.ns || ns);
     replSession.updateReplSessionType();

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -438,11 +438,12 @@ async function loadFile(
         outputWindow.append('; No results from file evaluation.');
       }
     } catch (e) {
-      outputWindow.append(`; Evaluation of file ${fileName} failed: ${e}`);
       if (res.stacktrace) {
         outputWindow.saveStacktrace(res.stacktrace.stacktrace);
-        outputWindow.printLastStacktrace();
       }
+      outputWindow.append(`; Evaluation of file ${fileName} failed: ${e}`, (_location, nextLocation) => {
+        outputWindow.markLastStacktraceRange(nextLocation);
+      });
     }
     outputWindow.setSession(session, res.ns || ns);
     replSession.updateReplSessionType();


### PR DESCRIPTION
## What has changed?

We now hide the stack trace behind a codelens like we do with evaluations.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1774

## My Calva PR Checklist

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- ~[ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - ~[ ] Figured if the change might have some side effects and tested those as well.~
  - ~[ ] Smoke tested the extension as such.~
  - ~[ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.~
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - ~[ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- ~[ ] Created the issue I am fixing/addressing, if it was not present.~
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
