### PR TITLE
Add `definitionProviderPriority` configuraion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Add configuration for which symbol definition provider to use](https://github.com/BetterThanTomorrow/calva/issues/1785)
+
 ## [2.0.287] - 2022-06-25
 
 - Fix: [Error reporting for load file differs from evaluate code](https://github.com/BetterThanTomorrow/calva/issues/1774)

--- a/package.json
+++ b/package.json
@@ -731,12 +731,25 @@
             "default": true
           },
           "calva.definitionProviderPriority": {
-            "enum": [
-              "replThenLsp",
-              "lspThenRepl"
-            ],
             "markdownDescription": "Calva can provide definitions using both the REPL connection and via clojure-lsp. Which provider should Calva prioritize when both are available?",
-            "default": "replThenLsp"
+            "enum": [
+              [
+                "repl",
+                "lsp"
+              ],
+              [
+                "lsp",
+                "repl"
+              ]
+            ],
+            "markdownEnumDescriptions": [
+              "Use dynamic (REPL) definitions when available.",
+              "Use static (clojure-lsp) definitions when available."
+            ],
+            "default": [
+              "repl",
+              "lsp"
+            ]
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -729,6 +729,14 @@
             "type": "boolean",
             "markdownDescription": "Show the Calva Says output panel on start?",
             "default": true
+          },
+          "calva.definitionProviderPriority": {
+            "enum": [
+              "replThenLsp",
+              "lspThenRepl"
+            ],
+            "markdownDescription": "Calva can provide definitions using both the REPL connection and via clojure-lsp. Which provider should Calva prioritize when both are available?",
+            "default": "replThenLsp"
           }
         }
       },

--- a/src/config.ts
+++ b/src/config.ts
@@ -163,6 +163,7 @@ function getConfig() {
     enableClojureLspOnStart: configOptions.get<boolean>('enableClojureLspOnStart'),
     projectRootsSearchExclude: configOptions.get<string[]>('projectRootsSearchExclude', []),
     useLiveShare: configOptions.get<boolean>('useLiveShare'),
+    definitionProviderPriority: configOptions.get<string>('definitionProviderPriority'),
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -163,7 +163,7 @@ function getConfig() {
     enableClojureLspOnStart: configOptions.get<boolean>('enableClojureLspOnStart'),
     projectRootsSearchExclude: configOptions.get<string[]>('projectRootsSearchExclude', []),
     useLiveShare: configOptions.get<boolean>('useLiveShare'),
-    definitionProviderPriority: configOptions.get<string>('definitionProviderPriority'),
+    definitionProviderPriority: configOptions.get<string[]>('definitionProviderPriority'),
   };
 }
 

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -5,13 +5,17 @@ import annotations from './annotations';
 import * as namespace from '../namespace';
 import * as outputWindow from '../results-output/results-doc';
 import * as replSession from '../nrepl/repl-session';
+import * as config from '../config';
 import { createConverter } from 'vscode-languageclient/lib/common/protocolConverter';
 import { getClient } from '../lsp/main';
 import { DefinitionRequest } from 'vscode-languageclient';
 
 const converter = createConverter(undefined, undefined);
 
-const definitionProviderOptions = { priority: ['lsp', 'repl'] };
+const definitionProviderOptions = {
+  replThenLsp: { priority: ['repl', 'lsp'] },
+  lspThenRepl: { priority: ['lsp', 'repl'] },
+};
 
 const definitionFunctions = { lsp: lspDefinition, repl: provideClojureDefinition };
 
@@ -49,7 +53,8 @@ export class ClojureDefinitionProvider implements vscode.DefinitionProvider {
   }
 
   async provideDefinition(document, position: vscode.Position, token) {
-    for (const provider of definitionProviderOptions.priority) {
+    const priority = config.getConfig().definitionProviderPriority;
+    for (const provider of definitionProviderOptions[priority].priority) {
       const definition = await definitionFunctions[provider](document, position, token);
 
       if (definition) {


### PR DESCRIPTION
## What has changed?

Adding a user setting for the choice between lsp and nrepl as definition provider. Defaulting to nrepl.

Fixes #1785

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
