### PR TITLE
Add some tests for killRange and top level format

### DIFF
--- a/src/cljs-lib/test/calva/fmt/formatter_test.cljs
+++ b/src/cljs-lib/test/calva/fmt/formatter_test.cljs
@@ -132,7 +132,11 @@ baz))"
   (is (= 11
          (:new-index (sut/format-text-at-idx {:eol "\n" :all-text "(foo\n (bar)\n )" :range [0 14] :idx 11}))))
   (is (= 1
-         (:new-index (sut/format-text-at-idx {:eol "\n" :all-text "(\n\n,)" :range [0 14] :idx 2})))))
+         (:new-index (sut/format-text-at-idx {:eol "\n" :all-text "(\n\n,)" :range [0 14] :idx 2}))))
+  (is (= 3
+         (:new-index (sut/format-text-at-idx {:eol "\n" :all-text "[a b c]" :range [0 7] :idx 3}))))
+  (is (= 2
+         (:new-index (sut/format-text-at-idx {:eol "\n" :all-text "a b c" :range [0 5] :idx 2})))))
 
 
 (def head-and-tail-text "(def a 1)

--- a/src/cljs-lib/test/calva/fmt/formatter_test.cljs
+++ b/src/cljs-lib/test/calva/fmt/formatter_test.cljs
@@ -27,7 +27,10 @@ baz)")
   (is (= [0 5]
          (:range (sut/format-text-at-idx {:eol "\n" :all-text "(\n\n,)" :range [0 5] :idx 2}))))
   (is (= "()"
-         (:range-text (sut/format-text-at-idx {:eol "\n" :all-text "(\n\n,)" :range [0 5] :idx 2})))))
+         (:range-text (sut/format-text-at-idx {:eol "\n" :all-text "(\n\n,)" :range [0 5] :idx 2}))))
+  ;; TODO: Figure out why the extra space is not removed
+  #_(is (= "a c"
+         (:range-text (sut/format-text-at-idx {:eol "\n" :all-text "a  c" :range [0 4] :idx 2})))))
 
 (def misaligned-text "(def foo
 (let[a   b
@@ -136,7 +139,9 @@ baz))"
   (is (= 3
          (:new-index (sut/format-text-at-idx {:eol "\n" :all-text "[a b c]" :range [0 7] :idx 3}))))
   (is (= 2
-         (:new-index (sut/format-text-at-idx {:eol "\n" :all-text "a b c" :range [0 5] :idx 2})))))
+         (:new-index (sut/format-text-at-idx {:eol "\n" :all-text "a b c" :range [0 5] :idx 2}))))
+  (is (= 2
+         (:new-index (sut/format-text-at-idx {:eol "\n" :all-text "a  c" :range [0 4] :idx 2})))))
 
 
 (def head-and-tail-text "(def a 1)

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1407,6 +1407,12 @@ describe('paredit', () => {
 
     describe('killRange', () => {
       it('Deletes top-level range with backward direction', async () => {
+        const a = docFromTextNotation('a |<|b|<| c');
+        const b = docFromTextNotation('a | c');
+        await paredit.killRange(a, textAndSelection(a)[1]);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('Deletes top-level range with backward direction, including space', async () => {
         const a = docFromTextNotation('a |<|b |<|c');
         const b = docFromTextNotation('a |c');
         await paredit.killRange(a, textAndSelection(a)[1]);

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1404,6 +1404,34 @@ describe('paredit', () => {
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
+
+    describe('killRange', () => {
+      it('Deletes top-level range with backward direction', async () => {
+        const a = docFromTextNotation('a |<|b |<|c');
+        const b = docFromTextNotation('a |c');
+        await paredit.killRange(a, textAndSelection(a)[1]);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('Deletes top-level range with forward direction', async () => {
+        const a = docFromTextNotation('a |>|b |>|c');
+        const b = docFromTextNotation('a |c');
+        await paredit.killRange(a, textAndSelection(a)[1]);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('Deletes nested range with backward direction', async () => {
+        const a = docFromTextNotation('{a |<|b |<|c}');
+        const b = docFromTextNotation('{a |c}');
+        await paredit.killRange(a, textAndSelection(a)[1]);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('Deletes nested range with forward direction', async () => {
+        const a = docFromTextNotation('{a |>|b |>|c}');
+        const b = docFromTextNotation('{a |c}');
+        await paredit.killRange(a, textAndSelection(a)[1]);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+    });
+
     describe('addRichComment', () => {
       it('Adds Rich Comment after Top Level form', async () => {
         const a = docFromTextNotation('(fo|o)••(bar)');


### PR DESCRIPTION
## What has changed?

Tracking down #1801 I started to suspect `paredit.killRange` and then the formatter (`format.ts ` and `formatter.cljs`) and added some test to expose the problem. Seems the issue is a regression upstream in VS Code, but the tests are still relevant.

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
