### PR TITLE
feat: add possibility to change color of inline evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Color customization for inline result](https://github.com/BetterThanTomorrow/calva/issues/1831)
+
 ## [2.0.292] - 2022-08-18
 
 - [Clojure Notebooks](https://github.com/BetterThanTomorrow/calva/issues/1824)

--- a/docs/site/customizing.md
+++ b/docs/site/customizing.md
@@ -47,6 +47,19 @@ Calva's pretty printing mode can be configured a bit. See [Pretty Printing](ppri
 
 This is highly customizable. See [Syntax highlighting](syntax-highlighting.md)
 
+## Color customizations 
+
+Calva defines a set of themable colors which can be provided by the user using [workbench.colorCustomizations](https://code.visualstudio.com/docs/getstarted/themes#_customize-a-color-theme).
+
+```json
+    "workbench.colorCustomizations": {
+        "calva.inlineErrorForegroundColor": "#ff0000",
+        "calva.inlineForegroundColor": "#ff9000"
+    }
+```
+
+<img width="1188" alt="image" src="https://user-images.githubusercontent.com/616193/185307813-c3e9ec7f-9c72-49a5-b1e6-8e350803c4ea.png">
+
 ## Automatic Parameter Hints Poppup
 
 Calva has helpful parameter hints to aid when typing function calls. They look like so:

--- a/package.json
+++ b/package.json
@@ -2780,6 +2780,26 @@
           }
         ]
       }
+    ],
+    "colors": [
+      {
+        "id": "calva.inlineForegroundColor",
+        "description": "Specifies the foreground color of the inline result",
+        "defaults": {
+          "dark": "#ffffffff",
+          "light": "#00000000",
+          "highContrast": "#00000000"
+        }
+      },
+      {
+        "id": "calva.inlineErrorForegroundColor",
+        "description": "Specifies the foreground color of the inline result with error",
+        "defaults": {
+          "dark": "#ffafaf",
+          "light": "#ff7f7f",
+          "highContrast": "#ff7f7f"
+        }
+      }
     ]
   },
   "scripts": {

--- a/src/providers/annotations.ts
+++ b/src/providers/annotations.ts
@@ -51,16 +51,9 @@ function evaluated(contentText, hoverText, hasError) {
       after: {
         contentText: contentText.replace(/ /g, '\u00a0'),
         overflow: 'hidden',
-      },
-      light: {
-        after: {
-          color: hasError ? 'rgb(255, 127, 127)' : 'black',
-        },
-      },
-      dark: {
-        after: {
-          color: hasError ? 'rgb(255, 175, 175)' : 'white',
-        },
+        color: hasError
+          ? new vscode.ThemeColor('calva.inlineErrorForegroundColor')
+          : new vscode.ThemeColor('calva.inlineForegroundColor'),
       },
     },
   };


### PR DESCRIPTION
## What has changed?

- Add possibility to change color of inline evaluation through the settings


Fixes #1831

## My Calva PR Checklist

If this PR involves code changes, I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
