### PR TITLE
Ensure found doc has file scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Staged file gets evaluated instead of uncommitted file](https://github.com/BetterThanTomorrow/calva/issues/1833)
+
 ## [2.0.293] - 2022-08-18
 
 - [Add jack-in support for Gradle/Clojurephant](https://github.com/BetterThanTomorrow/calva/pull/1815)

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -378,7 +378,9 @@ function scrollToBottom(editor: vscode.TextEditor) {
 }
 
 async function getFileContents(path: string) {
-  const doc = vscode.workspace.textDocuments.find((document) => document.uri.path === path);
+  const doc = vscode.workspace.textDocuments.find(
+    (d) => d.uri.path === path && d.uri.scheme === 'file'
+  );
   if (doc) {
     return doc.getText();
   }


### PR DESCRIPTION
## What has changed?

When loading a file in the REPL we use `utilities.getFileContents()`. It in turn uses `vscode.workspace.textDocuments.find()` which returns results both from the file system and from git. We just picked the first we found and it was from git and results in:

* #1833 

I've now added a check of the Uri scheme, ensuring it is `file`.

Fixes #1833

(Evaluating the wrong file version is bad. But if we at some pointe would have been using this utility function for something to do with the Token Cursor Calva would break pretty bad.)

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
