### PR TITLE
1846 deps clj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 
 - [Rich comment handling in notebooks](https://github.com/BetterThanTomorrow/calva/issues/1845)
 - [Default to use deps.clj instead of clojure for starting deps.edn projects](https://github.com/BetterThanTomorrow/calva/issues/1846)
+- Update deps.clj to version 0.1.1100
 
 ## [2.0.295] - 2022-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
-[Rich comment handling in notebooks](https://github.com/BetterThanTomorrow/calva/issues/1845)
+- [Rich comment handling in notebooks](https://github.com/BetterThanTomorrow/calva/issues/1845)
+- [Default to use deps.clj instead of clojure for starting deps.edn projects](https://github.com/BetterThanTomorrow/calva/issues/1846)
 
 ## [2.0.295] - 2022-08-28
 

--- a/docs/site/connect.md
+++ b/docs/site/connect.md
@@ -46,6 +46,7 @@ There are also these settings:
 * `calva.myCljAliases`: An array of `deps.edn` aliases not found in the project file. Use this to tell Calva Jack-in to launch your REPL using your user defined aliases.
 * `calva.myLeinProfiles`: An array of Leiningen profiles not found in `project.clj`. Use this to tell Calva Jack-in to launch your REPL using your user defined profiles.
 * `calva.openBrowserWhenFigwheelStarted`: _For Legacy Figwheel only._ A boolean controlling if Calva should automatically launch your ClojureScript app, once it is compiled by Figwheel. Defaults to `true`.
+* `calva.depsEdnJackInExecutable`: A string which should either be `clojure` or `deps.clj` (default). It determines which executable Calva Jack-in should use for starting a deps.edn project. Use `clojure` if you have it installed and it works. If you run into troubles you can revert back to the default of using `deps.clj`, which is bundled with Calva.
 
 !!! Note
     When processing the `calva.jackInEnv` setting you can refer to existing ENV variables with `${env:VARIABLE}`.

--- a/docs/site/jack-in-guide.md
+++ b/docs/site/jack-in-guide.md
@@ -143,6 +143,8 @@ If your full stack project is using shadow-cljs for the frontend, like [this Ful
 
 See [Workspace Layouts](workspace-layouts.md) for tips about how to open the same project folder in two separate VS Code windows.
 
+Please also consider to play around with starting the REPL and ClojureScript wiring entirely from the terminal, see [this example project](https://github.com/PEZ/shadow-w-backend) for some instructions on that. You can also use that project together with the `nil` for `connectCode` sequence mentioned above.
+
 ## Please Grab your Calva Jack-In Certificate
 
 There, you now know all there is to know about Calva Jack-In.
@@ -150,3 +152,4 @@ There, you now know all there is to know about Calva Jack-In.
 Just kidding, there are a few more details to it, some of which might find their way into this article at a later time.
 
 To really get to know it all, you will need to spend some time with the Calva Jack-In code. Head over to the [Calva Development Wiki](https://github.com/BetterThanTomorrow/calva/wiki) to learn how to hack on Calva.
+

--- a/package.json
+++ b/package.json
@@ -751,6 +751,15 @@
               "repl",
               "lsp"
             ]
+          },
+          "calva.depsEdnJackInExecutable": {
+            "markdownDescription": "Which executable should Calva Jack-in use for starting a deps.edn project? Use `clojure` if you have it installed and it works. If you run into troubles you can revert back to the default of using `deps.clj`, which is bundled with Calva.",
+            "enum": [
+              "clojure",
+              "deps.clj"
+            ],
+            "default": "deps.clj",
+            "type": "string"
           }
         }
       },

--- a/src/config.ts
+++ b/src/config.ts
@@ -164,6 +164,7 @@ function getConfig() {
     projectRootsSearchExclude: configOptions.get<string[]>('projectRootsSearchExclude', []),
     useLiveShare: configOptions.get<boolean>('useLiveShare'),
     definitionProviderPriority: configOptions.get<string[]>('definitionProviderPriority'),
+    depsEdnJackInExecutable: configOptions.get<string>('depsEdnJackInExecutable'),
   };
 }
 

--- a/src/extension-test/integration/suite/jack-in-test.ts
+++ b/src/extension-test/integration/suite/jack-in-test.ts
@@ -66,7 +66,7 @@ suite('Jack-in suite', () => {
 
     const cmdLine = await vscode.env.clipboard.readText();
 
-    assert.ok(cmdLine.startsWith('clojure'));
+    assert.ok(cmdLine.includes('deps.clj.jar'));
 
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     testUtil.log(suite, 'test.clj closed');

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -195,7 +195,7 @@ async function getJackInTerminalOptions(
       cmd = [...cmd, projectType.resolveBundledPathWin()];
     }
   } else {
-    cmd = projectType.cmd;
+    cmd = typeof projectType.cmd === 'function' ? projectType.cmd() : projectType.cmd;
     if (projectType.resolveBundledPathUnix) {
       cmd = [...cmd, projectType.resolveBundledPathUnix()];
     }

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -15,7 +15,7 @@ export const isWin = /^win/.test(process.platform);
 export type ProjectType = {
   name: string;
   cljsTypes?: string[];
-  cmd?: string[];
+  cmd?: string[] | (() => string[]);
   winCmd?: string[];
   resolveBundledPathWin?: () => string;
   resolveBundledPathUnix?: () => string;
@@ -325,7 +325,10 @@ const projectTypes: { [id: string]: ProjectType } = {
       'ClojureScript built-in for browser',
       'ClojureScript built-in for node',
     ],
-    cmd: ['clojure'],
+    cmd: () =>
+      getConfig().depsEdnJackInExecutable === 'deps.clj'
+        ? ['java', '-jar', `'${path.join(state.extensionContext.extensionPath, 'deps.clj.jar')}'`]
+        : ['clojure'],
     winCmd: ['java', '-jar'],
     resolveBundledPathWin: depsCljWindowsPath,
     processShellUnix: true,


### PR DESCRIPTION
## What has changed?

- Added a config for using either `clojure` or `deps.clj` as the executable when jacking in to deps.edn projects.
- Made `deps.clj` the default executable for this
- jack-in now checks if the project type's executable setting is a string or a function and uses either accordingly
- Made the deps.edn project type executable a function that checks the above mentioned config.
- Bumped deps.clj to latest version (0.1.1100)

Fixes #1846

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
