### PR TITLE
1848 check for clojure executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Check if `clojure` is installed and working before selecting default `deps.edn` Jack-in](https://github.com/BetterThanTomorrow/calva/issues/1848)
+
 ## [2.0.297] - 2022-08-29
 
 - Update deps.clj to version 0.1.1155

--- a/docs/site/connect.md
+++ b/docs/site/connect.md
@@ -46,7 +46,7 @@ There are also these settings:
 * `calva.myCljAliases`: An array of `deps.edn` aliases not found in the project file. Use this to tell Calva Jack-in to launch your REPL using your user defined aliases.
 * `calva.myLeinProfiles`: An array of Leiningen profiles not found in `project.clj`. Use this to tell Calva Jack-in to launch your REPL using your user defined profiles.
 * `calva.openBrowserWhenFigwheelStarted`: _For Legacy Figwheel only._ A boolean controlling if Calva should automatically launch your ClojureScript app, once it is compiled by Figwheel. Defaults to `true`.
-* `calva.depsEdnJackInExecutable`: A string which should either be `clojure` or `deps.clj` (default). It determines which executable Calva Jack-in should use for starting a deps.edn project. Use `clojure` if you have it installed and it works. If you run into troubles you can revert back to the default of using `deps.clj`, which is bundled with Calva.
+* `calva.depsEdnJackInExecutable`: A string which should either be `clojure` or `deps.clj`, or `clojure or deps.clj` (default). It determines which executable Calva Jack-in should use for starting a `deps.edn` project. With this setting at its default, `clojure or deps.clj`, Calva will test if the `clojure` executable works, and use it if it does, otherwise `deps.clj` will be used, which is bundled with Calva.
 
 !!! Note
     When processing the `calva.jackInEnv` setting you can refer to existing ENV variables with `${env:VARIABLE}`.

--- a/package.json
+++ b/package.json
@@ -753,7 +753,7 @@
             ]
           },
           "calva.depsEdnJackInExecutable": {
-            "markdownDescription": "Which executable should Calva Jack-in use for starting a deps.edn project? Use `clojure` if you have it installed and it works. If you run into troubles you can revert back to the default of using `deps.clj`, which is bundled with Calva. (This settings has no effect on Windows, where `deps.clj` will always be used.)",
+            "markdownDescription": "Which executable should Calva Jack-in use for starting a deps.edn project? The default is to let Calva choose. It will choose `clojure` if that is installed and working. Otherwise `deps.clj`, which is bundled with Calva, will be used. (This settings has no effect on Windows, where `deps.clj` will always be used.)",
             "enum": [
               "clojure",
               "deps.clj",

--- a/package.json
+++ b/package.json
@@ -753,12 +753,18 @@
             ]
           },
           "calva.depsEdnJackInExecutable": {
-            "markdownDescription": "Which executable should Calva Jack-in use for starting a deps.edn project? Use `clojure` if you have it installed and it works. If you run into troubles you can revert back to the default of using `deps.clj`, which is bundled with Calva.",
+            "markdownDescription": "Which executable should Calva Jack-in use for starting a deps.edn project? Use `clojure` if you have it installed and it works. If you run into troubles you can revert back to the default of using `deps.clj`, which is bundled with Calva. (This settings has no effect on Windows, where `deps.clj` will always be used.)",
             "enum": [
               "clojure",
-              "deps.clj"
+              "deps.clj",
+              "clojure or deps.clj"
             ],
-            "default": "deps.clj",
+            "markdownEnumDescriptions": [
+              "Always use `clojure`",
+              "Always use `deps.clj`",
+              "Prefer `clojure`, but use `deps.clj` if `clojure` doesn't seem to work"
+            ],
+            "default": "clojure or deps.clj",
             "type": "string"
           }
         }

--- a/src/extension-test/integration/suite/jack-in-test.ts
+++ b/src/extension-test/integration/suite/jack-in-test.ts
@@ -66,7 +66,7 @@ suite('Jack-in suite', () => {
 
     const cmdLine = await vscode.env.clipboard.readText();
 
-    assert.ok(cmdLine.includes('deps.clj.jar'));
+    assert.ok(cmdLine.startsWith('clojure'));
 
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     testUtil.log(suite, 'test.clj closed');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,6 +154,7 @@ async function activate(context: vscode.ExtensionContext) {
   }
 
   state.setExtensionContext(context);
+  state.initDepsEdnJackInExecutable();
 
   if (!fmtExtension) {
     try {

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -7,7 +7,7 @@ import * as pprint from '../printer';
 import { getConfig } from '../config';
 import { keywordize, unKeywordize } from '../util/string';
 import { CljsTypes, ReplConnectSequence } from './connectSequence';
-import { parseForms, parseEdn } from '../../out/cljs-lib/cljs-lib';
+import { getStateValue, parseForms, parseEdn } from '../../out/cljs-lib/cljs-lib';
 import * as joyride from '../joyride';
 
 export const isWin = /^win/.test(process.platform);
@@ -325,10 +325,15 @@ const projectTypes: { [id: string]: ProjectType } = {
       'ClojureScript built-in for browser',
       'ClojureScript built-in for node',
     ],
-    cmd: () =>
-      getConfig().depsEdnJackInExecutable === 'deps.clj'
+    cmd: () => {
+      const configuredCmd =
+        getConfig().depsEdnJackInExecutable === 'clojure or deps.clj'
+          ? getStateValue('depsEdnJackInDefaultExecutable') ?? 'deps.clj'
+          : getConfig().depsEdnJackInExecutable;
+      return configuredCmd === 'deps.clj'
         ? ['java', '-jar', `'${path.join(state.extensionContext.extensionPath, 'deps.clj.jar')}'`]
-        : ['clojure'],
+        : ['clojure'];
+    },
     winCmd: ['java', '-jar'],
     resolveBundledPathWin: depsCljWindowsPath,
     processShellUnix: true,

--- a/src/state.ts
+++ b/src/state.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import Analytics from './analytics';
 import * as util from './utilities';
 import * as path from 'path';
-import * as os from 'os';
+import * as child from 'child_process';
 import { getStateValue, setStateValue } from '../out/cljs-lib/cljs-lib';
 import * as projectRoot from './project-root';
 
@@ -12,6 +12,26 @@ export function setExtensionContext(context: vscode.ExtensionContext) {
   if (context.workspaceState.get('selectedCljTypeName') == undefined) {
     void context.workspaceState.update('selectedCljTypeName', 'unknown');
   }
+}
+
+export function initDepsEdnJackInExecutable() {
+  console.log('deps.edn launcher check, executing: `clojure -M -e :clojure-works` ...');
+  child.exec('clojure -M -e :clojure-works', (err, stdout, stderr) => {
+    console.log(`deps.edn launcher check - stdout: ${stdout}`);
+    console.log(`deps.edn launcher check - stderr: ${stderr}`);
+    if (err) {
+      console.log('deps.edn launcher check: Error running `clojure` command');
+      setStateValue('depsEdnJackInDefaultExecutable', 'deps.clj');
+      return;
+    }
+    if (stdout.startsWith(':clojure-works')) {
+      console.log('deps.edn launcher check: `clojure` command works');
+      setStateValue('depsEdnJackInDefaultExecutable', 'clojure');
+    } else {
+      console.log('deps.edn launcher check: `clojure` command not returning expected output');
+      setStateValue('depsEdnJackInDefaultExecutable', 'deps.clj');
+    }
+  });
 }
 
 // Super-quick fix for: https://github.com/BetterThanTomorrow/calva/issues/144


### PR DESCRIPTION
## What has changed?

Calva startup now includes a check if the `clojure` command works. Depending on the result a state value will be set which will determine the default `deps.edn` project launcher to use.

Fixes #1848

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
