### PR TITLE
Shortcut repl snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Bind any keys to custom custom repl commands](https://github.com/BetterThanTomorrow/calva/issues/1853)
+
 ## [2.0.298] - 2022-08-31
 
 - [Check if `clojure` is installed and working before selecting default `deps.edn` Jack-in](https://github.com/BetterThanTomorrow/calva/issues/1848)

--- a/docs/site/custom-commands.md
+++ b/docs/site/custom-commands.md
@@ -7,7 +7,10 @@ search:
 
 # Custom REPL Commands
 
-Calva supports configuration of custom command snippets that you can evaluate in the REPL at will. If your workflow has you repeatedly evaluate a particular piece of code, you can use the setting `calva.customREPLCommandSnippets` to configure it. Then either bind keyboard shortcuts to them or use the command **Run Custom REPL Command** to access it. The command will give you a menu with the snippets you have configured.
+Calva supports configuration of custom command snippets that you can evaluate in the REPL at will. If your workflow has you repeatedly evaluate a particular piece of code. There are two ways to use these
+
+1. You can use the setting `calva.customREPLCommandSnippets` to configure it. Then either bind keyboard shortcuts to them or use the command **Run Custom REPL Command** to access it. The command will give you a menu with the snippets you have configured.
+2. You can define a keyboard shortcut directly to a custom command snippet by inlining it in the shortcut definition. See [Binding keyboard shortcuts](#binding-keyboard-shortcuts)
 
 !!! Note "Joyride"
     For some use cases you might be better served by/want to combine these with using the [VS Code Extension API](https://code.visualstudio.com/api/references/vscode-ap), and [that of Calva](api.md), or any other extension, through [Joyride](joyride.md).
@@ -19,6 +22,7 @@ The `calva.customREPLCommandSnippets` is an array of objects with the following 
 * `key`: A key can be used to reference the snippet from **Run Custom REPL Command** keyboard shortcut arguments. It will also be used in the quick-pick menu.
 * `ns`: A namespace to evaluate the command in. If omitted the command will be executed in the namespace of the current editor.
 * `repl`: Which repl session to use for the evaluation. Either `"clj"` or `"cljs"`. Omit if you want to use the session of the current editor.
+* `evaluationSendCodeToOutputWindow`: (default `true`) Wether the evaluated code should be echoed tp the Output/REPL window 
 
 There are also substitutions available, which will take elements from the current state of Calva and splice them in to the text of your command before executing it. They are
 
@@ -26,6 +30,7 @@ There are also substitutions available, which will take elements from the curren
 * `$column`: Current column number in editor
 * `$file`: Full name of current file edited
 * `$ns`: The namespace used for evaluating the command
+* `$editor-ns`: The namespace of the editor from which the command was run
 * `$selection`: The currently selected text
 * `$current-form`: The text of the [current form](evaluation.md#current-form)
 * `$enclosing-form`: The text of the [current enclosing form](evaluation.md#evaluate-enclosing-form)
@@ -90,15 +95,31 @@ The default keyboard shortcut for the command is `ctrl+alt+space space`.
 
 ## Binding keyboard shortcuts
 
-There are three ways to bind shortcuts to custom commands:
+There are four ways to bind shortcuts to custom commands:
 
 1. Use a predefined `key` shortcut. These are predefined as `ctrl+alt+space <something>`, where `<something>` is one of:
     * The digits `0` through `9`
     * The English letters `a` through `z`
     * Arrow keys `right`, `left`, `up`, or `down`
     * One of `tab`, `backspace`, `,`, `.`, or `-` 
-2. Bind `calva.runCustomREPLCommand` to a shortcut with whatever code you want to evaluate in `args` key. You have access to the substitution variables here as well.
+2. Bind `calva.runCustomREPLCommand` to a shortcut with whatever code you want to evaluate in the `args` slot. You have access to the substitution variables here as well.
 3. Bind `calva.runCustomREPLCommand` to a keyboard shortcut referencing the `key` of one of your `calva.customREPLCommandSnippets`. (If not using any of the `key`s mentioned in **1.**)
+4. Bind `calva.runCustomREPLCommand` to a shortcut with a `customREPLCommandSnippets` in the `args` slot. You have access to the substitution variables here as well.
+
+Here's an example shortcut entry for the **4th** option:
+
+``` json
+    {
+        "key": "ctrl+cmd+u alt+enter",
+        "command": "calva.runCustomREPLCommand",
+        "args": {
+            "ns": "user",
+            "snippet": "$current-form",
+        }
+    },
+```
+
+This would evaluate the current form in the `user` namespace. Please note that this Custom REPL Command will not show up in the custom commands menu mentioned above.
 
 ## Custom REPL hover snippets
 

--- a/package.json
+++ b/package.json
@@ -405,7 +405,7 @@
           "calva.customREPLCommandSnippets": {
             "type": "array",
             "default": [],
-            "description": "Configuration for the command **Run Custom REPL Command**",
+            "markdownDescription": "Configuration for the command **Run Custom REPL Command**",
             "$schema": "http://json-schema.org/draft-06/schema#",
             "items": {
               "title": "replCommand",
@@ -424,25 +424,34 @@
                     "string",
                     "array"
                   ],
-                  "description": "Command to send to the REPL"
+                  "markDownDescription": "Command to send to the REPL"
                 },
                 "ns": {
                   "type": "string",
-                  "description": "(optional) Namespace to evaluate the command in. If omitted the command will be executed in the namespace of the current file."
+                  "markDownDescription": "(optional) Namespace to evaluate the command in. If omitted the command will be executed in the namespace of the current file."
                 },
                 "repl": {
                   "type": "string",
-                  "description": "Choose which REPL should the code should be evaluated in. If omitted, the same REPL as for the current file will be used.",
+                  "markDownDescription": "Choose which REPL should the code should be evaluated in. If omitted, the same REPL as for the current file will be used.",
                   "enum": [
                     "clj",
                     "cljs"
                   ]
+                },
+                "evaluationSendCodeToOutputWindow": {
+                  "type": "boolean",
+                  "markDownDescription": "Should the code snippet evaluated be echoed to the Output/REPL Window?"
                 }
               },
               "required": [
                 "name",
                 "snippet"
-              ]
+              ],
+              "default": {
+                "name": "",
+                "snippet": "",
+                "evaluationSendCodeToOutputWindow": true
+              }
             }
           },
           "calva.customREPLHoverSnippets": {

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -10,21 +10,60 @@ import * as replSession from './nrepl/repl-session';
 import * as evaluate from './evaluate';
 import * as state from './state';
 
-type snippetDefinition = {
+type SnippetDefinition = {
   snippet: string;
   ns: string;
   repl: string;
+  evaluationSendCodeToOutputWindow?: boolean;
 };
 
-async function evaluateCustomCodeSnippetCommand(codeOrKeyOrSnippet?: string | snippetDefinition) {
-  await evaluateCodeOrKey(codeOrKeyOrSnippet);
+export async function evaluateCustomCodeSnippetCommand(
+  codeOrKeyOrSnippet?: string | SnippetDefinition
+) {
+  await evaluateCodeOrKeyOrSnippet(codeOrKeyOrSnippet);
 }
 
-async function evaluateCodeOrKey(codeOrKeyOrSnippet?: string | snippetDefinition) {
+async function evaluateCodeOrKeyOrSnippet(codeOrKeyOrSnippet?: string | SnippetDefinition) {
   const editor = util.getActiveTextEditor();
-  const currentLine = editor.selection.active.line;
-  const currentColumn = editor.selection.active.character;
-  const currentFilename = editor.document.fileName;
+  const editorNS =
+    editor && editor.document && editor.document.languageId === 'clojure'
+      ? namespace.getNamespace(editor.document)
+      : undefined;
+  const editorRepl =
+    editor && editor.document && editor.document.languageId === 'clojure'
+      ? replSession.getReplSessionTypeFromState()
+      : 'clj';
+  const snippetDefinition: SnippetDefinition =
+    typeof codeOrKeyOrSnippet !== 'string' && codeOrKeyOrSnippet !== undefined
+      ? codeOrKeyOrSnippet
+      : await getSnippetDefinition(codeOrKeyOrSnippet as string, editorNS, editorRepl);
+
+  snippetDefinition.ns = snippetDefinition.ns ?? editorNS;
+  snippetDefinition.repl = snippetDefinition.repl ?? editorRepl;
+  snippetDefinition.evaluationSendCodeToOutputWindow =
+    snippetDefinition.evaluationSendCodeToOutputWindow ?? true;
+
+  const options = {};
+
+  options['evaluationSendCodeToOutputWindow'] = snippetDefinition.evaluationSendCodeToOutputWindow;
+  // don't allow addToHistory if we don't show the code but are inside the repl
+  options['addToHistory'] =
+    state.extensionContext.workspaceState.get('outputWindowActive') &&
+    !snippetDefinition.evaluationSendCodeToOutputWindow
+      ? false
+      : undefined;
+
+  const context = makeContext(editor, snippetDefinition.ns, editorNS, snippetDefinition.repl);
+  await evaluateCodeInContext(snippetDefinition.snippet, context, options);
+}
+
+async function evaluateCodeInContext(code: string, context: any, options: any) {
+  const result = await evaluateSnippet(code, context, options);
+  outputWindow.appendPrompt();
+  return result;
+}
+
+async function getSnippetDefinition(codeOrKey: string, editorNS: string, editorRepl: string) {
   const configErrors: { name: string; keys: string[] }[] = [];
   const globalSnippets = getConfig().customREPLCommandSnippetsGlobal;
   const workspaceSnippets = getConfig().customREPLCommandSnippetsWorkspace;
@@ -40,14 +79,6 @@ async function evaluateCodeOrKey(codeOrKeyOrSnippet?: string | snippetDefinition
   const snippetsDict = {};
   const snippetsKeyDict = {};
   const snippetsMenuItems: string[] = [];
-  const editorNS =
-    editor && editor.document && editor.document.languageId === 'clojure'
-      ? namespace.getNamespace(editor.document)
-      : undefined;
-  const editorRepl =
-    editor && editor.document && editor.document.languageId === 'clojure'
-      ? replSession.getReplSessionTypeFromState()
-      : 'clj';
   snippets.forEach((c: customREPLCommandSnippet) => {
     const undefs = ['name', 'snippet'].filter((k) => {
       return !c[k];
@@ -75,7 +106,7 @@ async function evaluateCodeOrKey(codeOrKeyOrSnippet?: string | snippetDefinition
   }
 
   let pick: string;
-  if (codeOrKeyOrSnippet === undefined) {
+  if (codeOrKey === undefined) {
     // Called without args, show snippets menu
     if (snippetsMenuItems.length > 0) {
       try {
@@ -99,41 +130,19 @@ async function evaluateCodeOrKey(codeOrKeyOrSnippet?: string | snippetDefinition
     }
   }
 
-  let snippet: string;
-  let ns: string;
-  let repl: string;
-
-  if (typeof codeOrKeyOrSnippet !== 'string' && codeOrKeyOrSnippet !== undefined) {
-    snippet = codeOrKeyOrSnippet.snippet;
-    ns = codeOrKeyOrSnippet.ns;
-    repl = codeOrKeyOrSnippet.repl;
-  } else {
-    if (pick === undefined) {
-      // still no pick, but codeOrKey might be one
-      pick = snippetsKeyDict[codeOrKeyOrSnippet as string];
-    }
-    snippet = pick !== undefined ? snippetsDict[pick].snippet : codeOrKeyOrSnippet;
-    ns = pick !== undefined ? snippetsDict[pick].ns : editorNS;
-    repl = pick !== undefined ? snippetsDict[pick].repl : editorRepl;
+  if (pick === undefined) {
+    // still no pick, but codeOrKey might be one
+    pick = snippetsKeyDict[codeOrKey];
   }
 
-  const options = {};
+  return pick !== undefined ? snippetsDict[pick] : { snippet: codeOrKey };
+}
 
-  if (pick !== undefined) {
-    options['evaluationSendCodeToOutputWindow'] =
-      snippetsDict[pick].evaluationSendCodeToOutputWindow;
-    // don't allow addToHistory if we don't show the code but are inside the repl
-    options['addToHistory'] =
-      state.extensionContext.workspaceState.get('outputWindowActive') &&
-      !snippetsDict[pick].evaluationSendCodeToOutputWindow
-        ? false
-        : undefined;
-  }
-
-  const context = {
-    currentLine,
-    currentColumn,
-    currentFilename,
+function makeContext(editor: vscode.TextEditor, ns: string, editorNS: string, repl: string) {
+  return {
+    currentLine: editor.selection.active.line,
+    currentColumn: editor.selection.active.character,
+    currentFilename: editor.document.fileName,
     ns,
     editorNS,
     repl,
@@ -150,14 +159,9 @@ async function evaluateCodeOrKey(codeOrKeyOrSnippet?: string | snippetDefinition
     tail: getText.toEndOfList(editor?.document)[1],
     ...getText.currentContext(editor.document, editor.selection.active),
   };
-  const result = await evaluateSnippet(snippet, context, options);
-
-  outputWindow.appendPrompt();
-
-  return result;
 }
 
-async function evaluateSnippet(code, context, options) {
+export async function evaluateSnippet(code, context, options) {
   const ns = context.ns;
   const repl = context.repl;
   const interpolatedCode = interpolateCode(code, context);
@@ -192,5 +196,3 @@ function interpolateCode(code: string, context): string {
     .replace(/\$hover-head/g, context.hoverhead)
     .replace(/\$hover-tail/g, context.hovertail);
 }
-
-export { evaluateCustomCodeSnippetCommand, evaluateSnippet };

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -10,11 +10,17 @@ import * as replSession from './nrepl/repl-session';
 import * as evaluate from './evaluate';
 import * as state from './state';
 
-async function evaluateCustomCodeSnippetCommand(codeOrKey?: string) {
-  await evaluateCodeOrKey(codeOrKey);
+type snippetDefinition = {
+  snippet: string;
+  ns: string;
+  repl: string;
+};
+
+async function evaluateCustomCodeSnippetCommand(codeOrKeyOrSnippet?: string | snippetDefinition) {
+  await evaluateCodeOrKey(codeOrKeyOrSnippet);
 }
 
-async function evaluateCodeOrKey(codeOrKey?: string) {
+async function evaluateCodeOrKey(codeOrKeyOrSnippet?: string | snippetDefinition) {
   const editor = util.getActiveTextEditor();
   const currentLine = editor.selection.active.line;
   const currentColumn = editor.selection.active.character;
@@ -69,8 +75,8 @@ async function evaluateCodeOrKey(codeOrKey?: string) {
   }
 
   let pick: string;
-  if (codeOrKey === undefined) {
-    // Without codeOrKey always show snippets menu
+  if (codeOrKeyOrSnippet === undefined) {
+    // Called without args, show snippets menu
     if (snippetsMenuItems.length > 0) {
       try {
         pick = await util.quickPickSingle({
@@ -92,13 +98,24 @@ async function evaluateCodeOrKey(codeOrKey?: string) {
       return;
     }
   }
-  if (pick === undefined) {
-    // still no pick, but codeOrKey might be one
-    pick = snippetsKeyDict[codeOrKey];
+
+  let snippet: string;
+  let ns: string;
+  let repl: string;
+
+  if (typeof codeOrKeyOrSnippet !== 'string' && codeOrKeyOrSnippet !== undefined) {
+    snippet = codeOrKeyOrSnippet.snippet;
+    ns = codeOrKeyOrSnippet.ns;
+    repl = codeOrKeyOrSnippet.repl;
+  } else {
+    if (pick === undefined) {
+      // still no pick, but codeOrKey might be one
+      pick = snippetsKeyDict[codeOrKeyOrSnippet as string];
+    }
+    snippet = pick !== undefined ? snippetsDict[pick].snippet : codeOrKeyOrSnippet;
+    ns = pick !== undefined ? snippetsDict[pick].ns : editorNS;
+    repl = pick !== undefined ? snippetsDict[pick].repl : editorRepl;
   }
-  const code = pick !== undefined ? snippetsDict[pick].snippet : codeOrKey;
-  const ns = pick !== undefined ? snippetsDict[pick].ns : editorNS;
-  const repl = pick !== undefined ? snippetsDict[pick].repl : editorRepl;
 
   const options = {};
 
@@ -118,6 +135,7 @@ async function evaluateCodeOrKey(codeOrKey?: string) {
     currentColumn,
     currentFilename,
     ns,
+    editorNS,
     repl,
     selection: editor.document.getText(editor.selection),
     currentForm: getText.currentFormText(editor?.document, editor?.selection.active)[1],
@@ -132,17 +150,16 @@ async function evaluateCodeOrKey(codeOrKey?: string) {
     tail: getText.toEndOfList(editor?.document)[1],
     ...getText.currentContext(editor.document, editor.selection.active),
   };
-  const result = await evaluateSnippet({ snippet: code }, context, options);
+  const result = await evaluateSnippet(snippet, context, options);
 
   outputWindow.appendPrompt();
 
   return result;
 }
 
-async function evaluateSnippet(snippet, context, options) {
-  const code = snippet.snippet;
-  const ns = snippet.ns ?? context.ns;
-  const repl = snippet.repl ?? context.repl;
+async function evaluateSnippet(code, context, options) {
+  const ns = context.ns;
+  const repl = context.repl;
   const interpolatedCode = interpolateCode(code, context);
   return await evaluate.evaluateInOutputWindow(interpolatedCode, repl, ns, options);
 }
@@ -156,6 +173,7 @@ function interpolateCode(code: string, context): string {
     .replace(/\$file/g, context.currentFilename)
     .replace(/\$hover-file/g, context.hoverFilename)
     .replace(/\$ns/g, context.ns)
+    .replace(/\$editor-ns/g, context.editorNS)
     .replace(/\$repl/g, context.repl)
     .replace(/\$selection/g, context.selection)
     .replace(/\$hover-text/g, context.hoverText)

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -33,6 +33,7 @@ export async function provideHover(document: vscode.TextDocument, position: vsco
 
       const context = {
         ns,
+        editorNs: ns,
         repl: document.languageId === 'clojure' ? replSession.getReplSessionTypeFromState() : 'clj',
         hoverText: text,
         hoverLine: position.line + 1,


### PR DESCRIPTION
## What has changed?

Added support for configuring a custom repl command as a keyboard shortcut directly, w/o adding it to any repl command registry, and allowing for whatever shortcut binding the user fancies.

Also added an evaluation context variable `$editor-ns` in case the `ns` configuration is supplied and the snippet needs to know what namespace the file is in.


Fixes #1853 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
