### PR TITLE
Notebooks-dont-recognize-rich-comments-at-the-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Notebooks don't recognize rich comments at the end](https://github.com/BetterThanTomorrow/calva/issues/1857)
+
 ## [2.0.299] - 2022-09-06
 
 - [Bind any keys to custom custom repl commands](https://github.com/BetterThanTomorrow/calva/issues/1853)

--- a/src/NotebookProvider.ts
+++ b/src/NotebookProvider.ts
@@ -71,9 +71,11 @@ function parseClojure(content: string): vscode.NotebookCellData[] {
 
       commentStartCursor.downList();
       commentStartCursor.forwardSexp();
+      commentStartCursor.forwardSexp(true, true);
 
-      while (commentStartCursor.forwardSexp()) {
+      do {
         const range = commentStartCursor.rangeForDefun(commentStartCursor.offsetStart);
+        const commentCellCursor = cursor.doc.getTokenCursor(range[0]);
         let leading = '';
         const indent = commentStartCursor.doc.getRowCol(range[0])[1]; // will break with tabs?
 
@@ -92,7 +94,7 @@ function parseClojure(content: string): vscode.NotebookCellData[] {
             trailing: '',
           },
         });
-      }
+      } while (commentStartCursor.forwardSexp(true, true));
 
       if (commentCells.length) {
         _.last(commentCells).metadata.trailing = content.substring(previouseEnd, end);

--- a/src/NotebookProvider.ts
+++ b/src/NotebookProvider.ts
@@ -51,14 +51,16 @@ function parseClojure(content: string): vscode.NotebookCellData[] {
     return index % 2 !== 0;
   });
 
+  const lastRangeAdjustment = content.length - fullRanges[fullRanges.length - 1];
   // last range should include end of file
   fullRanges[fullRanges.length - 1] = content.length;
 
   // start of file to end of top level sexp pairs
   const allRanges = _.zip(_.dropRight([_.first(topLevelRanges), ...fullRanges], 1), fullRanges);
 
-  const ranges = allRanges.flatMap(([start, end]) => {
-    const endForm = cursor.doc.getTokenCursor(end - 1);
+  const ranges = allRanges.flatMap(([start, end], index) => {
+    const endAdjustment = index + 1 === allRanges.length ? lastRangeAdjustment + 1 : 1;
+    const endForm = cursor.doc.getTokenCursor(end - endAdjustment);
     const afterForm = cursor.doc.getTokenCursor(end);
 
     if (endForm.getFunctionName() === 'comment') {

--- a/src/extension-test/integration/suite/jack-in-test.ts
+++ b/src/extension-test/integration/suite/jack-in-test.ts
@@ -51,8 +51,8 @@ suite('Jack-in suite', () => {
     await commands.executeCommand('calva.loadFile');
     const reversedLines = resultsDoc.model.lineInputModel.lines.reverse();
     assert.deepEqual(
-      ['; Evaluating file: test.clj', 'bar', 'nil', 'clj꞉test꞉> ', ''].reverse(),
-      reversedLines.slice(0, 5).map((v) => v.text)
+      ['bar', 'nil', 'clj꞉test꞉> ', ''].reverse(),
+      reversedLines.slice(0, 4).map((v) => v.text)
     );
 
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');

--- a/test-data/notebook.clj
+++ b/test-data/notebook.clj
@@ -45,3 +45,12 @@ meta-test
    40
    1
    1))
+
+(comment
+  forty-two
+
+  (foo)
+  ^{:portal.viewer/default :portal.viewer/hiccup}
+  [:h1 "hiccup rocks"]
+  ;; rich or poor comment?
+  (tap> "stuff"))


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- checks if the final form got "moved" because of extra whitespace

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1857

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

If this PR involves code changes, I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
