### PR TITLE
1843 pretty print code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix test running issue: [Two references to the same class in the same namespace can refer to two different instances of the class](https://github.com/BetterThanTomorrow/calva/issues/1821)
+- [Make it possible to format Clojure code using the pretty printer](https://github.com/BetterThanTomorrow/calva/issues/1843)
 
 ## [2.0.300] - 2022-09-11
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:deps {zprint/zprint {:mvn/version "1.2.2"}
+{:deps {zprint/zprint {:mvn/version "1.2.4"}
         cljfmt/cljfmt {:mvn/version "0.8.0"}
         thheller/shadow-cljs {:mvn/version "2.18.0"}
         org.clojars.liverm0r/dartclojure {:mvn/version "0.1.10-SNAPSHOT"}

--- a/docs/site/api.md
+++ b/docs/site/api.md
@@ -51,7 +51,7 @@ When using Joyride you can use its unique `require` API, for which one of the be
 
 ## `repl`
 
-The `repl` module contains provides access to Calva's REPL connection.
+The `repl` module provides access to Calva's REPL connection.
 
 ### `repl.currentSessionKey()`
 
@@ -268,6 +268,65 @@ _Corresponding [REPL Snippet](custom-commands.md) variable: `$top-level-defined-
     ```javascript
     const [range, text] = ranges.currentTopLevelForm();
     ```
+## `editor`
+
+The `editor` module has facilites (well, a facility, so far) for editing Clojure documents.
+
+### `editor.replace()`
+
+With `editor.replace()` you can replace a range in a Clojure editor with new text. The arguments are:
+
+* `editor`, a `vscode.TextEditor`
+* `range`, a `vscode.Range`
+* `newText`, a string
+
+=== "Joyride"
+
+    ```clojure
+    (-> (p/let [top-level-form-range (first (calva/ranges.currentTopLevelForm))
+                _ (calva/editor.replace vscode/window.activeTextEditor top-level-form-range "Some new text")]
+          (println "Text replaced!"))
+        (p/catch (fn [e]
+                   (println "Error replacing text:" e))))
+    ```
+
+=== "JavaScript"
+
+    ```javascript
+    const topLevelRange = calvaApi.ranges.currentTopLevelForm();
+    calva.editor.replace(topLevelRange, "Some new text")
+      .then((_) => console.log("Text replaced!"))
+      .catch((e) => console.log("Error replacing text:", e));
+    ```
+
+## `pprint`
+
+The `pprint` module lets you pretty print Clojure code/data using Calva's [pretty printing](pprint.md) engine (which in turn uses [zprint](https://github.com/kkinnear/zprint)).
+
+### `pprint.prettyPrint()`
+
+Use `pprint.prettyPrint()` to pretty print some Clojure data using your Calva pretty printing options. It accepts these arguments:
+
+* `text`, a `string` with the text to pretty print
+* `options`, a JavaScript object with [pretty printing](pprint.md) options, this is optional and will default to the current settings.
+
+The function is synchronous and returns the prettified text.
+
+=== "Joyride"
+
+    ``` clojure
+    (println (calva/pprint.prettyPrint "Some text")))
+    ```
+
+=== "JavaScript"
+
+    ``` javascript
+    console.log(calvaApi.pprint.prettyPrint();
+    ```
+
+### `pprint.prettyPrintingOptions()`
+
+Use to get the current pretty printint options:
 
 ## `vscode`
 
@@ -298,7 +357,8 @@ This is the `[vscode.languages](https://code.visualstudio.com/api/references/vsc
     ```javascript
     yourExtensionContext.subscriptions.push(calva.vscode.registerDocumentSymbolProvider(...));
     ```
-
+!!! Warning "Deprecation candidate"
+    VS Code is still creating a separate group, just with the same name as Calva's, so this API is not good for anything, and we will probably remove it.
 
 ## Feedback Welcome
 

--- a/docs/site/formatting.md
+++ b/docs/site/formatting.md
@@ -63,7 +63,7 @@ Basically, it behaves like if `:remove-multiple-non-indenting-spaces? true` was 
 
 ### 3. Replace Current Form (or Selection) with Pretty Printed Form
 
-This will run the code of the [Current Form](evaluation.md#current-form) through Calva's [pretty printer](pprint.md) (the engine named `calva`, which is using [zprint](https://github.com/kkinnear/zprint)) and replace the current form inline in the editor with the pretty printed results.
+This command will run the code of the [Current Form](evaluation.md#current-form) through Calva's [pretty printer](pprint.md) (the engine named `calva`, which is using [zprint](https://github.com/kkinnear/zprint)) and replace the current form inline in the editor with the pretty printed results.
 
 Unlike with the ”real” Calva Formatter, which never breaks up lines, this one will follow your [pretty printing](pprint.md) options and break up lines if you have set `maxWidth` to something that calls for breaking up lines.
 

--- a/docs/site/formatting.md
+++ b/docs/site/formatting.md
@@ -35,13 +35,13 @@ Not a fan of some default setting? The formatter is quite [configurable](#config
 
 ## Format current form command variants
 
-There are two special commands for formatting the current form:
+There are _three_ special commands for formatting the current form:
 
-### Format and Align Current Form
+### 1. Format and Align Current Form
 
 Aligns associative structures and bindings in two columns. See more [below](#about-aligning-associative-forms).
 
-### Format Current Form and trim space between forms
+### 2. Format Current Form and trim space between forms
 
 This formats the text, and trims consecutive, non-indent, whitespace on a line to just one space. Something like:
 
@@ -60,6 +60,15 @@ Becomes:
 ```
 
 Basically, it behaves like if `:remove-multiple-non-indenting-spaces? true` was added to the `cljfmt` config. Which, in fact, is what happens. Calva merges that onto your cljfmt config when this command is used.
+
+### 3. Replace Current Form (or Selection) with Pretty Printed Form
+
+This will run the code of the [Current Form](evaluation.md#current-form) through Calva's [pretty printer](pprint.md) (the engine named `calva`, which is using [zprint](https://github.com/kkinnear/zprint)) and replace the current form inline in the editor with the pretty printed results.
+
+Unlike with the ”real” Calva Formatter, which never breaks up lines, this one will follow your [pretty printing](pprint.md) options and break up lines if you have set `maxWidth` to something that calls for breaking up lines.
+
+!!! Note "Applies to the other Current Form"
+    Unlike the other Format commands, which applies to the current _enclosing_ form, this one applies to the [Current Form, same as with evaluations](evaluation.md#current-form). That is because this is not really part of the Calva formatter, but rather is a convenience command for tidying up code or data.
 
 ## Configuration
 

--- a/docs/site/pprint.md
+++ b/docs/site/pprint.md
@@ -7,6 +7,9 @@ description: Prettiness is on by default and all your evaluation results will ge
 
 In Calva, pretty printing is a mode. Prettiness is on by default and all your evaluation results will get that treatment.
 
+!!! Note "You can also pretty print code on demand"
+    There is a command **Replace Current Form (or Selection) with Pretty Printed Form**. See [Clojure Formmatting](formatting.md#3-replace-current-form-or-selection-with-pretty-printed-form) for more on this.
+
 ## Toggle it
 
 There is a `pprint` indicator to the right in the status bar which shows the status of the mode. Click the indicator to toggle prettification on and off. There is also a **Calva: Toggle Pretty Printing for All Evaluations** command.

--- a/package.json
+++ b/package.json
@@ -953,6 +953,11 @@
         "category": "Calva"
       },
       {
+        "command": "calva.prettyPrintReplaceCurrentForm",
+        "title": "Replace Current Form (or Selection) with Pretty Printed Form",
+        "category": "Calva"
+      },
+      {
         "command": "calva.clojureLsp.showClojureLspStoppedMenu",
         "title": "Show clojure-lsp menu",
         "enablement": "!clojureLsp:active",

--- a/src/api/editor.ts
+++ b/src/api/editor.ts
@@ -1,0 +1,3 @@
+import * as editor from '../edit';
+
+export const replace = editor.replace;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,6 +1,9 @@
 import * as repl from './repl';
 import * as ranges from './ranges';
 import * as calvaVsCode from './vscode';
+import * as editor from './editor';
+import * as pprint from './pprint';
+
 export function getApi() {
   return {
     // If we can avoid it we don't want to ever break our callers.
@@ -11,6 +14,8 @@ export function getApi() {
       repl,
       ranges,
       vscode: calvaVsCode,
+      editor,
+      pprint,
     },
   };
 }

--- a/src/api/pprint.ts
+++ b/src/api/pprint.ts
@@ -1,0 +1,4 @@
+import * as printer from '../printer';
+
+export const prettyPrint = printer.prettyPrint;
+export const prettyPrintingOptions = printer.prettyPrintingOptions;

--- a/src/cljs-lib/src/calva/pprint/printer.cljs
+++ b/src/cljs-lib/src/calva/pprint/printer.cljs
@@ -1,5 +1,5 @@
 (ns calva.pprint.printer
-  (:require [zprint.core :refer [zprint-str]]
+  (:require [zprint.core :as zprint]
             [calva.js-utils :refer [jsify cljify]]
             [clojure.string]))
 
@@ -10,7 +10,7 @@
   [s opts]
   (let [result (try
                  {:value
-                  (zprint-str s (assoc opts :parse-string? (string? s)))}
+                  (zprint/zprint-file-str s "Calva" opts)}
                  (catch js/Error e
                    {:value s
                     :error (str "Plain printing, b/c pprint failed. (" (.-message e) ")")}))]
@@ -26,13 +26,15 @@
                (assoc opts :map {:comma? map-commas?}))]
     (jsify (pretty-print s opts))))
 
-(defn pretty-print-js-bridge [s ^js opts]
+(defn ^:export pretty-print-js-bridge [s ^js opts]
   (pretty-print-js s (cljify opts)))
 
 
 ;; SCRAP
 (comment 
-  (pretty-print "{:a 1, :b 2 :c 3}" {:map {:comma? false}})
+  (zprint/zprint-file-str "{:a 1, :b 2 :c 3} {:a 1, :b 2 :c 3}" "id" {:map {:comma? false}})
+  (zprint/zprint-file-str "a s" "id" {})
+  (zprint/zprint-str "a s" {:parse-string? true})
   (pretty-print "[    [ [:foo
                       ]]        ]" nil)
   ;; => {:value "[[[:foo]]]"}

--- a/src/cljs-lib/src/calva/pprint/printer.cljs
+++ b/src/cljs-lib/src/calva/pprint/printer.cljs
@@ -17,10 +17,13 @@
     result))
 
 
-(defn pretty-print-js [s {:keys [width, maxLength, maxDepth]}]
+(defn pretty-print-js [s {:keys [width, maxLength, maxDepth, map-commas?]}]
   (let [opts (into {} (remove (comp nil? val) {:width width
                                                :max-length maxLength
-                                               :max-depth maxDepth}))]
+                                               :max-depth maxDepth}))
+        opts (if (nil? map-commas?)
+               opts
+               (assoc opts :map {:comma? map-commas?}))]
     (jsify (pretty-print s opts))))
 
 (defn pretty-print-js-bridge [s ^js opts]
@@ -28,7 +31,8 @@
 
 
 ;; SCRAP
-(comment
+(comment 
+  (pretty-print "{:a 1, :b 2 :c 3}" {:map {:comma? false}})
   (pretty-print "[    [ [:foo
                       ]]        ]" nil)
   ;; => {:value "[[[:foo]]]"}

--- a/src/cljs-lib/test/calva/pprint/printer_test.cljs
+++ b/src/cljs-lib/test/calva/pprint/printer_test.cljs
@@ -32,4 +32,10 @@
           (is (<= width 40)))
         (let [width (apply count (pretty-line-of 25 "foo" {:max-length 2}))]
           (is (< width 20)))
-        (is (re-find #"#" (:value (pretty-print shallow {:max-depth 1}))))))))
+        (is (re-find #"#" (:value (pretty-print shallow {:max-depth 1})))))
+      (testing "Commas added in maps with default options"
+        (is (= {:value "{:a 1, :b 1, :c 1}"}
+               (pretty-print "{:a 1, :b 1 :c 1}" nil))))
+      (testing "Can opt out of added commas in maps"
+        (is (= {:value "{:a 1 :b 1 :c 1}"}
+               (pretty-print "{:a 1, :b 1 :c 1}" {:map {:comma? false}})))))))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,7 @@ import * as definition from './providers/definition';
 import { CalvaSignatureHelpProvider } from './providers/signature';
 import testRunner from './testRunner';
 import annotations from './providers/annotations';
-import select from './select';
+import * as select from './select';
 import eval from './evaluate';
 import refresh from './refresh';
 import * as greetings from './greet';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -487,6 +487,12 @@ async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('calva.convertDart2Clj', converters.dart2clj)
   );
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'calva.prettyPrintReplaceCurrentForm',
+      edit.prettyPrintReplaceCurrentForm
+    )
+  );
 
   // Initial set of the provided contexts
   outputWindow.setContextForOutputWindowActive(false);

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1,5 +1,6 @@
 import { getConfig } from './config';
 import { assertIsDefined } from './utilities';
+import * as calvaLib from '../out/cljs-lib/cljs-lib';
 
 export type PrintFnOptions = {
   name: string;
@@ -125,4 +126,8 @@ export function getServerSidePrinterDependencies() {
   } else {
     return {};
   }
+}
+
+export function prettyPrint(value: any, options: any = prettyPrintingOptions()) {
+  return calvaLib.prettyPrint(value, options);
 }

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -12,7 +12,7 @@ import {
   CompletionItemLabel,
 } from 'vscode';
 import * as util from '../utilities';
-import select from '../select';
+import * as select from '../select';
 import * as docMirror from '../doc-mirror/index';
 import * as infoparser from './infoparser';
 import * as namespace from '../namespace';

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -4,7 +4,7 @@ import * as state from '../state';
 import { highlight } from '../highlight/src/extension';
 import { NReplSession } from '../nrepl';
 import * as util from '../utilities';
-import select from '../select';
+import * as select from '../select';
 import { formatCode } from '../calva-fmt/src/format';
 import * as namespace from '../namespace';
 import * as config from '../config';

--- a/src/select.ts
+++ b/src/select.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as util from './utilities';
 import * as docMirror from './doc-mirror/index';
 
-function selectionFromOffsetRange(
+export function selectionFromOffsetRange(
   doc: vscode.TextDocument,
   range: [number, number]
 ): vscode.Selection {
@@ -22,7 +22,7 @@ export function getFormSelection(
   }
 }
 
-function getEnclosingFormSelection(
+export function getEnclosingFormSelection(
   doc: vscode.TextDocument,
   pos: vscode.Position
 ): vscode.Selection | undefined {
@@ -59,13 +59,6 @@ function selectForm(
   }
 }
 
-function selectCurrentForm(document = {}) {
+export function selectCurrentForm(document = {}) {
   selectForm(document, getFormSelection, false);
 }
-
-export default {
-  getFormSelection,
-  getEnclosingFormSelection,
-  selectCurrentForm,
-  selectionFromOffsetRange,
-};

--- a/src/select.ts
+++ b/src/select.ts
@@ -9,7 +9,7 @@ function selectionFromOffsetRange(
   return new vscode.Selection(doc.positionAt(range[0]), doc.positionAt(range[1]));
 }
 
-function getFormSelection(
+export function getFormSelection(
   doc: vscode.TextDocument,
   pos: vscode.Position,
   topLevel: boolean

--- a/src/util/get-text.ts
+++ b/src/util/get-text.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import select from '../select';
+import * as select from '../select';
 import * as paredit from '../cursor-doc/paredit';
 import * as docMirror from '../doc-mirror/index';
 import * as cursorTextGetter from './cursor-get-text';


### PR DESCRIPTION
## What has changed?

- Added a command for replacing the current form with a pretty printed version of it
- Added Calva API for pretty printing some text
- Added Calva API for replacing a range in the text editor with new text

Fixes #1843 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
