### PR TITLE
Adds workaround doc for lein project in subfolder

### DIFF
--- a/docs/site/clojure-lsp.md
+++ b/docs/site/clojure-lsp.md
@@ -156,9 +156,11 @@ In such cases, when opening the folder `reporoot`, clojure-lsp doesn't help you.
 First, if you do need access to `otherstuff` inside `reporoot`, you can:
 
 1. open folder `reporoot`
-2. File -> Add Folder to Workspace...
+2. **File -> Add Folder to Workspace...**
 3. Add the `subfolder`
 4. The File Explorer now shows 2 project roots: drag the `subfolder` root above the `reporoot` root.
+
+Save the resulting Workspace to not have to repeat these steps.
 
 The second option, if you don't need access to `otherstuff` inside `reporoot`, is to just open the folder `subfolder` instead. 
 

--- a/docs/site/clojure-lsp.md
+++ b/docs/site/clojure-lsp.md
@@ -139,6 +139,29 @@ You can run the `Clojure-lsp Server Info` command to get information about the r
 
 You can open the clojure-lsp log file by running the command `Calva Diagnostics: Open Clojure-lsp Log File`. The log file will only be opened with this command if the clojure-lsp server is running and has finished initializing. If you need to open the file when the server is failing to run or initialize, see the [clojure-lsp docs](https://clojure-lsp.io/troubleshooting/#server-log) for information on the file location.
 
+### Leiningen project in subfolder
+
+Sometimes your Leiningen project root with its `project.clj` is located in a subfolder and not directly inside your repository root:
+
+```
+- reporoot
+  - subfolder (= project root)
+    - project.clj
+  - otherstuff
+  - .git
+```
+
+In such cases, when opening the folder `reporoot`, clojure-lsp doesn't help you. There are two workarounds:
+
+First, if you do need access to `otherstuff` inside `reporoot`, you can:
+
+1. open folder `reporoot`
+2. File -> Add Folder to Workspace...
+3. Add the `subfolder`
+4. The File Explorer now shows 2 project roots: drag the `subfolder` root above the `reporoot` root.
+
+The second option, if you don't need access to `otherstuff` inside `reporoot`, is to just open the folder `subfolder` instead. 
+
 ## Related
 
 See also:

--- a/docs/site/workspace-layouts.md
+++ b/docs/site/workspace-layouts.md
@@ -5,7 +5,7 @@ description: Single project repos, monorepos, polyrepos, project directory layou
 
 # Workspace Layouts
 
-Project directory layouts can vary quite a lot. From the ”template” projects where the Clojure project files are at the root, to, well, let's just say that the project files are not always at the root. And sometimes there is more than one project.
+Project directory layouts can vary quite a lot. From the ”template” projects where the Clojure project files are at the root, to, well, let's just say that the project files are not always at the root. And sometimes there is more than one project ([read here how to get clojure-lsp support with a Leiningen project in a subfolder](clojure-lsp.md#leiningen-project-in-subfolder)).
 
 Calva only really supports working with one project at a time per VS Code window. Here's a short guide for some different setups:
 


### PR DESCRIPTION
## What has changed?

- Documents workaround for clojure-lsp support when leiningen project is located in a subfolder

Works around #1866 

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

If this PR involves only documentation changes, I have:

- [x] Read [Editing Documentation](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Hack-on-Calva#editing-documentation)
- [x] ~Directed this pull request at the `published` branch.~
- [x] Built the site locally (if the changes were more involved than simple typo fixes), and verified that the site is presented as expected.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_ (if there was is an issue for the documentation change)
  - [x] ~If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)~
  - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.


Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
