### PR TITLE
Read snippet config from user config.edn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,9 @@ jobs:
           name: Compile Extension Tests
           command: npm run compile-test
       - run:
+          name: Install linnss
+          command: sudo apt install -y libnss3
+      - run:
           name: Run Extension Tests
           command: npm run integration-test
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
           path: ~/calva/junit
   test-integration:
     docker:
-      - image: cimg/clojure:1.11-node
+      - image: cimg/clojure:1.11-browsers
     working_directory: ~/calva
     steps:
       - attach_workspace:
@@ -230,9 +230,9 @@ jobs:
       - run:
           name: Compile Extension Tests
           command: npm run compile-test
-      - run:
-          name: Install linnss
-          command: sudo apt install -y libnss3
+      #- run:
+      #    name: Apt install missing dependencies
+      #    command: sudo apt update && sudo apt install -y libnss3 libcups2 libatk-bridge2.0-0
       - run:
           name: Run Extension Tests
           command: npm run integration-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             - build
   build:
     docker:
-      - image: cimg/clojure:1.11.1-openjdk-17.0-node
+      - image: cimg/clojure:1.11-node
     working_directory: ~/calva
     steps:
       - attach_workspace:
@@ -219,7 +219,7 @@ jobs:
           path: ~/calva/junit
   test-integration:
     docker:
-      - image: circleci/clojure:openjdk-11-tools-deps-bullseye-node-browsers-legacy
+      - image: cimg/clojure:1.11-node
     working_directory: ~/calva
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,9 +230,9 @@ jobs:
       - run:
           name: Compile Extension Tests
           command: npm run compile-test
-      #- run:
-      #    name: Apt install missing dependencies
-      #    command: sudo apt update && sudo apt install -y libnss3 libcups2 libatk-bridge2.0-0
+      - run:
+          name: Apt install missing dependencies
+          command: sudo apt update && sudo apt install -y libnss3
       - run:
           name: Run Extension Tests
           command: npm run integration-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Support user level `~/.config/calva/config.edn`](https://github.com/BetterThanTomorrow/calva/issues/1887)
+
 ## [2.0.306] - 2022-10-09
 
 - [Allow Clojure code in `.calva/config.edn` repl and hover snippets](https://github.com/BetterThanTomorrow/calva/issues/1885)

--- a/docs/site/custom-commands.md
+++ b/docs/site/custom-commands.md
@@ -153,6 +153,8 @@ There are now also `hover-` versions of most substitutions. Those currently only
 
 As for **2.**: There is a command **Calva: Refresh REPL snippets from User config.edn**.
 
+There is also a command to open the User config.edn, for convenience: **Calva: Open REPL snippets User config.edn**. This command creates the file if it doesn't previously exist.
+
 ## Snippets Inside Deps
 
 A new experimental feature lets library authors ship snippets inside their jar files. These accept the same options as above but should be placed in "resources/calva.exports/config.edn" inside the jar.

--- a/docs/site/custom-commands.md
+++ b/docs/site/custom-commands.md
@@ -145,8 +145,13 @@ There are now also `hover-` versions of most substitutions. Those currently only
 
 ## config.edn
 
-Your project can have a `.calva/config.edn` file that holds a map with calva configs. Currently only `:customREPLCommandSnippets` and `:customREPLHoverSnippets` get loaded.
-These will not get synced through vscode settings sync.
+`:customREPLCommandSnippets` and `:customREPLHoverSnippets` can be also be configured in your user config at `.config/calva/config.edn` realative to your system home directory, or `.calva/config.edn` relative to the workspace root. Three things to note about this:
+
+1. None of these two configs get synced through VS Code Settings Sync.
+2. Changes to workspace `.calva/config.edn` will be automatically noticed by Calva, and refresh the config. _This will not happen with the user config file._
+3. Internally in Calva, the settings are keyed on the snippet `:name` entry, and if you change the name, the old entry won't be removed until the VS Code window is reloaded.
+
+As for **2.**: There is a command **Calva: Refresh REPL snippets from User config.edn**.
 
 ## Snippets Inside Deps
 

--- a/package.json
+++ b/package.json
@@ -958,6 +958,11 @@
         "category": "Calva"
       },
       {
+        "command": "calva.rereadUserConfigEdn",
+        "title": "Refresh REPL snippets from User config.edn",
+        "category": "Calva"
+      },
+      {
         "command": "calva.clojureLsp.showClojureLspStoppedMenu",
         "title": "Show clojure-lsp menu",
         "enablement": "!clojureLsp:active",

--- a/package.json
+++ b/package.json
@@ -958,6 +958,11 @@
         "category": "Calva"
       },
       {
+        "command": "calva.openUserConfigEdn",
+        "title": "Open REPL snippets User config.edn",
+        "category": "Calva"
+      },
+      {
         "command": "calva.rereadUserConfigEdn",
         "title": "Refresh REPL snippets from User config.edn",
         "category": "Calva"

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,7 +69,7 @@ async function updateCalvaConfigFromUserConfigEdn(onDemand = true) {
   return fs.promises
     .access(userConfigFileUri.fsPath, fs.constants.F_OK)
     .then(async () => await updateCalvaConfigFromEdn(userConfigFileUri))
-    .catch(async (error) => {
+    .catch((error) => {
       if (error.code === 'ENOENT') {
         console.log('No user config.edn found');
         if (onDemand) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,7 +43,8 @@ async function updateCalvaConfigFromUserConfigEdn() {
   );
   return fs.promises
     .access(userConfigFileUri.fsPath, fs.constants.F_OK)
-    .then(async () => await updateCalvaConfigFromEdn(userConfigFileUri));
+    .then(async () => await updateCalvaConfigFromEdn(userConfigFileUri))
+    .catch((error) => console.error(error));
 }
 
 async function updateCalvaConfigFromEdn(uri?: vscode.Uri) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+import * as os from 'os';
+import * as fs from 'fs';
 import { customREPLCommandSnippet } from './evaluate';
 import { ReplConnectSequence } from './nrepl/connectSequence';
 import { PrettyPrintingOptions } from './printer';
@@ -32,7 +34,19 @@ function _trimAliasName(name: string): string {
   return name.replace(/^[\s,:]*/, '').replace(/[\s,:]*$/, '');
 }
 
-async function readEdnWorkspaceConfig(uri?: vscode.Uri) {
+async function updateCalvaConfigFromUserConfigEdn() {
+  const userConfigFileUri = vscode.Uri.joinPath(
+    vscode.Uri.file(os.homedir()),
+    '.config',
+    'calva',
+    'config.edn'
+  );
+  return fs.promises
+    .access(userConfigFileUri.fsPath, fs.constants.F_OK)
+    .then(async () => await updateCalvaConfigFromEdn(userConfigFileUri));
+}
+
+async function updateCalvaConfigFromEdn(uri?: vscode.Uri) {
   try {
     let resolvedUri: vscode.Uri;
     const configPath = state.resolvePath('.calva/config.edn');
@@ -96,7 +110,7 @@ const watcher = vscode.workspace.createFileSystemWatcher(
 );
 
 watcher.onDidChange((uri: vscode.Uri) => {
-  void readEdnWorkspaceConfig(uri);
+  void updateCalvaConfigFromEdn(uri);
 });
 
 // TODO find a way to validate the configs
@@ -104,10 +118,10 @@ function getConfig() {
   const configOptions = vscode.workspace.getConfiguration('calva');
   const pareditOptions = vscode.workspace.getConfiguration('calva.paredit');
 
-  const w =
+  const commands = (
     configOptions.inspect<customREPLCommandSnippet[]>('customREPLCommandSnippets')
-      ?.workspaceValue ?? [];
-  const commands = w.concat(
+      ?.workspaceValue ?? []
+  ).concat(
     (state.getProjectConfig()?.customREPLCommandSnippets as customREPLCommandSnippet[]) ?? []
   );
   const hoverSnippets = (
@@ -170,7 +184,8 @@ function getConfig() {
 }
 
 export {
-  readEdnWorkspaceConfig,
+  updateCalvaConfigFromEdn,
+  updateCalvaConfigFromUserConfigEdn,
   addEdnConfig,
   REPL_FILE_EXT,
   KEYBINDINGS_ENABLED_CONFIG_KEY,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,7 @@ function setKeybindingsEnabledContext() {
   );
 }
 
-async function initializeState() {
+function initializeState() {
   setStateValue('connected', false);
   setStateValue('connecting', false);
   setStateValue('outputChannel', vscode.window.createOutputChannel('Calva says'));
@@ -93,12 +93,12 @@ async function initializeState() {
     'diagnosticCollection',
     vscode.languages.createDiagnosticCollection('calva: Evaluation errors')
   );
-  await config.updateCalvaConfigFromUserConfigEdn();
 }
 
 async function activate(context: vscode.ExtensionContext) {
   console.info('Calva activate START');
-  await initializeState();
+  initializeState();
+  await config.updateCalvaConfigFromUserConfigEdn();
   await config.updateCalvaConfigFromEdn();
 
   status.updateNeedReplUi(false, context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,7 @@ function setKeybindingsEnabledContext() {
   );
 }
 
-function initializeState() {
+async function initializeState() {
   setStateValue('connected', false);
   setStateValue('connecting', false);
   setStateValue('outputChannel', vscode.window.createOutputChannel('Calva says'));
@@ -93,12 +93,13 @@ function initializeState() {
     'diagnosticCollection',
     vscode.languages.createDiagnosticCollection('calva: Evaluation errors')
   );
+  await config.updateCalvaConfigFromUserConfigEdn();
 }
 
 async function activate(context: vscode.ExtensionContext) {
   console.info('Calva activate START');
-  initializeState();
-  await config.readEdnWorkspaceConfig();
+  await initializeState();
+  await config.updateCalvaConfigFromEdn();
 
   status.updateNeedReplUi(false, context);
 
@@ -495,6 +496,12 @@ async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       'calva.prettyPrintReplaceCurrentForm',
       edit.prettyPrintReplaceCurrentForm
+    )
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'calva.rereadUserConfigEdn',
+      config.updateCalvaConfigFromUserConfigEdn
     )
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,7 +98,7 @@ function initializeState() {
 async function activate(context: vscode.ExtensionContext) {
   console.info('Calva activate START');
   initializeState();
-  await config.updateCalvaConfigFromUserConfigEdn();
+  await config.updateCalvaConfigFromUserConfigEdn(false);
   await config.updateCalvaConfigFromEdn();
 
   status.updateNeedReplUi(false, context);
@@ -503,6 +503,9 @@ async function activate(context: vscode.ExtensionContext) {
       'calva.rereadUserConfigEdn',
       config.updateCalvaConfigFromUserConfigEdn
     )
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('calva.openUserConfigEdn', config.openCalvaConfigEdn)
   );
 
   // Initial set of the provided contexts


### PR DESCRIPTION
## What has changed?

- Made so that we now also read REPL snippets config from `~/.config/calva/config.edn`
- Added a command for refreshing the config from this file.


Fixes #1887

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
