### PR TITLE
Fix liveshare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Jack-in as live share guest not working](https://github.com/BetterThanTomorrow/calva/issues/1625)
+
 ## [2.0.307] - 2022-10-11
 
 - [Support user level `~/.config/calva/config.edn`](https://github.com/BetterThanTomorrow/calva/issues/1887)
@@ -30,7 +32,7 @@ Changes to Calva.
 ## [2.0.302] - 2022-09-18
 
 - [Show error message if loading file results in an error](https://github.com/BetterThanTomorrow/calva/issues/1767)
-- Document workaround for: [Allow sending a different project-root-uri during LSP initialize request](https://github.com/BetterThanTomorrow/calva/issues/1866) 
+- Document workaround for: [Allow sending a different project-root-uri during LSP initialize request](https://github.com/BetterThanTomorrow/calva/issues/1866)
 
 ## [2.0.301] - 2022-09-16
 
@@ -137,7 +139,7 @@ Changes to Calva.
 ## [2.0.280] - 2022-05-31
 
 - Fix: [Debugger decorations are not working properly](https://github.com/BetterThanTomorrow/calva/issues/1165)
-- Add some logging when Calva starts and finishes activating 
+- Add some logging when Calva starts and finishes activating
 
 ## [2.0.279] - 2022-05-30
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,7 +98,7 @@ async function updateCalvaConfigFromEdn(uri?: vscode.Uri) {
     if (isDefined(uri)) {
       resolvedUri = uri;
     } else if (isDefined(configPath)) {
-      resolvedUri = vscode.Uri.file(configPath);
+      resolvedUri = configPath;
     } else {
       throw new Error('Expected a uri to be passed in or a config to exist at .calva/config.edn');
     }

--- a/src/extension-test/integration/suite/jack-in-test.ts
+++ b/src/extension-test/integration/suite/jack-in-test.ts
@@ -78,8 +78,7 @@ async function startJackInProcedure(suite: string, cmdId: string, projectType: s
   await testUtil.openFile(testFilePath);
   testUtil.log(suite, 'test.clj opened');
 
-  const projectRootPath = await projectRoot.findClosestProjectRootPath();
-  const projetcRootUri = projectRootPath;
+  const projetcRootUri = await projectRoot.findClosestProjectRootPath();
   // Project type pre-select, qps = quickPickSingle
   const saveAs = `qps-${projetcRootUri.toString()}/jack-in-type`;
   await state.extensionContext.workspaceState.update(saveAs, projectType);

--- a/src/extension-test/integration/suite/jack-in-test.ts
+++ b/src/extension-test/integration/suite/jack-in-test.ts
@@ -78,9 +78,9 @@ async function startJackInProcedure(suite: string, cmdId: string, projectType: s
   await testUtil.openFile(testFilePath);
   testUtil.log(suite, 'test.clj opened');
 
-  const projetcRootUri = await projectRoot.findClosestProjectRoot();
+  const projectRootUri = await projectRoot.findClosestProjectRoot();
   // Project type pre-select, qps = quickPickSingle
-  const saveAs = `qps-${projetcRootUri.toString()}/jack-in-type`;
+  const saveAs = `qps-${projectRootUri.toString()}/jack-in-type`;
   await state.extensionContext.workspaceState.update(saveAs, projectType);
 
   const res = commands.executeCommand(cmdId);

--- a/src/extension-test/integration/suite/jack-in-test.ts
+++ b/src/extension-test/integration/suite/jack-in-test.ts
@@ -79,7 +79,7 @@ async function startJackInProcedure(suite: string, cmdId: string, projectType: s
   testUtil.log(suite, 'test.clj opened');
 
   const projectRootPath = await projectRoot.findClosestProjectRootPath();
-  const projetcRootUri = vscode.Uri.file(projectRootPath);
+  const projetcRootUri = projectRootPath;
   // Project type pre-select, qps = quickPickSingle
   const saveAs = `qps-${projetcRootUri.toString()}/jack-in-type`;
   await state.extensionContext.workspaceState.update(saveAs, projectType);

--- a/src/extension-test/integration/suite/jack-in-test.ts
+++ b/src/extension-test/integration/suite/jack-in-test.ts
@@ -78,7 +78,7 @@ async function startJackInProcedure(suite: string, cmdId: string, projectType: s
   await testUtil.openFile(testFilePath);
   testUtil.log(suite, 'test.clj opened');
 
-  const projetcRootUri = await projectRoot.findClosestProjectRootPath();
+  const projetcRootUri = await projectRoot.findClosestProjectRoot();
   // Project type pre-select, qps = quickPickSingle
   const saveAs = `qps-${projetcRootUri.toString()}/jack-in-type`;
   await state.extensionContext.workspaceState.update(saveAs, projectType);

--- a/src/file-switcher/file-switcher.ts
+++ b/src/file-switcher/file-switcher.ts
@@ -56,7 +56,7 @@ export async function toggleBetweenImplAndTest() {
   let fileToOpen = vscode.workspace.asRelativePath(filePath, false);
   if (fileToOpen[0] === '/') {
     // When connected over live share, the above will result in an absolute path,
-    // which causes that workspace.findFiles won't find the file. So we strip the
+    // which causes workspace.findFiles to not find the file. So we strip the
     // leading slash to prevent such scenario's.
     fileToOpen = fileToOpen.substring(1);
   }

--- a/src/file-switcher/file-switcher.ts
+++ b/src/file-switcher/file-switcher.ts
@@ -57,7 +57,7 @@ export async function toggleBetweenImplAndTest() {
   if (fileToOpen[0] === '/') {
     // When connected over live share, the above will result in an absolute path,
     // which causes workspace.findFiles to not find the file. So we strip the
-    // leading slash to prevent such scenario's.
+    // leading slash to prevent such scenarios.
     fileToOpen = fileToOpen.substring(1);
   }
 

--- a/src/file-switcher/file-switcher.ts
+++ b/src/file-switcher/file-switcher.ts
@@ -36,7 +36,7 @@ function askToCreateANewFile(dir: vscode.Uri, filename: string) {
 export async function toggleBetweenImplAndTest() {
   const activeFile = getActiveTextEditor();
   const openedFilename = activeFile.document.fileName;
-  const projectRootUri = await projectRoot.findClosestProjectRootPath();
+  const projectRootUri = await projectRoot.findClosestProjectRoot();
   const projectRootPath = projectRootUri.fsPath;
   const pathAfterRoot = openedFilename.replace(projectRootPath, '');
   const fullFileName = path.basename(openedFilename);

--- a/src/files-cache.ts
+++ b/src/files-cache.ts
@@ -21,13 +21,13 @@ function writeToCache(uri: vscode.Uri) {
 export const content = (path: string | undefined) => {
   const resolvedPath = state.resolvePath(path);
   if (resolvedPath) {
-    if (!filesCache.has(resolvedPath)) {
-      writeToCache(vscode.Uri.file(resolvedPath));
-      const filesWatcher = vscode.workspace.createFileSystemWatcher(resolvedPath);
+    if (!filesCache.has(resolvedPath.fsPath)) {
+      writeToCache(resolvedPath);
+      const filesWatcher = vscode.workspace.createFileSystemWatcher(resolvedPath.fsPath);
       filesWatcher.onDidChange(writeToCache);
       filesWatcher.onDidCreate(writeToCache);
       filesWatcher.onDidDelete((uri) => filesCache.delete(uri.fsPath));
     }
-    return filesCache.get(resolvedPath);
+    return filesCache.get(resolvedPath.fsPath);
   }
 };

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -3,7 +3,7 @@ import * as util from './utilities';
 import * as config from './config';
 import * as path from 'path';
 
-export async function findProjectRootPaths() {
+export async function findProjectRoots(): Promise<vscode.Uri[]> {
   const projectFileNames: string[] = [
     'project.clj',
     'shadow-cljs.edn',
@@ -33,10 +33,10 @@ export function excludePattern(moreExcludes: string[] = []) {
   return `**/{${[...moreExcludes, ...config.getConfig().projectRootsSearchExclude].join(',')}}`;
 }
 
-export async function findClosestProjectRootPath(candidatePaths?: vscode.Uri[]) {
+export async function findClosestProjectRoot(candidatePaths?: vscode.Uri[]): Promise<vscode.Uri> {
   const doc = util.tryToGetDocument({});
   const docDir = doc && doc.uri ? doc.uri.with({ path: path.dirname(doc.uri.fsPath) }) : undefined;
-  candidatePaths = candidatePaths ?? (await findProjectRootPaths());
+  candidatePaths = candidatePaths ?? (await findProjectRoots());
   const closestRootPath = docDir
     ? candidatePaths
         .filter((u) => docDir.fsPath.startsWith(u.fsPath))
@@ -50,10 +50,10 @@ export async function findClosestProjectRootPath(candidatePaths?: vscode.Uri[]) 
   }
 }
 
-export async function pickProjectRootPath(
+export async function pickProjectRoot(
   candidatePaths: vscode.Uri[],
   closestRootPath: vscode.Uri
-) {
+): Promise<vscode.Uri> {
   if (closestRootPath !== undefined) {
     const pickedRootPath =
       candidatePaths.length < 2

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -16,14 +16,14 @@ export async function findProjectRootPaths() {
   const projectFilesGlob = `**/{${projectFileNames.join(',')}}`;
   const excludeDirsGlob = excludePattern();
   const t0 = new Date().getTime();
-  const rootPaths: string[] = [];
+  const rootPaths: vscode.Uri[] = [];
   if (vscode.workspace.workspaceFolders?.length > 0) {
-    const wsRootPaths = vscode.workspace.workspaceFolders.map((f) => f.uri.fsPath);
+    const wsRootPaths = vscode.workspace.workspaceFolders.map((f) => f.uri);
     rootPaths.push(...wsRootPaths);
   }
   const candidateUris = await vscode.workspace.findFiles(projectFilesGlob, excludeDirsGlob, 10000);
   console.debug('glob took', new Date().getTime() - t0, 'ms');
-  const projectFilePaths = candidateUris.map((uri) => path.dirname(uri.fsPath));
+  const projectFilePaths = candidateUris.map((uri) => uri.with({ path: path.dirname(uri.fsPath) }));
   rootPaths.push(...projectFilePaths);
   const candidatePaths = [...new Set(rootPaths)].sort();
   return candidatePaths;
@@ -33,13 +33,13 @@ export function excludePattern(moreExcludes: string[] = []) {
   return `**/{${[...moreExcludes, ...config.getConfig().projectRootsSearchExclude].join(',')}}`;
 }
 
-export async function findClosestProjectRootPath(candidatePaths?: string[]) {
+export async function findClosestProjectRootPath(candidatePaths?: vscode.Uri[]) {
   const doc = util.tryToGetDocument({});
-  const docDir = doc && doc.uri ? path.dirname(doc.uri.fsPath) : undefined;
+  const docDir = doc && doc.uri ? doc.uri.with({ path: path.dirname(doc.uri.fsPath) }) : undefined;
   candidatePaths = candidatePaths ?? (await findProjectRootPaths());
   const closestRootPath = docDir
     ? candidatePaths
-        .filter((p) => docDir.startsWith(p))
+        .filter((u) => docDir.fsPath.startsWith(u.fsPath))
         .sort()
         .reverse()[0]
     : candidatePaths[0];
@@ -50,22 +50,24 @@ export async function findClosestProjectRootPath(candidatePaths?: string[]) {
   }
 }
 
-export async function pickProjectRootPath(candidatePaths: string[], closestRootPath: string) {
+export async function pickProjectRootPath(
+  candidatePaths: vscode.Uri[],
+  closestRootPath: vscode.Uri
+) {
   if (closestRootPath !== undefined) {
     const pickedRootPath =
       candidatePaths.length < 2
         ? undefined
         : await util.quickPickSingle({
             title: 'Project root',
-            values: candidatePaths,
-            default: closestRootPath,
+            values: [...new Set(candidatePaths.map((u) => u.fsPath))],
+            default: closestRootPath.fsPath,
             placeHolder: 'Multiple Clojure projects found. Please pick the one you want to use.',
             saveAs: `projectRoot`,
             autoSelect: true,
           });
-    const projectRootPath = candidatePaths.includes(pickedRootPath)
-      ? pickedRootPath
-      : closestRootPath;
-    return projectRootPath;
+    const filtered = candidatePaths.filter((u) => u.fsPath === pickedRootPath);
+    const pickedRootUri = filtered.length > 0 ? filtered[0] : undefined;
+    return pickedRootUri ?? closestRootPath;
   }
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -183,12 +183,17 @@ export async function initProjectDir(uri?: vscode.Uri): Promise<void> {
  * Tries to resolve absolute path in relation to project root
  * @param filePath - absolute or relative to the project
  */
-export function resolvePath(filePath?: string) {
+export function resolvePath(filePath?: string): vscode.Uri {
   const root = getProjectWsFolder();
-  if (filePath && path.isAbsolute(filePath)) {
-    return filePath;
+
+  if (root.uri.scheme !== 'file') {
+    return vscode.Uri.joinPath(root.uri, filePath);
   }
-  return filePath && root && path.resolve(root.uri.fsPath, filePath);
+
+  if (filePath && path.isAbsolute(filePath)) {
+    return vscode.Uri.file(filePath);
+  }
+  return filePath && root && vscode.Uri.file(path.resolve(root.uri.fsPath, filePath));
 }
 
 export { extensionContext, outputChannel, connectionLogChannel, analytics };

--- a/src/state.ts
+++ b/src/state.ts
@@ -168,7 +168,7 @@ export async function initProjectDir(uri?: vscode.Uri): Promise<void> {
       closestRootPath
     );
     if (projectRootPath !== undefined) {
-      setStateValue(PROJECT_DIR_KEY, projectRootPath);
+      setStateValue(PROJECT_DIR_KEY, projectRootPath.fsPath);
       setStateValue(PROJECT_DIR_URI_KEY, projectRootPath);
     } else {
       await setOrCreateNonProjectRoot(extensionContext, true);

--- a/src/state.ts
+++ b/src/state.ts
@@ -161,11 +161,11 @@ export async function initProjectDir(uri?: vscode.Uri): Promise<void> {
     setStateValue(PROJECT_DIR_KEY, path.resolve(uri.fsPath));
     setStateValue(PROJECT_DIR_URI_KEY, uri);
   } else {
-    const candidatePaths: vscode.Uri[] = await projectRoot.findProjectRootPaths();
-    const closestRootPath: vscode.Uri = await projectRoot.findClosestProjectRootPath(
+    const candidatePaths: vscode.Uri[] = await projectRoot.findProjectRoots();
+    const closestRootPath: vscode.Uri = await projectRoot.findClosestProjectRoot(
       candidatePaths
     );
-    const projectRootPath: vscode.Uri = await projectRoot.pickProjectRootPath(
+    const projectRootPath: vscode.Uri = await projectRoot.pickProjectRoot(
       candidatePaths,
       closestRootPath
     );

--- a/src/state.ts
+++ b/src/state.ts
@@ -161,12 +161,17 @@ export async function initProjectDir(uri?: vscode.Uri): Promise<void> {
     setStateValue(PROJECT_DIR_KEY, path.resolve(uri.fsPath));
     setStateValue(PROJECT_DIR_URI_KEY, uri);
   } else {
-    const candidatePaths = await projectRoot.findProjectRootPaths();
-    const closestRootPath = await projectRoot.findClosestProjectRootPath(candidatePaths);
-    const projectRootPath = await projectRoot.pickProjectRootPath(candidatePaths, closestRootPath);
+    const candidatePaths: vscode.Uri[] = await projectRoot.findProjectRootPaths();
+    const closestRootPath: vscode.Uri = await projectRoot.findClosestProjectRootPath(
+      candidatePaths
+    );
+    const projectRootPath: vscode.Uri = await projectRoot.pickProjectRootPath(
+      candidatePaths,
+      closestRootPath
+    );
     if (projectRootPath !== undefined) {
       setStateValue(PROJECT_DIR_KEY, projectRootPath);
-      setStateValue(PROJECT_DIR_URI_KEY, vscode.Uri.file(projectRootPath));
+      setStateValue(PROJECT_DIR_URI_KEY, projectRootPath);
     } else {
       await setOrCreateNonProjectRoot(extensionContext, true);
     }

--- a/src/state.ts
+++ b/src/state.ts
@@ -162,9 +162,7 @@ export async function initProjectDir(uri?: vscode.Uri): Promise<void> {
     setStateValue(PROJECT_DIR_URI_KEY, uri);
   } else {
     const candidatePaths: vscode.Uri[] = await projectRoot.findProjectRoots();
-    const closestRootPath: vscode.Uri = await projectRoot.findClosestProjectRoot(
-      candidatePaths
-    );
+    const closestRootPath: vscode.Uri = await projectRoot.findClosestProjectRoot(candidatePaths);
     const projectRootPath: vscode.Uri = await projectRoot.pickProjectRoot(
       candidatePaths,
       closestRootPath


### PR DESCRIPTION
## What has changed?

Live share support in Calva was broken: as a guest you could no longer connect to the host's REPL. Also using the workspace's `config.edn` file was not handled properly on the guest.

Fixes #1625.

Please note that `npm run eslint` currently fails on the `dev` branch, so it also fails on this branch. My changes don't introduce new linting issues.

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

If this PR involves code changes, I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [ ] ~If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).
- [ ] ~Add tests or some other mechanism to help prevent breaking changes to live share support in the future~ For now the team is going to try and cover this in their code reviews. Issue #1895 was created to add integration tests for this.

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
