### PR TITLE
Disable notebook support for normal clojure file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2842,7 +2842,7 @@
         "priority": "option",
         "selector": [
           {
-            "filenamePattern": "*.{clj,cljc,cljs,cljx}"
+            "filenamePattern": "*.{cljnb,cljcnb,cljsnb,cljxnb}"
           }
         ]
       }


### PR DESCRIPTION
This is a work-around because currently Live Share causes clojure files to always be opened as notebooks.

See:

https://github.com/BetterThanTomorrow/calva/issues/1850

This PR is not intended actually be merged. It is a method (proposed by @PEZ) to use custom Calva builds without notebook support, so that we're not stuck on an older version of Calva. Hopefully the dynamic notebook APIs will be added to VSCode soon, so that we don't have to configure it in `package.json` anymore and this PR can be deleted.

This PR is automatically built by CircleCI. You can click "show all checks", click on the link to "ci/circleci: build", go to the artefacts tab, and grab the built `vsix` there, and manually install it. 