### PR TITLE
Make eval-to-cursor selection aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [A more flexible evaluate-to-cursor command](https://github.com/BetterThanTomorrow/calva/
+issues/1901)
+
 ## [2.0.307] - 2022-10-11
 
 - [Support user level `~/.config/calva/config.edn`](https://github.com/BetterThanTomorrow/calva/issues/1887)

--- a/docs/site/evaluation.md
+++ b/docs/site/evaluation.md
@@ -66,9 +66,22 @@ An ”exception” is introduced by the `comment` form. It will create a new top
 
 At the top level the selection of which form is the current top level form follows the same rules as those for [the current form](#current-form).
 
+### Evaluate Enclosing Form
+
+The default keyboard shortcut for evaluating the current enclosing form (the list the cursor is in) is `ctrl+shift+enter`.
+
+```clojure
+(let [foo :bar]
+  (when false (str| foo))) ; => ":bar"
+```
+
 ### Evaluate to Cursor
 
-There is also a command for evaluating the text from the start of the current list to where the cursor is. Convenient for checking intermediate results in thread or `doto`, or similar pipelines. The cursor is right behind `:d` in this form:
+There are several commands for evaluating a piece of code, closing brackets. It's good, especially in threads, but can also come in handy in other situations, for instance when you want to evaluate something that depends on bindings, such as in a `let` form.
+
+### Evaluate From Start of List to Cursor, Closing Brackets
+
+This command evaluates the text from the start of the current enclosing list to where the cursor is, and it adds the missing closing bracket for you. Convenient for checking intermediate results in thread or `doto`, or similar pipelines. The cursor is right behind `:d` in this form:
 
 ```clojure
   (->> [1 1 2 3 5 8 13 21]
@@ -79,11 +92,40 @@ There is also a command for evaluating the text from the start of the current li
        (Math/abs))
 ```
 
-The default shortcut for this command is `ctrl+alt+enter`.
+The default shortcut for this command is <kbd>ctrl+alt+enter</kbd>.
 
-### Evaluate Top Level Form to Cursor
+### Evaluate Selection, Closing Brackets
 
-This command has a default shortcut keybinding of `shift+alt+enter`. It will create a form from the start of the current top level form, up to the cursor, then fold the form, closing all brackets, and this will then be evaluated. Good for examining code blocks up to a certain point.
+This is the most versatile of the ”evaluation, closing brackets” commands. It will do what it says. 😄 It's extra handy in combination with the command **Paredit: Select Backward Up Sexp/Form** (<kbd>shift+ctrl+up</kbd>). Consider this contrieved form (buggy code, because it was supposed to result in `42`, not `-42`):
+
+```clojure
+(defn fortytwo-from-thirty
+  []
+  (let [thirty 30]
+    (-> thirty
+        inc            ;1
+        (send-off)
+        (+ 1 2 3)
+        (->>
+         (+ 2 2)       ;2
+         (+))
+        list
+        (->>
+         (into [1])
+         (reduce + 1))
+        (- 1)          ;3
+        (* -1))))
+```
+
+At `;1`, you can do **backward up sexp** (<kbd>shift+ctrl+up</kbd>) twice to select up to the `(let ..)`, then issue **Evaluate Selection, Closing Brackets**. It has the same default keybinding as the command for [evaluating the current list up to the cursor](#evaluate-from-start-of-list-to-cursor-closing-brackets): <kbd>ctrl+alt+enter</kbd>.
+
+At `;2` you need select backwards up three times.
+
+`;3` is included because it is close to the bug. (Which was introduced when the thread-last, `->>` was added to make this example.) Please practice the **Evaluate Selection, Closing Brackets** command to fix the bug.
+
+### Evaluate From Start of Top Level Form to Cursor, Closing Brackets
+
+This command has a default shortcut keybinding of `shift+alt+enter`. It will create a form from the start of the current top level form, up to the cursor, close all brackets, and this will then be evaluated. Good for examining code blocks up to a certain point. Often comes in handy in Rich comments (`(comment ...)`).
 
 Take this example and paste it in a file loaded into the REPL, then place the cursor in front of each line comment and try the command.
 
@@ -116,16 +158,11 @@ Take this example and paste it in a file loaded into the REPL, then place the cu
           ))))
 ```
 
-### Evaluate Enclosing Form
+### Evaluate From Start of File to Cursor, Closing Brackets
 
-The default keyboard shortcut for evaluating the current enclosing form (the list the cursor is in) is `ctrl+shift+enter`.
+Yup, that command also exists. 😄
 
-```clojure
-(let [foo :bar]
-  (when false (str| foo))) ; => ":bar"
-```
-
-### Copying the inline results
+## Copying the inline results
 
 There is a command called **Copy last evaluation results**, `ctrl+alt+c ctrl+c`.
 

--- a/package.json
+++ b/package.json
@@ -1133,19 +1133,25 @@
       },
       {
         "command": "calva.evaluateToCursor",
-        "title": "Evaluate From Start of List to Cursor",
-        "enablement": "calva:connected",
+        "title": "Evaluate From Start of List to Cursor, Closing Brackets",
+        "enablement": "calva:connected && !editorHasSelection",
+        "category": "Calva"
+      },
+      {
+        "command": "calva.evaluateSelectionToSelectionEnd",
+        "title": "Evaluate Selection, Closing Brackets",
+        "enablement": "calva:connected && editorHasSelection",
         "category": "Calva"
       },
       {
         "command": "calva.evaluateTopLevelFormToCursor",
-        "title": "Evaluate From Start of Top Level Form to Cursor",
+        "title": "Evaluate From Start of Top Level Form to Cursor, Closing Brackets",
         "enablement": "calva:connected",
         "category": "Calva"
       },
       {
         "command": "calva.evaluateStartOfFileToCursor",
-        "title": "Evaluate From Start of File to Cursor",
+        "title": "Evaluate From Start of File to Cursor, Closing Brackets",
         "enablement": "calva:connected",
         "category": "Calva"
       },
@@ -1889,7 +1895,12 @@
       {
         "command": "calva.evaluateToCursor",
         "key": "ctrl+alt+enter",
-        "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
+        "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && !editorHasSelection"
+      },
+      {
+        "command": "calva.evaluateSelectionToSelectionEnd",
+        "key": "ctrl+alt+enter",
+        "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && editorHasSelection"
       },
       {
         "command": "calva.evaluateTopLevelFormToCursor",

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -377,7 +377,9 @@ function evaluateUsingTextAndSelectionGetter(
 
 function evaluateToCursor(document = {}, options = {}) {
   evaluateUsingTextAndSelectionGetter(
-    getText.currentEnclosingFormToCursor,
+    vscode.window.activeTextEditor.selection.isEmpty
+      ? getText.currentEnclosingFormToCursor
+      : getText.selectionAddingBrackets,
     (code) => `${code}`,
     document,
     options

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -268,6 +268,9 @@ async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('calva.evaluateToCursor', eval.evaluateToCursor)
   );
   context.subscriptions.push(
+    vscode.commands.registerCommand('calva.evaluateSelectionToSelectionEnd', eval.evaluateToCursor)
+  );
+  context.subscriptions.push(
     vscode.commands.registerCommand(
       'calva.evaluateTopLevelFormToCursor',
       eval.evaluateTopLevelFormToCursor

--- a/src/util/cursor-get-text.ts
+++ b/src/util/cursor-get-text.ts
@@ -39,14 +39,15 @@ export function currentTopLevelForm(doc: EditableDocument): RangeAndText {
   return defunRange ? [defunRange, doc.model.getText(...defunRange)] : [undefined, ''];
 }
 
-function rangeOrStartOfFileToCursor(
+function rangeToCursor(
   doc: EditableDocument,
   foldRange: [number, number],
-  startFrom: number
+  startFrom: number,
+  active: number
 ): RangeAndText {
   if (foldRange) {
     const closeBrackets: string[] = [];
-    const bracketCursor = doc.getTokenCursor(doc.selection.active);
+    const bracketCursor = doc.getTokenCursor(active);
     bracketCursor.backwardWhitespace(true);
     const rangeEnd = bracketCursor.offsetStart;
     while (
@@ -65,17 +66,25 @@ function rangeOrStartOfFileToCursor(
 export function currentEnclosingFormToCursor(doc: EditableDocument): RangeAndText {
   const cursor = doc.getTokenCursor(doc.selection.active);
   const enclosingRange = cursor.rangeForList(1);
-  return rangeOrStartOfFileToCursor(doc, enclosingRange, enclosingRange[0]);
+  return rangeToCursor(doc, enclosingRange, enclosingRange[0], doc.selection.active);
 }
 
 export function currentTopLevelFormToCursor(doc: EditableDocument): RangeAndText {
   const cursor = doc.getTokenCursor(doc.selection.active);
   const defunRange = cursor.rangeForDefun(doc.selection.active);
-  return rangeOrStartOfFileToCursor(doc, defunRange, defunRange[0]);
+  return rangeToCursor(doc, defunRange, defunRange[0], doc.selection.active);
 }
 
 export function startOfFileToCursor(doc: EditableDocument): RangeAndText {
   const cursor = doc.getTokenCursor(doc.selection.active);
   const defunRange = cursor.rangeForDefun(doc.selection.active, false);
-  return rangeOrStartOfFileToCursor(doc, defunRange, 0);
+  return rangeToCursor(doc, defunRange, 0, doc.selection.active);
+}
+
+export function selectionAddingBrackets(doc: EditableDocument): RangeAndText {
+  const [left, right] = [doc.selection.anchor, doc.selection.active].sort();
+  const cursor = doc.getTokenCursor(left);
+  cursor.forwardSexp(true, true, true);
+  const rangeEnd = cursor.offsetStart;
+  return rangeToCursor(doc, [left, rangeEnd], left, right);
 }

--- a/src/util/get-text.ts
+++ b/src/util/get-text.ts
@@ -105,6 +105,13 @@ export function currentTopLevelFormToCursor(
   return selectionAndText(doc, cursorTextGetter.currentTopLevelFormToCursor, pos);
 }
 
+export function selectionAddingBrackets(
+  doc: vscode.TextDocument,
+  pos: vscode.Position
+): SelectionAndText {
+  return selectionAndText(doc, cursorTextGetter.selectionAddingBrackets, pos);
+}
+
 export function startOFileToCursor(
   doc: vscode.TextDocument,
   pos: vscode.Position


### PR DESCRIPTION
## What has changed?

The **Evaluate from Start of List** command (`ctrl+alt+enter`) has been updated to consider if there is a selection. Then it will take that selection and pad on the missing brackets and evaluate the result.

This allows the user to place the cursor in some form (often a nested thread) and do **Paredit: Backward Up** a few times until enough of the start of the form is included and then press `ctrl+alt+enter` to examine the thread up to the cursor.


Fixes #1901

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
