### PR TITLE
Filter out code action errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Filter out code action errors](https://github.com/BetterThanTomorrow/calva/pull/1904), addressing [this issue](https://github.com/BetterThanTomorrow/calva/issues/1889)
+
 ## [2.0.308] - 2022-10-19
 
 - [A more flexible evaluate-to-cursor command](https://github.com/BetterThanTomorrow/calva/issues/1901)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,7 @@ import * as joyride from './joyride';
 import * as api from './api/index';
 import * as depsClj from './nrepl/deps-clj';
 import * as clojureDocs from './clojuredocs';
+import * as overrides from './overrides';
 
 async function onDidSave(testController: vscode.TestController, document: vscode.TextDocument) {
   const { evalOnSave, testOnSave } = config.getConfig();
@@ -97,6 +98,9 @@ function initializeState() {
 
 async function activate(context: vscode.ExtensionContext) {
   console.info('Calva activate START');
+
+  overrides.activate();
+
   initializeState();
   await config.updateCalvaConfigFromUserConfigEdn(false);
   await config.updateCalvaConfigFromEdn();

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -1,0 +1,14 @@
+import * as vscode from 'vscode';
+
+const vscodeShowErrorMessage = vscode.window.showErrorMessage;
+
+async function calvaShowErrorMessage(message: string) {
+  const exlusionRegexps = [/Request textDocument\/codeAction failed./];
+  if (!exlusionRegexps.some((re) => re.test(message))) {
+    return vscodeShowErrorMessage(message);
+  }
+}
+
+export function activate() {
+  vscode.window.showErrorMessage = calvaShowErrorMessage;
+}


### PR DESCRIPTION
## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- This filters out the codeAction errors that popup in some imbalanced form situations, which can be annoying to users. When you have this form: `({})`, if you add `:` in the middle, the error pops up. With this PR, the error is filtered out and no popup is shown.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Addresses #1889.

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- ~[ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - ~[ ] Figured if the change might have some side effects and tested those as well.~
  - ~[ ] Smoke tested the extension as such.~
  - ~[ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.~
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - ~[ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)~
  - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- ~[ ] Created the issue I am fixing/addressing, if it was not present.~
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
