### PR TITLE
Consolidate commands, providers, events into collections (resubmitted from #1898)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Refactor
+  extension.ts for less boilerplate and improved readability.](https://github.com/BetterThanTomorrow/calva/issues/1906)
 - [Filter out code action errors](https://github.com/BetterThanTomorrow/calva/pull/1904), addressing [this issue](https://github.com/BetterThanTomorrow/calva/issues/1889)
 
 ## [2.0.308] - 2022-10-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Refactor
-  extension.ts for less boilerplate and improved readability.](https://github.com/BetterThanTomorrow/calva/issues/1906)
+  `extension.ts` for less boilerplate and improved readability](https://github.com/BetterThanTomorrow/calva/issues/1906)
 - [Filter out code action errors](https://github.com/BetterThanTomorrow/calva/pull/1904), addressing [this issue](https://github.com/BetterThanTomorrow/calva/issues/1889)
 
 ## [2.0.308] - 2022-10-19

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,34 +40,8 @@ import * as joyride from './joyride';
 import * as api from './api/index';
 import * as depsClj from './nrepl/deps-clj';
 import * as clojureDocs from './clojuredocs';
+import { capitalize } from './utilities';
 import * as overrides from './overrides';
-
-async function onDidSave(testController: vscode.TestController, document: vscode.TextDocument) {
-  const { evalOnSave, testOnSave } = config.getConfig();
-
-  if (document.languageId !== 'clojure') {
-    return;
-  }
-
-  if (evalOnSave) {
-    if (!outputWindow.isResultsDoc(document)) {
-      await eval.loadFile(document, config.getConfig().prettyPrintingOptions);
-      outputWindow.appendPrompt();
-      state.analytics().logEvent('Calva', 'OnSaveLoad').send();
-    }
-  }
-
-  if (testOnSave && util.getConnectedState()) {
-    void testRunner.runNamespaceTests(testController, document);
-    state.analytics().logEvent('Calva', 'OnSaveTest').send();
-  }
-}
-
-function onDidOpen(document) {
-  if (document.languageId !== 'clojure') {
-    return;
-  }
-}
 
 function onDidChangeEditorOrSelection(editor: vscode.TextEditor) {
   replHistory.setReplHistoryCommandsActiveContext(editor);
@@ -121,6 +95,13 @@ async function activate(context: vscode.ExtensionContext) {
   model.initScanner(vscode.workspace.getConfiguration('editor').get('maxTokenizationLineLength'));
 
   const chan = state.outputChannel();
+
+  context.subscriptions.push(
+    new vscode.Disposable(() => {
+      connector.disconnect();
+      chan.dispose();
+    })
+  );
 
   const legacyExtension = vscode.extensions.getExtension('cospaia.clojure4vscode');
   const fmtExtension = vscode.extensions.getExtension('cospaia.calva-fmt');
@@ -192,250 +173,108 @@ async function activate(context: vscode.ExtensionContext) {
 
   status.update(context);
 
+  // Initial set of the provided contexts
+  outputWindow.setContextForOutputWindowActive(false);
+  void vscode.commands.executeCommand('setContext', 'calva:launching', false);
+  void vscode.commands.executeCommand('setContext', 'calva:connected', false);
+  void vscode.commands.executeCommand('setContext', 'calva:connecting', false);
+  setKeybindingsEnabledContext();
+
   // COMMANDS
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.startJoyrideReplAndConnect', async () => {
-      const projectDir: string = await joyride.prepareForJackingOrConnect();
-      if (projectDir !== undefined) {
-        void joyride.joyrideJackIn(projectDir);
-      }
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.startOrConnectRepl', replStart.startOrConnectRepl)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.startStandaloneRepl', () => {
-      void replStart.startStandaloneRepl(context, replStart.USER_TEMPLATE, true);
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.startStandaloneHelloRepl', () => {
-      void replStart.startStandaloneRepl(context, replStart.HELLO_TEMPLATE, false);
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.startStandaloneCljsBrowserRepl', () => {
-      void replStart.startStandaloneRepl(context, replStart.HELLO_CLJS_BROWSER_TEMPLATE, false);
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.startStandaloneCljsNodeRepl', () => {
-      void replStart.startStandaloneRepl(context, replStart.HELLO_CLJS_NODE_TEMPLATE, false);
-    })
-  );
-  context.subscriptions.push(vscode.commands.registerCommand('calva.jackIn', jackIn.jackInCommand));
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.copyJackInCommandToClipboard',
-      jackIn.copyJackInCommandToClipboard
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.connectNonProjectREPL', () => {
-      void connector.connectNonProjectREPLCommand(context);
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.connect', connector.connectCommand)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.disconnect', jackIn.calvaDisconnect)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.toggleCLJCSession', connector.toggleCLJCSession)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.switchCljsBuild', connector.switchCljsBuild)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.selectCurrentForm', select.selectCurrentForm)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.loadFile', async () => {
+  const commands = {
+    clearInlineResults: annotations.clearEvaluationDecorations,
+    clearReplHistory: replHistory.clearHistory,
+    connect: connector.connectCommand,
+    connectNonProjectREPL: () => void connector.connectNonProjectREPLCommand(context),
+    continueComment: edit.continueCommentCommand,
+    convertDart2Clj: converters.dart2clj,
+    convertJs2Cljs: converters.js2cljs,
+    copyAnnotationHoverText: annotations.copyHoverTextCommand,
+    copyJackInCommandToClipboard: jackIn.copyJackInCommandToClipboard,
+    copyLastResults: eval.copyLastResultCommand,
+    'debug.instrument': eval.instrumentTopLevelForm,
+    'diagnostics.toggleNreplLoggingEnabled': nreplLogging.toggleEnabled,
+    disconnect: jackIn.calvaDisconnect,
+    evaluateCurrentTopLevelForm: eval.evaluateTopLevelForm,
+    evaluateEnclosingForm: eval.evaluateEnclosingForm,
+    evaluateOutputWindowForm: eval.evaluateOutputWindowForm,
+    evaluateSelection: eval.evaluateCurrentForm,
+    evaluateSelectionAsComment: eval.evaluateSelectionAsComment,
+    evaluateSelectionReplace: eval.evaluateSelectionReplace,
+    evaluateSelectionToSelectionEnd: eval.evaluateToCursor,
+    evaluateStartOfFileToCursor: eval.evaluateStartOfFileToCursor,
+    evaluateToCursor: eval.evaluateToCursor,
+    evaluateTopLevelFormAsComment: eval.evaluateTopLevelFormAsComment,
+    evaluateTopLevelFormToCursor: eval.evaluateTopLevelFormToCursor,
+    evaluateUser: eval.evaluateUser,
+    interruptAllEvaluations: eval.interruptAllEvaluations,
+    jackIn: jackIn.jackInCommand,
+    loadFile: async () => {
       await eval.loadFile({}, config.getConfig().prettyPrintingOptions);
       return new Promise((resolve) => {
         outputWindow.appendPrompt(resolve);
       });
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.interruptAllEvaluations', eval.interruptAllEvaluations)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.evaluateSelection', eval.evaluateCurrentForm)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.evaluateEnclosingForm', eval.evaluateEnclosingForm)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.evaluateToCursor', eval.evaluateToCursor)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.evaluateSelectionToSelectionEnd', eval.evaluateToCursor)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.evaluateTopLevelFormToCursor',
-      eval.evaluateTopLevelFormToCursor
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.evaluateStartOfFileToCursor',
-      eval.evaluateStartOfFileToCursor
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.evaluateUser', eval.evaluateUser)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.evaluateCurrentTopLevelForm', eval.evaluateTopLevelForm)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.evaluateOutputWindowForm', eval.evaluateOutputWindowForm)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.evaluateSelectionReplace', eval.evaluateSelectionReplace)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.evaluateSelectionAsComment',
-      eval.evaluateSelectionAsComment
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.evaluateTopLevelFormAsComment',
-      eval.evaluateTopLevelFormAsComment
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.togglePrettyPrint', eval.togglePrettyPrint)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.toggleEvaluationSendCodeToOutputWindow',
-      eval.toggleEvaluationSendCodeToOutputWindow
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.runTestUnderCursor', () => {
-      testRunner.runTestUnderCursorCommand(controller);
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.runNamespaceTests', () => {
-      testRunner.runNamespaceTestsCommand(controller);
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.runAllTests', () => {
-      testRunner.runAllTestsCommand(controller);
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.rerunTests', () => {
-      testRunner.rerunTestsCommand(controller);
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.clearInlineResults',
-      annotations.clearEvaluationDecorations
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.copyAnnotationHoverText',
-      annotations.copyHoverTextCommand
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.copyLastResults', eval.copyLastResultCommand)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.requireREPLUtilities', eval.requireREPLUtilitiesCommand)
-  );
-  context.subscriptions.push(vscode.commands.registerCommand('calva.refresh', refresh.refresh));
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.refreshAll', refresh.refreshAll)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.debug.instrument', eval.instrumentTopLevelForm)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.runCustomREPLCommand',
-      snippets.evaluateCustomCodeSnippetCommand
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.tapSelection', () =>
-      snippets.evaluateCustomCodeSnippetCommand('(tap> $current-form)')
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.tapCurrentTopLevelForm', () =>
-      snippets.evaluateCustomCodeSnippetCommand('(tap> $top-level-form)')
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.showOutputWindow', () => {
-      outputWindow.revealResultsDoc(false);
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.showFileForOutputWindowNS', () => {
-      void outputWindow.revealDocForCurrentNS(false);
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.toggleBetweenImplAndTest', () => {
-      void fileSwitcher.toggleBetweenImplAndTest();
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.setOutputWindowNamespace',
-      outputWindow.setNamespaceFromCurrentFile
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.sendCurrentFormToOutputWindow',
-      outputWindow.appendCurrentForm
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.sendCurrentTopLevelFormToOutputWindow',
-      outputWindow.appendCurrentTopLevelForm
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.printLastStacktrace', () => {
+    },
+    openCalvaDocs: () => {
+      void context.globalState.update(VIEWED_CALVA_DOCS, true);
+      open(CALVA_DOCS_URL)
+        .then(() => {
+          state.analytics().logEvent('Calva', 'Docs opened');
+        })
+        .catch((e) => {
+          console.error(`Problems visiting calva docs: ${e}`);
+        });
+    },
+    openUserConfigEdn: config.openCalvaConfigEdn,
+    prettyPrintReplaceCurrentForm: edit.prettyPrintReplaceCurrentForm,
+    printClojureDocsToOutputWindow: clojureDocs.printClojureDocsToOutputWindow,
+    printClojureDocsToRichComment: clojureDocs.printClojureDocsToRichComment,
+    printLastStacktrace: () => {
       outputWindow.printLastStacktrace();
       outputWindow.appendPrompt();
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.showPreviousReplHistoryEntry',
-      replHistory.showPreviousReplHistoryEntry
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.showNextReplHistoryEntry',
-      replHistory.showNextReplHistoryEntry
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.clearReplHistory', replHistory.clearHistory)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.toggleKeybindingsEnabled', () => {
+    },
+    printTextToOutputWindowCommand: clojureDocs.printTextToOutputWindowCommand,
+    printTextToRichCommentCommand: clojureDocs.printTextToRichCommentCommand,
+    refresh: refresh.refresh,
+    refreshAll: refresh.refreshAll,
+    requireREPLUtilities: eval.requireREPLUtilitiesCommand,
+    rereadUserConfigEdn: config.updateCalvaConfigFromUserConfigEdn,
+    rerunTests: () => testRunner.rerunTestsCommand(controller),
+    runAllTests: () => testRunner.runAllTestsCommand(controller),
+    runCustomREPLCommand: snippets.evaluateCustomCodeSnippetCommand,
+    runNamespaceTests: () => testRunner.runNamespaceTestsCommand(controller),
+    runTestUnderCursor: () => testRunner.runTestUnderCursorCommand(controller),
+    selectCurrentForm: select.selectCurrentForm,
+    sendCurrentFormToOutputWindow: outputWindow.appendCurrentForm,
+    sendCurrentTopLevelFormToOutputWindow: outputWindow.appendCurrentTopLevelForm,
+    setOutputWindowNamespace: outputWindow.setNamespaceFromCurrentFile,
+    showFileForOutputWindowNS: () => void outputWindow.revealDocForCurrentNS(false),
+    showNextReplHistoryEntry: replHistory.showNextReplHistoryEntry,
+    showOutputWindow: () => outputWindow.revealResultsDoc(false),
+    showPreviousReplHistoryEntry: replHistory.showPreviousReplHistoryEntry,
+    startJoyrideReplAndConnect: async () => {
+      const projectDir: string = await joyride.prepareForJackingOrConnect();
+      if (projectDir !== undefined) {
+        void joyride.joyrideJackIn(projectDir);
+      }
+    },
+    startOrConnectRepl: replStart.startOrConnectRepl,
+    startStandaloneCljsBrowserRepl: () =>
+      void replStart.startStandaloneRepl(context, replStart.HELLO_CLJS_BROWSER_TEMPLATE, false),
+    startStandaloneCljsNodeRepl: () =>
+      void replStart.startStandaloneRepl(context, replStart.HELLO_CLJS_NODE_TEMPLATE, false),
+    startStandaloneHelloRepl: () =>
+      void replStart.startStandaloneRepl(context, replStart.HELLO_TEMPLATE, false),
+    startStandaloneRepl: () =>
+      void replStart.startStandaloneRepl(context, replStart.USER_TEMPLATE, true),
+    switchCljsBuild: connector.switchCljsBuild,
+    tapCurrentTopLevelForm: () =>
+      snippets.evaluateCustomCodeSnippetCommand('(tap> $top-level-form)'),
+    tapSelection: () => snippets.evaluateCustomCodeSnippetCommand('(tap> $current-form)'),
+    toggleBetweenImplAndTest: () => void fileSwitcher.toggleBetweenImplAndTest(),
+    toggleCLJCSession: connector.toggleCLJCSession,
+    toggleEvaluationSendCodeToOutputWindow: eval.toggleEvaluationSendCodeToOutputWindow,
+    toggleKeybindingsEnabled: () => {
       const keybindingsEnabled = vscode.workspace
         .getConfiguration()
         .get(config.KEYBINDINGS_ENABLED_CONFIG_KEY);
@@ -446,172 +285,115 @@ async function activate(context: vscode.ExtensionContext) {
           !keybindingsEnabled,
           vscode.ConfigurationTarget.Global
         );
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.openCalvaDocs', () => {
-      void context.globalState.update(VIEWED_CALVA_DOCS, true);
-      open(CALVA_DOCS_URL)
-        .then(() => {
-          state.analytics().logEvent('Calva', 'Docs opened');
-        })
-        .catch((e) => {
-          console.error(`Problems visiting calva docs: ${e}`);
-        });
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.continueComment', edit.continueCommentCommand)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.diagnostics.toggleNreplLoggingEnabled',
-      nreplLogging.toggleEnabled
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.printClojureDocsToOutputWindow',
-      clojureDocs.printClojureDocsToOutputWindow
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.printClojureDocsToRichComment',
-      clojureDocs.printClojureDocsToRichComment
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.printTextToRichCommentCommand',
-      clojureDocs.printTextToRichCommentCommand
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.printTextToOutputWindowCommand',
-      clojureDocs.printTextToOutputWindowCommand
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.convertJs2Cljs', converters.js2cljs)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.convertDart2Clj', converters.dart2clj)
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.prettyPrintReplaceCurrentForm',
-      edit.prettyPrintReplaceCurrentForm
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'calva.rereadUserConfigEdn',
-      config.updateCalvaConfigFromUserConfigEdn
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('calva.openUserConfigEdn', config.openCalvaConfigEdn)
-  );
+    },
+    togglePrettyPrint: eval.togglePrettyPrint,
+  };
 
-  // Initial set of the provided contexts
-  outputWindow.setContextForOutputWindowActive(false);
-  void vscode.commands.executeCommand('setContext', 'calva:launching', false);
-  void vscode.commands.executeCommand('setContext', 'calva:connected', false);
-  void vscode.commands.executeCommand('setContext', 'calva:connecting', false);
-  setKeybindingsEnabledContext();
+  function registerCalvaCommand([command, callback]) {
+    const calvaCmd = `calva.${command}`;
+    context.subscriptions.push(vscode.commands.registerCommand(calvaCmd, callback));
+  }
+
+  Object.entries(commands).forEach(registerCalvaCommand);
 
   // PROVIDERS
   context.subscriptions.push(
-    vscode.languages.registerCompletionItemProvider(
-      config.documentSelector,
-      new CalvaCompletionItemProvider()
-    )
-  );
-  context.subscriptions.push(
-    vscode.languages.registerHoverProvider(config.documentSelector, new HoverProvider())
-  );
-  context.subscriptions.push(
-    vscode.languages.registerDefinitionProvider(
-      config.documentSelector,
-      new definition.ClojureDefinitionProvider()
-    )
-  );
-  context.subscriptions.push(
-    vscode.languages.registerDefinitionProvider(
-      config.documentSelector,
-      new definition.StackTraceDefinitionProvider()
-    )
-  );
-  context.subscriptions.push(
-    vscode.languages.registerSignatureHelpProvider(
-      config.documentSelector,
-      new CalvaSignatureHelpProvider(),
-      ' ',
-      ' '
-    )
+    vscode.workspace.registerTextDocumentContentProvider('jar', new JarContentProvider())
   );
 
-  vscode.workspace.registerTextDocumentContentProvider('jar', new JarContentProvider());
+  const languageProviders = {
+    completionItemProvider: {
+      provider: new CalvaCompletionItemProvider(),
+    },
+    definitionProvider: [
+      {
+        provider: new definition.ClojureDefinitionProvider(),
+      },
+      {
+        provider: new definition.StackTraceDefinitionProvider(),
+      },
+    ],
+    hoverProvider: {
+      provider: new HoverProvider(),
+    },
+    signatureHelpProvider: {
+      provider: new CalvaSignatureHelpProvider(),
+      registerArgs: [' '],
+    },
+  };
 
-  // //EVENTS
-  context.subscriptions.push(
-    vscode.workspace.onDidOpenTextDocument((document) => {
-      onDidOpen(document);
-    })
-  );
-  context.subscriptions.push(
-    vscode.workspace.onDidSaveTextDocument((document) => {
-      void onDidSave(controller, document);
-    })
-  );
-  context.subscriptions.push(
-    vscode.window.onDidChangeActiveTextEditor((editor) => {
-      status.update();
-      onDidChangeEditorOrSelection(editor);
-    })
-  );
-  context.subscriptions.push(
-    vscode.workspace.onDidChangeTextDocument(annotations.onDidChangeTextDocument)
-  );
-  context.subscriptions.push(
-    new vscode.Disposable(() => {
-      connector.disconnect();
-      chan.dispose();
-    })
-  );
+  function registerLangProvider([service, providers]) {
+    providers = Array.isArray(providers) ? providers : [providers];
+    const register = `register${capitalize(service)}`;
 
-  context.subscriptions.push(
-    vscode.workspace.onDidChangeConfiguration((_: vscode.ConfigurationChangeEvent) => {
-      statusbar.update();
-    })
-  );
-  context.subscriptions.push(
-    vscode.window.onDidChangeTextEditorSelection((event) => {
-      onDidChangeEditorOrSelection(event.textEditor);
-    })
-  );
-  context.subscriptions.push(
-    vscode.workspace.onDidCloseTextDocument((document) => {
-      if (outputWindow.isResultsDoc(document)) {
-        outputWindow.setContextForOutputWindowActive(false);
-      }
-    })
-  );
-  context.subscriptions.push(
-    vscode.window.onDidChangeVisibleTextEditors((editors) => {
-      if (!editors.some((editor) => outputWindow.isResultsDoc(editor.document))) {
-        outputWindow.setContextForOutputWindowActive(false);
-      }
-    })
-  );
-  context.subscriptions.push(
-    vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
-      if (e.affectsConfiguration(config.KEYBINDINGS_ENABLED_CONFIG_KEY)) {
-        setKeybindingsEnabledContext();
-      }
-    })
+    providers.forEach(({ provider, registerArgs = [] }) => {
+      context.subscriptions.push(
+        vscode.languages[register](config.documentSelector, provider, ...registerArgs)
+      );
+    });
+  }
+
+  Object.entries(languageProviders).forEach(registerLangProvider);
+
+  //EVENTS
+  const onDidEvents = {
+    workspace: {
+      saveTextDocument: async (document: vscode.TextDocument) => {
+        const { evalOnSave, testOnSave } = config.getConfig();
+
+        if (document.languageId !== 'clojure') {
+          return;
+        }
+
+        if (evalOnSave) {
+          if (!outputWindow.isResultsDoc(document)) {
+            await eval.loadFile(document, config.getConfig().prettyPrintingOptions);
+            outputWindow.appendPrompt();
+            state.analytics().logEvent('Calva', 'OnSaveLoad').send();
+          }
+        }
+
+        if (testOnSave && util.getConnectedState()) {
+          void testRunner.runNamespaceTests(controller, document);
+          state.analytics().logEvent('Calva', 'OnSaveTest').send();
+        }
+      },
+      changeTextDocument: annotations.onDidChangeTextDocument,
+      closeTextDocument: (document) => {
+        if (outputWindow.isResultsDoc(document)) {
+          outputWindow.setContextForOutputWindowActive(false);
+        }
+      },
+      changeConfiguration: (e: vscode.ConfigurationChangeEvent) => {
+        if (e.affectsConfiguration(config.KEYBINDINGS_ENABLED_CONFIG_KEY)) {
+          setKeybindingsEnabledContext();
+          statusbar.update();
+        }
+      },
+    },
+    window: {
+      changeActiveTextEditor: (editor) => {
+        status.update();
+        onDidChangeEditorOrSelection(editor);
+      },
+      changeTextEditorSelection: (event) => onDidChangeEditorOrSelection(event.textEditor),
+      changeVisibleTextEditors: (editors) => {
+        if (!editors.some((editor) => outputWindow.isResultsDoc(editor.document))) {
+          outputWindow.setContextForOutputWindowActive(false);
+        }
+      },
+    },
+  };
+
+  function registerOnDidEventHandler(scope) {
+    return ([eventName, callback]) => {
+      const event = `onDid${capitalize(eventName)}`;
+      context.subscriptions.push(vscode[scope][event](callback));
+    };
+  }
+
+  Object.entries(onDidEvents).forEach(([scope, handlers]) =>
+    Object.entries(handlers).forEach(registerOnDidEventHandler(scope))
   );
 
   // Clojure debug adapter setup

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -15,6 +15,10 @@ import { isNullOrUndefined } from 'util';
 const specialWords = ['-', '+', '/', '*']; //TODO: Add more here
 const syntaxQuoteSymbol = '`';
 
+export function capitalize(str: string) {
+  return str.length === 0 ? str : str[0].toUpperCase() + str.substring(1);
+}
+
 export function stripAnsi(str: string) {
   return str.replace(
     // eslint-disable-next-line no-control-regex


### PR DESCRIPTION
Make dictionary collecting each of Commands, Providers, and Events. Then iterate over each collection to register w/ Code and push into disposables storage.

<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Move commands, providers, and events into collections in extension.ts
- Iterate over the collections to register them and store disposables.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1897

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

If this PR involves only documentation changes, I have:

- ~[ ] Read [Editing Documentation]~(https://github.com/BetterThanTomorrow/calva/wiki/How-to-Hack-on-Calva#editing-documentation)
- ~[ ] Directed this pull request at the `published` branch.~
- ~[ ] Built the site locally (if the changes were more involved than simple typo fixes), and verified that the site is presented as expected.~
- ~[ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_ (if there was is an issue for the documentation change)~
  - ~[ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)~
  - ~[ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~

If this PR involves code changes, I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - ~[ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
