### PR TITLE
Check that we are in a list form when considering if we should drag pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 
 - Calva development: [Use requirements.txt in CI for publishing docs](https://github.com/BetterThanTomorrow/calva/issues/1913)
 - Bump deps.clj to v1.11.1.1182
+- [Drag sexps in value part of doseq sometimes jumps 2 sexps instead of 1](https://github.com/BetterThanTomorrow/calva/issues/1914)
 
 ## [2.0.310] - 2022-10-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changes to Calva.
 
 - Calva development: [Use requirements.txt in CI for publishing docs](https://github.com/BetterThanTomorrow/calva/issues/1913)
 - Bump deps.clj to v1.11.1.1182
-- [Drag sexps in value part of doseq sometimes jumps 2 sexps instead of 1](https://github.com/BetterThanTomorrow/calva/issues/1914)
+- Fix: [Drag sexps in value part of doseq sometimes jumps 2 sexps instead of 1](https://github.com/BetterThanTomorrow/calva/issues/1914)
 
 ## [2.0.310] - 2022-10-24
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1181,7 +1181,7 @@ function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boolean {
     if (opening.endsWith('[')) {
       probeCursor.backwardUpList();
       probeCursor.backwardList();
-      if (probeCursor.getPrevToken().raw.endsWith('{')) {
+      if (!probeCursor.getPrevToken().raw.endsWith('(')) {
         return false;
       }
       const fn = probeCursor.getFunctionName();

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -830,6 +830,34 @@ describe('paredit', () => {
         await paredit.dragSexprBackward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
+
+      it('drags single sexpr forward in bound vectors', async () => {
+        const a = docFromTextNotation(`(b [x [1| 2 3]])`);
+        const b = docFromTextNotation(`(b [x [2 1| 3]])`);
+        await paredit.dragSexprForward(a, ['b']);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('drags single sexpr backward in bound vectors', async () => {
+        const a = docFromTextNotation(`(b [x [1 2 |3]])`);
+        const b = docFromTextNotation(`(b [x [1 |3 2]])`);
+        await paredit.dragSexprBackward(a, ['b']);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('drags single sexpr forward in bound lists', async () => {
+        const a = docFromTextNotation(`(b [x (1 2| 3)])`);
+        const b = docFromTextNotation(`(b [x (1 3 2|)])`);
+        await paredit.dragSexprForward(a, ['b']);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('drags single sexpr backward in bound lists', async () => {
+        const a = docFromTextNotation(`(b [x (1 2 |3)])`);
+        const b = docFromTextNotation(`(b [x (1 |3 2)])`);
+        await paredit.dragSexprBackward(a, ['b']);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
     });
 
     describe('backwardUp - one line', () => {


### PR DESCRIPTION
## What has changed?

We were treating the binding box of a bound vector as if it was the binding form. Now we check that it is a list. I think this is actually just fixing the symptoms of something in the `isPairs` logic that is wrong, but the approach has worked for destructurings so far, so let's defer the real fix a while more...

Fixes #1914

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
