### PR TITLE
Fix #1918: code formatting in Getting Started REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes to Calva.
 - Calva development: [Use requirements.txt in CI for publishing docs](https://github.com/BetterThanTomorrow/calva/issues/1913)
 - Bump deps.clj to v1.11.1.1182
 - Fix: [Drag sexps in value part of doseq sometimes jumps 2 sexps instead of 1](https://github.com/BetterThanTomorrow/calva/issues/1914)
+- Fix: [Can't do formatting code from Calva: Fire up the Getting Started REPL on hello_repl.clj](https://github.com/BetterThanTomorrow/calva/issues/1918)
 
 ## [2.0.310] - 2022-10-24
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -184,7 +184,7 @@ export async function initProjectDir(uri?: vscode.Uri): Promise<void> {
 export function resolvePath(filePath?: string): vscode.Uri {
   const root = getProjectWsFolder();
 
-  if (root.uri.scheme !== 'file') {
+  if (root && root.uri.scheme !== 'file') {
     return vscode.Uri.joinPath(root.uri, filePath);
   }
 


### PR DESCRIPTION
## What has changed?

A check was missing for a var that can be undefined.

Fixes #1918.

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

If this PR involves code changes, I have:

- [X] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [X] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [X] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [X] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [X] ~Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- [X] ~Added to or updated docs in this branch, if appropriate~
- [X] Tests
  - [X] Tested the particular change
  - [X] Figured if the change might have some side effects and tested those as well.
  - [X] Smoke tested the extension as such.
  - [X] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [X] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [X] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [X] ~If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [X] ~Created the issue I am fixing/addressing, if it was not present.~
- [X] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [X] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
