### PR TITLE
Kill right squashing leading whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Calva formatting does not trim spaces when applying Paredit: Kill/Delete Right](https://github.com/BetterThanTomorrow/calva/issues/1923)
+
 ## [2.0.313] - 2022-10-31
 
 - [Use format-as-you-type for Paredit](https://github.com/BetterThanTomorrow/calva/issues/1924)

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -214,6 +214,22 @@ describe('paredit', () => {
         expect(actual).toEqual(expected);
       });
 
+      it('Advances past newline, preserving leading whitepace when invoked on newline with squash off', () => {
+        const a = docFromTextNotation('(a|\n   e) g)');
+        const b = docFromTextNotation('(a|\n|   e)');
+        const expected = textAndSelection(b)[1];
+        const actual = paredit.forwardHybridSexpRange(a, a.selection.active, false);
+        expect(actual).toEqual(expected);
+      });
+
+      it('Advances past newline, squashing leading whitepace when invoked on newline', () => {
+        const a = docFromTextNotation('(a|\n   e) g)');
+        const b = docFromTextNotation('(a|\n  | e) g)');
+        const expected = textAndSelection(b)[1];
+        const actual = paredit.forwardHybridSexpRange(a);
+        expect(actual).toEqual(expected);
+      });
+
       it('Finds end of vectors', () => {
         const a = docFromTextNotation('[a [b |c d e f] g h]');
         const b = docFromTextNotation('[a [b |c d e f|] g h]');

--- a/test-data/paredit_sandbox.clj
+++ b/test-data/paredit_sandbox.clj
@@ -90,3 +90,16 @@ string. "
            e
            f) g]
 :a
+
+;; Kill right
+
+"This |
+    needs to find the end of the string."
+
+
+(map inc (map inc|
+              (range 3)))
+
+(map inc (map inc|
+              ))
+


### PR DESCRIPTION
Fixes #1923

## What has changed?


## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
