### PR TITLE
Add newline when evaluating from prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Newline lacking before results when evaluating at the REPL prompt](https://github.com/BetterThanTomorrow/calva/issues/1931)
+
 ## [2.0.313] - 2022-10-31
 
 - [Use format-as-you-type for Paredit](https://github.com/BetterThanTomorrow/calva/issues/1924)

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -239,6 +239,12 @@ async function evaluateSelection(document = {}, options) {
         undefined,
         annotations.AnnotationStatus.PENDING
       );
+      if (
+        state.extensionContext.workspaceState.get('outputWindowActive') &&
+        !(await outputWindow.lastLineIsEmpty())
+      ) {
+        outputWindow.appendLine();
+      }
       await evaluateCodeUpdatingUI(
         code,
         { ...options, ns, line, column, filePath, session },

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -364,7 +364,7 @@ export function append(text: string, onAppended?: OnAppendedCallback): void {
   void flushOutput();
 }
 
-export function appendLine(text: string, onAppended?: OnAppendedCallback): void {
+export function appendLine(text = '', onAppended?: OnAppendedCallback): void {
   append(`${text}\n`, onAppended);
 }
 

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -266,10 +266,13 @@ export function appendCurrentTopLevelForm() {
   void appendFormGrabbingSessionAndNS(true);
 }
 
-function lastLineIsEmpty(doc: vscode.TextDocument): boolean {
-  const { lineCount } = doc;
-  const lastLine = doc.getText(new vscode.Range(lineCount - 1, 0, lineCount - 1, Infinity));
-  return lastLine === '';
+export async function lastLineIsEmpty(): Promise<boolean> {
+  try {
+    const doc = await vscode.workspace.openTextDocument(DOC_URI());
+    return util.lastLineIsEmpty(doc);
+  } catch (error) {
+    console.error('Failed opening results doc', error);
+  }
 }
 
 function visibleResultsEditors(): vscode.TextEditor[] {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -547,6 +547,14 @@ function pathExists(path: string): boolean {
   return fs.existsSync(path);
 }
 
+export function lastLineIsEmpty(
+  doc: vscode.TextDocument = vscode.window.activeTextEditor.document
+): boolean {
+  const { lineCount } = doc;
+  const lastLine = doc.getText(new vscode.Range(lineCount - 1, 0, lineCount - 1, Infinity));
+  return lastLine === '';
+}
+
 export {
   distinct,
   getWordAtPosition,


### PR DESCRIPTION
## What has changed?

Maybe our old scheme of normalizing newlines was partly about ”always do the right thing” when printing to the output window... Not reinstating that madness here though, instead adding a check if we are evaluating from the prompt and if the last line of the ouput window doc is non-empty. If so we add a newline before the results.

Fixes #1931

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
