### PR TITLE
Don't add extra lines for output in default message handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ backup/
 # Calva grammars (running the atom-ci docker image locally)
 src/calva-fmt/atom-language-clojure/.cache/
 src/calva-fmt/atom-language-clojure/.bash_history
+
+# Leiningen
+.lein-repl-history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Warnings printed with an added `;` on a line of its own](https://github.com/BetterThanTomorrow/calva/issues/1930)
+- Fix: [Extra newlines are printed in output from function called from test](https://github.com/BetterThanTomorrow/calva/issues/1937)
 
 ## [2.0.314] - 2022-11-01
 

--- a/src/extension-test/unit/results-output/util-test.ts
+++ b/src/extension-test/unit/results-output/util-test.ts
@@ -10,7 +10,7 @@ describe('addToHistory', () => {
   });
   it('should push text to history array without whitespace or eol characters', () => {
     const history = [];
-    const newHistory = util.addToHistory(history, ' \t\nhello \n\r');
+    const newHistory = util.addToHistory(history, ' \t\nhello \r\n');
     expect(newHistory[0]).toBe('hello');
   });
   it('should not push text to history array if empty string', () => {
@@ -36,8 +36,8 @@ describe('formatAsLineComments', () => {
     const formattedError = util.formatAsLineComments(error);
     expect(formattedError).toBe('; hello\n; world');
   });
-  it('should account for \\n\\r line endings', () => {
-    const error = 'hello\n\rworld\n\r';
+  it('should account for \\r\\n line endings', () => {
+    const error = 'hello\r\nworld\r\n';
     const formattedError = util.formatAsLineComments(error);
     expect(formattedError).toBe('; hello\n; world');
   });

--- a/src/nrepl/cider.ts
+++ b/src/nrepl/cider.ts
@@ -74,14 +74,6 @@ function resultMessage(resultItem: Readonly<TestResult>): string {
   return `${msg.length > 0 ? stripTrailingNewlines(msg.join(': ')) : ''}`;
 }
 
-// Remove any trailing blank lines from any of the string in result.
-export function cleanUpWhiteSpace(result: TestResult) {
-  for (const prop in result) {
-    if (typeof result[prop] === 'string') {
-      result[prop] = stripTrailingNewlines(result[prop]);
-    }
-  }
-}
 // Given a summary, return a message suitable for printing in the REPL to show
 // the user a quick summary of the test run.
 // Examples:

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -247,7 +247,7 @@ export class NReplSession {
 
     if ((msgData.out || msgData.err) && this.replType) {
       if (msgData.out) {
-        outputWindow.appendLine(msgData.out);
+        outputWindow.append(msgData.out);
       } else if (msgData.err) {
         const err = formatAsLineComments(msgData.err);
         outputWindow.appendLine(err, (_) => {

--- a/src/results-output/util.ts
+++ b/src/results-output/util.ts
@@ -14,7 +14,7 @@ function addToHistory(history: string[], content?: string): string[] {
 }
 
 function formatAsLineComments(str: string): string {
-  return `; ${str}`.replace(/\n\r?$/, '').replace(/\n\r?/g, '\n; ');
+  return `; ${str}`.replace(/\r?\n$/, '').replace(/\r?\n/g, '\n; ');
 }
 
 function splitEditQueueForTextBatching(

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -205,8 +205,6 @@ async function reportTests(
       const resultSet = result.results[ns];
       for (const test in resultSet) {
         for (const a of resultSet[test]) {
-          cider.cleanUpWhiteSpace(a);
-
           const messages = cider.detailedMessage(a);
 
           if (a.type == 'error') {

--- a/test-data/projects/pirate-lang/test/pez/pirate_lang_test.clj
+++ b/test-data/projects/pirate-lang/test/pez/pirate_lang_test.clj
@@ -13,3 +13,17 @@
   (testing "Hear rövarspråk"
     (is (= "Har du hört talas om rövarspråket?"
            (sut/from-pirate-talk "HoHaror dodu hohörortot totalolasos omom rorövovarorsospoproråkoketot?" sut/swedish-o)))))
+
+(deftest extra-lines
+  ;; Test that Calva doesn't add or remove whitespace from test output
+  ;; NB: "seven" and "eight" are lost, we never get them back from the nREPL server, I think
+  (testing "printing w/ retained whitespace"
+    (is (nil? (do
+                (print "one")
+                (println "two")
+                (println "three")
+                (print "  four")
+                (println "  five")
+                (println "  six")
+                (print "seven")
+                (print "eight"))))))


### PR DESCRIPTION
## What has changed?

We were using `appendLine` when printing stdout things in the nrepl client's default message handler. This PR uses `append` instead. I also removed a `cleanUpWhiteSpace` thing in the testRunner. We will be printing whatever comes in without adding or removing newlines.

Fixes #1937

Also fixed a bug in line-comments output where I had mixed up the order of CRLF for Windows line endings.

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
