### PR TITLE
Add rcf snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 
 - Bundle deps.clj.jar v1.11.1.1189
 - [Honor pretty-print settings for load-file](https://github.com/BetterThanTomorrow/calva/issues/1905)
+- [Add snippet for Rich Comments marked with trailing `:rcf`](https://github.com/BetterThanTomorrow/calva/issues/1941)
 
 ## [2.0.315] - 2022-11-03
 

--- a/docs/site/rich-comments.md
+++ b/docs/site/rich-comments.md
@@ -44,9 +44,12 @@ To develop or refine a function you might:
 Calva has several features to facilitate the Rich comments workflow, e.g.
 
 1. A command that helps you create a new Rich comment form quickly: **Calva: Add Rich Comment**, <kbd>ctrl+alt+r c</kbd>
+1. A snippet for creating Rich comment form quickly. Typing `(rcf`, will make it appear.
 1. Special [Syntax highlight](customizing.md#calva-highlight). By default `comment` forms are rendered in _italics_
 1. Special [top-level form](evaluation.md#current-top-level-form) context
 1. Special formatting
+
+Note that the command and snippet for creating Rich comments add the keyword `:rcf` right before the closing paren. This makes the closing paren stay and not fold when you format the code. The special formatting (see below) will treat this and also any ignored (with `#_`) form at the end of the form specially.
 
 ### `comment` is top-level
 
@@ -82,6 +85,28 @@ With the cursor somewhere directly inside the comment form (denoted with a `|`):
 
 !!! Note "Only for the current comment form”
     The special formatting only applies in the current `comment` form. When outside it, formatting tucks the closing paren in again. That's why fold when done, [below](#fold-when-done) works like it does. This also applies to VS Code commands like **Format Document**, or when you have **Format On Save** enabled. There are several reasons for this, and one is that there is no `cljfmt` config for it and leaving the closing comment un-tucked might give you troubles with CI pipelines that enforce some cljfmt config be followed. (Another reason is that it would be pretty hard to do on the whole document.)
+
+#### Special formatting disabled for trailing `:rcf`
+
+If the Rich comment ends with `:rcf` (or an ignored form), the special formatting doesn't happen. So if you have:
+
+``` clojure
+(comment
+  (def foo
+:foo)
+  |
+  :rcf)
+```
+
+And hit <kbd>tab</kbd>, you will get:
+
+``` clojure
+(comment
+  (def foo
+    :foo)
+  |
+  :rcf)
+```
 
 #### Thinking space is kept
 
@@ -130,9 +155,6 @@ To fold the trailing paren automatically, place the cursor immediately outside (
 #### Enabled by default
 
 You can disable this behavior with the setting: `calva.fmt.keepCommentTrailParenOnOwnLine`.
-
-But why would you? It is awesome! 😄
-
 
 #### Only for the Current Form
 

--- a/package.json
+++ b/package.json
@@ -116,6 +116,12 @@
         "path": "./clojure.tmLanguage.json"
       }
     ],
+    "snippets": [
+      {
+        "language": "clojure",
+        "path": "./snippets.jsonc"
+      }
+    ],
     "configurationDefaults": {
       "[clojure]": {
         "editor.wordSeparators": "\t ()\"':,;~@#$%^&{}[]`",

--- a/snippets.jsonc
+++ b/snippets.jsonc
@@ -1,0 +1,27 @@
+{
+	// Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
+	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
+	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
+	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
+	// Placeholders with the same ids are connected.
+	// Example:
+	// "Print to console": {
+	// 	"scope": "javascript,typescript",
+	// 	"prefix": "log",
+	// 	"body": [
+	// 		"console.log('$1');",
+	// 		"$2"
+	// 	],
+	// 	"description": "Log output to console"
+	// }
+
+	"RCF": {
+		"prefix": "(rcf",
+		"body": [
+			"(comment",
+			"  $0",
+			"  :rcf"
+		],
+		"description": "RCF"
+	}
+}

--- a/src/cljs-lib/src/calva/fmt/formatter.cljs
+++ b/src/cljs-lib/src/calva/fmt/formatter.cljs
@@ -192,16 +192,19 @@
 
 (def trailing-bracket_symbol "_calva-fmt-trail-symbol_")
 (def trailing-bracket_pattern (re-pattern (str "_calva-fmt-trail-symbol_\\)$")))
+(def rich-comment-keyword :rcf)
+(def trailing-rcf-marker-pattern (re-pattern (str "(" rich-comment-keyword "|#_\\S+)\\s*\\)$")))
 
 (defn add-trail-symbol-if-comment
   "If the `range-text` is a comment, add a symbol at the end, preventing the last paren from folding"
   [{:keys [range all-text config idx] :as m}]
-  (let [keep-trailing-bracket-on-own-line?
+  (let [range-text (extract-range-text m)
+        keep-trailing-bracket-on-own-line?
         (and (:keep-comment-forms-trail-paren-on-own-line? config)
-             (:comment-form? config))]
+             (:comment-form? config)
+             (not (re-find trailing-rcf-marker-pattern range-text)))]
     (if keep-trailing-bracket-on-own-line?
-      (let [range-text (extract-range-text m)
-            new-range-text (clojure.string/replace
+      (let [new-range-text (clojure.string/replace
                             range-text
                             #"\n{0,1}[ \t,]*\)$"
                             (str "\n" trailing-bracket_symbol ")"))
@@ -254,7 +257,9 @@
       (index-for-tail-in-range)
       (remove-indent-token-if-empty-current-line)
       (remove-trail-symbol-if-comment range)))
-
+(comment
+  
+  :rcf)
 (defn format-text-at-idx-on-type
   "Relax formating some when used as an on-type handler"
   [m]

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1497,7 +1497,9 @@ export async function addRichComment(
   p = doc.selection.active,
   contents?: string
 ) {
-  const richComment = `(comment\n  ${contents ? adaptContentsToRichComment(contents) : ''}\n  )`;
+  const richComment = `(comment\n  ${
+    contents ? adaptContentsToRichComment(contents) : ''
+  }\n  :rcf)`;
   let cursor = doc.getTokenCursor(p);
   const topLevelRange = rangeForDefun(doc, p, false);
   const isInsideForm = !(p <= topLevelRange[0] || p >= topLevelRange[1]);

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1485,31 +1485,31 @@ describe('paredit', () => {
     describe('addRichComment', () => {
       it('Adds Rich Comment after Top Level form', async () => {
         const a = docFromTextNotation('(fo|o)••(bar)');
-        const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
+        const b = docFromTextNotation('(foo)••(comment•  |•  :rcf)••(bar)');
         await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Inserts Rich Comment between Top Levels', async () => {
         const a = docFromTextNotation('(foo)•|•(bar)');
-        const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
+        const b = docFromTextNotation('(foo)••(comment•  |•  :rcf)••(bar)');
         await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Inserts Rich Comment between Top Levels, before Top Level form', async () => {
         const a = docFromTextNotation('(foo)••|(bar)');
-        const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
+        const b = docFromTextNotation('(foo)••(comment•  |•  :rcf)••(bar)');
         await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Inserts Rich Comment between Top Levels, after Top Level form', async () => {
         const a = docFromTextNotation('(foo)|••(bar)');
-        const b = docFromTextNotation('(foo)••(comment•  |•  )••(bar)');
+        const b = docFromTextNotation('(foo)••(comment•  |•  :rcf)••(bar)');
         await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Inserts Rich Comment between Top Levels, in comment', async () => {
         const a = docFromTextNotation('(foo)•;foo| bar•(bar)');
-        const b = docFromTextNotation('(foo)•;foo bar••(comment•  |•  )••(bar)');
+        const b = docFromTextNotation('(foo)•;foo bar••(comment•  |•  :rcf)••(bar)');
         await paredit.addRichComment(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });

--- a/test-data/projects/frankenstein/src/pretty_printing.clj
+++ b/test-data/projects/frankenstein/src/pretty_printing.clj
@@ -29,3 +29,19 @@
    [:.error {:color :white, :opacity "100%"}]])
 
 some-data
+
+(comment
+
+  satisfies?
+  
+
+  )
+
+#_{:clj-kondo/ignore [:redefined-var]}
+(comment
+  ;; Add-lib library for hot-loading
+  (require '[clojure.tools.deps.alpha.repl :refer [add-libs]])
+  (add-libs '{domain/library-name {:mvn/version "1.0.0"}})
+  #__)
+
+

--- a/test-data/projects/frankenstein/src/pretty_printing.clj
+++ b/test-data/projects/frankenstein/src/pretty_printing.clj
@@ -29,19 +29,3 @@
    [:.error {:color :white, :opacity "100%"}]])
 
 some-data
-
-(comment
-
-  satisfies?
-  
-
-  )
-
-#_{:clj-kondo/ignore [:redefined-var]}
-(comment
-  ;; Add-lib library for hot-loading
-  (require '[clojure.tools.deps.alpha.repl :refer [add-libs]])
-  (add-libs '{domain/library-name {:mvn/version "1.0.0"}})
-  #__)
-
-


### PR DESCRIPTION
## What has changed?

Added an `(rcf...` snippet.

Adapted the formatter to relax special rich comment formatting when the `:rcf` marker is present in the Rich comment.

Fixes #1941

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
