### PR TITLE
Remove calva.fmt.formatAsYouType setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes to Calva.
 - [Add editor snippet for Rich Comments marked with trailing `:rcf`](https://github.com/BetterThanTomorrow/calva/issues/1941)
 - [Add custom REPL command snippet `$current-pair` variable](https://github.com/BetterThanTomorrow/calva/issues/1943)
 - [Add custom REPL command snippet `$file-text` variable](https://github.com/BetterThanTomorrow/calva/issues/1944)
+- [Remove `calva.fmt.formatAsYouType` setting](https://github.com/BetterThanTomorrow/calva/issues/1827)
 
 ## [2.0.315] - 2022-11-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Remove `calva.fmt.formatAsYouType` setting](https://github.com/BetterThanTomorrow/calva/issues/1827)
+
 ## [2.0.316] - 2022-11-05
 
 - Bundle deps.clj.jar v1.11.1.1189
@@ -11,7 +13,6 @@ Changes to Calva.
 - [Add editor snippet for Rich Comments marked with trailing `:rcf`](https://github.com/BetterThanTomorrow/calva/issues/1941)
 - [Add custom REPL command snippet `$current-pair` variable](https://github.com/BetterThanTomorrow/calva/issues/1943)
 - [Add custom REPL command snippet `$file-text` variable](https://github.com/BetterThanTomorrow/calva/issues/1944)
-- [Remove `calva.fmt.formatAsYouType` setting](https://github.com/BetterThanTomorrow/calva/issues/1827)
 
 ## [2.0.315] - 2022-11-03
 

--- a/package.json
+++ b/package.json
@@ -827,11 +827,6 @@
             "type": "string",
             "markdownDescription": "Path to [cljfmt](https://github.com/weavejester/cljfmt#configuration) configuration file. Absolute or relative to the project root directory. To provide the config via [clojure-lsp](https://clojure-lsp.io), set this to `CLOJURE-LSP` (case sensitive)."
           },
-          "calva.fmt.formatAsYouType": {
-            "type": "boolean",
-            "default": true,
-            "description": "Auto-adjust indentation and format as you enter new lines."
-          },
           "calva.fmt.newIndentEngine": {
             "type": "boolean",
             "default": true,

--- a/src/calva-fmt/src/extension.ts
+++ b/src/calva-fmt/src/extension.ts
@@ -82,12 +82,4 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   );
   vscode.window.onDidChangeActiveTextEditor(inferer.updateState);
-  vscode.workspace.onDidChangeConfiguration(async (e) => {
-    if (e.affectsConfiguration('calva.fmt.formatAsYouType')) {
-      vscode.languages.setLanguageConfiguration(
-        'clojure',
-        getLanguageConfiguration(await config.getConfig()['format-as-you-type'])
-      );
-    }
-  });
 }

--- a/src/calva-fmt/src/providers/ontype_formatter.ts
+++ b/src/calva-fmt/src/providers/ontype_formatter.ts
@@ -34,7 +34,13 @@ export class FormatOnTypeEditProvider implements vscode.OnTypeFormattingEditProv
     const editor = util.getActiveTextEditor();
 
     const pos = editor.selection.active;
-    if (vscode.workspace.getConfiguration('calva.fmt').get('formatAsYouType')) {
+    if (
+      vscode.workspace.getConfiguration('editor').get('formatOnType') ||
+      vscode.workspace
+        .getConfiguration('editor')
+        .inspect('formatOnType')
+        .languageIds.includes(document.languageId)
+    ) {
       if (vscode.workspace.getConfiguration('calva.fmt').get('newIndentEngine')) {
         void formatter.indentPosition(pos, document);
       } else {


### PR DESCRIPTION
## What has changed?

* Fixes #1827

I see in the changelog that we have removed this before and then reverted it. But I can't see that we have documented why. So trying again. If we again find the reason why we should keep this setting, this time we can document it. 😄 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
