### PR TITLE
Some VIM co-existence fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Make Calva more VIM friendly](https://github.com/BetterThanTomorrow/calva/issues/1947)
+
 ## [2.0.316] - 2022-11-05
 
 - Bundle deps.clj.jar v1.11.1.1189

--- a/docs/site/vim.md
+++ b/docs/site/vim.md
@@ -5,38 +5,19 @@ description: Calva and the VIM Extension
 
 # Calva and the VIM Extension
 
-First thing first. The [VIM Extension](https://github.com/VSCodeVim/Vim) and Calva has some friction between them. The alternative [VSCode Neovim](https://github.com/asvetliakov/vscode-neovim) extension may fare a bit better as it unbinds keystrokes from VS Code while not in insert mode and uses Neovim as a backend.
-
-## Selection commands
-
-Calva's various structural selection commands [do not put VIM into VISUAL mode](https://github.com/BetterThanTomorrow/calva/issues/297). This is true for many [VS Code selection scenarios](https://github.com/VSCodeVim/Vim/issues/2224) too, so it is not really Calva's fault, but it will be problematic for VIM Extension Calva users, regardless.
+First thing first. The [VIM Extension](https://github.com/VSCodeVim/Vim) and Calva has a history of friction between them. Less so these days, but you might still encounter some rough edges. Please don't hesitate to reach out to the Calva team, as we might be able to fix things if only we are aware of them.
 
 ## Key bindings
 
 In general Calva's default key bindings are not very VI-ish.
 
-You can add these keybindings to your `init.vim` if you are using the VSCode Neovim extension. It is inspired by and tries to emulate the keybindings found in [vim-fireplace](https://github.com/tpope/vim-fireplace) which is the most popular vim plugin for Clojure.
+### Expand selection on Mac
 
-```
-nmap cqp :call VSCodeNotify('calva.jackIn')<CR>
-nmap cqq :call VSCodeNotify('calva.disconnect')<CR>
-nmap cpr :call VSCodeNotify('calva.loadFile')<CR>
-nmap cpR :call VSCodeNotify('calva.loadNamespace')<CR>
-nmap cpp :call VSCodeNotify('calva.evaluateSelection')<CR>
-nmap cqc :call VSCodeNotify('calva.evalCurrentFormInREPLWindow')<CR>
-```
-
-Unfortunately these key combinations will not work in the normal VIM extension as `c` is an [operator key](https://github.com/VSCodeVim/Vim/issues/4464) and cannot be remapped. **This is a call for someone to share their VIM re-mappings**.
-
-### Expand selection
-
-Calva binds **expand selection** to `ctrl+w` (`shift+alt+right` on Windows and Linux). This conflicts with the VIM Extension's default mapping of window splitting shortcuts. You'll need to remap it either with Calva or with the VIM Extension.
+Om Mac Calva binds **expand selection** to `ctrl+w`. This conflicts with the VIM Extension's default mapping of window splitting shortcuts. You'll need to remap it either with Calva or with the VIM Extension.
 
 ### The `esc` key
 
-Calva binds the `esc` key to dismiss the display of inline results. This gets into conflict with any `vi` coding since `esc` then is used to go back to command mode. You can either change Calva's default keybinding or the VIM extension's.
-
-Alternatively, you can use the native Vim command `Ctrl + [` to escape and get back to command mode. Rebinding your keyboard's CapsLock key to Control may make this even easier.
+While showing inline evaluation results, Calva binds the `esc` key to dismiss the display of inline results. If you want to be able to use the `esc` key to enter command mode while inline results are showing, you'll need to rebind Calva's command for dismissing the inline results.
 
 #### Remap Calva's `clearInlineResults`
 
@@ -74,3 +55,18 @@ Remap vim's insert mode keybinding to go into command mode by adding the followi
 ```
 
 (Change `before` to whatever keybinding you are comfortable with!)
+
+### Vim Fireplace-ish keybindings
+
+You can add these keybindings to your `init.vim` if you are using the VSCode Neovim extension. It is inspired by and tries to emulate the keybindings found in [vim-fireplace](https://github.com/tpope/vim-fireplace) which is the most popular vim plugin for Clojure.
+
+```
+nmap cqp :call VSCodeNotify('calva.jackIn')<CR>
+nmap cqq :call VSCodeNotify('calva.disconnect')<CR>
+nmap cpr :call VSCodeNotify('calva.loadFile')<CR>
+nmap cpR :call VSCodeNotify('calva.loadNamespace')<CR>
+nmap cpp :call VSCodeNotify('calva.evaluateSelection')<CR>
+nmap cqc :call VSCodeNotify('calva.evalCurrentFormInREPLWindow')<CR>
+```
+
+Unfortunately these key combinations will not work in the normal VIM extension as `c` is an [operator key](https://github.com/VSCodeVim/Vim/issues/4464) and cannot be remapped. **This is a call for someone to share their VIM re-mappings**.

--- a/package.json
+++ b/package.json
@@ -1886,7 +1886,7 @@
       {
         "command": "calva.clearInlineResults",
         "key": "escape",
-        "when": "calva:keybindingsEnabled && editorTextFocus && !editorHasMultipleSelections && !editorHasSelection && !editorReadOnly && !hasOtherSuggestions && !parameterHintsVisible && !selectionAnchorSet && !suggestWidgetVisible && !inlineSuggestionVisible && editorLangId == clojure"
+        "when": "calva:keybindingsEnabled && calva:hasInlineResults && editorTextFocus && !editorHasMultipleSelections && !editorHasSelection && !editorReadOnly && !hasOtherSuggestions && !parameterHintsVisible && !selectionAnchorSet && !suggestWidgetVisible && !inlineSuggestionVisible && editorLangId == clojure"
       },
       {
         "command": "calva.evaluateSelection",

--- a/src/calva-fmt/src/config.ts
+++ b/src/calva-fmt/src/config.ts
@@ -15,7 +15,7 @@ let lspFormatConfig: string | undefined;
 
 function configuration(workspaceConfig: vscode.WorkspaceConfiguration, cljfmt: string) {
   return {
-    'format-as-you-type': !!workspaceConfig.get<boolean>('formatAsYouType'),
+    'format-as-you-type': !!formatOnTypeEnabled(),
     'keep-comment-forms-trail-paren-on-own-line?': !!workspaceConfig.get<boolean>(
       'keepCommentTrailParenOnOwnLine'
     ),
@@ -65,4 +65,14 @@ async function readConfiguration(): Promise<{
 export async function getConfig() {
   const config = await readConfiguration();
   return config;
+}
+
+export function formatOnTypeEnabled() {
+  return (
+    vscode.workspace.getConfiguration('editor').get('formatOnType') ||
+    vscode.workspace
+      .getConfiguration('editor')
+      .inspect('formatOnType')
+      .languageIds.includes('clojure')
+  );
 }

--- a/src/calva-fmt/src/extension.ts
+++ b/src/calva-fmt/src/extension.ts
@@ -79,7 +79,7 @@ export function activate(context: vscode.ExtensionContext) {
     )
   );
   vscode.window.onDidChangeActiveTextEditor(inferer.updateState);
-  vscode.workspace.onDidChangeConfiguration(async (e) => {
+  vscode.workspace.onDidChangeConfiguration((e) => {
     if (e.affectsConfiguration('calva.fmt.formatAsYouType')) {
       vscode.languages.setLanguageConfiguration('clojure', getLanguageConfiguration());
     }

--- a/src/calva-fmt/src/extension.ts
+++ b/src/calva-fmt/src/extension.ts
@@ -7,32 +7,29 @@ import * as docmirror from '../../doc-mirror/index';
 import * as config from './config';
 import * as calvaConfig from '../../config';
 
-function getLanguageConfiguration(autoIndentOn: boolean): vscode.LanguageConfiguration {
-  return {
-    onEnterRules:
-      autoIndentOn && calvaConfig.getConfig().formatOnSave
-        ? [
-            // When Calva is the formatter disable all vscode default indentation
-            // (By outdenting a lot, which is the only way I have found that works)
-            // TODO: Make it actually consider whether Calva is the formatter or not
-            {
-              beforeText: /.*/,
-              action: {
-                indentAction: vscode.IndentAction.Outdent,
-                removeText: Number.MAX_VALUE,
-              },
+function getLanguageConfiguration(): vscode.LanguageConfiguration {
+  const languageConfiguration = {
+    onEnterRules: config.formatOnTypeEnabled()
+      ? [
+          // When Calva is the formatter disable all vscode default indentation
+          // (By outdenting a lot, which is the only way I have found that works)
+          // TODO: Make it actually consider whether Calva is the formatter or not
+          {
+            beforeText: /.*/,
+            action: {
+              indentAction: vscode.IndentAction.Outdent,
+              removeText: Number.MAX_VALUE,
             },
-          ]
-        : [],
+          },
+        ]
+      : [],
   };
+  return languageConfiguration;
 }
 
-export async function activate(context: vscode.ExtensionContext) {
+export function activate(context: vscode.ExtensionContext) {
   docmirror.activate();
-  vscode.languages.setLanguageConfiguration(
-    'clojure',
-    getLanguageConfiguration(await config.getConfig()['format-as-you-type'])
-  );
+  vscode.languages.setLanguageConfiguration('clojure', getLanguageConfiguration());
   context.subscriptions.push(
     vscode.commands.registerTextEditorCommand(
       'calva-fmt.formatCurrentForm',
@@ -84,10 +81,7 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.window.onDidChangeActiveTextEditor(inferer.updateState);
   vscode.workspace.onDidChangeConfiguration(async (e) => {
     if (e.affectsConfiguration('calva.fmt.formatAsYouType')) {
-      vscode.languages.setLanguageConfiguration(
-        'clojure',
-        getLanguageConfiguration(await config.getConfig()['format-as-you-type'])
-      );
+      vscode.languages.setLanguageConfiguration('clojure', getLanguageConfiguration());
     }
   });
 }

--- a/src/calva-fmt/src/providers/ontype_formatter.ts
+++ b/src/calva-fmt/src/providers/ontype_formatter.ts
@@ -5,6 +5,7 @@ import { EditableDocument } from '../../../cursor-doc/model';
 import * as paredit from '../../../cursor-doc/paredit';
 import { getConfig } from '../../../config';
 import * as util from '../../../utilities';
+import * as formatterConfig from '../config';
 
 export class FormatOnTypeEditProvider implements vscode.OnTypeFormattingEditProvider {
   async provideOnTypeFormattingEdits(
@@ -34,7 +35,7 @@ export class FormatOnTypeEditProvider implements vscode.OnTypeFormattingEditProv
     const editor = util.getActiveTextEditor();
 
     const pos = editor.selection.active;
-    if (vscode.workspace.getConfiguration('calva.fmt').get('formatAsYouType')) {
+    if (formatterConfig.formatOnTypeEnabled()) {
       if (vscode.workspace.getConfiguration('calva.fmt').get('newIndentEngine')) {
         void formatter.indentPosition(pos, document);
       } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -426,16 +426,14 @@ async function activate(context: vscode.ExtensionContext) {
     chan.appendLine(`VIM Extension detected. Please read: ${VIM_DOC_URL} now and then.\n`);
     if (!context.globalState.get(VIEWED_VIM_DOCS)) {
       void vscode.window
-        .showErrorMessage(
+        .showInformationMessage(
           'VIM Extension detected. Please view the docs for tips (and to stop this info box from appearing).',
           ...[BUTTON_GOTO_DOC]
         )
         .then((v) => {
           if (v == BUTTON_GOTO_DOC) {
             void context.globalState.update(VIEWED_VIM_DOCS, true);
-            open(VIM_DOC_URL).catch(() => {
-              // do nothing
-            });
+            void vscode.commands.executeCommand('simpleBrowser.show', VIM_DOC_URL);
           }
         });
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -182,7 +182,7 @@ async function activate(context: vscode.ExtensionContext) {
 
   // COMMANDS
   const commands = {
-    clearInlineResults: annotations.clearEvaluationDecorations,
+    clearInlineResults: annotations.clearAllEvaluationDecorations,
     clearReplHistory: replHistory.clearHistory,
     connect: connector.connectCommand,
     connectNonProjectREPL: () => void connector.connectNonProjectREPLCommand(context),

--- a/src/providers/annotations.ts
+++ b/src/providers/annotations.ts
@@ -109,6 +109,7 @@ function clearAllEvaluationDecorations() {
   vscode.window.visibleTextEditors.forEach((editor) => {
     clearEvaluationDecorations(editor);
   });
+  void vscode.commands.executeCommand('setContext', 'calva:hasInlineResults', false);
 }
 
 function decorateResults(
@@ -128,6 +129,7 @@ function decorateResults(
   decoration['range'] = new vscode.Selection(codeSelection.end, codeSelection.end);
   decorationRanges.push(decoration);
   setResultDecorations(editor, decorationRanges);
+  void vscode.commands.executeCommand('setContext', 'calva:hasInlineResults', true);
 }
 
 function decorateSelection(


### PR DESCRIPTION
## What has changed?

* Introduce a context state for when inline results are displayed or not
* Using the new context state to only bind `escape` when inline results are showing
* Explicitly set the new cursor position after re-indenting with the new indent engine
* Some bug fixes with how we make sure the new indent engine gets a clean slate to start from

In my testing, the explicit cursor positioning fixes the problem with the cursor ending up at the start of te line when the VIM extension is enabled. 

Fixes #1947

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
