### PR TITLE
Fix override error message function signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Calva doesn't show action buttons in error message boxes](https://github.com/BetterThanTomorrow/calva/issues/1949)
+
 ## [2.0.317] - 2022-11-06
 
 - [Make Calva more VIM friendly](https://github.com/BetterThanTomorrow/calva/issues/1947)

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -2,10 +2,10 @@ import * as vscode from 'vscode';
 
 const vscodeShowErrorMessage = vscode.window.showErrorMessage;
 
-async function calvaShowErrorMessage(message: string) {
+async function calvaShowErrorMessage<T extends string>(message: string, ...items: T[]) {
   const exlusionRegexps = [/Request textDocument\/codeAction failed./];
   if (!exlusionRegexps.some((re) => re.test(message))) {
-    return vscodeShowErrorMessage(message);
+    return vscodeShowErrorMessage(message, ...items);
   }
 }
 


### PR DESCRIPTION
## What has changed?

I've changed the signature of the function we use to override VS Code's showErrorMessage function, so that we keep showing buttons when we use it with the ”buttoned” signatures.

* Fixes #1949 

I'm suprised that TypeScript didn't help us avoid this regression. Do you know if it is some setting we can use for the compiler, or if ESLint can help with things like this, @corasaurus-hex? 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
