### PR TITLE
Make indenter disregard namespace when matching cljfmt rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [The indenter fails matching cljfmt rules on qualified symbols](https://github.com/BetterThanTomorrow/calva/issues/1956)
+
 ## [2.0.318] - 2022-11-08
 
 - Fix: [Calva doesn't show action buttons in error message boxes](https://github.com/BetterThanTomorrow/calva/issues/1949)

--- a/src/cljs-lib/src/calva/fmt/formatter.cljs
+++ b/src/cljs-lib/src/calva/fmt/formatter.cljs
@@ -5,7 +5,8 @@
             [calva.js-utils :refer [jsify cljify]]
             [calva.fmt.util :as util]
             [calva.parse :refer [parse-clj-edn]]
-            [clojure.string]))
+            [clojure.string]
+            [clojure.core :as c]))
 
 (defn- merge-default-indents
   "Merges onto default-indents.

--- a/src/cursor-doc/indent.ts
+++ b/src/cursor-doc/indent.ts
@@ -91,7 +91,7 @@ export function collectIndents(
 
       const pattern =
         isList &&
-        _.find(_.keys(rules), (pattern) => pattern === token || testCljRe(pattern, token));
+        _.find(_.keys(rules), (p) => testCljRe(`#"^(.*/)?${p}$"`, token) || testCljRe(p, token));
       const indentRule = pattern ? rules[pattern] : [];
       indents.unshift({
         first: token,
@@ -140,7 +140,7 @@ export function collectIndents(
 
 const testCljRe = (re, str) => {
   const matches = re.match(/^#"(.*)"$/);
-  return matches && RegExp(matches[1]).test(str);
+  return matches && RegExp(matches[1]).test(str.replace(/^.*\//, ''));
 };
 
 /** Returns the expected newline indent for the given position, in characters. */

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -42,5 +42,5 @@
     "titleBar.inactiveBackground": "#90B4FEd5",
     "titleBar.inactiveForeground": "#13172299"
   },
-  "calva.fmt.configPath": "projects/pirate-lang/.cljfmt.edn"
+  "calva.fmt.configPath": "cljfmt.edn"
 }

--- a/test-data/cljfmt.edn
+++ b/test-data/cljfmt.edn
@@ -1,0 +1,1 @@
+{:indents {inner-0-form [[:inner 0]]}}

--- a/test-data/indenter-cases.clj
+++ b/test-data/indenter-cases.clj
@@ -1,0 +1,39 @@
+#_:clj-kondo/ignore
+(ns foo
+  {:clj-kondo/config '{:linters {:unresolved-symbol {:level :off}
+                                 :unused-bindings {:level :off}}}})
+
+; Should indent like `(def ...`
+(foo/defbars body
+  [:body {}])
+
+; Should not indent like `(def ...`
+
+(foo/ddefbars body
+  [:body {}])
+
+
+; Should indent like `(let ...`
+(clojure.core/let [x :x]
+  x)
+
+; Should not indent like `(let ...`
+(clojure.core-let [x :x]
+  x)
+
+; Should indent using `[[:inner 0]]`
+; Assuming a custom `cljfmt.edn` is used and it has:
+; `{:indents {inner-0-form [[:inner 0]]}}`
+(foo/inner-0-form :a
+  ss
+  :foo)
+
+; Should not indent using `[[:inner 0]]`
+(foo-inner-0-form :a
+  ss
+  :foo)
+
+; Should indent like
+(deftype MyType [arg1 arg2]
+  IMyProto 
+  (method1 [this] |(print "hello")))


### PR DESCRIPTION
## What has changed?

Allowing for an optional namespace to prepend the symbol used for matching cljfmt rules when indenting a line.

Fixes #1956

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
