### PR TITLE
Use printFn if configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix [Suppling a custom printFn to the pretty printer does not work](https://github.com/BetterThanTomorrow/calva/issues/1979)
+
 ## [2.0.320] - 2022-11-23
 
 - [Stop the nrepl client from spamming the server with ops it doesn't support](https://github.com/BetterThanTomorrow/calva/issues/1969)

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -59,7 +59,16 @@ const zprintExtraOptions = {
 };
 
 export function getServerSidePrinter(pprintOptions: PrettyPrintingOptions) {
-  if (pprintOptions.enabled && pprintOptions.printEngine !== 'calva') {
+  if (pprintOptions.printFn) {
+    const printerFn = pprintOptions.printFn;
+    return getPrinter(
+      pprintOptions,
+      printerFn.name,
+      printerFn?.maxWidthArgument,
+      printerFn?.seqLimitArgument,
+      printerFn?.maxDepthArgument
+    );
+  } else if (pprintOptions.enabled && pprintOptions.printEngine !== 'calva') {
     switch (pprintOptions.printEngine) {
       case 'pprint':
         return getPrinter(
@@ -97,15 +106,6 @@ export function getServerSidePrinter(pprintOptions: PrettyPrintingOptions) {
       default:
         return undefined;
     }
-  } else if (pprintOptions.printFn) {
-    const printerFn = pprintOptions.printFn;
-    return getPrinter(
-      pprintOptions,
-      printerFn.name,
-      printerFn?.maxWidthArgument,
-      printerFn?.seqLimitArgument,
-      printerFn?.maxDepthArgument
-    );
   }
 }
 


### PR DESCRIPTION
## What has changed?

We are defaulting to `pprint` printEngine early in the call chain (in the config module). So I just check for printFn first before printEngine.

Still not sure this actually works. Would need to configure an actual nrelpl.pprint function to test it. But at least if someone would try this setting, having done that work, we will now get better diagnostics.

Closes #1979

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
