### PR TITLE
Add test ns query under var-query field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 
 - Fix [Suppling a custom printFn to the pretty printer does not work](https://github.com/BetterThanTomorrow/calva/issues/1979)
 - Fix [CI: Webpack build throws with an error: [webpack-cli] Error: error:0308010C:digital envelope routines::unsupported](https://github.com/BetterThanTomorrow/calva/issues/1985)
+- Fix [Running a single test runs all tests (polylith)](https://github.com/BetterThanTomorrow/calva/issues/1981)
 
 ## [2.0.320] - 2022-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changes to Calva.
 
 - Fix [Suppling a custom printFn to the pretty printer does not work](https://github.com/BetterThanTomorrow/calva/issues/1979)
 - Fix [CI: Webpack build throws with an error: [webpack-cli] Error: error:0308010C:digital envelope routines::unsupported](https://github.com/BetterThanTomorrow/calva/issues/1985)
-- Fix [Running a single test runs all tests (polylith)](https://github.com/BetterThanTomorrow/calva/issues/1981)
+- Fix [Running a single test runs all tests](https://github.com/BetterThanTomorrow/calva/issues/1981)
 
 ## [2.0.320] - 2022-11-23
 

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -581,7 +581,7 @@ export class NReplSession {
         op: 'test-var-query',
         id,
         session: this.sessionId,
-        ...query,
+        'var-query': query,
       };
       if (this.supports(msg.op)) {
         this.messageHandlers[id] = resultHandler(resolve, reject);


### PR DESCRIPTION
Closes #1981.

## What has changed?

Running a single test would result in every test in every namespace being run. This was because the test var query was being spread into the nrepl payload, rather than being passed as 'var-query'.

Looks to have been introduced by commit [f7844f3](https://github.com/BetterThanTomorrow/calva/commit/f7844f3398cd2f77e670bb7a46f5c2aeba62201e).


## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

If this PR involves only documentation changes, I have:

- [ ~] Read [Editing Documentation](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Hack-on-Calva#editing-documentation)
- [ ~] Directed this pull request at the `published` branch.
- [ ~] Built the site locally (if the changes were more involved than simple typo fixes), and verified that the site is presented as expected.
- [ ~] Referenced the issue I am fixing/addressing _in a commit message for the pull request_ (if there was is an issue for the documentation change)
  - [~] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [~] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.

If this PR involves code changes, I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [~] Added to or updated docs in this branch, if appropriate
- [~] Tests
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
  - [ ] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [~] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [~] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
