### PR TITLE
Fix issue with wrong EOL val passed to LineInputModel on MS-Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Fix breakage with notebooks containing CRLF newlines on MS-Windows](https://github.com/BetterThanTomorrow/calva/issues/1994)
+
 ## [2.0.321] - 2022-12-05
 
 - Fix: [Supplying a custom printFn to the pretty printer does not work](https://github.com/BetterThanTomorrow/calva/issues/1979)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- [Fix breakage with notebooks containing CRLF newlines on MS-Windows](https://github.com/BetterThanTomorrow/calva/issues/1994)
+- Fix: [Clojure notebooks don't seem to work on MS-Windows](https://github.com/BetterThanTomorrow/calva/issues/1994)
 
 ## [2.0.321] - 2022-12-05
 

--- a/package.json
+++ b/package.json
@@ -2881,7 +2881,7 @@
     "integration-test": "node ./out/extension-test/integration/runTests.js",
     "unit-test": "npx mocha --require ts-node/register 'src/extension-test/unit/**/*-test.ts'",
     "unit-test-watch": "npx mocha --watch --require ts-node/register --watch-extensions ts --watch-files src 'src/extension-test/unit/**/*-test.ts'",
-    "prettier-format": "npx prettier --write \"./**/*.{ts,js,json}\"",
+    "prettier-format": "npx prettier --write './**/*.{ts,js,json}'",
     "prettier-check": "npx prettier --check './**/*.{ts,js,json}'",
     "prettier-check-watch": "onchange './**/*.{ts,js,json}' -- prettier --check {{changed}}",
     "prettier-format-watch": "onchange './**/*.{ts,js,json}' -- prettier --write {{changed}}",

--- a/package.json
+++ b/package.json
@@ -2881,7 +2881,7 @@
     "integration-test": "node ./out/extension-test/integration/runTests.js",
     "unit-test": "npx mocha --require ts-node/register 'src/extension-test/unit/**/*-test.ts'",
     "unit-test-watch": "npx mocha --watch --require ts-node/register --watch-extensions ts --watch-files src 'src/extension-test/unit/**/*-test.ts'",
-    "prettier-format": "npx prettier --write './**/*.{ts,js,json}'",
+    "prettier-format": "npx prettier --write \"./**/*.{ts,js,json}\"",
     "prettier-check": "npx prettier --check './**/*.{ts,js,json}'",
     "prettier-check-watch": "onchange './**/*.{ts,js,json}' -- prettier --check {{changed}}",
     "prettier-format-watch": "onchange './**/*.{ts,js,json}' -- prettier --write {{changed}}",

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -10,14 +10,11 @@ export function initScanner(maxLength: number) {
 }
 
 /**
- * @param text The text to look at for the line ending seq.
- * @returns The first line ending sequence found in TEXT, if any.
+ * @param text The text to look in for the end of line seq.
+ * @returns The first end of line sequence found in TEXT, if any.
  */
-export function getFirstLineEndingSeq(text: string) {
-  const found = text.match(/\r\n|\n/g);
-  if (found) {
-    return found[0];
-  }
+export function getFirstEol(text: string) {
+  return text.match(/\r\n|\n/g)?.[0];
 }
 
 export class TextLine {
@@ -538,11 +535,9 @@ export class LineInputModel implements EditableModel {
 
 export class StringDocument implements EditableDocument {
   constructor(contents?: string) {
-    let lineEndingSeq = null;
-    if (contents) {
-      lineEndingSeq = getFirstLineEndingSeq(contents);
-    }
-    this.model = new LineInputModel(lineEndingSeq ? lineEndingSeq.length : 1, this);
+    const eol = contents ? getFirstEol(contents) : null;
+
+    this.model = new LineInputModel(eol ? eol.length : 1, this);
     if (contents) {
       this.insertString(contents);
     }

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -9,6 +9,17 @@ export function initScanner(maxLength: number) {
   scanner = new Scanner(maxLength);
 }
 
+/**
+ * @param text The text to look at for the line ending seq.
+ * @returns The first line ending sequence found in TEXT, if any.
+ */
+export function getFirstLineEndingSeq(text: string) {
+  const found = text.match(/\r\n|\n/g);
+  if (found) {
+    return found[0];
+  }
+}
+
 export class TextLine {
   tokens: Token[] = [];
   text: string;
@@ -527,6 +538,11 @@ export class LineInputModel implements EditableModel {
 
 export class StringDocument implements EditableDocument {
   constructor(contents?: string) {
+    let lineEndingSeq = null;
+    if (contents) {
+      lineEndingSeq = getFirstLineEndingSeq(contents);
+    }
+    this.model = new LineInputModel(lineEndingSeq ? lineEndingSeq.length : 1, this);
     if (contents) {
       this.insertString(contents);
     }
@@ -534,7 +550,7 @@ export class StringDocument implements EditableDocument {
 
   selection: ModelEditSelection;
 
-  model: LineInputModel = new LineInputModel(1, this);
+  model: LineInputModel;
 
   selectionStack: ModelEditSelection[] = [];
 

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -1,4 +1,4 @@
-import { getFirstLineEndingSeq, LineInputModel } from './model';
+import { getFirstEol, LineInputModel } from './model';
 import { Token, validPair } from './clojure-lexer';
 
 function tokenIsWhiteSpace(token: Token) {
@@ -943,8 +943,8 @@ export class LispTokenCursor extends TokenCursor {
  * Creates a `LispTokenCursor` for walking and manipulating the string `s`.
  */
 export function createStringCursor(s: string): LispTokenCursor {
-  const lineEndingSeq = getFirstLineEndingSeq(s);
-  const model = new LineInputModel(lineEndingSeq ? lineEndingSeq.length : 1);
+  const eol = getFirstEol(s);
+  const model = new LineInputModel(eol ? eol.length : 1);
   model.insertString(0, s);
   return model.getTokenCursor(0);
 }

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -1,4 +1,4 @@
-import { LineInputModel } from './model';
+import { getFirstLineEndingSeq, LineInputModel } from './model';
 import { Token, validPair } from './clojure-lexer';
 
 function tokenIsWhiteSpace(token: Token) {
@@ -943,7 +943,8 @@ export class LispTokenCursor extends TokenCursor {
  * Creates a `LispTokenCursor` for walking and manipulating the string `s`.
  */
 export function createStringCursor(s: string): LispTokenCursor {
-  const model = new LineInputModel();
+  const lineEndingSeq = getFirstLineEndingSeq(s);
+  const model = new LineInputModel(lineEndingSeq ? lineEndingSeq.length : 1);
   model.insertString(0, s);
   return model.getTokenCursor(0);
 }

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -177,8 +177,7 @@ describe('paredit', () => {
         const b = docFromTextNotation('(a| b (c\r\n d)| e)');
         const [start, end] = textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        // off by 1 because \r\n is treated as 1 char?
-        expect(actual).toEqual([start, end - 1]);
+        expect(actual).toEqual([start, end]);
       });
 
       it('Maintains balanced delimiters 2', () => {
@@ -194,8 +193,7 @@ describe('paredit', () => {
         const b = docFromTextNotation('(aa| (c (e\r\nf))|g)');
         const [start, end] = textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        // off by 1 because \r\n is treated as 1 char?
-        expect(actual).toEqual([start, end - 1]);
+        expect(actual).toEqual([start, end]);
       });
 
       it('Maintains balanced delimiters 3', () => {

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -1,5 +1,5 @@
 import * as expect from 'expect';
-import { LispTokenCursor } from '../../../cursor-doc/token-cursor';
+import { createStringCursor, LispTokenCursor } from '../../../cursor-doc/token-cursor';
 import { docFromTextNotation, textAndSelection } from '../common/text-notation';
 
 describe('Token Cursor', () => {
@@ -24,6 +24,20 @@ describe('Token Cursor', () => {
     it('moves from beginning to end of symbol', () => {
       const a = docFromTextNotation('(|c•#f)');
       const b = docFromTextNotation('(c|•#f)');
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      cursor.forwardSexp();
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
+    });
+    it('forwardSexp with newline', () => {
+      const a = docFromTextNotation('|(a\n(b))');
+      const b = docFromTextNotation('(a\n(b))|');
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+      cursor.forwardSexp();
+      expect(cursor.offsetStart).toBe(b.selection.anchor);
+    });
+    it('forwardSexp with newline (MS-Windows)', () => {
+      const a = docFromTextNotation('|(a\r\n(b))');
+      const b = docFromTextNotation('(a\r\n(b))|');
       const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
       cursor.forwardSexp();
       expect(cursor.offsetStart).toBe(b.selection.anchor);
@@ -874,6 +888,18 @@ describe('Token Cursor', () => {
         const a = docFromTextNotation('([|');
         const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
         expect(cursor.getFunctionName()).toBeUndefined();
+      });
+    });
+    describe('createStringCursor', () => {
+      it('Ranges account for newline', () => {
+        const cursor = createStringCursor('(a\n(b))');
+        const topLevelRanges = cursor.rangesForTopLevelForms().flat();
+        expect(topLevelRanges).toEqual([0, 7]);
+      });
+      it('Ranges account for newline (MS-Windows)', () => {
+        const cursor = createStringCursor('(a\r\n(b))');
+        const topLevelRanges = cursor.rangesForTopLevelForms().flat();
+        expect(topLevelRanges).toEqual([0, 8]);
       });
     });
   });


### PR DESCRIPTION
Hi 

could you please consider patch to account CRLF as two characters in the LineInputModel.

This is my first ever TS submission, so please scrutinize thoroughly as such.

## What has changed?

LineInputModel now receives as first argument the size of EOL seq in the text it is about to parse.

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- It appears that LineInputModel accepts as first argument the number of characters in the EOL it parses. This default to 1, but on MS-Windows, the EOL length is two, so it is updated as such.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1994

## My Calva PR Checklist

Hi, there are few points below which I couldn't figure out what you want me to do.

<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

If this PR involves code changes, I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
~- [ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
  - [x] Tested the particular change
  ~- [] Figured if the change might have some side effects and tested those as well.~
  - [ ] Smoke tested the extension as such. === I don't understand what you want me to do here. ===
 - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. ===  Not sure what you want me to do here ===
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-~keywords) === The link is broken when i copy pate it from the raw template. ===
~- [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik

Thanks