### PR TITLE
Deftype formatter issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Provider completions not handling errors gracefully](https://github.com/BetterThanTomorrow/calva/issues/2006)
+- Partly fix (indenter): [Indenter and formatter fails while typing out body of deftype method](https://github.com/BetterThanTomorrow/calva/issues/1957)
 
 ## [2.0.322] - 2022-12-14
 

--- a/src/calva-fmt/src/config.ts
+++ b/src/calva-fmt/src/config.ts
@@ -13,6 +13,16 @@ const defaultCljfmtContent =
 const LSP_CONFIG_KEY = 'CLOJURE-LSP';
 let lspFormatConfig: string | undefined;
 
+function cljfmtOptionsFromString(cljfmt: string) {
+  const options = cljsLib.cljfmtOptionsFromString(cljfmt);
+  return {
+    ...options,
+    // because we can't correctly pass ordered map from cljs
+    // but we need it to determine the order of applying indent rules
+    indents: Object.fromEntries(options['indents']),
+  };
+}
+
 function configuration(workspaceConfig: vscode.WorkspaceConfiguration, cljfmt: string) {
   return {
     'format-as-you-type': !!formatOnTypeEnabled(),
@@ -20,7 +30,7 @@ function configuration(workspaceConfig: vscode.WorkspaceConfiguration, cljfmt: s
       'keepCommentTrailParenOnOwnLine'
     ),
     'cljfmt-options-string': cljfmt,
-    'cljfmt-options': cljsLib.cljfmtOptionsFromString(cljfmt),
+    'cljfmt-options': cljfmtOptionsFromString(cljfmt),
   };
 }
 

--- a/src/cljs-lib/src/calva/fmt/formatter.cljs
+++ b/src/cljs-lib/src/calva/fmt/formatter.cljs
@@ -16,6 +16,13 @@
     indents
     (merge cljfmt/default-indents indents)))
 
+(defn- sort-indents
+  "Sorts rules in order to prevent default rule application
+   before specific one"
+  [indents]
+  #_{:clj-kondo/ignore [:private-call]}
+  (sort-by cljfmt/indent-order indents))
+
 (def ^:private default-fmt
   {:remove-surrounding-whitespace? true
    :remove-trailing-whitespace? true
@@ -27,6 +34,7 @@
   [fmt]
   (as-> fmt $
     (update $ :indents merge-default-indents)
+    (update $ :indents sort-indents)
     (merge default-fmt $)))
 
 (defn- read-cljfmt
@@ -259,7 +267,7 @@
       (remove-indent-token-if-empty-current-line)
       (remove-trail-symbol-if-comment range)))
 (comment
-  
+
   :rcf)
 (defn format-text-at-idx-on-type
   "Relax formating some when used as an on-type handler"

--- a/src/extension-test/unit/cursor-doc/indent-test.ts
+++ b/src/extension-test/unit/cursor-doc/indent-test.ts
@@ -151,7 +151,19 @@ describe('indent', () => {
   (method1 [this]
 |(print "hello")))`);
 
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(4);
+        expect(
+          indent.getIndent(
+            doc.model,
+            textAndSelection(doc)[1][0],
+            mkConfig({
+              deftype: [
+                ['block', 2],
+                ['inner', 1],
+              ],
+              '#"^def(?!ault)(?!late)(?!er)"': [['inner', 0]],
+            })
+          )
+        ).toEqual(4);
       });
     });
   });


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Fix the issue with indent rules order - now we apply the same order mechanism as in cljfmt, so e.g. the default value for `def` keywords now at the end of the rules list. The specific rules for e.g. `deftype` are no longer shadowed by the #"^def(?!ault)(?!late)(?!er)" rule => indentation on type now works correctly
- `getIndent` function was refactored

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Partly fixes indenter case of #1957

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [x] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
