### PR TITLE
Handle completion response failures gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Provider completions not handling errors gracefully](https://github.com/BetterThanTomorrow/calva/issues/2006)
+
 ## [2.0.322] - 2022-12-14
 
 - Fix: [Clojure notebooks don't seem to work on MS-Windows](https://github.com/BetterThanTomorrow/calva/issues/1994)

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -51,7 +51,15 @@ async function provideCompletionItems(
     if (results.length && !completionProviderOptions.merge) {
       break;
     }
-    const completions = await completionFunctions[provider](document, position, token, context);
+
+    const completions = await completionFunctions[provider](
+      document,
+      position,
+      token,
+      context
+    ).catch((err) => {
+      console.log('Failed to get results from remote', err);
+    });
 
     if (completions) {
       results = [


### PR DESCRIPTION
The provider completions subsystem requests results from the `lsp` and `nrepl` providers sequentially and then merges the results together. If either of these providers fail to report completion items and throws an error then the entire flow fails.

Ideally if one of the providers is working and is able to report results then the completions should continue to work.

This commit fixes this issue by catching errors from the completions provider and quietly logging them to console instead of bubbling the error upstream.

Fixes #2006
