### PR TITLE
Fix deftype formatter case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix (formatter): [Indenter and formatter fails while typing out body of deftype method](https://github.com/BetterThanTomorrow/calva/issues/1957)
+
 ## [2.0.323] - 2023-01-07
 
 - Fix: [Provider completions not handling errors gracefully](https://github.com/BetterThanTomorrow/calva/issues/2006)

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -17,6 +17,11 @@ import {
 } from '../../../out/cljs-lib/cljs-lib';
 import * as util from '../../utilities';
 import { isUndefined, cloneDeep } from 'lodash';
+import { LispTokenCursor } from '../../cursor-doc/token-cursor';
+
+const FormatDepthDefaults = {
+  deftype: 2,
+};
 
 export async function indentPosition(position: vscode.Position, document: vscode.TextDocument) {
   const editor = util.getActiveTextEditor();
@@ -67,7 +72,7 @@ export async function formatRangeEdits(
       text,
       document.getText(),
       rangeTuple,
-      document.eol == 2 ? '\r\n' : '\n'
+      _convertEolNumToStringNotation(document.eol)
     );
     if (newText) {
       return [vscode.TextEdit.replace(range, newText)];
@@ -94,20 +99,14 @@ export async function formatPositionInfo(
   extraConfig = {}
 ) {
   const doc: vscode.TextDocument = editor.document;
-  const pos: vscode.Position = editor.selection.active;
-  const index = doc.offsetAt(pos);
-  const mirroredDoc: MirroredDocument = getDocument(doc);
-  const cursor = mirroredDoc.getTokenCursor(index);
-  const formatDepth = extraConfig['format-depth'] ? extraConfig['format-depth'] : 1;
-  const isComment = cursor.getFunctionName() === 'comment';
-  const config = { ...extraConfig, 'comment-form?': isComment };
-  let formatRange = cursor.rangeForList(formatDepth);
-  if (!formatRange) {
-    formatRange = cursor.rangeForCurrentForm(index);
-    if (!formatRange || !formatRange.includes(index)) {
-      return;
-    }
+  const index = doc.offsetAt(editor.selection.active);
+  const cursor = getDocument(doc).getTokenCursor(index);
+
+  const formatRange = _calculateFormatRange(extraConfig, cursor, index);
+  if (!formatRange?.includes(index)) {
+    return;
   }
+
   const formatted: {
     'range-text': string;
     range: number[];
@@ -116,9 +115,12 @@ export async function formatPositionInfo(
     doc.getText(),
     formatRange,
     index,
-    doc.eol == 2 ? '\r\n' : '\n',
+    _convertEolNumToStringNotation(doc.eol),
     onType,
-    config
+    {
+      ...extraConfig,
+      'comment-form?': cursor.getFunctionName() === 'comment',
+    }
   );
   const range: vscode.Range = new vscode.Range(
     doc.positionAt(formatted.range[0]),
@@ -133,6 +135,21 @@ export async function formatPositionInfo(
     previousIndex: index,
     newIndex: newIndex,
   };
+}
+
+function _calculateFormatRange(
+  config: { 'format-depth'?: number },
+  cursor: LispTokenCursor,
+  index: number
+) {
+  const formatDepth = config?.['format-depth'] ?? _defaultFormatDepth(cursor);
+  return cursor.rangeForList(formatDepth) ?? cursor.rangeForCurrentForm(index);
+}
+
+function _defaultFormatDepth(cursor: LispTokenCursor) {
+  const cursorClone = cursor.clone();
+  cursorClone.backwardFunction(1);
+  return FormatDepthDefaults?.[cursorClone.getFunctionName()] ?? 1;
 }
 
 export async function formatPosition(
@@ -195,7 +212,7 @@ export function trimWhiteSpacePositionCommand(editor: vscode.TextEditor) {
 export async function formatCode(code: string, eol: number) {
   const d = {
     'range-text': code,
-    eol: eol == 2 ? '\r\n' : '\n',
+    eol: _convertEolNumToStringNotation(eol),
     config: await config.getConfig(),
   };
   const result = jsify(formatText(d));
@@ -248,4 +265,8 @@ async function _formatRange(
   if (!result['error']) {
     return result['range-text'];
   }
+}
+
+function _convertEolNumToStringNotation(eol: vscode.EndOfLine) {
+  return eol == 2 ? '\r\n' : '\n';
 }

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -142,11 +142,11 @@ function _calculateFormatRange(
   cursor: LispTokenCursor,
   index: number
 ) {
-  const formatDepth = config?.['format-depth'] ?? _defaultFormatDepth(cursor);
+  const formatDepth = config?.['format-depth'] ?? _formatDepth(cursor);
   return cursor.rangeForList(formatDepth) ?? cursor.rangeForCurrentForm(index);
 }
 
-function _defaultFormatDepth(cursor: LispTokenCursor) {
+function _formatDepth(cursor: LispTokenCursor) {
   const cursorClone = cursor.clone();
   cursorClone.backwardFunction(1);
   return FormatDepthDefaults?.[cursorClone.getFunctionName()] ?? 1;

--- a/src/cljs-lib/test/calva/fmt/formatter_test.cljs
+++ b/src/cljs-lib/test/calva/fmt/formatter_test.cljs
@@ -14,6 +14,9 @@
 
 baz)")
 
+(def deftype-all-text
+  "(deftype MyType [arg1 arg2]\n  IMyProto\n  (method1 [this]\n           (smth)))")
+
 (deftest format-text-at-idx
   (is (= "(defn bar
     [x]
@@ -28,6 +31,8 @@ baz)")
          (:range (sut/format-text-at-idx {:eol "\n" :all-text "(\n\n,)" :range [0 5] :idx 2}))))
   (is (= "()"
          (:range-text (sut/format-text-at-idx {:eol "\n" :all-text "(\n\n,)" :range [0 5] :idx 2}))))
+  (is (= "(deftype MyType [arg1 arg2]\n  IMyProto\n  (method1 [this]\n    (smth)))"
+         (:range-text (sut/format-text-at-idx {:eol "\n" :all-text deftype-all-text :range [0 76] :idx 68}))))
   ;; TODO: Figure out why the extra space is not removed
   #_(is (= "a c"
          (:range-text (sut/format-text-at-idx {:eol "\n" :all-text "a  c" :range [0 4] :idx 2})))))


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Fix the formatter case of #1957
- Add a `deftype` unit test for `format-text-at-idx`

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

If this PR involves code changes, I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
