### PR TITLE
Improve repl output window performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Rogue loops that print output to stdout cause Calva to hang](https://github.com/BetterThanTomorrow/calva/issues/2010)
 ## [2.0.323] - 2023-01-07
 
 - Fix: [Provider completions not handling errors gracefully](https://github.com/BetterThanTomorrow/calva/issues/2006)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Rogue loops that print output to stdout cause Calva to hang](https://github.com/BetterThanTomorrow/calva/issues/2010)
+- Fix: [Output window becomes very slow when number of lines of content is very high](https://github.com/BetterThanTomorrow/calva/issues/804)
+- Partial Fix: [Output window becomes very slow when number of lines of content is very high](https://github.com/BetterThanTomorrow/calva/issues/942)
+
 ## [2.0.323] - 2023-01-07
 
 - Fix: [Provider completions not handling errors gracefully](https://github.com/BetterThanTomorrow/calva/issues/2006)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changes to Calva.
 
 - Fix: [Rogue loops that print output to stdout cause Calva to hang](https://github.com/BetterThanTomorrow/calva/issues/2010)
 - Fix: [Output window becomes very slow when number of lines of content is very high](https://github.com/BetterThanTomorrow/calva/issues/804)
-- Partial Fix: [Output window becomes very slow when number of lines of content is very high](https://github.com/BetterThanTomorrow/calva/issues/942)
+- Partial Fix: [REPL is Slow and Performance Degrades as the Output Grows](https://github.com/BetterThanTomorrow/calva/issues/942)
 
 ## [2.0.323] - 2023-01-07
 

--- a/package.json
+++ b/package.json
@@ -770,6 +770,11 @@
               "lsp"
             ]
           },
+          "calva.replOutputThrottleRate": {
+            "markdownDescription": "If the repl outputs too quickly then results will be dropped from the output window. Setting this to 0 will disable throttling.",
+            "type": "number",
+            "default": 100
+          },
           "calva.depsEdnJackInExecutable": {
             "markdownDescription": "Which executable should Calva Jack-in use for starting a deps.edn project? The default is to let Calva choose. It will choose `clojure` if that is installed and working. Otherwise `deps.clj`, which is bundled with Calva, will be used. (This settings has no effect on Windows, where `deps.clj` will always be used.)",
             "enum": [

--- a/package.json
+++ b/package.json
@@ -775,6 +775,11 @@
             "type": "number",
             "default": 100
           },
+          "calva.replOutputMaxLines": {
+            "markdownDescription": "The maximum number of lines to retain in the repl output window. Having the repl output window grow too large can significantly affect performance. Setting this to 0 will disable truncating",
+            "type": "number",
+            "default": 1000
+          },
           "calva.depsEdnJackInExecutable": {
             "markdownDescription": "Which executable should Calva Jack-in use for starting a deps.edn project? The default is to let Calva choose. It will choose `clojure` if that is installed and working. Otherwise `deps.clj`, which is bundled with Calva, will be used. (This settings has no effect on Windows, where `deps.clj` will always be used.)",
             "enum": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ const KEYBINDINGS_ENABLED_CONFIG_KEY = 'calva.keybindingsEnabled';
 const KEYBINDINGS_ENABLED_CONTEXT_KEY = 'calva:keybindingsEnabled';
 
 const REPL_OUTPUT_THROTTLE_RATE_CONFIG_KEY = 'calva.replOutputThrottleRate';
+const REPL_OUTPUT_MAX_LINES_CONFIG_KEY = 'calva.replOutputMaxLines';
 
 type ReplSessionType = 'clj' | 'cljs';
 
@@ -237,6 +238,7 @@ export {
   KEYBINDINGS_ENABLED_CONFIG_KEY,
   KEYBINDINGS_ENABLED_CONTEXT_KEY,
   REPL_OUTPUT_THROTTLE_RATE_CONFIG_KEY,
+  REPL_OUTPUT_MAX_LINES_CONFIG_KEY,
   documentSelector,
   ReplSessionType,
   getConfig,

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,8 @@ const REPL_FILE_EXT = 'calva-repl';
 const KEYBINDINGS_ENABLED_CONFIG_KEY = 'calva.keybindingsEnabled';
 const KEYBINDINGS_ENABLED_CONTEXT_KEY = 'calva:keybindingsEnabled';
 
+const REPL_OUTPUT_THROTTLE_RATE_CONFIG_KEY = 'calva.replOutputThrottleRate';
+
 type ReplSessionType = 'clj' | 'cljs';
 
 // include the 'file' and 'untitled' to the
@@ -234,6 +236,7 @@ export {
   REPL_FILE_EXT,
   KEYBINDINGS_ENABLED_CONFIG_KEY,
   KEYBINDINGS_ENABLED_CONTEXT_KEY,
+  REPL_OUTPUT_THROTTLE_RATE_CONFIG_KEY,
   documentSelector,
   ReplSessionType,
   getConfig,

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -17,6 +17,9 @@ import { formatAsLineComments, splitEditQueueForTextBatching } from './util';
 
 const RESULTS_DOC_NAME = `output.${config.REPL_FILE_EXT}`;
 
+const REPL_OUTPUT_THROTTLE_RATE = vscode.workspace
+  .getConfiguration()
+  .get<number>(config.REPL_OUTPUT_THROTTLE_RATE_CONFIG_KEY);
 const PROMPT_HINT = 'Use `alt+enter` to evaluate';
 
 const START_GREETINGS = [
@@ -331,6 +334,16 @@ export interface OnAppendedCallback {
 
 let resultsBuffer: ResultsBuffer = [];
 
+type BufferThrottleState = {
+  count: number;
+  dropped: number;
+  timeout?: NodeJS.Timeout;
+};
+const throttleState: BufferThrottleState = {
+  count: 0,
+  dropped: 0,
+};
+
 async function writeNextOutputBatch() {
   if (!resultsBuffer[0]) {
     return;
@@ -366,6 +379,30 @@ async function flushOutput() {
 
 /* If something must be done after a particular edit, use the onAppended callback. */
 export function append(text: string, onAppended?: OnAppendedCallback): void {
+  if (REPL_OUTPUT_THROTTLE_RATE > 0) {
+    throttleState.count++;
+
+    if (!throttleState.timeout) {
+      throttleState.timeout = setTimeout(() => {
+        if (throttleState.dropped > 0) {
+          resultsBuffer.push({
+            text: `;; Dropped ${throttleState.dropped} items from output due to throttling\n`,
+          });
+          void flushOutput();
+        }
+
+        throttleState.timeout = undefined;
+        throttleState.count = 0;
+        throttleState.dropped = 0;
+      }, 500);
+    }
+
+    if (throttleState.count > REPL_OUTPUT_THROTTLE_RATE) {
+      throttleState.dropped++;
+      return;
+    }
+  }
+
   resultsBuffer.push({ text, onAppended });
   void flushOutput();
 }

--- a/src/results-output/util.ts
+++ b/src/results-output/util.ts
@@ -24,7 +24,7 @@ function splitEditQueueForTextBatching(
   const nextBatch = takeWhile(editQueue, (value, index) => {
     return index < maxBatchSize && !value.onAppended;
   }).map((x) => x.text);
-  const remainingEditQueue = [...editQueue].slice(nextBatch.length);
+  const remainingEditQueue = editQueue.slice(nextBatch.length);
   return [nextBatch, remainingEditQueue];
 }
 


### PR DESCRIPTION
This PR introduces two new config entries - `replOutputThrottleRate` and `replOutputMaxLines` which are both used to improve the performance of the repl output window/file.

### `replOutputThrottleRate`

If set to a non-0 number this will throttle output from the repl connection. If more output items are received than the throttle rate in a 500ms window then they will just be dropped.

### `replOutputMaxLines`

If set to a non-0 number this will cause the output window to be truncated if it grows
beyond this threshold.

This should fix #2010 and #804 and should help address #942 (or maybe fix it?)