### PR TITLE
Don't block on snippet evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Evaluating blocking snippets deadlocks the editor](https://github.com/BetterThanTomorrow/calva/issues/2012)
+
 ## [2.0.323] - 2023-01-07
 
 - Fix: [Provider completions not handling errors gracefully](https://github.com/BetterThanTomorrow/calva/issues/2006)

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -17,10 +17,10 @@ type SnippetDefinition = {
   evaluationSendCodeToOutputWindow?: boolean;
 };
 
-export async function evaluateCustomCodeSnippetCommand(
-  codeOrKeyOrSnippet?: string | SnippetDefinition
-) {
-  await evaluateCodeOrKeyOrSnippet(codeOrKeyOrSnippet);
+export function evaluateCustomCodeSnippetCommand(codeOrKeyOrSnippet?: string | SnippetDefinition) {
+  evaluateCodeOrKeyOrSnippet(codeOrKeyOrSnippet).catch((err) => {
+    console.log('Failed to run snippet', err);
+  });
 }
 
 async function evaluateCodeOrKeyOrSnippet(codeOrKeyOrSnippet?: string | SnippetDefinition) {


### PR DESCRIPTION
If a snippet is evaluated with runCustomREPLCommand and it blocks (due to a bug or some such) then the editor almost completely deadlocks.

This commit changes the command handler for `runCustomREPLCommand` to not block on snippet evaluation.

Fixes #2012