### PR TITLE
Add missing move-form clojure-lsp refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [The move-form clojure-lsp refactoring is missing in Calva](https://github.com/BetterThanTomorrow/calva/issues/2015)
+
 ## [2.0.326] - 2023-01-24
 
 - Fix: [`afterCLJReplJackInCode` fails if no editor is open](https://github.com/BetterThanTomorrow/calva/issues/2025)

--- a/docs/site/refactoring.md
+++ b/docs/site/refactoring.md
@@ -31,6 +31,7 @@ Thread Last | `clojureLsp.refactor.threadLast` | ![](images/refactoring/threadLa
 Thread Last All | `clojureLsp.refactor.threadLastAll` | ![](images/refactoring/threadLastAll.gif)
 Unwind All | `clojureLsp.refactor.unwindAll` | ![](images/refactoring/unwindAll.gif)
 Unwind Thread | `clojureLsp.refactor.unwindThread` | ![](images/refactoring/unwindThread.gif)
+Move Form | `clojureLsp.refactor.moveForm` | Opens a file picker to select the file to move a given form to. After selecting the destination, the form is moved and references to the form are updated.
 
 !!! Note "Formatting"
     The way that some of the refactorings are applied to the document, makes it difficult for Calva to format the results. So, sometimes you'll need to navigate the cursor to the enclosing form and hit `tab` to tidy up the formatting after a refactoring. See also [Formatting](formatting.md).

--- a/package.json
+++ b/package.json
@@ -1771,6 +1771,12 @@
         "enablement": "editorLangId == clojure && clojureLsp:active"
       },
       {
+        "command": "clojureLsp.refactor.moveForm",
+        "title": "Move form",
+        "category": "clojure-lsp Refactor",
+        "enablement": "editorLangId == clojure && clojureLsp:active"
+      },
+      {
         "command": "clojureLsp.refactor.threadFirst",
         "title": "Thread First",
         "category": "clojure-lsp Refactor",


### PR DESCRIPTION
## What has changed?

Clojure-lsp has a move-form refactoring that doesn't have an equivalent command in Calva yet. This PR adds the refactoring.


Fixes #2015

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [ ] ~If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
