### PR TITLE
Fix test on save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ src/calva-fmt/atom-language-clojure/.bash_history
 
 # Leiningen
 .lein-repl-history
+
+# Portal
+.portal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Setting calva.testOnSave broken: no tests found](https://github.com/BetterThanTomorrow/calva/issues/2005)
+
 ## [2.0.324] - 2023-01-15
 
 - Fix: [Evaluating blocking snippets deadlocks the editor](https://github.com/BetterThanTomorrow/calva/issues/2012)

--- a/src/nrepl/cider.ts
+++ b/src/nrepl/cider.ts
@@ -71,7 +71,9 @@ function resultMessage(resultItem: Readonly<TestResult>): string {
   if (resultItem.message) {
     msg.push(resultItem.message);
   }
-  return `${msg.length > 0 ? stripTrailingNewlines(msg.join(': ')) : ''}`;
+  return `${
+    msg.length > 0 ? stripTrailingNewlines(msg.filter((m) => typeof m === 'string').join(': ')) : ''
+  }`;
 }
 
 // Given a summary, return a message suitable for printing in the REPL to show

--- a/src/nrepl/cider.ts
+++ b/src/nrepl/cider.ts
@@ -72,6 +72,8 @@ function resultMessage(resultItem: Readonly<TestResult>): string {
     msg.push(resultItem.message);
   }
   return `${
+    // We filter on typeof m === 'string' because a case has been seen in which the first element is actually an array instead of a string,
+    // which results in a string like ": <some message>".
     msg.length > 0 ? stripTrailingNewlines(msg.filter((m) => typeof m === 'string').join(': ')) : ''
   }`;
 }

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -390,12 +390,14 @@ export function getStacktraceEntryForKey(key: string): OutputStacktraceEntry {
 }
 
 function stackEntryString(entry: any): string {
-  const type = entry.type;
   const name = entry.var || entry.name;
   return `${name} (${entry.file}:${entry.line})`;
 }
 
 export function saveStacktrace(stacktrace: any[]): void {
+  if (stacktrace === undefined || stacktrace.length === 0) {
+    return;
+  }
   _lastStacktrace = [];
   stacktrace
     .filter((entry) => {

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -293,7 +293,11 @@ async function runNamespaceTestsImpl(
 
   const session = getSession(util.getFileType(document));
 
-  outputWindow.appendLine(`; Running tests for ${nss[0]}...`);
+  outputWindow.appendLine(
+    `; Running tests for the following namespaces:\n${
+      nss.map((item) => `;   ${item}`).join('\n') + '\n'
+    }`
+  );
 
   const resultPromises = nss.map((ns) => {
     return session.testNs(ns);
@@ -317,6 +321,7 @@ async function runNamespaceTests(controller: vscode.TestController, document: vs
   const session = getSession(util.getFileType(document));
   const currentDocNs = namespace.getNamespace(doc);
   await loadTestNS(currentDocNs, session);
+  // TODO: Write tests
   const namespacesToRunTestsFor = [
     currentDocNs,
     currentDocNs.endsWith('-test') ? currentDocNs.slice(0, -5) : currentDocNs + '-test',

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -315,9 +315,13 @@ async function runNamespaceTests(controller: vscode.TestController, document: vs
     return;
   }
   const session = getSession(util.getFileType(document));
-  const ns = namespace.getNamespace(doc);
-  await loadTestNS(ns, session);
-  void runNamespaceTestsImpl(controller, document, [ns]);
+  const currentDocNs = namespace.getNamespace(doc);
+  await loadTestNS(currentDocNs, session);
+  const namespacesToRunTestsFor = [
+    currentDocNs,
+    currentDocNs.endsWith('-test') ? currentDocNs.slice(0, -5) : currentDocNs + '-test',
+  ];
+  void runNamespaceTestsImpl(controller, document, namespacesToRunTestsFor);
 }
 
 function getTestUnderCursor() {

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -321,7 +321,6 @@ async function runNamespaceTests(controller: vscode.TestController, document: vs
   const session = getSession(util.getFileType(document));
   const currentDocNs = namespace.getNamespace(doc);
   await loadTestNS(currentDocNs, session);
-  // TODO: Write tests
   const namespacesToRunTestsFor = [
     currentDocNs,
     currentDocNs.endsWith('-test') ? currentDocNs.slice(0, -5) : currentDocNs + '-test',


### PR DESCRIPTION
## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

Fixed the test-on-save feature.

I made Calva run tests for the source namespace too because tests could be defined there, such as:

```clojure
(defn my-function
  "this function adds two numbers"
  {:test #(do
            (assert (= (my-function 2 3) 5))
            (assert (= (my-function 99 4) 8)))}
  ([x y] (+ x y)))
```

~However, with the above, I get an error in the output window - `; TypeError: Cannot read properties of undefined (reading 'filter')` - so I need to look into that when I get back to this.~

The above is now fixed by the check for `undefined` in `saveStacktrace`.

~I think we should probably also allow `testNs` to take an array of namespaces (and change its name to something like `testNamespaces`) since the `ns-query`'s `exactly` prop can take a collection of namespaces. Then we can avoid mapping over namespaces and dealing with an array of promises.~

Maybe the above can wait until later and we can keep the changes smaller in this PR?

I updated the test reporting for running namespace tests. We now say list the namespaces being tested.

I also fixed an issue which caused an error to be printed with `: ` in front of it. See the filtering related to `typeof m === 'string'`. In the problem case, the first item in `msg` was an empty array, for some reason, and the second was a string. This problem happened when I had a failing assertion in the metadata of a function in the source namespace (see the pic below which shows the case after the fix).

Example of running tests from a source namespace which also has test assertions in the metadata of a function, one of which fails.

![image](https://user-images.githubusercontent.com/12722744/212242540-9f2932e2-069d-4a63-88fd-ac9fe1ea3599.png)


<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2005 

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - ~[ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.~
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
