### PR TITLE
Fix typo: "Om Mac" => "On Mac,"

### DIFF
--- a/docs/site/vim.md
+++ b/docs/site/vim.md
@@ -13,7 +13,7 @@ In general Calva's default key bindings are not very VI-ish.
 
 ### Expand selection on Mac
 
-Om Mac Calva binds **expand selection** to `ctrl+w`. This conflicts with the VIM Extension's default mapping of window splitting shortcuts. You'll need to remap it either with Calva or with the VIM Extension.
+On Mac, Calva binds **expand selection** to `ctrl+w`. This conflicts with the VIM Extension's default mapping of window splitting shortcuts. You'll need to remap it either with Calva or with the VIM Extension.
 
 ### The `esc` key
 


### PR DESCRIPTION
Just a simple typo on the VIM docs. Hilariously, I suspect it was overlooked easily because [Om](https://github.com/omcljs/om) is such a cool lib. LOL. I also added a comma so my third grade teacher doesn't yell at me.

## My Calva PR Checklist
<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

If this PR involves only documentation changes, I have:

- [x] Read [Editing Documentation](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Hack-on-Calva#editing-documentation)
- [x] Directed this pull request at the `published` branch.
- [x] Built the site locally (if the changes were more involved than simple typo fixes), and verified that the site is presented as expected.
- ~[ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_ (if there was is an issue for the documentation change)~
  - ~[ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)~
  - ~[ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
