### PR TITLE
Fix evaluate updating UI, when there is no editor active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [`afterCLJReplJackInCode` fails if no editor is open](https://github.com/BetterThanTomorrow/calva/issues/2025)
+
 ## [2.0.325] - 2023-01-21
 
 - Fix: [Setting calva.testOnSave broken: no tests found](https://github.com/BetterThanTomorrow/calva/issues/2005)

--- a/test-data/projects/repl-connected-code/README.md
+++ b/test-data/projects/repl-connected-code/README.md
@@ -9,4 +9,4 @@ This project has a connect sequence with a simple `afterCLJReplJackInCode` code 
 2. Jack-in, selecting the **Test broken jack-in code evaluation** sequence.
 
 * **Expected**: `"afterCLJReplJackInCode evaluated"` is printed in the REPL window
-* **Actual**: It ^ is not happening
+* **Actual**: `; Evaluation failed.` is printed in the REPL window


### PR DESCRIPTION
## What has changed?

When we evaluate connect sequence `afterCLJReplJackInCode` provided code, we use `evaluate.evaluateCodeUpdatingUI` function. I don't know exactly why, but maybe it is because with `UI` we mean both the REPL window and the decorations in the active editor. But if there is no active editor, we run into trouble. Most commands and shortcuts for evaluating things in the active editor have `when` clauses that guards, but the jack-in should work regardless of active editor or not.

This code is very messy and in bad need of restructuring. With this PR I pile on to the technical debt, because I don't have a good idea about how the code should be structure. It's a tiny change, just checking that we have an `editor` before we go access it. All use cases that have this will continue to work as before, and use cases that don't, might start working, and if they don't, they didn't work before either.

In any case the issue exposing this problem is fixed by this.

* Fixes #2025

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [ ] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [ ] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
