### PR TITLE
Jack-in error messaging instead of silent failure when no shadow builds are selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes to Calva.
 ## [2.0.325] - 2023-01-21
 
 - Fix: [Setting calva.testOnSave broken: no tests found](https://github.com/BetterThanTomorrow/calva/issues/2005)
+- Fix: [shadow-cljs jack-in silently fails when no builds are selected](https://github.com/BetterThanTomorrow/calva/issues/2022)
 
 ## [2.0.324] - 2023-01-15
 

--- a/docs/site/async-out.md
+++ b/docs/site/async-out.md
@@ -7,7 +7,7 @@ description: Tips on using Calva to create Node scripts using shadow-cljs
 
 When working on NodeJS projects with `shadow-cljs` and Calva, async output does not always appear in the Calva output window. To work around this problem, follow these steps:
 
-1. Run the command "Calva: Copy Jack-in Command to Clipboard", then paste the command in a terminal and run it.
+1. Run the command "Calva: Copy Jack-in Command Line to Clipboard", then paste the command in a terminal and run it.
 2. Wait for the message `shadow-cljs - nREPL server started on port <some-port>`
 3. Issue the command **Calva: Connect to a running REPL server in your project**, `ctrl+alt+c ctrl+alt+c`. For project type select `shadow-cljs`, accept the proposed `localhost:<some-port>`, and for `build` select `node-repl`.
 4. Load a file from your project with the command `ctrl+alt+c Enter.` Evaluating forms in Calva will show results in the output window. Synchronous `stdout` output will be printed in both the output window and in the terminal where you started the repl. Some asynchronous output may show up in the output window, but all will appear in the terminal.

--- a/docs/site/debugger.md
+++ b/docs/site/debugger.md
@@ -172,9 +172,9 @@ If you want a breakpoint to work within the test, evaluate the test form with a 
 
 ### "No reader function for tag" error
 
-If you get an error like this, it's likely that you connected to a REPL instead of jacking in, and you don't have the proper dependencies loaded in your REPL. You can run the command "Copy Jack-in Command to Clipboard" to see what command would be run if you jacked in.
+If you get an error like this, it's likely that you connected to a REPL instead of jacking in, and you don't have the proper dependencies loaded in your REPL. You can run the command "Copy Jack-in Command Line to Clipboard" to see what command would be run if you jacked in.
 
-Most importantly, make sure you have `cider/cider-nrepl` as a dependency, and `cider.nrepl/cider-middleware` as middleware loaded in your REPL. For example, this is a jack-in command for a deps.edn project:
+Most importantly, make sure you have `cider/cider-nrepl` as a dependency, and `cider.nrepl/cider-middleware` as middleware loaded in your REPL. For example, this is a jack-in command line for a deps.edn project:
 
 ```sh
 clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version,"0.8.3"},cider/cider-nrepl {:mvn/version,"0.25.8"}}}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"

--- a/docs/site/pprint.md
+++ b/docs/site/pprint.md
@@ -72,6 +72,6 @@ The current options are limited, because our time developing Calva is limited. B
 
 #### pprint is not working
 
-If pprint is not working, try a different pprint engine or use Calva's jack-in to make sure the necessary dependencies are loaded in your REPL. If you are starting your REPL without jack-in and want to continue doing so, you can use the command `Copy Jack-in Command to Clipboard` then paste the command somewhere to see what dependencies it injects. You can then add these dependencies to your REPL in whatever way suits your needs.
+If pprint is not working, try a different pprint engine or use Calva's jack-in to make sure the necessary dependencies are loaded in your REPL. If you are starting your REPL without jack-in and want to continue doing so, you can use the command `Copy Jack-in Command Line to Clipboard` then paste the command somewhere to see what dependencies it injects. You can then add these dependencies to your REPL in whatever way suits your needs.
 
 Enjoy Prettiful Printing! ❤️

--- a/package.json
+++ b/package.json
@@ -1024,7 +1024,7 @@
       },
       {
         "command": "calva.copyJackInCommandToClipboard",
-        "title": "Copy Jack-In Command to Clipboard",
+        "title": "Copy Jack-In Command Line to Clipboard",
         "category": "Calva",
         "enablement": "workspaceFolderCount > 0"
       },

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -144,10 +144,14 @@ export async function copyJackInCommandToClipboard(): Promise<void> {
     return;
   }
   if (projectConnectSequence) {
-    const { executable, args } = await getJackInTerminalOptions(projectConnectSequence);
-    if (executable && args) {
-      void vscode.env.clipboard.writeText(createCommandLine(executable, args));
-      void vscode.window.showInformationMessage('Jack-in command copied to the clipboard.');
+    try {
+      const { executable, args } = await getJackInTerminalOptions(projectConnectSequence);
+      if (executable && args) {
+        void vscode.env.clipboard.writeText(createCommandLine(executable, args));
+        void vscode.window.showInformationMessage('Jack-in command copied to the clipboard.');
+      }
+    } catch (e) {
+      void vscode.window.showErrorMessage(`Error creating Jack-in command line: ${e}`, 'OK');
     }
   } else {
     void vscode.window.showInformationMessage('No supported project types detected.');
@@ -270,9 +274,13 @@ export async function jackIn(connectSequence: ReplConnectSequence, cb?: () => un
     if (projectType.startFunction) {
       void projectType.startFunction();
     } else {
-      const terminalJackInOptions = await getJackInTerminalOptions(projectConnectSequence);
-      if (terminalJackInOptions) {
-        executeJackInTask(terminalJackInOptions, projectConnectSequence, cb);
+      try {
+        const terminalJackInOptions = await getJackInTerminalOptions(projectConnectSequence);
+        if (terminalJackInOptions) {
+          executeJackInTask(terminalJackInOptions, projectConnectSequence, cb);
+        }
+      } catch (e) {
+        void vscode.window.showErrorMessage(`Error creating Jack-in command line: ${e}`, 'OK');
       }
     }
   } else {

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -280,7 +280,7 @@ export async function jackIn(connectSequence: ReplConnectSequence, cb?: () => un
           executeJackInTask(terminalJackInOptions, projectConnectSequence, cb);
         }
       } catch (e) {
-        void vscode.window.showErrorMessage(`Error creating Jack-in command line: ${e}`, 'OK');
+        void vscode.window.showErrorMessage(`Error creating jack-in command line: ${e}`, 'OK');
       }
     }
   } else {

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -148,7 +148,7 @@ export async function copyJackInCommandToClipboard(): Promise<void> {
       const { executable, args } = await getJackInTerminalOptions(projectConnectSequence);
       if (executable && args) {
         void vscode.env.clipboard.writeText(createCommandLine(executable, args));
-        void vscode.window.showInformationMessage('Jack-in command copied to the clipboard.');
+        void vscode.window.showInformationMessage('Jack-in command line copied to the clipboard.');
       }
     } catch (e) {
       void vscode.window.showErrorMessage(`Error creating Jack-in command line: ${e}`, 'OK');

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -127,6 +127,9 @@ async function selectShadowBuilds(
   if (aliasesOption && aliasesOption.length) {
     args.push(aliasesOption);
   }
+  if (selectedBuilds.length == 0) {
+    throw new Error('No builds selected');
+  }
   return { selectedBuilds, args };
 }
 


### PR DESCRIPTION
## What has changed?

* Catch and show error message in jack-in and copy jack-in command
   <img width="472" alt="image" src="https://user-images.githubusercontent.com/30010/213930365-81b281ea-d2dc-4bc7-ab06-1085f4d22afe.png">

* Fixes #2022

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [ ] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [ ] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
