### PR TITLE
Print full evaluation error to output window

### DIFF
--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -901,6 +901,20 @@ export class NReplSession {
   }
 }
 
+type StackTraceItem = {
+  class: string;
+  file: string;
+  line: number;
+  method: string;
+  name: string;
+  type: string;
+};
+type NReplEvaluationErrorStackTrace = {
+  class: string;
+  message: string;
+  stacktrace: StackTraceItem[];
+};
+
 /**
  * A running nREPL eval call.
  */
@@ -919,7 +933,7 @@ export class NReplEvaluation {
 
   private _exception: string;
 
-  private _stacktrace: any;
+  private _stacktrace: NReplEvaluationErrorStackTrace | undefined | any;
 
   private _msgs: any[] = [];
 
@@ -1093,6 +1107,7 @@ export class NReplEvaluation {
         const cause = msg.causes[0];
         const errorMessage = `${cause.class}: ${cause.message}`;
         this._stacktrace = { stacktrace: cause.stacktrace };
+        console.log('HAS STATUS', msg);
         this.err(errorMessage);
       }
       if (msg.value !== undefined || msg['debug-value'] !== undefined) {
@@ -1135,6 +1150,7 @@ export class NReplEvaluation {
             this.session
               .stacktrace()
               .then((stacktrace) => {
+                console.log('GOT THING', stacktrace);
                 this._stacktrace = stacktrace;
                 this.doReject(this.exception);
               })

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -389,7 +389,7 @@ export function getStacktraceEntryForKey(key: string): OutputStacktraceEntry {
   return _stacktraceEntries[key];
 }
 
-function stackEntryString(entry: any): string {
+export function stackEntryString(entry: any): string {
   const name = entry.var || entry.name;
   return `${name} (${entry.file}:${entry.line})`;
 }


### PR DESCRIPTION
This is a PoC to demonstrate the REPL output behaviour I would like to see when editor evaluations throw errors. This is to address #2029 - please read that issue first to get a better idea of the problem this is trying to solve.

This is just a draft to show what I would like and to open the discussion on how we want this to work in practice. I'm sure people will have a lot of differing opinions on this one - probably requiring some calva configuration to control the behaviour.

This change will result in evaluation errors looking as follows:

Simple error:
![Screenshot 2023-01-23 at 12 19 03](https://user-images.githubusercontent.com/8571121/214037967-69cbcafa-6620-4f5a-a1d3-4b36f8aad0ab.png)

More complex error with additional data:
![Screenshot 2023-01-23 at 12 18 32](https://user-images.githubusercontent.com/8571121/214038054-5e0cbe3f-ef74-44ca-ae13-aaed455cdfea.png)

This addresses the three main points of the issue raised:

- It is immediately easier to parse as a result of the syntax highlighting. My eye is drawn to the right pieces of information and is structured such that I don't need to scroll the window horizontally to read the full error.
- It contains the full stacktrace without needing to click to see it. For me, this is always the behaviour I want
- It does not omit important information needed to resolve the issue. For the second image, this would be the `:data` key.

This implementation is quite primitive - I would guess some errors also contain other information besides `:data` that would need to be printed. This would need to be taken into account for a real implementation.

---

### Checklist

- [ ] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [ ] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [ ] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
  - [ ] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [ ] Created the issue I am fixing/addressing, if it was not present.
- [ ] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [ ] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
