### PR TITLE
Fix regexp tets function according to latest changes of the indention rules sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Sort aliases for deps.edn projects](https://github.com/BetterThanTomorrow/calva/issues/2035)
+- Fix: [Indenter and formatter not in agreement about some forms](https://github.com/BetterThanTomorrow/calva/issues/2032)
 
 ## [2.0.327] - 2023-01-26
 

--- a/src/cursor-doc/indent.ts
+++ b/src/cursor-doc/indent.ts
@@ -1,5 +1,6 @@
 import { EditableModel } from './model';
 import * as _ from 'lodash';
+import { testCljOrJsRegex } from '../util/regex';
 
 const whitespace = new Set(['ws', 'comment', 'eol']);
 
@@ -91,7 +92,10 @@ export function collectIndents(
 
       const pattern =
         isList &&
-        _.find(_.keys(rules), (p) => testCljRe(`#"^(.*/)?${p}$"`, token) || testCljRe(p, token));
+        _.find(
+          _.keys(rules),
+          (p) => testCljOrJsRegex(`#"^(.*/)?${p}$"`, token) || testCljOrJsRegex(p, token)
+        );
       const indentRule = pattern ? rules[pattern] : [];
       indents.unshift({
         first: token,
@@ -137,11 +141,6 @@ export function collectIndents(
   }
   return indents;
 }
-
-const testCljRe = (re, str) => {
-  const matches = re.match(/^#"(.*)"$/);
-  return matches && RegExp(matches[1]).test(str.replace(/^.*\//, ''));
-};
 
 const calculateDefaultIndent = (indentInfo: IndentInformation) =>
   indentInfo.exprsOnLine > 0 ? indentInfo.firstItemIdent : indentInfo.startIndent;

--- a/src/extension-test/unit/cursor-doc/indent-test.ts
+++ b/src/extension-test/unit/cursor-doc/indent-test.ts
@@ -1,8 +1,7 @@
 import * as expect from 'expect';
 import * as model from '../../../cursor-doc/model';
 import * as indent from '../../../cursor-doc/indent';
-import { docFromTextNotation, textAndSelection, text } from '../common/text-notation';
-import { ModelEditSelection } from '../../../cursor-doc/model';
+import { docFromTextNotation, textAndSelection } from '../common/text-notation';
 
 model.initScanner(20000);
 
@@ -164,6 +163,36 @@ describe('indent', () => {
             })
           )
         ).toEqual(4);
+      });
+    });
+    describe('and', () => {
+      it('calculates indents for cursor on the new line before the second argument with clojure regex config', () => {
+        const doc = docFromTextNotation(`
+(and x
+|y)`);
+        expect(
+          indent.getIndent(
+            doc.model,
+            textAndSelection(doc)[1][0],
+            mkConfig({
+              '#"\\S+"': [['inner', 0]],
+            })
+          )
+        ).toEqual(2);
+      });
+      it('calculates indents for cursor on the new line before the second argument with js regex config', () => {
+        const doc = docFromTextNotation(`
+(and x
+|y)`);
+        expect(
+          indent.getIndent(
+            doc.model,
+            textAndSelection(doc)[1][0],
+            mkConfig({
+              '/\\S+/': [['inner', 0]],
+            })
+          )
+        ).toEqual(2);
       });
     });
   });

--- a/src/extension-test/unit/util/regex-test.ts
+++ b/src/extension-test/unit/util/regex-test.ts
@@ -1,0 +1,16 @@
+import * as expect from 'expect';
+import { testCljOrJsRegex } from '../../../util/regex';
+
+describe('regex', () => {
+  describe('testCljOrJsRegex', () => {
+    it('works with the clojure regex string', () => {
+      expect(testCljOrJsRegex('#"^\\w"', 'function1')).toBeTruthy();
+    });
+    it('works with the js regex string', () => {
+      expect(testCljOrJsRegex('/^\\w/', 'function1')).toBeTruthy();
+    });
+    it('works with the plain text', () => {
+      expect(testCljOrJsRegex('ANY', 'ANY')).toBeTruthy();
+    });
+  });
+});

--- a/src/util/regex.ts
+++ b/src/util/regex.ts
@@ -1,0 +1,8 @@
+import { trim } from 'lodash';
+
+export const testCljOrJsRegex = (regexp: string, str: string) => {
+  const clojureReMatches = regexp.match(/^#"(.*)"$/);
+  const normalizedRe =
+    (clojureReMatches && RegExp(clojureReMatches[1])) || RegExp(trim(regexp, '/'));
+  return normalizedRe.test(str.replace(/^.*\//, ''));
+};


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️
## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2032

If this PR involves code changes, I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
  - [x] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
