### PR TITLE
Sort REPL connect/jack-in projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 
 - [Sort aliases for deps.edn projects](https://github.com/BetterThanTomorrow/calva/issues/2035)
 - Fix: [Indenter and formatter not in agreement about some forms](https://github.com/BetterThanTomorrow/calva/issues/2032)
+- [Sort pre-selected project at the top in REPL connect menu](https://github.com/BetterThanTomorrow/calva/issues/2043)
 
 ## [2.0.327] - 2023-01-26
 

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -134,18 +134,9 @@ export async function pickProjectRoot(
     return rootToUri(uris[0]);
   }
 
-  uris.sort((a, b) => {
-    if (!selected) {
-      return 0;
-    }
-    return rootToUri(a).fsPath === selected.fsPath
-      ? -1
-      : rootToUri(b).fsPath === selected.fsPath
-      ? 1
-      : 0;
-  });
+  const sorted = sortPreSelectedFirst(uris, selected);
 
-  const project_root_options = uris.map((root_or_uri) => {
+  const project_root_options = sorted.map((root_or_uri) => {
     let uri;
     let reason;
     if (root_or_uri instanceof vscode.Uri) {
@@ -179,4 +170,17 @@ export async function pickProjectRoot(
   picker.dispose();
 
   return selected_root?.value;
+}
+
+function sortPreSelectedFirst(uris: (ProjectRoot | vscode.Uri)[], selected: vscode.Uri) {
+  return [...uris].sort((a, b) => {
+    if (!selected) {
+      return 0;
+    }
+    return rootToUri(a).fsPath === selected.fsPath
+      ? -1
+      : rootToUri(b).fsPath === selected.fsPath
+      ? 1
+      : 0;
+  });
 }

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -134,6 +134,17 @@ export async function pickProjectRoot(
     return rootToUri(uris[0]);
   }
 
+  uris.sort((a, b) => {
+    if (!selected) {
+      return 0;
+    }
+    return rootToUri(a).fsPath === selected.fsPath
+      ? -1
+      : rootToUri(b).fsPath === selected.fsPath
+      ? 1
+      : 0;
+  });
+
   const project_root_options = uris.map((root_or_uri) => {
     let uri;
     let reason;


### PR DESCRIPTION
## What has changed?

Sorting the REPL connect/jack-in projects menu such that any pre-selected item is at the top.

* Fixes #2043 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- ~[ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
