### PR TITLE
Fix clojure-lsp regressions from #2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Changes to Calva.
 
 - [Sort aliases for deps.edn projects](https://github.com/BetterThanTomorrow/calva/issues/2035)
 - Fix: [Indenter and formatter not in agreement about some forms](https://github.com/BetterThanTomorrow/calva/issues/2032)
-- [Sort pre-selected project at the top in REPL connect menu](https://github.com/BetterThanTomorrow/calva/issues/2043)
+- Fix: [Sort pre-selected project at the top in REPL connect menu](https://github.com/BetterThanTomorrow/calva/issues/2043)
+- Fix: [Regressions introduced with clojure-lsp multi-project support in 2.0.327](https://github.com/BetterThanTomorrow/calva/issues/2041)
+- Fix: [Can't use add require feature after updating to 2.0.327 version](https://github.com/BetterThanTomorrow/calva/issues/2040)
 
 ## [2.0.328] - 2023-01-27
 - Rollback, first part of: [Regressions introduced with clojure-lsp multi-project support in 2.0.327](https://github.com/BetterThanTomorrow/calva/issues/2041)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,7 +80,7 @@ async function activate(context: vscode.ExtensionContext) {
       testRunner.onTestTree(testController, tree);
     },
   });
-  clientProvider.init();
+  await clientProvider.init();
 
   lsp.registerGlobally(clientProvider);
 

--- a/src/lsp/commands/lsp-commands.ts
+++ b/src/lsp/commands/lsp-commands.ts
@@ -221,7 +221,7 @@ export function registerLspCommands(clients: defs.LSPClientMap) {
     ...clojureLspCommands.map((command) => registerUserspaceLspCommand(clients, command)),
 
     /**
-     * The clojure-lsp server previously used to dynamically register all of these top-level commands however that behaviour was
+     * The clojure-lsp server previously used to dynamically register all of these top-level commands. However, that behaviour was
      * disabled to add support for provisioning multiple lsp clients in the same vscode window. The built-in behaviour resulted
      * in command registration conflicts.
      *

--- a/src/lsp/commands/lsp-commands.ts
+++ b/src/lsp/commands/lsp-commands.ts
@@ -1,3 +1,4 @@
+import * as vscode_lsp from 'vscode-languageclient/node';
 import * as calva_utils from '../../utilities';
 import * as defs from '../definitions';
 import * as vscode from 'vscode';
@@ -53,16 +54,37 @@ function sendCommandRequest(
   }
 
   client
-    .sendRequest('workspace/executeCommand', {
+    .sendRequest(vscode_lsp.ExecuteCommandRequest.type, {
       command,
       arguments: args,
+    })
+    .catch((error) => {
+      return client.handleFailedRequest(
+        vscode_lsp.ExecuteCommandRequest.type,
+        undefined,
+        error,
+        undefined
+      );
     })
     .catch((e) => {
       console.error('Failed to execute lsp command', e);
     });
 }
 
-function registerLspCommand(
+const getLSPCommandParams = () => {
+  const editor = calva_utils.getActiveTextEditor();
+  const document = calva_utils.tryToGetDocument(editor.document);
+  if (!document || document.languageId !== 'clojure') {
+    return;
+  }
+
+  const line = editor.selection.start.line;
+  const column = editor.selection.start.character;
+  const doc_uri = `${document.uri.scheme}://${document.uri.path}`;
+  return [doc_uri, line, column];
+};
+
+function registerUserspaceLspCommand(
   clients: defs.LSPClientMap,
   command: ClojureLspCommand
 ): vscode.Disposable {
@@ -71,18 +93,26 @@ function registerLspCommand(
     m.substring(1).toUpperCase()
   )}`;
   return vscode.commands.registerCommand(vscodeCommand, async () => {
-    const editor = calva_utils.getActiveTextEditor();
-    const document = calva_utils.tryToGetDocument(editor.document);
-    if (document && document.languageId === 'clojure') {
-      const line = editor.selection.start.line;
-      const column = editor.selection.start.character;
-      const docUri = `${document.uri.scheme}://${document.uri.path}`;
-      const params = [docUri, line, column];
-      const extraParam = command.extraParamFn ? await command.extraParamFn() : undefined;
-      if (!command.extraParamFn || (command.extraParamFn && extraParam)) {
-        sendCommandRequest(clients, command.command, extraParam ? [...params, extraParam] : params);
-      }
+    const params = getLSPCommandParams();
+    if (!params) {
+      return;
     }
+
+    const extraParam = command.extraParamFn ? await command.extraParamFn() : undefined;
+    if (command.extraParamFn && !extraParam) {
+      return;
+    }
+
+    sendCommandRequest(clients, command.command, extraParam ? [...params, extraParam] : params);
+  });
+}
+
+function registerInternalLspCommand(
+  clients: defs.LSPClientMap,
+  command: ClojureLspCommand
+): vscode.Disposable {
+  return vscode.commands.registerCommand(command.command, async (...args) => {
+    sendCommandRequest(clients, command.command, args);
   });
 }
 
@@ -124,51 +154,46 @@ export function registerLspCommands(clients: defs.LSPClientMap) {
   ];
 
   const clojureLspCommands: ClojureLspCommand[] = [
-    {
-      command: 'clean-ns',
-    },
-    {
-      command: 'add-missing-libspec',
-    },
-    // This seems to be similar to Calva's rewrap commands
-    //{
-    //    command: 'cycle-coll'
-    //},
-    {
-      command: 'cycle-privacy',
-    },
-    {
-      command: 'drag-backward',
-      category: 'clojureLsp',
-    },
-    {
-      command: 'drag-forward',
-      category: 'clojureLsp',
-    },
-    {
-      command: 'expand-let',
-    },
-    {
-      command: 'thread-first',
-    },
-    {
-      command: 'thread-first-all',
-    },
-    {
-      command: 'thread-last',
-    },
-    {
-      command: 'thread-last-all',
-    },
-    {
-      command: 'inline-symbol',
-    },
-    {
-      command: 'unwind-all',
-    },
-    {
-      command: 'unwind-thread',
-    },
+    { command: 'add-import-to-namespace' },
+    { command: 'add-missing-import' },
+    { command: 'add-missing-libspec' },
+    { command: 'add-require-suggestion' },
+    { command: 'change-coll' },
+    { command: 'clean-ns' },
+    { command: 'create-function' },
+    { command: 'create-test' },
+    { command: 'cycle-coll' },
+    { command: 'cycle-keyword-auto-resolve' },
+    { command: 'cycle-privacy' },
+    { command: 'demote-fn' },
+    { command: 'destructure-keys' },
+    { command: 'drag-backward', category: 'clojureLsp' },
+    { command: 'drag-forward', category: 'clojureLsp' },
+    { command: 'drag-param-backward' },
+    { command: 'drag-param-forward' },
+    { command: 'expand-let' },
+    { command: 'extract-to-def' },
+    { command: 'get-in-all' },
+    { command: 'get-in-less' },
+    { command: 'get-in-more' },
+    { command: 'get-in-none' },
+    { command: 'inline-symbol' },
+    { command: 'move-coll-entry-down' },
+    { command: 'move-coll-entry-up' },
+    { command: 'move-form' },
+    { command: 'promote-fn' },
+    { command: 'resolve-macro-as' },
+    { command: 'restructure-keys' },
+    { command: 'sort-clauses' },
+    { command: 'sort-map' },
+    { command: 'suppress-diagnostic' },
+    { command: 'thread-first' },
+    { command: 'thread-first-all' },
+    { command: 'thread-last' },
+    { command: 'thread-last-all' },
+    { command: 'unwind-all' },
+    { command: 'unwind-thread' },
+
     {
       command: 'introduce-let',
       extraParamFn: makePromptForInput('Bind to'),
@@ -193,7 +218,19 @@ export function registerLspCommands(clients: defs.LSPClientMap) {
       });
     }),
 
-    ...clojureLspCommands.map((command) => registerLspCommand(clients, command)),
+    ...clojureLspCommands.map((command) => registerUserspaceLspCommand(clients, command)),
+
+    /**
+     * The clojure-lsp server previously used to dynamically register all of these top-level commands however that behaviour was
+     * disabled to add support for provisioning multiple lsp clients in the same vscode window. The built-in behaviour resulted
+     * in command registration conflicts.
+     *
+     * There are several vscode operations (such as organise-imports) which are bound to execute these internal lsp commands which
+     * would no longer function if these commands are not correctly registered (as they used to be).
+     *
+     * We therefore manually register them here with added support for selecting the appropriate active lsp client on execution.
+     */
+    ...clojureLspCommands.map((command) => registerInternalLspCommand(clients, command)),
   ];
 }
 

--- a/src/lsp/commands/lsp-commands.ts
+++ b/src/lsp/commands/lsp-commands.ts
@@ -111,7 +111,7 @@ function registerInternalLspCommand(
   clients: defs.LSPClientMap,
   command: ClojureLspCommand
 ): vscode.Disposable {
-  return vscode.commands.registerCommand(command.command, async (...args) => {
+  return vscode.commands.registerCommand(command.command, (...args) => {
     sendCommandRequest(clients, command.command, args);
   });
 }

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -86,6 +86,14 @@ export function excludePattern(moreExcludes: string[] = []) {
   return `**/{${[...moreExcludes, ...config.getConfig().projectRootsSearchExclude].join(',')}}/**`;
 }
 
+export async function isValidClojureProject(uri: vscode.Uri) {
+  return findProjectRootsWithReasons().then((roots) => {
+    return !!roots.find((root) => {
+      return uri.path === root.uri.path && root.valid_project;
+    });
+  });
+}
+
 function findMatchingParent(
   from: vscode.Uri,
   uris: vscode.Uri[],

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -61,7 +61,7 @@ export async function findProjectRootsWithReasons(params?: FindRootParams) {
     const dir = uri.with({ path: path.dirname(uri.fsPath) });
     return {
       uri: dir,
-      label: getPathRelativeToWorkspace(uri),
+      label: getPathRelativeToWorkspace(dir),
       reason: path.basename(uri.path),
       valid_project: true,
     };

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -164,19 +164,20 @@ const groupsToChoices = (groups: vscode.Uri[][]) => {
   }, []);
 };
 
+function groupContainsUri(uris: vscode.Uri[], uri: vscode.Uri) {
+  return !!uris.find((next) => next.path === uri.path);
+}
+
 function sortPreSelectedFirst(groups: vscode.Uri[][], selected: vscode.Uri) {
   // First sort the groups, bringing the group containing the preselected item to the top.
   const sorted_groups = groups.sort((a, b) => {
     if (!selected) {
       return 0;
     }
-    function groupContainsUri(uris: vscode.Uri[]) {
-      return !!uris.find((uri) => uri.path === selected.path);
-    }
-    if (groupContainsUri(a)) {
+    if (groupContainsUri(a, selected)) {
       return -1;
     }
-    if (groupContainsUri(b)) {
+    if (groupContainsUri(b, selected)) {
       return 1;
     }
     return 0;

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -1,20 +1,23 @@
 import * as config from './config';
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as _ from 'lodash';
 
 export type ProjectRoot = {
   uri: vscode.Uri;
+  label: string;
   reason: string;
 
   workspace_root?: boolean;
   valid_project?: boolean;
 };
 
-export const rootToUri = (root_or_uri: ProjectRoot | vscode.Uri) => {
-  if (root_or_uri instanceof vscode.Uri) {
-    return root_or_uri;
+export const getPathRelativeToWorkspace = (uri: vscode.Uri) => {
+  const root = vscode.workspace.getWorkspaceFolder(uri);
+  if (!root) {
+    return uri.path;
   }
-  return root_or_uri.uri;
+  return path.relative(path.dirname(root.uri.path), uri.path);
 };
 
 type FindRootParams = {
@@ -46,6 +49,7 @@ export async function findProjectRootsWithReasons(params?: FindRootParams) {
     const wsRootPaths = vscode.workspace.workspaceFolders.map((f) => {
       return {
         uri: f.uri,
+        label: path.basename(f.uri.path),
         reason: 'Workspace Root',
         workspace_root: true,
       };
@@ -57,6 +61,7 @@ export async function findProjectRootsWithReasons(params?: FindRootParams) {
     const dir = uri.with({ path: path.dirname(uri.fsPath) });
     return {
       uri: dir,
+      label: getPathRelativeToWorkspace(uri),
       reason: path.basename(uri.path),
       valid_project: true,
     };
@@ -131,41 +136,100 @@ export function findFurthestParent(from: vscode.Uri, uris: vscode.Uri[]) {
   });
 }
 
-export async function pickProjectRoot(
-  uris: Array<vscode.Uri | ProjectRoot>,
-  selected?: vscode.Uri
-) {
+const groupByProject = (uris: vscode.Uri[]) => {
+  return Object.values(
+    _.groupBy(uris, (uri) => {
+      return vscode.workspace.getWorkspaceFolder(uri)?.uri.path;
+    })
+  );
+};
+
+const groupsToChoices = (groups: vscode.Uri[][]) => {
+  return groups.reduce((choices: (vscode.QuickPickItem & { value?: vscode.Uri })[], uris) => {
+    choices.push({
+      kind: vscode.QuickPickItemKind.Separator,
+      label: 'Workspace Root',
+    });
+
+    const items = uris.map((uri) => {
+      return {
+        label: getPathRelativeToWorkspace(uri),
+        value: uri,
+      };
+    });
+
+    choices.push(...items);
+
+    return choices;
+  }, []);
+};
+
+function sortPreSelectedFirst(groups: vscode.Uri[][], selected: vscode.Uri) {
+  // First sort the groups, bringing the group containing the preselected item to the top.
+  const sorted_groups = groups.sort((a, b) => {
+    if (!selected) {
+      return 0;
+    }
+    function groupContainsUri(uris: vscode.Uri[]) {
+      return !!uris.find((uri) => uri.path === selected.path);
+    }
+    if (groupContainsUri(a)) {
+      return -1;
+    }
+    if (groupContainsUri(b)) {
+      return 1;
+    }
+    return 0;
+  });
+
+  // Next sort the items within each group, first attempting to bring the preselected item to the top and then
+  // falling back to sorting by path length
+  return sorted_groups.map((group) => {
+    const [root, ...remaining] = group;
+
+    const sorted = remaining.sort((a, b) => {
+      // Try bring the pre-selected entry to the top
+      if (selected) {
+        if (a.path === selected.path) {
+          return -1;
+        }
+        if (b.path === selected.path) {
+          return 1;
+        }
+      }
+
+      // Fall back to sorting by length
+      if (a.path < b.path) {
+        return -1;
+      }
+      if (a.path > b.path) {
+        return 1;
+      }
+
+      return 0;
+    });
+
+    return [root, ...sorted];
+  });
+}
+
+export async function pickProjectRoot(uris: vscode.Uri[], selected?: vscode.Uri) {
   if (uris.length === 0) {
     return;
   }
   if (uris.length === 1) {
-    return rootToUri(uris[0]);
+    return uris[0];
   }
 
-  const sorted = sortPreSelectedFirst(uris, selected);
-
-  const project_root_options = sorted.map((root_or_uri) => {
-    let uri;
-    let reason;
-    if (root_or_uri instanceof vscode.Uri) {
-      uri = root_or_uri;
-    } else {
-      uri = root_or_uri.uri;
-      reason = root_or_uri.reason;
-    }
-    return {
-      label: uri.path,
-      detail: reason,
-      picked: uri.path === selected?.path,
-      value: uri,
-    };
-  });
+  const grouped = groupByProject(uris);
+  const sorted = sortPreSelectedFirst(grouped, selected);
+  const choices = groupsToChoices(sorted);
 
   const picker = vscode.window.createQuickPick();
-  picker.items = project_root_options;
+  picker.items = choices;
   picker.title = 'Project Selection';
   picker.placeholder = 'Pick the Clojure project you want to use as the root';
-  picker.activeItems = project_root_options.filter((root) => root.label === selected?.path);
+  picker.activeItems = choices.filter((root) => root.value?.path === selected?.path);
   picker.show();
 
   const selected_root = await new Promise<any>((resolve) => {
@@ -178,17 +242,4 @@ export async function pickProjectRoot(
   picker.dispose();
 
   return selected_root?.value;
-}
-
-function sortPreSelectedFirst(uris: (ProjectRoot | vscode.Uri)[], selected: vscode.Uri) {
-  return [...uris].sort((a, b) => {
-    if (!selected) {
-      return 0;
-    }
-    return rootToUri(a).fsPath === selected.fsPath
-      ? -1
-      : rootToUri(b).fsPath === selected.fsPath
-      ? 1
-      : 0;
-  });
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -161,13 +161,10 @@ function getProjectWsFolder(): vscode.WorkspaceFolder | undefined {
  * Figures out the current clojure project root, and stores it in Calva state
  */
 export async function initProjectDir() {
-  const candidatePaths = await projectRoot.findProjectRootsWithReasons();
+  const candidatePaths = await projectRoot.findProjectRoots();
   const active_uri = vscode.window.activeTextEditor?.document.uri;
   const closestRootPath: vscode.Uri = active_uri
-    ? projectRoot.findClosestParent(
-        active_uri,
-        candidatePaths.map((path) => path.uri)
-      )
+    ? projectRoot.findClosestParent(active_uri, candidatePaths)
     : undefined;
   const projectRootPath: vscode.Uri = await projectRoot.pickProjectRoot(
     candidatePaths,


### PR DESCRIPTION
This is a collection of fixes which should resolve the regressions and issues reported as a result of #2020.

- When using the `"when-workspace-opened-use-workspace-root"` setting the clojure-lsp server is only started in valid clojure workspaces.
- Ensures that operations like `Organise Imports` continue to work. This was an unforeseen  side-effect of disabling the dynamic lsp command registrations the client was performing. This default behaviour is still disabled, but now we manually register the commands (once) and augment them with support for selecting the correct lsp client to forward the request to.
- The project selection menus have been cleaned up and had some behavioural tweaks. See below:

### Project Menus

There were a few changes made to the project menus:

- The second line containing `details` on why the project was considered has been removed.
- Projects are now grouped by their workspace root which should help make it easier to sort through the list visually.
- Project folders are now sorted within their groups to make the list more deterministic.
- Project folders show the path relative to the workspace root instead of the absolute path. This should help make scanning the list easier by removing unnecessary/duplicate information.

When sorting projects the behaviour is as follows:

- The workspace group containing the preselected project is sorted to the top.
- The projects within each group are sorted such that the workspace root is first, the preselected item is second and then the remaining items are sorted by path length.

<img width="1478" alt="image" src="https://user-images.githubusercontent.com/8571121/215552381-c401f929-5031-44bb-8582-17b237861bc2.png">

# Checklist

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
  - [ ] Smoke tested the extension as such.
  - [ ] Tested the VSIX built from the PR (so, after you've submitted the PR). You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [ ] Created the issue I am fixing/addressing, if it was not present.
- [ ] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [ ] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik