### PR TITLE
Remove setting for deprecated Clojure CLI aliases flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Bump npm deps [jszip](https://github.com/BetterThanTomorrow/calva/pull/2056), [http-cache-semantics](https://github.com/BetterThanTomorrow/calva/pull/2059)
+- Fix: [Missing required argument for "-M ALIASES"](https://github.com/BetterThanTomorrow/calva/issues/2039)
 
 ## [2.0.330] - 2023-02-03
 

--- a/package.json
+++ b/package.json
@@ -370,11 +370,6 @@
           "calva.customCljsRepl": {
             "deprecationMessage": "This settings is deprecated. Use `cljsType` in a `calva.replConnectSequences` item instead."
           },
-          "calva.jackIn.useDeprecatedAliasFlag": {
-            "type": "boolean",
-            "default": false,
-            "markdownDescription": "Use the `-A` flag instead of `-M` for Clojure CLI versions < `1.10.697`."
-          },
           "calva.jackInEnv": {
             "type": "object",
             "default": {},

--- a/src/config.ts
+++ b/src/config.ts
@@ -214,9 +214,6 @@ function getConfig() {
       'strictPreventUnmatchedClosingBracket'
     ),
     showCalvaSaysOnStart: configOptions.get<boolean>('showCalvaSaysOnStart'),
-    jackIn: {
-      useDeprecatedAliasFlag: configOptions.get<boolean>('jackIn.useDeprecatedAliasFlag'),
-    },
     enableClojureLspOnStart: configOptions.get<boolean>('enableClojureLspOnStart'),
     projectRootsSearchExclude: configOptions.get<string[]>('projectRootsSearchExclude', []),
     useLiveShare: configOptions.get<boolean>('useLiveShare'),

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -575,7 +575,7 @@ async function cljCommandLine(connectSequence: ReplConnectSequence, cljsType: Cl
   };
   const useMiddleware = [...middleware, ...(cljsType ? cljsMiddleware[cljsType] : [])];
 
-  const aliasesFlag = getConfig().jackIn.useDeprecatedAliasFlag ? ['-A', ''] : ['-M', '-M'];
+  const aliasesFlag = getStateValue('isClojureCLIVersionAncient') ? ['-A', ''] : ['-M', '-M'];
   const aliasesOption =
     aliases.length > 0 ? `${aliasesFlag[0]}${aliases.join('')}` : aliasesFlag[1];
   const q = isWin ? '"' : "'";


### PR DESCRIPTION
## What has changed?

Instead of the setting we now check the version of the installed `clojure` executable and use the old command line flag if so.

* Closes #2039

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Smoke tested the extension as such.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
