### PR TITLE
Make indenter ignore regex rules for keywords (like cljfmt does)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Bump npm deps [jszip](https://github.com/BetterThanTomorrow/calva/pull/2056), [http-cache-semantics](https://github.com/BetterThanTomorrow/calva/pull/2059)
+- Fix: [Indenter and formatter do not agree on keyword in function position when regex indent rules are involved](https://github.com/BetterThanTomorrow/calva/issues/2044)
 
 ## [2.0.330] - 2023-02-03
 

--- a/src/extension-test/unit/formatting-test.ts
+++ b/src/extension-test/unit/formatting-test.ts
@@ -23,9 +23,9 @@ describe('formatter, indenter and paredit comparison', () => {
 
   configs.forEach((config) => {
     it(`correctly formats 'and' form with formatter, indenter and paredit using config: ${config['cljfmt-options-string']}`, () => {
-      const formatterIndent = getFormatterIndent('(and x\ny)', 7, config);
+      const formatterIndent = getFormatterIndent('(and x\n|y)', config);
       const indenterIndent = getIndenterIndent('(and x\n|y)', config);
-      const pareditIndent = getPareditIndent('(and x\n\n  |y)', 10, config);
+      const pareditIndent = getPareditIndent('(and x\n\n  |y)', config);
 
       expect(formatterIndent).toEqual(indenterIndent);
       expect(formatterIndent).toEqual(pareditIndent);
@@ -34,18 +34,23 @@ describe('formatter, indenter and paredit comparison', () => {
 });
 
 function getIndenterIndent(form: string, config: ReturnType<typeof mkConfig>) {
-  const indenterDoc = docFromTextNotation(form);
-  return indent.getIndent(indenterDoc.model, textAndSelection(indenterDoc)[1][0], config);
+  const doc = docFromTextNotation(form);
+  const p = textAndSelection(doc)[1][0];
+  return indent.getIndent(doc.model, p, config);
 }
 
-function getFormatterIndent(form: string, cursor: number, config: ReturnType<typeof mkConfig>) {
-  const formatterResult = formatIndex(form, [0, form.length], cursor, '\n', false, config);
+function getFormatterIndent(notation: string, config: ReturnType<typeof mkConfig>) {
+  const doc = docFromTextNotation(notation);
+  const form = textAndSelection(doc)[0];
+  const p = textAndSelection(doc)[1][0];
+  const formatterResult = formatIndex(form, [0, notation.length], p, '\n', false, config);
   return formatterResult['new-index'] - formatterResult.idx;
 }
 
-function getPareditIndent(form: string, cursor: number, config: ReturnType<typeof mkConfig>) {
-  const pareditDoc = docFromTextNotation(form);
-  return backspaceOnWhitespace(pareditDoc, pareditDoc.getTokenCursor(cursor), config).indent;
+function getPareditIndent(notation: string, config: ReturnType<typeof mkConfig>) {
+  const doc = docFromTextNotation(notation);
+  const p = textAndSelection(doc)[1][0];
+  return backspaceOnWhitespace(doc, doc.getTokenCursor(p), config).indent;
 }
 
 function mkConfig(rules: indent.IndentRules, rulesString: string) {

--- a/src/extension-test/unit/formatting-test.ts
+++ b/src/extension-test/unit/formatting-test.ts
@@ -15,20 +15,39 @@ describe('formatter, indenter and paredit comparison', () => {
     ),
     mkConfig(
       {
+        '/\\S+/': [['block', 0]],
+      },
+      '{:indents {#"\\S+" [[:block 0]]}}'
+    ),
+    mkConfig(
+      {
         '/\\S+/': [['inner', 1]],
       },
       '{:indents {#"\\S+" [[:inner 1]]}}'
     ),
   ];
 
-  configs.forEach((config) => {
-    it(`correctly formats 'and' form with formatter, indenter and paredit using config: ${config['cljfmt-options-string']}`, () => {
-      const formatterIndent = getFormatterIndent('(and x\n|y)', config);
-      const indenterIndent = getIndenterIndent('(and x\n|y)', config);
-      const pareditIndent = getPareditIndent('(and x\n\n  |y)', config);
+  describe('indents `and` form the same with formatter, indenter, and paredit', () => {
+    configs.forEach((config) => {
+      it(`indents 'and' form the same with formatter, indenter, and paredit, using config: ${config['cljfmt-options-string']}`, () => {
+        const formatterIndent = getFormatterIndent('(and x\n|y)', config);
+        const indenterIndent = getIndenterIndent('(and x\n|y)', config);
+        const pareditIndent = getPareditIndent('(and x\n\n  |y)', config);
+        expect(formatterIndent).toEqual(indenterIndent);
+        expect(formatterIndent).toEqual(pareditIndent);
+      });
+    });
+  });
 
-      expect(formatterIndent).toEqual(indenterIndent);
-      expect(formatterIndent).toEqual(pareditIndent);
+  describe('indents keyword form the same with formatter, indenter and paredit', () => {
+    configs.forEach((config) => {
+      it(`indents keyword form the same with formatter, indenter, and paredit, using config: ${config['cljfmt-options-string']}`, () => {
+        const formatterIndent = getFormatterIndent('(:kw x\n|y)', config);
+        const indenterIndent = getIndenterIndent('(:kw x\n|y)', config);
+        const pareditIndent = getPareditIndent('(:kw x\n\n  |y)', config);
+        expect(formatterIndent).toEqual(indenterIndent);
+        expect(formatterIndent).toEqual(pareditIndent);
+      });
     });
   });
 });

--- a/src/util/regex.ts
+++ b/src/util/regex.ts
@@ -1,6 +1,11 @@
 import { trim } from 'lodash';
 
 export const testCljOrJsRegex = (regexp: string, str: string) => {
+  if (str.startsWith(':')) {
+    // We don't want to match keywords
+    // https://github.com/weavejester/cljfmt/issues/298
+    return false;
+  }
   const clojureReMatches = regexp.match(/^#"(.*)"$/);
   const normalizedRe =
     (clojureReMatches && RegExp(clojureReMatches[1])) || RegExp(trim(regexp, '/'));


### PR DESCRIPTION
## What has changed?

**cljfmt** does not apply custom indenter rules to keywords. So our indenter shouldn't either, or we will be conflicting with our formatter.

* See: https://github.com/weavejester/cljfmt/issues/298
* Fixes #2044

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
