### PR TITLE
Jack-in without prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Establish REPL connection without being prompted for the kind of project every time](https://github.com/BetterThanTomorrow/calva/issues/2049)
+
 ## [2.0.331] - 2023-02-05
 
 - Bump npm deps [jszip](https://github.com/BetterThanTomorrow/calva/pull/2056), [http-cache-semantics](https://github.com/BetterThanTomorrow/calva/pull/2059)
@@ -27,6 +29,7 @@ Changes to Calva.
 - Calva development, Fix: [We build Calva twice in CI](https://github.com/BetterThanTomorrow/calva/issues/2052)
 
 ## [2.0.328] - 2023-01-27
+
 - Rollback of 2.0.327, first part of: [Regressions introduced with clojure-lsp multi-project support in 2.0.327](https://github.com/BetterThanTomorrow/calva/issues/2041)
 
 ## [2.0.327] - 2023-01-27

--- a/docs/site/connect.md
+++ b/docs/site/connect.md
@@ -70,6 +70,23 @@ All this said, I still recommend you challenge the conclusion that you can't use
 
 If your project is setup so that the REPL server is started by the application code, you will need to get the cider-nrepl middleware in place. See the cider-nrepl docs about [embedding nREPL in your application](https://docs.cider.mx/cider-nrepl/usage.html#via-embedding-nrepl-in-your-application).
 
+## Auto-select Project Type
+
+You can make both Jack-in and Connect stop prompting you for project type in projects where you always want to use the same. The setting `calva.autoSelectReplConnectProjectType` is used for this. Here's how to use it:
+
+1. Connect the REPL and manually select the project type/connect sequence you want to use.
+1. In the Output/REPL window Calva will print about auto-selecting project type, including the value you need. **Copy this value**
+1. In VS Code Settings, search for ”Calva auto” and you will find the setting
+1. Make sure you are editing Workspace settings
+1. **Paste the project type value you copied above**
+
+Next time you connect the REPL, Calva will use this value and the project type prompt will not be shown.
+
+To make Calva prompt for the project type, reset this setting (there's a cog icon there giving you an option to do this).
+
+!!! Or edit Workspace Settings JSON
+    You can of course also edit this setting manually in `.vscode/settings.json` for the workspace. ”Reset” is then equivalent to removing the setting from this file.
+
 ## Monorepos / multiple Clojure projects in one workspace
 
 If the workspace is a monorepo, Polylith repo or just a repository with more than one Clojure project, Calva will start the connect sequence with prompting for which project to start/connect to.

--- a/package.json
+++ b/package.json
@@ -375,10 +375,10 @@
             "default": {},
             "description": "Specifies any environment variables your project needs. (Probably mostly for your Workspace Settings.)"
           },
-          "calva.jackInProjectType": {
+          "calva.autoSelectReplConnectProjectType": {
             "type": "string",
             "default": null,
-            "description": "Specifies the project type for Jack-in by default. (Probably mostly for your Workspace Settings.)"
+            "description": "When set Calva will not prompt for a project type, at Jack-in or Connect. Instead the project name specified here will be used. (Probably mostly for your Workspace Settings.)"
           },
           "calva.jackInDependencyVersions": {
             "type": "object",

--- a/package.json
+++ b/package.json
@@ -375,6 +375,11 @@
             "default": {},
             "description": "Specifies any environment variables your project needs. (Probably mostly for your Workspace Settings.)"
           },
+          "calva.jackInProjectType": {
+            "type": "string",
+            "default": null,
+            "description": "Specifies the project type for Jack-in by default. (Probably mostly for your Workspace Settings.)"
+          },
           "calva.jackInDependencyVersions": {
             "type": "object",
             "description": "Versions of the dependencies injected by Calva Jack-in",

--- a/src/config.ts
+++ b/src/config.ts
@@ -224,7 +224,7 @@ function getConfig() {
   };
 }
 
-type Config = ReturnType<typeof getConfig>;
+export type Config = ReturnType<typeof getConfig>;
 
 async function updateWorkspaceConfig<T extends keyof Config>(section: T, value: Config[T]) {
   return vscode.workspace.getConfiguration('calva').update(section, value);

--- a/src/config.ts
+++ b/src/config.ts
@@ -220,8 +220,14 @@ function getConfig() {
     definitionProviderPriority: configOptions.get<string[]>('definitionProviderPriority'),
     depsEdnJackInExecutable: configOptions.get<string>('depsEdnJackInExecutable'),
     depsCljPath: configOptions.get<string>('depsCljPath'),
-    jackInProjectType: configOptions.get<string>('jackInProjectType'),
+    autoSelectReplConnectProjectType: configOptions.get<string>('autoSelectReplConnectProjectType'),
   };
+}
+
+type Config = ReturnType<typeof getConfig>;
+
+async function updateWorkspaceConfig<T extends keyof Config>(section: T, value: Config[T]) {
+  return vscode.workspace.getConfiguration('calva').update(section, value);
 }
 
 export {
@@ -235,4 +241,5 @@ export {
   documentSelector,
   ReplSessionType,
   getConfig,
+  updateWorkspaceConfig,
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -220,6 +220,7 @@ function getConfig() {
     definitionProviderPriority: configOptions.get<string[]>('definitionProviderPriority'),
     depsEdnJackInExecutable: configOptions.get<string>('depsEdnJackInExecutable'),
     depsCljPath: configOptions.get<string>('depsCljPath'),
+    jackInProjectType: configOptions.get<string>('jackInProjectType'),
   };
 }
 

--- a/src/extension-test/integration/suite/jack-in-test.ts
+++ b/src/extension-test/integration/suite/jack-in-test.ts
@@ -11,6 +11,7 @@ import * as outputWindow from '../../../results-output/results-doc';
 import { commands } from 'vscode';
 import { getDocument } from '../../../doc-mirror';
 import * as projectRoot from '../../../project-root';
+import { updateWorkspaceConfig } from '../../../config';
 
 // TODO: Add more smoke tests for the extension
 // TODO: Start building integration test coverage
@@ -23,7 +24,7 @@ suite('Jack-in suite', () => {
   });
 
   after(async () => {
-    await vscode.workspace.getConfiguration('calva').update('jackInProjectType', null);
+    await updateWorkspaceConfig('autoSelectReplConnectProjectType', null);
     testUtil.showMessage(suite, `suite done!`);
   });
 
@@ -56,7 +57,7 @@ suite('Jack-in suite', () => {
   test('Jack-in works with pre-configured project type', async () => {
     testUtil.log(suite, 'start repl and connect (jack-in)');
 
-    await vscode.workspace.getConfiguration('calva').update('jackInProjectType', 'deps.edn');
+    await updateWorkspaceConfig('autoSelectReplConnectProjectType', 'deps.edn');
 
     await startJackInProcedure(suite, 'calva.jackIn', 'Leiningen');
 

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -368,7 +368,7 @@ function getDefaultSequence(
       return defaultSequence;
     } else {
       void vscode.window.showInformationMessage(
-        `No such project "${defaultProject}" available for Jack-in, please check your config.`
+        `No such project type - "${defaultProject}" - available for jack-in. Please check your settings.`
       );
     }
   }

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -358,7 +358,7 @@ function getDefaultSequence(
 
     if (defaultSequence) {
       void vscode.window.showInformationMessage(
-        `Used "${defaultSequence.name}" as a default project for Jack-in.`
+        `Used "${defaultSequence.name}" as a default project type for jack-in.`
       );
       void state.extensionContext.workspaceState.update(
         `d-${saveAsPath}`,

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -328,7 +328,8 @@ function getConnectSequences(projectTypes: string[]): ReplConnectSequence[] {
 
 async function askToSetDefaultProjectForJackIn(project: string) {
   const setAsDefault = await utilities.showBooleanInformationMessage(
-    `Do you want to set "${project}" as the jack-in project type for the current workspace?`
+    `Do you want to set "${project}" as the jack-in project type for the current workspace?`,
+    'autoSelectReplConnectProjectTypeNotShow'
   );
 
   if (setAsDefault) {

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -288,12 +288,15 @@ const defaultCljsTypes: { [id: string]: CljsTypeConfig } = {
 const autoSelectProjectTypeSetting: `calva.${keyof Config}` =
   'calva.autoSelectReplConnectProjectType';
 
+const autoSelectDocLink = `  - See https://calva.io/connect/#auto-select-project-type`;
+
 const defaultProjectSettingMsg = (project: string) =>
   formatAsLineComments(
     [
-      `If you want to set the selected project type as the default for the current workspace`,
-      `please add this setting to your .vscode/settings.json file:`,
-      `  "${autoSelectProjectTypeSetting}": "${project}"`,
+      `Connecting using "${project}" project type.`,
+      `You can make Calva auto-select this:`,
+      `"${autoSelectProjectTypeSetting}": "${project}"`,
+      autoSelectDocLink,
       '\n',
     ].join('\n')
   );
@@ -369,9 +372,9 @@ function getUserSpecifiedSequence(
       outputWindow.appendLine(
         formatAsLineComments(
           [
-            `Used "${defaultSequence.name}" as a default for jack-in.`,
-            `If you want to change it, please remove "${autoSelectProjectTypeSetting}"`,
-            `  from settings.json and re-run the jack-in command.`,
+            `Auto-selecting project type "${defaultSequence.name}".`,
+            `You can change this from settings:`,
+            autoSelectDocLink,
             '\n',
           ].join('\n')
         )
@@ -386,8 +389,9 @@ function getUserSpecifiedSequence(
       outputWindow.appendLine(
         formatAsLineComments(
           [
-            `No such project type - "${userSpecifiedProjectType}" - available for jack-in.`,
-            `Please check your "${autoSelectProjectTypeSetting}" settings.`,
+            `Project type "${userSpecifiedProjectType}" not found.`,
+            `You need to update the auto-select setting.`,
+            autoSelectDocLink,
             '\n',
           ].join('\n')
         )

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -327,7 +327,7 @@ function getConnectSequences(projectTypes: string[]): ReplConnectSequence[] {
 
 async function askToSetDefaultProjectForJackIn(project: string) {
   const setAsDefault = await utilities.showBooleanInformationMessage(
-    `Do you want to set "${project}" as a default Jack-in project type for the current workspace?`
+    `Do you want to set "${project}" as the jack-in project type for the current workspace?`
   );
 
   if (setAsDefault) {

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import * as state from '../state';
 import * as utilities from '../utilities';
-import { getConfig } from '../config';
+import { getConfig, updateWorkspaceConfig } from '../config';
+import * as outputWindow from '../results-output/results-doc';
 
 enum ProjectTypes {
   'Leiningen' = 'Leiningen',
@@ -331,7 +332,7 @@ async function askToSetDefaultProjectForJackIn(project: string) {
   );
 
   if (setAsDefault) {
-    await vscode.workspace.getConfiguration('calva').update('jackInProjectType', project);
+    await updateWorkspaceConfig('autoSelectReplConnectProjectType', project);
   }
 }
 
@@ -349,7 +350,7 @@ function getDefaultSequence(
   sequences: ReplConnectSequence[],
   saveAsPath: string
 ): ReplConnectSequence | undefined {
-  const defaultProject = getConfig().jackInProjectType;
+  const defaultProject = getConfig().autoSelectReplConnectProjectType;
 
   if (defaultProject) {
     const defaultSequence = sequences.find(
@@ -357,7 +358,7 @@ function getDefaultSequence(
     );
 
     if (defaultSequence) {
-      void vscode.window.showInformationMessage(
+      outputWindow.appendLine(
         `Used "${defaultSequence.name}" as a default project type for jack-in.`
       );
       void state.extensionContext.workspaceState.update(
@@ -367,7 +368,7 @@ function getDefaultSequence(
 
       return defaultSequence;
     } else {
-      void vscode.window.showInformationMessage(
+      outputWindow.appendLine(
         `No such project type - "${defaultProject}" - available for jack-in. Please check your settings.`
       );
     }

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -346,15 +346,15 @@ function getDefaultCljsType(cljsType: string): CljsTypeConfig {
   return defaultCljsTypes[cljsType];
 }
 
-function getDefaultSequence(
+function getUserSpecifiedSequence(
   sequences: ReplConnectSequence[],
   saveAsPath: string
 ): ReplConnectSequence | undefined {
-  const defaultProject = getConfig().autoSelectReplConnectProjectType;
+  const userSpecifiedProjectType = getConfig().autoSelectReplConnectProjectType;
 
-  if (defaultProject) {
+  if (userSpecifiedProjectType) {
     const defaultSequence = sequences.find(
-      (s) => s.name.toLocaleLowerCase() === defaultProject.toLocaleLowerCase()
+      (s) => s.name.toLocaleLowerCase() === userSpecifiedProjectType.toLocaleLowerCase()
     );
 
     if (defaultSequence) {
@@ -369,7 +369,7 @@ function getDefaultSequence(
       return defaultSequence;
     } else {
       outputWindow.appendLine(
-        `No such project type - "${defaultProject}" - available for jack-in. Please check your settings.`
+        `No such project type - "${userSpecifiedProjectType}" - available for jack-in. Please check your settings.`
       );
     }
   }
@@ -386,7 +386,7 @@ async function askForConnectSequence(
   const projectRootUri = state.getProjectRootUri();
   const saveAsPath = projectRootUri ? `${projectRootUri.toString()}/${saveAs}` : saveAs;
 
-  const defaultSequence = getDefaultSequence(sequences, saveAsPath);
+  const defaultSequence = getUserSpecifiedSequence(sequences, saveAsPath);
 
   void state.extensionContext.workspaceState.update('askForConnectSequenceQuickPick', true);
   const projectConnectSequenceName =
@@ -400,9 +400,7 @@ async function askForConnectSequence(
       autoSelect: true,
     }));
 
-  !defaultSequence &&
-    utilities.isNonEmptyString(projectConnectSequenceName) &&
-    void askToSetDefaultProjectForJackIn(projectConnectSequenceName);
+  !defaultSequence && void askToSetDefaultProjectForJackIn(projectConnectSequenceName);
 
   void state.extensionContext.workspaceState.update('askForConnectSequenceQuickPick', false);
   if (!projectConnectSequenceName || projectConnectSequenceName.length <= 0) {

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -400,7 +400,9 @@ async function askForConnectSequence(
       autoSelect: true,
     }));
 
-  !defaultSequence && void askToSetDefaultProjectForJackIn(projectConnectSequenceName);
+  !defaultSequence &&
+    utilities.isNonEmptyString(projectConnectSequenceName) &&
+    void askToSetDefaultProjectForJackIn(projectConnectSequenceName);
 
   void state.extensionContext.workspaceState.update('askForConnectSequenceQuickPick', false);
   if (!projectConnectSequenceName || projectConnectSequenceName.length <= 0) {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -542,8 +542,22 @@ function getActiveTextEditor(): vscode.TextEditor {
   return editor;
 }
 
-async function showBooleanInformationMessage(title: string): Promise<boolean> {
-  const answer = await vscode.window.showInformationMessage(title, 'Yes', 'No');
+async function showBooleanInformationMessage(
+  title: string,
+  doNotShowKey?: string
+): Promise<boolean> {
+  if (state.extensionContext.workspaceState.get<boolean>(doNotShowKey)) {
+    return;
+  }
+  const answer = await vscode.window.showInformationMessage(
+    title,
+    'Yes',
+    'No',
+    'Do not show again'
+  );
+  if (doNotShowKey && answer === 'Do not show again') {
+    void state.extensionContext.workspaceState.update(doNotShowKey, true);
+  }
   return answer === 'Yes';
 }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -543,6 +543,11 @@ function getActiveTextEditor(): vscode.TextEditor {
   return editor;
 }
 
+async function showBooleanInformationMessage(title: string): Promise<boolean> {
+  const answer = await vscode.window.showInformationMessage(title, 'Yes', 'No');
+  return answer === 'Yes';
+}
+
 function pathExists(path: string): boolean {
   return fs.existsSync(path);
 }
@@ -597,4 +602,5 @@ export {
   getActiveTextEditor,
   pathExists,
   calvaTmpDir,
+  showBooleanInformationMessage,
 };

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -53,5 +53,6 @@
         "cljAliases": ["dev", "test"]
       }
     }
-  ]
+  ],
+  "calva.jackInProjectType": null
 }

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -54,5 +54,5 @@
       }
     }
   ],
-  "calva.jackInProjectType": null
+  "calva.autoSelectReplConnectProjectType": null
 }


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.

## What you can expect:

Here are some things we consider before we merge:

- We make sure the PR is directed at the `dev` branch (unless reasons).
- We figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and will help you test there if it is hard for you to do so. (We appreciate a lot if you take on the work do this of course.)
- We read the source changes. (Surprise! 😄)
- We given feedback and guidance on source changes, if needed. Far from everything is captured in our [code guidelines](https://github.com/BetterThanTomorrow/calva/wiki/Coding-Style).
- We use our domain knowledge to try catch if you have missed some facility already provided in the code base.
- We read the updates to the documentation and help with feedback, trying to keep the documentation site serving well.
- We often check out your code changes and test them.
- We sometimes send the VSIX built from the PR out in the `#calva` channel on slack for others to test. (Actually, we will probably encourage you to do this.)
- We sometimes have a chat within the team about particular changes.
- NB: We also consider if your changes belong in the Calva product we want to maintain. Before you spend a lot of work on a PR, please consider chatting us up first, and filing issues.

We try to be speedy and attentive. Please don't hesitate to bump a PR, or contact us, if we seem to have dropped the ball (that has happened).

We use checklists in order to not forget about important lessons we and others have learnt along the way.

-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2049 

Now you can set up the default project for Jack-in via config or after the Jack-in run by click on `Yes`.
I'm not sure that it's great UI/UX but it's pretty simple and the information window doesn't block other input.
<img width="571" alt="Снимок экрана_20230213_203329" src="https://user-images.githubusercontent.com/26674286/218448624-c7b6ab8e-553f-41c2-b420-ae055342437a.png">
<img width="1052" alt="Снимок экрана_20230213_203538" src="https://user-images.githubusercontent.com/26674286/218448639-eeb390f3-4533-42e9-914c-aa0d400253d2.png">
<img width="1052" alt="Снимок экрана_20230213_203621" src="https://user-images.githubusercontent.com/26674286/218448652-f8552ac3-7504-48e0-bff1-f4b0bd7968b6.png">


## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
