### PR TITLE
Rollback clojure-lsp auto-start behaviour default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Rollback clojure-lsp auto-start behaviour default](https://github.com/BetterThanTomorrow/calva/pull/2077)
 - Fix: [clojure-lsp does not start in a workspace without project files](https://github.com/BetterThanTomorrow/calva/issues/2069)
 
 ## [2.0.332] - 2023-02-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- [Rollback clojure-lsp auto-start behaviour default](https://github.com/BetterThanTomorrow/calva/pull/2077)
+- Fix: [Default clojure-lsp startup behaviour is changed since v2.0.327](https://github.com/BetterThanTomorrow/calva/issues/2084)
 - Fix: [clojure-lsp does not start in a workspace without project files](https://github.com/BetterThanTomorrow/calva/issues/2069)
 
 ## [2.0.332] - 2023-02-15

--- a/docs/site/clojure-lsp.md
+++ b/docs/site/clojure-lsp.md
@@ -16,15 +16,20 @@ By default you won't need to install/setup anything as Calva handles that for yo
 
 Calva is able to automatically start the clojure-lsp server for you and can be configured to start the server under various different conditions. These behaviours can be configured through the `calva.enableClojureLspOnStart` setting, which takes the following options:
 
++ "always-use-first-workspace-root"
 + "when-workspace-opened-use-workspace-root"
 + "when-file-opened-use-furthest-project"
 + "never"
 
-#### "when-workspace-opened-use-workspace-root" [default]
+#### "always-use-first-workspace-root" [default]
 
-When set to `"when-workspace-opened-use-workspace-root"` Calva will start the clojure-lsp in the root of all opened vscode workspaces. All Clojure files in a workspace will be serviced by the clojure-lsp server running in that workspace. This behavior requires that you are opening workspaces with a valid Clojure project in the root (the directory must contain a `deps.edn`, `project.clj` or `shadow-cljs.edn` file).
+When set to `"always-use-first-workspace-root"` Calva will attempt to start the clojure-lsp in the root of the first workspace folder if it is a valid clojure project. If it is not a valid clojure project it will fall back to starting the [fallback server](#fallback-server).
 
 This is the default auto-start behaviour.
+
+#### "when-workspace-opened-use-workspace-root"
+
+When set to `"when-workspace-opened-use-workspace-root"` Calva will start the clojure-lsp in the root of all opened vscode workspaces. All Clojure files in a workspace will be serviced by the clojure-lsp server running in that workspace. This behavior requires that you are opening workspaces with a valid Clojure project in the root (the directory must contain a `deps.edn`, `project.clj` or `shadow-cljs.edn` file).
 
 #### "when-file-opened-use-furthest-project"
 

--- a/package.json
+++ b/package.json
@@ -173,14 +173,16 @@
             "enum": [
               "when-workspace-opened-use-workspace-root",
               "when-file-opened-use-furthest-project",
+              "always-use-first-workspace-root",
               "never"
             ],
             "enumDescriptions": [
               "Start clojure-lsp automatically when a workspace containing a Clojure project is opened. The server will be started with its project root set to the workspace root. Best option for many single-Clojure-project workspaces and Polylith-like projects. It is recommended to configure your project so that you can use this option and have only one clojure-lsp server running.",
               "Start clojure-lsp automatically when a Clojure file is opened. The server will be started with its project root set to the project found furthest from the opened file. Use this option if your monorepo has several Clojure projects, but lacks a governing project file at the workspace root.",
+              "Start clojure-lsp automatically in the first workspace root. Use this option to avoid starting multiple lsp servers when multiple independent clojure projects are added as workspace folders",
               "Don't start clojure-lsp automatically. You can always start clojure-lsp at will via the command palette or from the statusbar. Good option in multi-project workspaces where you want to start a clojure-lsp for a particular project. Also useful if you are running on a machine with limited resources, like a Raspberry Pi."
             ],
-            "default": "when-workspace-opened-use-workspace-root"
+            "default": "always-use-first-workspace-root"
           },
           "calva.prettyPrintingOptions": {
             "type": "object",

--- a/src/lsp/config.ts
+++ b/src/lsp/config.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 
 export enum AutoStartBehaviour {
   WorkspaceOpened = 'when-workspace-opened-use-workspace-root',
+  FirstWorkspace = 'always-use-first-workspace-root',
   FileOpened = 'when-file-opened-use-furthest-project',
   Never = 'never',
 }


### PR DESCRIPTION
This reverts the auto-start behaviour back to using the first workspace folder by default.

This is achieved by modifying the `calva.enableClojureLspOnStart` setting to include `"always-use-first-workspace-root"` and sets this as the default. The previous settings and associated behaviours still exist and can be enabled by changing the default.

This new default setting will only ever start a single clojure-lsp server, which will be started in the first workspace folder (or in an os tmp directory if the first workspace folder is not a valid clojure project).

This PR currently bases off of #2076 (and therefore depends on it) in order to take advantage of the tmp directory support, but if we want to inverse the order I can change that. As such, only the last commit here is relevant as the first few commits comes from #2076.

Long term I don't think this should remain the default, instead using the `"when-workspace-opened-use-workspace-root"` as the default - but we can discus changing the default in a future PR.

### Checklist

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [ ] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->