### PR TITLE
Disable fallback lsp server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Monorepo setup working on v2.0.333, broken on v2.0.334](https://github.com/BetterThanTomorrow/calva/issues/2088)
+- Fix: [Calva v2.0.333 is not working for me in VSCode Insiders on Windows 11](https://github.com/BetterThanTomorrow/calva/issues/2087)
+
 ## [2.0.334] - 2023-02-22
 
 - Rollback of 2.0.333, first part of: [Calva v2.0.333 is not working for me in VSCode Insiders on Windows 11](https://github.com/BetterThanTomorrow/calva/issues/2087)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Monorepo setup working on v2.0.333, broken on v2.0.334](https://github.com/BetterThanTomorrow/calva/issues/2088)
-- Fix: [Calva v2.0.333 is not working for me in VSCode Insiders on Windows 11](https://github.com/BetterThanTomorrow/calva/issues/2087)
+- Fix: [Calva v2.0.333 has startup and repl issues on Windows](https://github.com/BetterThanTomorrow/calva/issues/2087)
 
 ## [2.0.334] - 2023-02-22
 

--- a/src/lsp/client/client.ts
+++ b/src/lsp/client/client.ts
@@ -223,7 +223,7 @@ export const createClient = (params: CreateClientParams): defs.LspClient => {
 
   return {
     id: params.id,
-    path: params.uri.path,
+    uri: params.uri,
     client,
     get status() {
       return utils.lspClientStateToStatus(client.state);

--- a/src/lsp/commands/vscode-commands.ts
+++ b/src/lsp/commands/vscode-commands.ts
@@ -27,7 +27,7 @@ type StartHandler = (uri: vscode.Uri) => Promise<void>;
  */
 const startHandler = async (clients: defs.LspClientStore, handler: StartHandler, uri?: string) => {
   if (uri) {
-    await handler(vscode.Uri.parse(uri));
+    await handler(vscode.Uri.file(uri));
     return;
   }
 
@@ -64,9 +64,9 @@ const pickClient = async (clients: defs.LspClientStore) => {
   if (clients.size === 1) {
     return Array.from(clients.keys())[0];
   }
-  const choices = Array.from(clients.keys()).map((uri) => {
+  const choices = Array.from(clients.keys()).map((id) => {
     return {
-      label: uri,
+      label: id,
     };
   });
   const selected_client = await vscode.window.showQuickPick(choices, { title: 'clojure-lsp' });
@@ -103,10 +103,11 @@ const restartHandler = async (
     return;
   }
 
+  const client = clients.get(id);
   await stopClient(clients, id);
   clients.delete(id);
 
-  await startHandler(vscode.Uri.parse(id));
+  await startHandler(client.uri);
 };
 
 async function showServerInfo(clients: defs.LspClientStore, id: string) {
@@ -180,7 +181,7 @@ const manageHandler = async (
       }
 
       return {
-        label: `${icon} ${project_utils.getPathRelativeToWorkspace(vscode.Uri.parse(client.path))}`,
+        label: `${icon} ${project_utils.getPathRelativeToWorkspace(client.uri)}`,
         detail: api.isFallbackClient(client)
           ? 'Fallback client for serving workspaces or files that do not belong to a project'
           : undefined,
@@ -300,7 +301,7 @@ const manageHandler = async (
 
   switch (action.value) {
     case '::start': {
-      void start(vscode.Uri.parse(choice.value));
+      void start(vscode.Uri.file(choice.value));
       return;
     }
     case '::stop': {
@@ -308,10 +309,7 @@ const manageHandler = async (
       return;
     }
     case '::restart': {
-      await stopClient(clients, choice.value);
-      clients.delete(choice.value);
-
-      void start(vscode.Uri.parse(choice.value));
+      void restartHandler(clients, start, choice.value);
       return;
     }
     case '::info': {

--- a/src/lsp/commands/vscode-commands.ts
+++ b/src/lsp/commands/vscode-commands.ts
@@ -11,7 +11,7 @@ export const filterOutRootsWithClients = (
   clients: defs.LspClientStore
 ) => {
   return uris.filter((root) => {
-    const client = clients.get(root.uri.path);
+    const client = clients.get(root.uri.fsPath);
     return !client || !api.clientIsAlive(client);
   });
 };

--- a/src/lsp/definitions.ts
+++ b/src/lsp/definitions.ts
@@ -1,5 +1,6 @@
 // This file contains type definitions related to the language server protocol
 import * as vscode_lsp from 'vscode-languageclient/node';
+import * as vscode from 'vscode';
 
 export interface Position {
   line: number;
@@ -46,7 +47,7 @@ export enum LspStatus {
 
 export type LspClient = {
   id: string;
-  path: string;
+  uri: vscode.Uri;
   client: vscode_lsp.LanguageClient;
   status: LspStatus;
 };

--- a/src/lsp/provider.ts
+++ b/src/lsp/provider.ts
@@ -150,7 +150,15 @@ export const createClientProvider = (params: CreateClientProviderParams) => {
     });
   };
 
+  /**
+   * Provision a fallback lsp client in an OS temp directory to service any clojure files not part of any opened
+   * valid clojure projects.
+   *
+   * This logic has been disabled for now as it does not function correctly on Windows. This can be re-enabled
+   * once support for windows has been added.
+   */
   const provisionFallbackClient = async () => {
+    return;
     const dir = path.join(os.tmpdir(), 'calva-clojure-lsp');
     await fs.mkdir(dir, {
       recursive: true,
@@ -181,10 +189,16 @@ export const createClientProvider = (params: CreateClientProviderParams) => {
 
   const provisionClientInFirstWorkspaceRoot = async () => {
     const folder = vscode.workspace.workspaceFolders[0];
-    if (folder && (await project_utils.isValidClojureProject(folder.uri))) {
-      return provisionClient(folder.uri);
+    if (!folder) {
+      return;
     }
-    return provisionFallbackClient();
+    return provisionClient(folder.uri);
+
+    // TODO: Rather provision fallback client if not a valid clojure project:
+    // if (folder && (await project_utils.isValidClojureProject(folder.uri))) {
+    //   return provisionClient(folder.uri);
+    // }
+    // return provisionFallbackClient();
   };
 
   return {

--- a/src/lsp/provider.ts
+++ b/src/lsp/provider.ts
@@ -101,7 +101,7 @@ export const createClientProvider = (params: CreateClientProviderParams) => {
   };
 
   let lsp_server_path: Promise<string | void> | undefined = undefined;
-  const provisionClient = async (uri: vscode.Uri, id = uri.path) => {
+  const provisionClient = async (uri: vscode.Uri, id = uri.fsPath) => {
     if (lsp_server_path === undefined) {
       lsp_server_path = lsp_client.ensureLSPServer(params.context).catch((err) => {
         console.error('Failed to download lsp server', err);

--- a/src/lsp/provider.ts
+++ b/src/lsp/provider.ts
@@ -163,7 +163,7 @@ export const createClientProvider = (params: CreateClientProviderParams) => {
     await fs.mkdir(dir, {
       recursive: true,
     });
-    return provisionClient(vscode.Uri.parse(dir), api.FALLBACK_CLIENT_ID);
+    return provisionClient(vscode.Uri.file(dir), api.FALLBACK_CLIENT_ID);
   };
 
   const provisionClientForOpenedDocument = async (document: vscode.TextDocument) => {

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -69,9 +69,9 @@ export async function findProjectRootsWithReasons(params?: FindRootParams) {
   }
   const candidateUris = await vscode.workspace.findFiles(projectFilesGlob, excludeDirsGlob, 10000);
   const projectFilePaths = candidateUris.map((uri) => {
-    let dir = vscode.Uri.parse(path.dirname(uri.path));
+    let dir = vscode.Uri.file(path.dirname(uri.path));
     if (lspDirectories.find((file) => uri.path.endsWith(file))) {
-      dir = vscode.Uri.parse(path.join(uri.path, '../..'));
+      dir = vscode.Uri.file(path.join(uri.path, '../..'));
     }
     return {
       uri: dir,


### PR DESCRIPTION
The clojure-lsp fallback server does not seem to work as expected on Windows machines. It's a bit non-deterministic to test as I was sometimes able to get it to work and sometimes not. There definitely seems to be some behavioural differences though.

The function to start the fallback server has now been changed to return early until support for Windows can be safely added.

Additionally the logic for `"always-use-first-workspace-root"` now always starts the lsp server in the first project root instead of starting the fallback server if the first project root is not a valid clojure project.

As much as possible the code for working with the fallback server has been left alone in order to facilitate re-enabling these code-paths once Windows support has been figured out.

---

The issue reported in #2087 talks more about being unable to start the REPL. This I was not able to reproduce at all however my intuition tells me that this was a red herring caused by the Calva extension not booting/initialising (as a result of the fallback server not booting).

The issue with starting the clojure-lsp server in a temp dir _seems_ to be an upstream issue in the clojure-lsp project itself and seems to have something to do with Java path comparisons. See logs:

<details>
<summary>Server Logs</summary>

```
2023-02-22T00:54:25.183Z  INFO [clojure-lsp.server:592] - [SERVER] Starting server...
2023-02-22T00:54:25.185Z  DEBUG [clojure-lsp.nrepl:21] - nrepl not found, skipping nrepl server start...
2023-02-22T00:54:25.187Z  INFO [clojure-lsp.server:483] - Initializing...
2023-02-22T00:54:25.189Z  ERROR [clojure-lsp.db:73] - [DB] No cache DB file found
2023-02-22T00:54:25.189Z  INFO [clojure-lsp.db:66] - [DB] Reading transit analysis cache from \Users\richa\AppData\Local\Temp\calva-clojure-lsp\.lsp\.cache\db.transit.json db took 0ms
2023-02-22T00:54:29.730Z  INFO [clojure-lsp.source-paths:86] - [Startup] Using default source-paths: ["C:\\Users\\richa\\AppData\\Local\\Temp\\calva-clojure-lsp\\src" "C:\\Users\\richa\\AppData\\Local\\Temp\\calva-clojure-lsp\\test"]
2023-02-22T00:54:29.731Z  INFO [clojure-lsp.startup:114] - Copying kondo configs from classpath to project if any...
2023-02-22T00:54:29.732Z  WARN [clojure-lsp.kondo:306] - Non-fatal error from clj-kondo: No configs copied.
2023-02-22T00:54:29.733Z  INFO [clojure-lsp.startup:116] - Copied kondo configs, took 1ms secs.
2023-02-22T00:54:29.733Z  INFO [clojure-lsp.startup:86] - Analyzing classpath for project root #object[sun.nio.fs.WindowsPath 0x20fc3e24 "\\Users\\richa\\AppData\\Local\\Temp\\calva-clojure-lsp"]
2023-02-22T00:54:29.734Z  ERROR [clojure-lsp.server:55] - Error receiving message: Internal error (-32603)
{:id 0, :method "initialize"}
com.oracle.svm.core.windows.WindowsPlatformThreads.osThreadStartRoutine  WindowsPlatformThreads.java:  143
          com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine         PlatformThreads.java:  705
                                                   java.lang.Thread.run                  Thread.java:  829
                     java.util.concurrent.ThreadPoolExecutor$Worker.run      ThreadPoolExecutor.java:  628
                      java.util.concurrent.ThreadPoolExecutor.runWorker      ThreadPoolExecutor.java: 1128
                                                                    ...                                   
                                      clojure.core.async/thread-call/fn                    async.clj:  484
                                           lsp4clj.server.ChanServer/fn                   server.clj:  209
                                         lsp4clj.server/receive-message                   server.clj:  124
                              lsp4clj.server.ChanServer/receive-request                   server.clj:  265
                                lsp4clj.server/pending-received-request                   server.clj:  177
                                                                    ...                                   
                                                  clojure-lsp.server/fn                   server.clj:  493
                                        clojure-lsp.handlers/initialize                 handlers.clj:  133
                                 clojure-lsp.startup/initialize-project                  startup.clj:  224
                        clojure-lsp.startup/analyze-external-classpath!                  startup.clj:   88
                                                       clojure.core/set                     core.clj: 4114
                                                   clojure.core/reduce1                     core.clj:  932
                                                       clojure.core/seq                     core.clj:  139
                                                                    ...                                   
                                                    clojure.core/map/fn                     core.clj: 2770
                     clojure-lsp.startup/analyze-external-classpath!/fn                  startup.clj:   88
                                 clojure-lsp.shared/relativize-filepath                   shared.clj:  288
                                      sun.nio.fs.WindowsPath.relativize             WindowsPath.java:   42
                                      sun.nio.fs.WindowsPath.relativize             WindowsPath.java:  400
java.lang.IllegalArgumentException: 'other' is different type of Path
```
</details>

With `java.lang.IllegalArgumentException: 'other' is different type of Path` seeming to be produced when two paths don't share the same root. My guess is that this has something to do with the omission/inclusion of `C:\` in some of the paths (see below excerpt) though I don't really know. Maybe @ericdallo can add some insight here?

```
2023-02-22T00:54:25.189Z  INFO [clojure-lsp.db:66] - [DB] Reading transit analysis cache from \Users\richa\AppData\Local\Temp\calva-clojure-lsp\.lsp\.cache\db.transit.json db took 0ms
2023-02-22T00:54:29.730Z  INFO [clojure-lsp.source-paths:86] - [Startup] Using default source-paths: ["C:\\Users\\richa\\AppData\\Local\\Temp\\calva-clojure-lsp\\src" "C:\\Users\\richa\\AppData\\Local\\Temp\\calva-clojure-lsp\\test"]
```

Closes https://github.com/BetterThanTomorrow/calva/issues/2088
Fixes https://github.com/BetterThanTomorrow/calva/issues/2087

### Checklist

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - ~[ ] Figured if the change might have some side effects and tested those as well.~
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - ~[ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- ~[ ] Created the issue I am fixing/addressing, if it was not present.~
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).
