### PR TITLE
Return enclosing list also when it's top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Formatting inside top level forms broken since 2.0.337](https://github.com/BetterThanTomorrow/calva/issues/2114)
 - Bump bundled deps.clj to v1.11.1.1257
 
 ## [2.0.338] - 2023-03-15

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -161,8 +161,8 @@ function _calculateFormatRange(
             });
         }
       }
-      return rangeForList;
     }
+    return rangeForList;
   }
 
   const rangeForCurrentForm = cursor.rangeForCurrentForm(index);

--- a/test-data/projects/current-form/src/top_level.clj
+++ b/test-data/projects/current-form/src/top_level.clj
@@ -1,4 +1,7 @@
-(ns top-level)
+(ns top-level
+  (:require
+[foo]
+   [bar]))
 
 (defn -main
   "I don't do a whole lot ... yet."
@@ -7,6 +10,9 @@
           (println "Nested RFC"))}
   [& _args]
   (println "Hello, World!"))
+
+  (def x
+              'y)
 
 (comment
   (-main))


### PR DESCRIPTION
When adding a check for if the formatted form is a top level form I accidentely missed to return the list...

* Fixes #2114

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
