### PR TITLE
Use tree-kill again for the jack-in process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- Fix: [Formatting inside top level forms broken since 2.0.337](https://github.com/BetterThanTomorrow/calva/issues/2114)
+- Fix: [Stopping Jacked-in REPL process doesn't kill Unix Java process](https://github.com/BetterThanTomorrow/calva/issues/2116)
+- Fix: [Formatting inside top level forms broken](https://github.com/BetterThanTomorrow/calva/issues/2114)
 - Bump bundled deps.clj to v1.11.1.1257
 
 ## [2.0.338] - 2023-03-15

--- a/src/nrepl/jack-in-terminal.ts
+++ b/src/nrepl/jack-in-terminal.ts
@@ -116,8 +116,16 @@ export class JackInTerminal implements vscode.Pseudoterminal {
       this.writeEmitter.fire('🛑 Stopping/killing the Jacked-in REPL process... 🛑\r\n');
       console.log('Jack-in terminal killProcess(): Closing any ongoing stdin event');
       this.process.stdin.end(() => {
-        console.log('Jack-in terminal killProcess(): Closing any ongoing stdin event');
-        this.process.kill();
+        // On some machines we need to use tree-kill to kill the process, so we do it always
+        // https://github.com/BetterThanTomorrow/calva/issues/2116
+        console.log('Jack-in terminal killProcess(): Killing process using tree-kill');
+        kill(this.process.pid, 'SIGTERM', (err) => {
+          if (err) {
+            console.log('Jack-in terminal killProcess(): Error killing process', err);
+          }
+          // The test for this.process.killed above needs this to have happened too
+          this.process.kill();
+        });
       });
     } else if (this.process && this.process.killed) {
       this.writeEmitter.fire(


### PR DESCRIPTION
We shifted to just calling `.kill()` on the process in 2.0.337, which fixed an issue with us not being able to detect if we had killed the process or not. But it also caused us to fail to kill any REPL processes that have child processes. So now we are doing both tree-kill and calling the `.kill()` method.

* Fixes #2116

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
