### PR TITLE
rewrap set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Bump bundled deps.clj to v1.11.1.1267
+- [Rewrap to and from sets (`#{}`)](https://github.com/BetterThanTomorrow/calva/issues/2137)
+
 ## [2.0.344] - 2023-03-29
 
 - [Calva Notebook nrepl integration flag](https://github.com/BetterThanTomorrow/calva/issues/2133)

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -118,7 +118,7 @@ Default keybinding                | Action | Description
  `ctrl+alt+shift+s`                        | **Wrap Around []** | Wraps the current form, or selection, with square brackets. <br> ![](images/paredit/wrap-around-brackets.gif)
  `ctrl+alt+shift+c`                        | **Wrap Around {}** | Wraps the current form, or selection, with curlies. <br> ![](images/paredit/wrap-around-curlies.gif)
  `ctrl+alt+shift+q`                        | **Wrap Around ""** | Wraps the current form, or selection, with double quotes. Inside strings it will quote the quotes. <br> ![](images/paredit/wrap-around-quotes.gif)
- `ctrl+alt+r`<br>`ctrl+alt+p`/`s`/`c`/`q`                        | **Rewrap** | Changes enclosing brackets of the current form to parens/square brackets/curlies/double quotes.. <br> ![](images/paredit/rewrap.gif)
+ `ctrl+alt+r`<br>`ctrl+alt+p`/`s`/`c`/`q`/`h`                        | **Rewrap** | Changes enclosing brackets of the current form to parens/square brackets/curlies/double quotes and set (`#{}`) <br> ![](images/paredit/rewrap.gif)
 
 !!! Note "Copy to Clipboard when killing text"
     You can have the *kill* commands always copy the deleted code to the clipboard by setting `calva.paredit.killAlsoCutsToClipboard` to `true`.  If you want to do this more on-demand, you can kill text by using the [selection commands](#selecting) and then *Cut* once you have the selection.

--- a/package.json
+++ b/package.json
@@ -1696,6 +1696,12 @@
       },
       {
         "category": "Calva Paredit",
+        "command": "paredit.rewrapSet",
+        "title": "Rewrap #{}",
+        "enablement": "editorLangId == clojure"
+      },
+      {
+        "category": "Calva Paredit",
         "command": "paredit.rewrapQuote",
         "title": "Rewrap \"\"",
         "enablement": "editorLangId == clojure"
@@ -2369,6 +2375,11 @@
       {
         "command": "paredit.rewrapCurly",
         "key": "ctrl+alt+r ctrl+alt+c",
+        "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
+      },
+      {
+        "command": "paredit.rewrapSet",
+        "key": "ctrl+alt+r ctrl+alt+h",
         "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/"
       },
       {

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -500,17 +500,20 @@ export async function rewrapSexpr(
 ): Promise<Thenable<boolean>> {
   const cursor = doc.getTokenCursor(end);
   if (cursor.backwardList()) {
-    const openStart = cursor.offsetStart - 1,
-      openEnd = cursor.offsetStart;
-    if (cursor.forwardList()) {
-      const closeStart = cursor.offsetStart,
-        closeEnd = cursor.offsetEnd;
+    cursor.backwardUpList();
+    const oldOpenStart = cursor.offsetStart;
+    const oldOpenLength = cursor.getToken().raw.length;
+    const oldOpenEnd = oldOpenStart + oldOpenLength;
+    if (cursor.forwardSexp()) {
+      const oldCloseStart = cursor.offsetStart - close.length;
+      const oldCloseEnd = cursor.offsetStart;
+      const d = open.length - oldOpenLength;
       return doc.model.edit(
         [
-          new ModelEdit('changeRange', [closeStart, closeEnd, close]),
-          new ModelEdit('changeRange', [openStart, openEnd, open]),
+          new ModelEdit('changeRange', [oldCloseStart, oldCloseEnd, close]),
+          new ModelEdit('changeRange', [oldOpenStart, oldOpenEnd, open]),
         ],
-        { selection: new ModelEditSelection(end) }
+        { selection: new ModelEditSelection(end + d) }
       );
     }
   }

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1031,6 +1031,61 @@ describe('paredit', () => {
       });
     });
 
+    describe('Rewrap', () => {
+      it('Rewraps () -> []', async () => {
+        const a = docFromTextNotation('a (b c|) d');
+        const b = docFromTextNotation('a [b c|] d');
+        await paredit.rewrapSexpr(a, '[', ']');
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('Rewraps [] -> ()', async () => {
+        const a = docFromTextNotation('a [b c|] d');
+        const b = docFromTextNotation('a (b c|) d');
+        await paredit.rewrapSexpr(a, '(', ')');
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('Rewraps [] -> {}', async () => {
+        const a = docFromTextNotation('a [b c|] d');
+        const b = docFromTextNotation('a {b c|} d');
+        await paredit.rewrapSexpr(a, '{', '}');
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('Rewraps #{} -> {}', async () => {
+        const a = docFromTextNotation('a #{b c|} d');
+        const b = docFromTextNotation('a {b c|} d');
+        await paredit.rewrapSexpr(a, '{', '}');
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      // TODO: Something is broken in Peredit or the test utilities
+      //       this test make a lot of other tests fail
+      xit('Rewraps #{} -> ""', async () => {
+        const a = docFromTextNotation('a #{b c|} d');
+        const b = docFromTextNotation('a "b c|" d');
+        await paredit.rewrapSexpr(a, '"', '"');
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('Rewraps [] -> #{}', async () => {
+        const a = docFromTextNotation('[b c|] d');
+        const b = docFromTextNotation('#{b c|} d');
+        await paredit.rewrapSexpr(a, '#{', '}');
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      // TODO: This tests current behavior. What should happen?
+      it('Rewraps ^{} -> #{}', async () => {
+        const a = docFromTextNotation('^{b c|} d');
+        const b = docFromTextNotation('#{b c|} d');
+        await paredit.rewrapSexpr(a, '#{', '}');
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      // TODO: This tests current behavior. What should happen?
+      it('Rewraps ~{} -> #{}', async () => {
+        const a = docFromTextNotation('~{b c|} d');
+        const b = docFromTextNotation('#{b c|} d');
+        await paredit.rewrapSexpr(a, '#{', '}');
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+    });
+
     describe('Slurping', () => {
       describe('Slurping forwards', () => {
         it('slurps form after list', async () => {

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -350,6 +350,12 @@ const pareditCommands: PareditCommand[] = [
     },
   },
   {
+    command: 'paredit.rewrapSet',
+    handler: (doc: EditableDocument) => {
+      return paredit.rewrapSexpr(doc, '#{', '}');
+    },
+  },
+  {
     command: 'paredit.rewrapQuote',
     handler: (doc: EditableDocument) => {
       return paredit.rewrapSexpr(doc, '"', '"');


### PR DESCRIPTION
Add a Paredit rewrap `set` command to complete the other rewrappings.

* Fixes #2137


## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
