### PR TITLE
clojure lsp command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Add a generic `clojure-lsp.command` for binding to keyboard shortcuts with arguments](https://github.com/BetterThanTomorrow/calva/issues/2139)
+
 ## [2.0.345] - 2023-04-03
 
 - Bump bundled deps.clj to v1.11.1.1267

--- a/docs/site/clojure-lsp.md
+++ b/docs/site/clojure-lsp.md
@@ -113,7 +113,27 @@ Example:
 !!! Note "Will override any `calva.clojureLspVersion` setting"
     When `calva.clojureLspPath` is set, the binary at the path will be used uncoditionally, and the `calva.clojureLspVersion` setting will be ignored.
 
-## clojure-lsp drag fwd/back
+## Extra commands
+
+clojure-lsp provides many useful [commands], and Calva has configuration for most of them.
+
+### `clojure-lsp.command`
+
+Though the clojure-lsp team works fast and sometimes Calva might miss some command. Besides, Calva's configuration only really work for clojure-lsp commands that take no argument, or where it makes sense to prompt for the argument. Therefore Calva provides a generic command id, `clojure-lsp.command` which can be used with keyboard shortcuts and that allow for providing arguments that way. (The command can be used from [Joyride](https://github.com/BetterThanTomorrow/joyride) too, of course.)
+
+When using the command, provide the args as an tuple of `[command-name, arguments]`, where `arguments` is an array of any arguments after `file-uri, row, col` which are common for all clojure-lsp extra commands and are provided automatically by Calva, based on active text editor and where the cursor is. It can look like so binding a shortcut for `change-coll` to `set`:
+
+```json
+    {
+        "key": "ctrl+alt+r s",
+        "command": "clojure-lsp.command",
+        "args": ["change-coll", ["set"]]
+    },
+```
+
+Note that even though `change-coll` takes only one argument, you should still provide it via an array.
+
+### clojure-lsp drag fwd/back
 
 clojure-lsp contributes two commands for dragging forms forward or backward. They are similar to Calva's [Paredit](paredit.md) corresponding commands.
 

--- a/src/lsp/commands/lsp-commands.ts
+++ b/src/lsp/commands/lsp-commands.ts
@@ -116,6 +116,14 @@ function registerInternalLspCommand(
   });
 }
 
+function sendCommand(clients: defs.LspClientStore, command: string, args?: any[]) {
+  const params = getLSPCommandParams();
+  if (!params) {
+    return;
+  }
+  sendCommandRequest(clients, command, [...params, ...(args ? args : [])]);
+}
+
 const codeLensReferencesHandler: LSPCommandHandler = async (params) => {
   const [_, line, character] = params.args;
   calva_utils.getActiveTextEditor().selection = new vscode.Selection(
@@ -231,6 +239,11 @@ export function registerLspCommands(clients: defs.LspClientStore) {
      * We therefore manually register them here with added support for selecting the appropriate active lsp client on execution.
      */
     ...clojureLspCommands.map((command) => registerInternalLspCommand(clients, command)),
+    ...[
+      vscode.commands.registerCommand('clojure-lsp.command', ([command, args]) =>
+        sendCommand(clients, command, args)
+      ),
+    ],
   ];
 }
 


### PR DESCRIPTION
## What has changed?

Registering a generic `clojure-lsp.command`

* Fixes #2139 

It is not added to the extension manifest, because it doesn't make sense to use it without arguments.

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
