### PR TITLE
Comment creates toplevel context even when nested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Evaluate Rich Commment forms as top-level when the RCF is nested in other lists](https://github.com/BetterThanTomorrow/calva/issues/2109)
+
 ## [2.0.346] - 2023-04-04
 
 - [Add a generic `clojure-lsp.command` for binding to keyboard shortcuts with arguments](https://github.com/BetterThanTomorrow/calva/issues/2139)

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -771,11 +771,14 @@ export class LispTokenCursor extends TokenCursor {
     while (cursor.forwardList() && cursor.upList()) {
       const commentCursor = cursor.clone();
       commentCursor.backwardDownList();
-      if (
-        !commentCreatesTopLevel ||
-        commentCursor.getToken().raw !== ')' ||
-        commentCursor.getFunctionName() !== 'comment'
-      ) {
+      if (commentCreatesTopLevel && commentCursor.getFunctionName() === 'comment') {
+        if (commentCursor.getToken().raw !== ')') {
+          commentCursor.upList();
+          return commentCursor.rangeForCurrentForm(commentCursor.offsetStart);
+        } else {
+          return lastCandidateRange;
+        }
+      } else {
         lastCandidateRange = cursor.rangeForCurrentForm(cursor.offsetStart);
       }
     }

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -751,7 +751,7 @@ describe('Token Cursor', () => {
   });
 
   describe('Top Level Form', () => {
-    it('Finds range when nested down a some forms', () => {
+    it('Finds range when nested down some forms', () => {
       const a = docFromTextNotation(
         'aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b| :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) (ddd eee)'
       );
@@ -784,6 +784,12 @@ describe('Token Cursor', () => {
     it('Finds range for a top level form inside a comment', () => {
       const a = docFromTextNotation('aaa (comment (comment [bbb cc|c]  ddd))');
       const b = docFromTextNotation('aaa (comment (comment |[bbb ccc]|  ddd))');
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+      expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+    });
+    it('Finds range for a top level form inside a comment inside a form', () => {
+      const a = docFromTextNotation('a (b (comment [c |d] e))');
+      const b = docFromTextNotation('a (b (comment |[c d]| e))');
       const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
       expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
     });


### PR DESCRIPTION
## What has changed?

The TokenCursor method for finding the top level form has been updated to consider any forms at the top level of `comment` form as top level (if it is called with the flag to treat comments as creating a top level context). Before, only comment forms that were themselves top-level forms was treated like RCFs.

* Fixes #2109

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
