### PR TITLE
Quoted symbol lookup, strip leading quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [The nrepl client fails to look up definition on quoted symbols](https://github.com/BetterThanTomorrow/calva/issues/2144)
+
 ## [2.0.347] - 2023-04-04
 
 - [Evaluate Rich Commment forms as top-level when the RCF is nested in other lists](https://github.com/BetterThanTomorrow/calva/issues/2109)

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -551,7 +551,7 @@ export class NReplSession {
       const msg = {
         op: 'info',
         ns,
-        symbol,
+        symbol: symbol.replace(/^'/, ''),
         id,
         session: this.sessionId,
       };


### PR DESCRIPTION
## What has changed?

We strip any leading quote of a symbol when sending the `info` op.

The reason we need to do this is that `'` is not excluded as a word character here:
* https://github.com/BetterThanTomorrow/calva/blob/d12ea27fc193aa3001dcf8658d238ed88648ce7f/language-configuration.json#L5

Which makes sense since `foo'` is a valid symbol.

Fixes #2144 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
