### PR TITLE
Only test regex rules for matching cljOrJsregex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Indenter and formatter do not agree on some simple forms (and the formatter is right)](https://github.com/BetterThanTomorrow/calva/issues/2148)
+
 ## [2.0.348] - 2023-04-06
 
 - Fix: [The nrepl client fails to look up definition on quoted symbols](https://github.com/BetterThanTomorrow/calva/issues/2144)

--- a/src/cursor-doc/indent.ts
+++ b/src/cursor-doc/indent.ts
@@ -1,6 +1,6 @@
 import { EditableModel } from './model';
 import * as _ from 'lodash';
-import { testCljOrJsRegex } from '../util/regex';
+import * as regexUtil from '../util/regex';
 import { FormatterConfig } from '../formatter-config';
 
 const whitespace = new Set(['ws', 'comment', 'eol']);
@@ -95,7 +95,9 @@ export function collectIndents(
         isList &&
         _.find(
           _.keys(rules),
-          (p) => testCljOrJsRegex(`#"^(.*/)?${p}$"`, token) || testCljOrJsRegex(p, token)
+          (p) =>
+            regexUtil.testCljOrJsRegex(`#"^(.*/)?${p}$"`, token) ||
+            (regexUtil.isCljOrJsRegex(p) && regexUtil.testCljOrJsRegex(p, token))
         );
       const indentRule = pattern ? rules[pattern] : [];
       indents.unshift({

--- a/src/extension-test/unit/cursor-doc/indent-test.ts
+++ b/src/extension-test/unit/cursor-doc/indent-test.ts
@@ -68,6 +68,19 @@ describe('indent', () => {
           )
         ).toEqual(2);
       });
+      it('calculates indents for `foo` given different rules for `fo` and `foo`', () => {
+        const doc = docFromTextNotation('(foo [] |x)');
+        expect(
+          indent.getIndent(
+            doc.model,
+            textAndSelection(doc)[1][0],
+            mkConfig({
+              fo: [['block', 0]],
+              foo: [['block', 1]],
+            })
+          )
+        ).toEqual(2);
+      });
     });
 
     describe('vectors', () => {
@@ -268,6 +281,22 @@ describe('indent', () => {
         );
         expect(state.length).toEqual(1);
         expect(state[0].rules).toEqual(rule1);
+      });
+      it('collects indents for `foo` given different rules for `fo` and `foo`', () => {
+        const doc = docFromTextNotation('(foo|)');
+        const rule1: indent.IndentRule[] = [['inner', 0]];
+        const rule2: indent.IndentRule[] = [['block', 0]];
+        const rules: indent.IndentRules = {
+          fo: rule1,
+          foo: rule2,
+        };
+        const state: indent.IndentInformation[] = indent.collectIndents(
+          doc.model,
+          textAndSelection(doc)[1][0],
+          mkConfig(rules)
+        );
+        expect(state.length).toEqual(1);
+        expect(state[0].rules).toEqual(rule2);
       });
     });
 

--- a/src/util/regex.ts
+++ b/src/util/regex.ts
@@ -1,5 +1,9 @@
 import { trim } from 'lodash';
 
+export const isCljOrJsRegex = (regexp: string) => {
+  return regexp.startsWith('#"') || regexp.startsWith('/');
+};
+
 export const testCljOrJsRegex = (regexp: string, str: string) => {
   if (str.startsWith(':')) {
     // We don't want to match keywords
@@ -9,5 +13,6 @@ export const testCljOrJsRegex = (regexp: string, str: string) => {
   const clojureReMatches = regexp.match(/^#"(.*)"$/);
   const normalizedRe =
     (clojureReMatches && RegExp(clojureReMatches[1])) || RegExp(trim(regexp, '/'));
+  console.log(normalizedRe, str, normalizedRe.test(str.replace(/^.*\//, '')));
   return normalizedRe.test(str.replace(/^.*\//, ''));
 };

--- a/test-data/indenter_vs_formatter.clj
+++ b/test-data/indenter_vs_formatter.clj
@@ -1,0 +1,6 @@
+;; indent :a by putting the cursor in front and hit enter, then hit tab
+
+(doseq [x xs] :a)
+
+;; do the same here
+(for [x xs] :a)


### PR DESCRIPTION
## What has changed?

When finding matching rules for a token we matched non-regex rules as if it was a regex, causing us to match e.g. the rule for `do` for the token `doseq`. Now we check that it is a regex and if it isn't we only match against exactly matching rules.

* Fixes #2148

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
