### PR TITLE
Add option to auto-refer repl-utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Auto-refer `repl-requires` as part of connecting (or always)](https://github.com/BetterThanTomorrow/calva/issues/2154)
 - Bump bundled deps.clj to v1.11.1.1273
 
 ## [2.0.350] - 2023-04-10

--- a/package.json
+++ b/package.json
@@ -830,6 +830,21 @@
                 "default": false
               }
             }
+          },
+          "calva.autoReferReplUtilities": {
+            "type": "string",
+            "markdownDescription": "Should Calva automatically refer in the `repl-requires`/REPL utilities (like `source`, `doc`, etcetera), and when should it do that? (There is also a command to do this on demand.)",
+            "enum": [
+              "on-connect",
+              "always",
+              "never"
+            ],
+            "default": "on-connect",
+            "markdownEnumDescriptions": [
+              "Auto-refer the REPL utilities only in the initial namespace immediately after connecting the REPL.",
+              "Auto-refer the REPL utilities in all namespaces.",
+              "Never auto-refer the REPL utilities."
+            ]
           }
         }
       },
@@ -1283,7 +1298,7 @@
       },
       {
         "command": "calva.requireREPLUtilities",
-        "title": "Require REPL utilities, like (doc) etcetera, into Current Namespace",
+        "title": "Require (refer) REPL utilities, like (doc) etcetera, into Current Namespace",
         "enablement": "calva:connected",
         "category": "Calva"
       },

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ import * as state from './state';
 import _ = require('lodash');
 import { isDefined } from './utilities';
 import * as converters from './converters';
+import * as nrepl from './nrepl/index';
 
 const REPL_FILE_EXT = 'calva-repl';
 const KEYBINDINGS_ENABLED_CONFIG_KEY = 'calva.keybindingsEnabled';
@@ -224,6 +225,8 @@ function getConfig() {
     autoSelectNReplPortFromPortFile: configOptions.get<boolean>('autoSelectNReplPortFromPortFile'),
     autoConnectRepl: configOptions.get<boolean>('autoConnectRepl'),
     html2HiccupOptions: configOptions.get<converters.HiccupOptions>('html2HiccupOptions'),
+    autoReferReplUtilities:
+      configOptions.get<nrepl.AutoReferReplUtilities>('autoReferReplUtilities'),
   };
 }
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -116,6 +116,9 @@ async function connectToHost(hostname: string, port: number, connectSequence: Re
     replSession.updateReplSessionType();
 
     outputWindow.setSession(cljSession, nClient.ns);
+    if (getConfig().autoReferReplUtilities !== 'never') {
+      await cljSession.requireREPLUtilities();
+    }
 
     if (connectSequence.afterCLJReplJackInCode) {
       outputWindow.appendLine(`; Evaluating 'afterCLJReplJackInCode'`);
@@ -196,6 +199,9 @@ function setUpCljsRepl(session, build) {
     )}`
   );
   outputWindow.setSession(session, 'cljs.user');
+  if (getConfig().autoReferReplUtilities !== 'never') {
+    session.requireREPLUtilities();
+  }
   replSession.updateReplSessionType();
 }
 

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -14,6 +14,8 @@ import { getStateValue, prettyPrint } from '../../out/cljs-lib/cljs-lib';
 import { getConfig } from '../config';
 import { log, Direction } from './logging';
 
+export type AutoReferReplUtilities = 'on-connect' | 'always' | 'never';
+
 function hasStatus(res: any, status: string): boolean {
   return res.status && res.status.indexOf(status) > -1;
 }
@@ -349,6 +351,13 @@ export class NReplSession {
 
   async switchNS(ns: any) {
     await this.eval(`(in-ns '${ns})`, this.client.ns).value;
+  }
+
+  async requireREPLUtilities() {
+    const CLJS_FORM =
+      "(require '[cljs.repl :refer [apropos dir doc find-doc print-doc pst source]])";
+    const CLJ_FORM = '(clojure.core/apply clojure.core/require clojure.main/repl-requires)';
+    await this.eval(this.replType === 'clj' ? CLJ_FORM : CLJS_FORM, this.client.ns).value;
   }
 
   private _createEvalOperationMessage(code: string, ns: string, opts: any) {

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -233,6 +233,9 @@ export async function setNamespaceFromCurrentFile() {
   const ns = namespace.getNamespace(util.tryToGetDocument({}));
   if (getNs() !== ns && util.isDefined(ns)) {
     await session.switchNS(ns);
+    if (config.getConfig().autoReferReplUtilities === 'always') {
+      await session.requireREPLUtilities();
+    }
   }
   setSession(session, ns);
   replSession.updateReplSessionType();
@@ -255,6 +258,9 @@ async function appendFormGrabbingSessionAndNS(topLevel: boolean) {
   if (code != '') {
     if (getNs() !== ns) {
       await session.switchNS(ns);
+      if (config.getConfig().autoReferReplUtilities === 'always') {
+        await session.requireREPLUtilities();
+      }
     }
     setSession(session, ns);
     appendLine(code, (_) => revealResultsDoc(false));


### PR DESCRIPTION
I've added an option to have REPL utilities (`clojure.main/repl-requires`) auto-referred on connect of the REPL. So that things like `(doc <something>)` works. This works when starting a `clj` REPL on the command line, Leiningen does it, and so does CIDER.

I made it enabled by default to happen on-connect, and there are options such that the user can opt out entirely, and also to opt in for it happening in all namespaces.

* Fixes #2154

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
