### PR TITLE
Always check if selected alias has main-opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [With `autoSelectForJackIn` is true, Calva drops its `:main-opts` guard](https://github.com/BetterThanTomorrow/calva/issues/2161)
+
 ## [2.0.352] - 2023-04-16
 
 - [Add custom Jack-in command lines to connect sequences](https://github.com/BetterThanTomorrow/calva/issues/2152)

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -575,19 +575,19 @@ async function cljCommandLine(connectSequence: ReplConnectSequence, cljsType: Cl
   const launchAliases = menuSelections ? menuSelections.cljAliases : undefined;
   let aliases: string[] = [];
   const aliasesWithMain: string[] = [];
+  let projectAliases = parsed && parsed.aliases != undefined ? Object.keys(parsed.aliases) : [];
+  for (const projectAlias of projectAliases) {
+    const aliasKey = unKeywordize(projectAlias);
+    if (parsed && parsed.aliases) {
+      const alias = parsed.aliases[aliasKey];
+      if (alias && alias['main-opts'] != undefined && alias['main-opts'].length > 0) {
+        aliasesWithMain.push(`:${projectAlias}`);
+      }
+    }
+  }
   if (launchAliases) {
     aliases = launchAliases.map(keywordize);
   } else {
-    let projectAliases = parsed && parsed.aliases != undefined ? Object.keys(parsed.aliases) : [];
-    for (const projectAlias of projectAliases) {
-      const aliasKey = unKeywordize(projectAlias);
-      if (parsed && parsed.aliases) {
-        const alias = parsed.aliases[aliasKey];
-        if (alias && alias['main-opts'] != undefined && alias['main-opts'].length > 0) {
-          aliasesWithMain.push(`:${projectAlias}`);
-        }
-      }
-    }
     if (aliasesWithMain.length > 0) {
       const alertKey = 'calva.jackInMainOptsWarningEnabled';
       if (state.extensionContext.workspaceState.get(alertKey, true)) {

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -55,6 +55,17 @@
       }
     },
     {
+      "name": "Connect Sequence deps-main-opts",
+      "projectType": "deps.edn",
+      "projectRootPath": ["projects/deps-main-opts"],
+      "afterCLJReplJackInCode": "(require 'repl)",
+      //"autoSelectForJackIn": true,
+      "cljsType": "none",
+      "menuSelections": {
+        "cljAliases": ["dev", "has-main-opts-starting-nrepl"]
+      }
+    },
+    {
       "name": "custom command line shadow",
       "projectType": "shadow-cljs",
       "afterCLJReplJackInCode": "(println \"Hello custom command line\")",


### PR DESCRIPTION
* Fixes #2161

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Created the issue I am fixing/addressing, if it was not present.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
