### PR TITLE
Only log cljfmt+clojure-lsp error if clojure-lsp has started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [cljfmt isn't found unless project is started](https://github.com/BetterThanTomorrow/calva/issues/2078)
+
 ## [2.0.353] - 2023-04-17
 
 - Fix: [With `autoSelectForJackIn` is true, Calva drops its `:main-opts` guard](https://github.com/BetterThanTomorrow/calva/issues/2161)

--- a/src/formatter-config.ts
+++ b/src/formatter-config.ts
@@ -51,15 +51,12 @@ export async function getConfig(
   if (configPath === LSP_CONFIG_KEY && document) {
     const clientProvider = lsp.getClientProvider();
     const client = clientProvider.getClientForDocumentUri(document.uri);
-    if (client) {
+    if (client && client.isRunning) {
       lspFormatConfig = await lsp.api.getCljFmtConfig(client);
     }
-  }
-  if (configPath === LSP_CONFIG_KEY && !lspFormatConfig) {
-    void vscode.window.showErrorMessage(
-      'Fetching formatting settings from clojure-lsp failed. Check that you are running a version of clojure-lsp that provides "cljfmt-raw" in serverInfo.',
-      'Roger that'
-    );
+    if (client.isRunning && !lspFormatConfig) {
+      console.error('Fetching formatting settings from clojure-lsp failed. Check that you are running a version of clojure-lsp that provides "cljfmt-raw" in serverInfo.');
+    }
   }
   const cljfmtContent: string | undefined =
     configPath === LSP_CONFIG_KEY

--- a/src/formatter-config.ts
+++ b/src/formatter-config.ts
@@ -55,7 +55,9 @@ export async function getConfig(
       lspFormatConfig = await lsp.api.getCljFmtConfig(client);
     }
     if (client.isRunning && !lspFormatConfig) {
-      console.error('Fetching formatting settings from clojure-lsp failed. Check that you are running a version of clojure-lsp that provides "cljfmt-raw" in serverInfo.');
+      console.error(
+        'Fetching formatting settings from clojure-lsp failed. Check that you are running a version of clojure-lsp that provides "cljfmt-raw" in serverInfo.'
+      );
     }
   }
   const cljfmtContent: string | undefined =

--- a/src/formatter-config.ts
+++ b/src/formatter-config.ts
@@ -53,11 +53,11 @@ export async function getConfig(
     const client = clientProvider.getClientForDocumentUri(document.uri);
     if (client && client.isRunning) {
       lspFormatConfig = await lsp.api.getCljFmtConfig(client);
-    }
-    if (client.isRunning && !lspFormatConfig) {
-      console.error(
-        'Fetching formatting settings from clojure-lsp failed. Check that you are running a version of clojure-lsp that provides "cljfmt-raw" in serverInfo.'
-      );
+      if (!lspFormatConfig) {
+        console.error(
+          'Fetching formatting settings from clojure-lsp failed. Check that you are running a version of clojure-lsp that provides "cljfmt-raw" in serverInfo.'
+        );
+      }
     }
   }
   const cljfmtContent: string | undefined =


### PR DESCRIPTION
## What has changed?

- Log error to console instead of alerting about it
- Only log error if the server has started

The trade-off here is that the user might get default formatting without having been noticed. But it should be rare, and not the worlds biggest deal.

* Fixes #2078

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [ ] Tests
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
