### PR TITLE
Reinstall custom lsp showMessage handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [cljfmt isn't found unless project is started](https://github.com/BetterThanTomorrow/calva/issues/2078)
+- Fix: [”Resolve macro as” menu buttons are unreadable](https://github.com/BetterThanTomorrow/calva/issues/2156)
 
 ## [2.0.353] - 2023-04-17
 

--- a/src/lsp/client/client.ts
+++ b/src/lsp/client/client.ts
@@ -1,3 +1,4 @@
+import * as messages from './messages';
 import { provideSignatureHelp } from '../../providers/signature';
 import { isResultsDoc } from '../../results-output/results-doc';
 import * as vscode_lsp from 'vscode-languageclient/node';
@@ -216,6 +217,8 @@ export const createClient = (params: CreateClientParams): defs.LspClient => {
   client.registerFeature(testTree);
 
   // client.registerFeature(new ExecuteCommandDisablement());
+
+  client.onRequest('window/showMessageRequest', messages.handleShowMessageRequest);
 
   void client.start().catch((err) => {
     console.error('Client failed to start', err);


### PR DESCRIPTION
* Fixes #2156

Not that I get how **Resolve Macro As** is supposed to work, but that's a different matter.

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
