### PR TITLE
Drag backwards around ignore markers

### DIFF
--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -653,6 +653,7 @@ export class LispTokenCursor extends TokenCursor {
         cursor.getToken().type !== 'reader' &&
         !cursor.tokenBeginsMetadata() &&
         cursor.getPrevToken().type !== 'reader' &&
+        cursor.getPrevToken().type !== 'ignore' &&
         !cursor.prevTokenBeginsMetadata()
       ) {
         if (cursor.backwardSexp() && !cursor.tokenBeginsMetadata()) {

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -405,7 +405,7 @@ export class LispTokenCursor extends TokenCursor {
     let hasReader = false;
     while (true) {
       cursor.backwardWhitespace();
-      if (cursor.getPrevToken().type === 'reader') {
+      if (['reader', 'ignore'].includes(cursor.getPrevToken().type)) {
         cursor.previous();
         this.set(cursor);
         hasReader = true;
@@ -425,7 +425,7 @@ export class LispTokenCursor extends TokenCursor {
     let hasReader = false;
     while (true) {
       cursor.forwardWhitespace();
-      if (cursor.getToken().type === 'reader') {
+      if (['reader', 'ignore'].includes(cursor.getToken().type)) {
         cursor.next();
         this.set(cursor);
         hasReader = true;

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1464,6 +1464,33 @@ describe('paredit', () => {
         await paredit.dragSexprBackward(a, ['b']);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
+
+      describe('Ignore markers', () => {
+        it('Drags past symbol', async () => {
+          const a = docFromTextNotation('#_a (:b c)|');
+          const b = docFromTextNotation('#_(:b c)| a');
+          await paredit.dragSexprBackward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Drags past map', async () => {
+          const a = docFromTextNotation('#_{:a b} (:c d)|');
+          const b = docFromTextNotation('#_(:c d)| {:a b}');
+          await paredit.dragSexprBackward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Drags past ignore after newline', async () => {
+          const a = docFromTextNotation('(:a b)•#_{:c d}|');
+          const b = docFromTextNotation('(:a b)•{:c d}|#_');
+          await paredit.dragSexprBackward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Drags past ignore after space', async () => {
+          const a = docFromTextNotation('(:a b) #_{:c d}|');
+          const b = docFromTextNotation('(:a b) {:c d}|#_');
+          await paredit.dragSexprBackward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+      });
     });
 
     describe('backwardUp - one line', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1493,6 +1493,35 @@ describe('paredit', () => {
       });
     });
 
+    describe('currentSexpsRange', () => {
+      const docSelectionCursorPosition = (positionNotation: string, rangeNotation: string) => {
+        const positionDoc = docFromTextNotation(positionNotation);
+        const rangeDoc = docFromTextNotation(rangeNotation);
+        const [_text1, positionSelection] = textAndSelection(positionDoc);
+        const position = positionSelection[0];
+        const [_text2, selection] = textAndSelection(rangeDoc);
+        const cursor = positionDoc.getTokenCursor(position);
+        return { doc: positionDoc, selection: selection, cursor, position };
+      };
+
+      it('Finds range with cursor between ignore marker and form, separated by whitespace before', () => {
+        const { doc, selection, cursor, position } = docSelectionCursorPosition(
+          '#_ |(:a b)',
+          '#_ |(:a b)|'
+        );
+        const range = paredit.currentSexpsRange(doc, cursor, position, false);
+        expect(range).toStrictEqual(selection);
+      });
+      it('Finds range with cursor between ignore marker and form, no whitespace', () => {
+        const { doc, selection, cursor, position } = docSelectionCursorPosition(
+          '#_|(:a b)',
+          '#_|(:a b)|'
+        );
+        const range = paredit.currentSexpsRange(doc, cursor, position, false);
+        expect(range).toStrictEqual(selection);
+      });
+    });
+
     describe('backwardUp - one line', () => {
       it('Drags up from start of vector', async () => {
         const b = docFromTextNotation(`(def foo [:|foo :bar :baz])`);

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -747,6 +747,18 @@ describe('Token Cursor', () => {
       const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toBeUndefined();
     });
+    it('Selects atomic form to the right, when squeezed by an ignore marker', () => {
+      const a = docFromTextNotation('#_|a');
+      const b = docFromTextNotation('#_|a|');
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+    });
+    it('Selects list form to the right, when squeezed by an ignore marker', () => {
+      const a = docFromTextNotation('#_|(a)');
+      const b = docFromTextNotation('#_|(a)|');
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+    });
   });
 
   describe('Top Level Form', () => {


### PR DESCRIPTION
## What has changed?

- Added some tests for the cases mentioned in #2164

* Fixes #2164 (eventually)

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [ ] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [ ] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [ ] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [ ] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
        - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [ ] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [ ] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
