### PR TITLE
Pez/plausible start only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changes to Calva.
 
 - Fix: [cljfmt isn't found unless project is started](https://github.com/BetterThanTomorrow/calva/issues/2078)
 - Fix: [”Resolve macro as” menu buttons are unreadable](https://github.com/BetterThanTomorrow/calva/issues/2156)
-- Calva development: Add [Plausible](plausible.io) analytics, intended to replace Google Analytics
+- Calva development: Add [Plausible](https://plausible.io) analytics, intended to replace Google Analytics
 
 ## [2.0.353] - 2023-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Calva development: Only log app start with plausible.io
+
 ## [2.0.354] - 2023-05-03
 
 - Fix: [cljfmt isn't found unless project is started](https://github.com/BetterThanTomorrow/calva/issues/2078)

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -11,6 +11,13 @@ function userAllowsTelemetry(): boolean {
   return config.get<boolean>('enableTelemetry', false);
 }
 
+const FACT_KEY = 'tracked-facts';
+type TRACKED_FACT =
+  | 'connected-clj-repl'
+  | 'connected-cljs-repl'
+  | 'connect-initiated'
+  | 'evaluated-form';
+
 export default class Analytics {
   private visitor: UA.Visitor;
   private extension: vscode.Extension<any>;
@@ -63,15 +70,23 @@ export default class Analytics {
     return this;
   }
 
-  async logPlausiblePageview(path: string, props: any = {}) {
+  // Facts stored for logging on next startup
+  async storeFact(fact: TRACKED_FACT, info?: string) {
+    if (userAllowsTelemetry()) {
+      const facts = this.store.get(FACT_KEY, {});
+      facts[fact] = info ? info : true;
+      await this.store.update(FACT_KEY, facts);
+    }
+  }
+
+  private clearFacts() {
+    void this.store.update(FACT_KEY, {});
+  }
+
+  async logPlausiblePageview(path: string) {
     if (!userAllowsTelemetry()) {
       return;
     }
-    const { cljsType: rawCljsType, ...otherProps } = props;
-    const updatedProps = {
-      ...(rawCljsType ? { cljsType: cljsType(rawCljsType) } : {}),
-      ...otherProps,
-    };
     const userAgent = `Mozilla/5.0 (${os.platform()}; ${os.release()}; ${
       os.type
     }) Code/1.67 Calva/2.0 (${hashUuid(this.userID())}; Clojure)`;
@@ -83,7 +98,7 @@ export default class Analytics {
           name: 'pageview',
           url: `ext://calva/${path.replace(/^\//, '')}`,
           props: {
-            ...updatedProps,
+            ...this.store.get(FACT_KEY, {}),
             'calva-version': this.extensionVersion,
             'vscode-version': vscode.version,
             'os-platform': os.platform(),
@@ -102,6 +117,7 @@ export default class Analytics {
       .catch(function (error) {
         console.log(error);
       });
+    this.clearFacts();
   }
 
   logEvent(category: string, action: string, label?: string, value?: string): Analytics {
@@ -143,8 +159,4 @@ function hashUuid(uuid: string): string {
     }, 0);
   };
   return uuid.split('-').map(simpleHash).join('.');
-}
-
-function cljsType(type: CljsTypes | CljsTypeConfig) {
-  return typeof type === 'string' ? type : type.dependsOn;
 }

--- a/src/debugger/calva-debug.ts
+++ b/src/debugger/calva-debug.ts
@@ -107,7 +107,6 @@ class CalvaDebugSession extends LoggingDebugSession {
       .analytics()
       .logEvent(DEBUG_ANALYTICS.CATEGORY, DEBUG_ANALYTICS.EVENT_ACTIONS.ATTACH)
       .send();
-    void state.analytics().logPlausiblePageview('/debugger-attach');
   }
 
   protected continueRequest(
@@ -131,7 +130,6 @@ class CalvaDebugSession extends LoggingDebugSession {
       .analytics()
       .logEvent(DEBUG_ANALYTICS.CATEGORY, DEBUG_ANALYTICS.EVENT_ACTIONS.CONTINUE)
       .send();
-    void state.analytics().logPlausiblePageview('/debugger-continue');
   }
 
   protected restartRequest(
@@ -164,7 +162,6 @@ class CalvaDebugSession extends LoggingDebugSession {
       .analytics()
       .logEvent(DEBUG_ANALYTICS.CATEGORY, DEBUG_ANALYTICS.EVENT_ACTIONS.STEP_OVER)
       .send();
-    void state.analytics().logPlausiblePageview('/debugger-step-over');
   }
 
   protected stepInRequest(
@@ -188,7 +185,6 @@ class CalvaDebugSession extends LoggingDebugSession {
       .analytics()
       .logEvent(DEBUG_ANALYTICS.CATEGORY, DEBUG_ANALYTICS.EVENT_ACTIONS.STEP_IN)
       .send();
-    void state.analytics().logPlausiblePageview('/debugger-step-in');
   }
 
   protected stepOutRequest(
@@ -212,7 +208,6 @@ class CalvaDebugSession extends LoggingDebugSession {
       .analytics()
       .logEvent(DEBUG_ANALYTICS.CATEGORY, DEBUG_ANALYTICS.EVENT_ACTIONS.STEP_OUT)
       .send();
-    void state.analytics().logPlausiblePageview('/debugger-step-out');
   }
 
   protected threadsRequest(
@@ -456,7 +451,6 @@ debug.onDidStartDebugSession((session) => {
   void session.customRequest(REQUESTS.SEND_STOPPED_EVENT, {
     reason: 'breakpoint',
   });
-  void state.analytics().logPlausiblePageview('/debugger-session-started');
 });
 
 function convertOneBasedToZeroBased(n: number): number {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -69,6 +69,7 @@ async function evaluateCodeUpdatingUI(
   options,
   selection?: vscode.Selection
 ): Promise<string | null> {
+  void state.analytics().storeFact('evaluated-form');
   const pprintOptions = options.pprintOptions || getConfig().prettyPrintingOptions;
   // passed options overwrite config options
   const evaluationSendCodeToOutputWindow =
@@ -240,10 +241,6 @@ async function evaluateSelection(document = {}, options) {
     const column = codeSelection.start.character;
     const filePath = doc.fileName;
     const session = replSession.getSession(util.getFileType(doc));
-    void state.analytics().logPlausiblePageview('/repl-evaluate-current-form', {
-      replType: session?.replType,
-      fileExtension: doc ? path.extname(doc.fileName) : 'unknown',
-    });
 
     if (code.length > 0) {
       if (options.debug) {
@@ -428,10 +425,6 @@ async function loadFile(
 
   if (doc && doc.languageId == 'clojure' && fileType != 'edn' && getStateValue('connected')) {
     state.analytics().logEvent('Evaluation', 'LoadFile').send();
-    void state.analytics().logPlausiblePageview('/repl-load-file', {
-      replType: session?.replType,
-      fileExtension: doc ? path.extname(doc.fileName) : 'unknown',
-    });
     const docUri = outputWindow.isResultsDoc(doc)
       ? await namespace.getUriForNamespace(session, ns)
       : doc.uri;
@@ -580,7 +573,6 @@ function instrumentTopLevelForm() {
     .analytics()
     .logEvent(DEBUG_ANALYTICS.CATEGORY, DEBUG_ANALYTICS.EVENT_ACTIONS.INSTRUMENT_FORM)
     .send();
-  void state.analytics().logPlausiblePageview('/debugger-instrument-form');
 }
 
 export async function evaluateInOutputWindow(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -471,7 +471,6 @@ async function activate(context: vscode.ExtensionContext) {
   }
 
   state.analytics().logPath('/activated').logEvent('LifeCycle', 'Activated').send();
-  void state.analytics().logPlausiblePageview('/activated');
 
   if (!cwExtension) {
     try {

--- a/src/joyride.ts
+++ b/src/joyride.ts
@@ -55,6 +55,7 @@ export async function prepareForJackingOrConnect() {
 }
 
 export async function joyrideJackIn(projectDir: string) {
+  void state.analytics().storeFact('connect-initiated', 'joyride-jack-in');
   const joyrideExtension = getJoyrideExtension();
   if (joyrideExtension && isJoyrideExtensionCompliant(joyrideExtension)) {
     joyrideExtension.exports

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -449,9 +449,6 @@ async function askForConnectSequence(
 
   if (!projectConnectSequenceName || projectConnectSequenceName.length <= 0) {
     state.analytics().logEvent('REPL', logLabel, 'NoProjectTypePicked').send();
-    void state.analytics().logPlausiblePageview('/connecting-no-sequence-picked', {
-      connectType,
-    });
     return;
   }
   const sequence = sequences.find((seq) => seq.name === projectConnectSequenceName);

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -331,7 +331,6 @@ export class NReplSession {
   }
 
   stacktrace() {
-    void state.analytics().logPlausiblePageview('/repl-stacktrace');
     // https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#stacktrace
     return new Promise<any>((resolve, reject) => {
       const id = this.client.nextId;
@@ -351,7 +350,6 @@ export class NReplSession {
   }
 
   async switchNS(ns: any) {
-    void state.analytics().logPlausiblePageview('/repl-switch-ns');
     await this.eval(`(in-ns '${ns})`, this.client.ns).value;
   }
 
@@ -359,7 +357,6 @@ export class NReplSession {
     const CLJS_FORM =
       "(require '[cljs.repl :refer [apropos dir doc find-doc print-doc pst source]])";
     const CLJ_FORM = '(clojure.core/apply clojure.core/require clojure.main/repl-requires)';
-    void state.analytics().logPlausiblePageview('/repl-require-repl-utilities');
     await this.eval(this.replType === 'clj' ? CLJ_FORM : CLJS_FORM, this.client.ns).value;
   }
 
@@ -373,7 +370,6 @@ export class NReplSession {
           debug.DEBUG_ANALYTICS.EVENT_ACTIONS.EVALUATE_IN_DEBUG_CONTEXT
         )
         .send();
-      void state.analytics().logPlausiblePageview('/debugger-evaluate-in-context');
       return {
         id: debugResponse.id,
         session: this.sessionId,

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -145,7 +145,6 @@ export async function copyJackInCommandToClipboard(): Promise<void> {
     console.error('An error occurred while initializing project directory.', e);
     return;
   }
-  void state.analytics().logPlausiblePageview('/jack-in-copy-command-line-initiated', {});
 
   let projectConnectSequence: ReplConnectSequence;
   try {
@@ -159,15 +158,6 @@ export async function copyJackInCommandToClipboard(): Promise<void> {
       if (options) {
         void vscode.env.clipboard.writeText(createCommandLine(options));
         void vscode.window.showInformationMessage('Jack-in command line copied to the clipboard.');
-        void state.analytics().logPlausiblePageview('/jack-in-copy-command-line-success', {
-          projectType: projectConnectSequence.projectType,
-          cljsType: projectConnectSequence.cljsType,
-          autoSelectForConnect: projectConnectSequence.autoSelectForConnect,
-          autoSelectForJackIn: projectConnectSequence.autoSelectForJackIn,
-          hasAfterCLJReplJackInCode: !!projectConnectSequence.afterCLJReplJackInCode,
-          hasCustomJackInCommandLine: !!projectConnectSequence.customJackInCommandLine,
-          hasJackInEnv: !!projectConnectSequence.jackInEnv,
-        });
       }
     } catch (e) {
       void vscode.window.showErrorMessage(`Error creating Jack-in command line: ${e}`, 'OK');
@@ -296,6 +286,8 @@ export async function jackIn(
   disableAutoSelect: boolean,
   cb?: () => unknown
 ) {
+  void state.analytics().storeFact('connect-initiated', 'jack-in');
+
   try {
     await liveShareSupport.setupLiveShareListener();
   } catch (e) {
@@ -309,20 +301,6 @@ export async function jackIn(
     return;
   }
   state.analytics().logEvent('REPL', 'JackInInitiated').send();
-  void state.analytics().logPlausiblePageview(
-    '/jack-in-initiated',
-    connectSequence
-      ? {
-          projectType: connectSequence.projectType,
-          cljsType: connectSequence.cljsType,
-          autoSelectForConnect: connectSequence.autoSelectForConnect,
-          autoSelectForJackIn: connectSequence.autoSelectForJackIn,
-          hasAfterCLJReplJackInCode: !!connectSequence.afterCLJReplJackInCode,
-          hasCustomJackInCommandLine: !!connectSequence.customJackInCommandLine,
-          hasJackInEnv: !!connectSequence.jackInEnv,
-        }
-      : {}
-  );
   await outputWindow.initResultsDoc();
   outputWindow.appendLine('; Jacking in...');
   await outputWindow.openResultsDoc();
@@ -343,15 +321,6 @@ export async function jackIn(
     }
   }
   if (projectConnectSequence) {
-    void state.analytics().logPlausiblePageview('/jack-in-initiated-connect-sequence-selected', {
-      projectType: projectConnectSequence.projectType,
-      cljsType: projectConnectSequence.cljsType,
-      autoSelectForConnect: projectConnectSequence.autoSelectForConnect,
-      autoSelectForJackIn: projectConnectSequence.autoSelectForJackIn,
-      hasAfterCLJReplJackInCode: !!projectConnectSequence.afterCLJReplJackInCode,
-      hasCustomJackInCommandLine: !!projectConnectSequence.customJackInCommandLine,
-      hasJackInEnv: !!projectConnectSequence.jackInEnv,
-    });
     const projectType = projectTypes.getProjectTypeForName(projectConnectSequence.projectType);
     if (projectType.startFunction) {
       void projectType.startFunction();

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -83,7 +83,6 @@ export async function downloadDrams(
   configPath: string,
   filePaths: string[]
 ) {
-  void state.analytics().logPlausiblePageview('/drams-download');
   await Promise.all(
     filePaths.map(async (filePath) => {
       await downloadDram(storageUri, configPath, filePath)
@@ -149,11 +148,6 @@ export async function startStandaloneRepl(
   dramTemplate: DramTemplate,
   areBundled: boolean
 ) {
-  void state.analytics().logPlausiblePageview('/repl-start-standalone-repl', {
-    template:
-      typeof dramTemplate.config == 'string' ? dramTemplate.config : dramTemplate.config.name,
-  });
-
   const config =
     typeof dramTemplate.config === 'string'
       ? await fetchConfig(dramTemplate.config)
@@ -275,15 +269,6 @@ export function startOrConnectRepl() {
   const sortedCommands = utilities.sortByPresetOrder(Object.keys(commands), PREFERRED_ORDER);
   void vscode.window.showQuickPick(sortedCommands).then((v) => {
     if (commands[v]) {
-      void state.analytics().logPlausiblePageview(`/repl-menu/${commands[v]}`, {
-        connectState: utilities.getConnectedState()
-          ? 'connected'
-          : utilities.getConnectingState()
-          ? 'connecting'
-          : utilities.getLaunchingState()
-          ? 'launching'
-          : 'disconnected',
-      });
       void vscode.commands.executeCommand(commands[v]);
     }
   });


### PR DESCRIPTION
## What has changed?

I've removed all plausible.io logging, but one: When Calva starts.

With this logging, we send some data from the last session. So far only

- wether a REPL is started
    - what kind of REPL (Clojure/ClojureScript), and how (standalone connect or jack-in).
- if any form is evaluated (manually)

Main reason being costs. Plausible is not made for tracking app usage. At least not their pricing. 😄 


## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
