### PR TITLE
2180 autoconnect autoload code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -163,6 +163,7 @@
     "rickmoynihan",
     "ringe",
     "rlwrap",
+    "Runtimes",
     "sauvala",
     "sbin",
     "scaturro",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Add autoEvalOnConnect and autoEvalOnFileLoaded settings](https://github.com/BetterThanTomorrow/calva/issues/2180)
+- [Make the shadow-cljs connect process wait for a running CLJS REPL server](https://github.com/BetterThanTomorrow/calva/issues/1027)
+
 ## [2.0.355] - 2023-05-04
 
 - Fix: [REPL connect fails if requiring clojure.main/repl-requires fails](https://github.com/BetterThanTomorrow/calva/issues/2178)

--- a/docs/site/connect.md
+++ b/docs/site/connect.md
@@ -40,54 +40,7 @@ There are ways to tell Calva the answers to these prompts beforehand, so that Ja
 
 ### Customizing Jack-in
 
-The main mechanism for customizing your Jack-in, including automating menu selections, and custom CLJS REPL types is [Custom Connect Sequences](connect-sequences.md).
-
-There are also these settings:
-
-* `calva.jackInEnv`: An object with environment variables that will be added to the environment of the Jack-in process.
-* `calva.myCljAliases`: An array of `deps.edn` aliases not found in the project file. Use this to tell Calva Jack-in to launch your REPL using your user defined aliases.
-* `calva.myLeinProfiles`: An array of Leiningen profiles not found in `project.clj`. Use this to tell Calva Jack-in to launch your REPL using your user defined profiles.
-* `calva.openBrowserWhenFigwheelStarted`: _For Legacy Figwheel only._ A boolean controlling if Calva should automatically launch your ClojureScript app, once it is compiled by Figwheel. Defaults to `true`.
-* `calva.depsEdnJackInExecutable`: A string which should either be `clojure` or `deps.clj`, or `clojure or deps.clj` (default). It determines which executable Calva Jack-in should use for starting a `deps.edn` project. With this setting at its default, `clojure or deps.clj`, Calva will test if the `clojure` executable works, and use it if it does, otherwise `deps.clj` will be used, which is bundled with Calva.
-
-!!! Note
-    When processing the `calva.jackInEnv` setting you can refer to existing ENV variables with `${env:VARIABLE}`.
-
-#### Options for the Jack-in Command 
-
-The `calva.jackIn` command takes an optional options argument defined like so:
-
-```typescript
-  options?: {
-    connectSequence?: string | ReplConnectSequence;
-    disableAutoSelect?: boolean;
-  }
-```
-
-Where `ReplConnectSequence` is a [Connect Sequences](connect-sequences.md). If you provide a string it needs to match against a built-in or custom connect sequence. With `disableAutoSelect` you can force the jack-in menus to be provided even if a custom connect sequence is set to be autoSelected.
-
-You can provide these options from keyboard shortcuts or from [Joyride](https://github.com/BetterThanTomorrow/joyride) scripts.
-
-Here's a keyboard shortcut for connecting to a running REPL bypassing any connect sequence with `autoSelectForConnect`.
-
-```json
-    {
-        "command": "calva.jackIn",
-        "args": {"disableAutoSelect": true},
-        "key": "ctrl+alt+c shift+j",
-    },
-```
-
-A Joyride command for starting a `deps.edn` REPL for a project in the root of the workspace.
-
-```clojure
-(vscode/commands.executeCommand
- "calva.jackIn"
- (clj->js {:connectSequence {:projectType "deps.edn"
-                             :projectRootPath ["."]}}))
-```
-
-It will prompt for any aliases it finds in the `deps.edn` file.    
+The main mechanism for customizing your Jack-in, including automating menu selections, and custom CLJS REPL types is [Custom Connect Sequences](connect-sequences.md). See also [Customizing Jack-in and Connect](customizing-jack-in-and-connect.md)
 
 ## Connecting Without Jack-in
 
@@ -102,46 +55,7 @@ All this said, I still recommend you challenge the conclusion that you can't use
 !!! Note
     There is a Calva command for copying the Jack-in command line to the clipboard. It will copy the command line including commands to change to the current REPL project root, avoiding hard-to-detect errors when starting the REPL in the wrong directory.
 
-### Customizing Connect
-
-If there is an nRepl port file, Calva will use it and not prompt for `host:port` when connecting. You can make Calva prompt for this by setting the boolean config `calva.autoSelectNReplPortFromPortFile` to `false`.
-
-With the setting `calva.autoConnectRepl` you can make Calva automatically connect the REPL if there is an nRepl port file present when the project is opened.
-
-With this and the below mentioned auto-select options you can make connect a prompt-less experience. See: [Connect Sequences](connect-sequences.md).
-
-#### Options for the Connect Command 
-
-The `calva.connect` command takes an optional options argument defined like so:
-
-```typescript
-  options?: {
-    host?: string;
-    port?: string;
-    connectSequence?: string | ReplConnectSequence;
-    disableAutoSelect?: boolean;
-  }
-```
-
-Where `ReplConnectSequence` is a [Connect Sequences](connect-sequences.md). If you provide a string it needs to match against a built-in or custom connect sequence. With `disableAutoSelect` you can force the connect menus to be provided even if a custom connect sequence is set to be autoSelected.
-
-You can provide these options from keyboard shortcuts or from [Joyride](https://github.com/BetterThanTomorrow/joyride) scripts.
-
-Here's a keyboard shortcut for connecting to a running REPL bypassing any connect sequence with `autoSelectForConnect`.
-
-```json
-    {
-        "command": "calva.connect",
-        "args": {"disableAutoSelect": true},
-        "key": "ctrl+alt+c shift+c",
-    },
-```
-
-A Joyride command for connecting to a REPL on port 55555, without being asked for project type:
-
-```clojure
-(vscode/commands.executeCommand "calva.connect" (clj->js {:port "55555" :connectSequence "Generic"}))
-```
+See also [Customizing Jack-in and Connect](customizing-jack-in-and-connect.md)
 
 ### Starting the REPL from application code?
 
@@ -156,13 +70,6 @@ You can make both Jack-in and Connect stop prompting you for project type and pr
 If the workspace is a monorepo, Polylith repo or just a repository with more than one Clojure project, Calva will start the connect sequence with prompting for which project to start/connect to.
 
 ![The project roots menu](images/calva-monorepo-project-roots-menu.png)
-
-When searching for project roots in your workspace, Calva will glob for all files matching `project.clj`, `deps.edn`, or `shadow-cljs.edn`. This is done using VS Code's workspace search engine, and is very efficient. However, in a large monorepo, it is still a substantial task. In order to not waste resources Calva will exclude any directories in the setting `calva.projectRootsSearchExclude`. 
-
-![calva.projectRootsSearchExclude setting](images/calva-project-roots-search-exclude.png)
-
-!!! Note "Exclude entry globs"
-    Each entry is a partial *glob* and will be part of a resulting *glob* of the form `**/{glob1,glob2,...,globN}`. This means that all directories in the workspace matching an entry will be excluded, regardless of where in the workspace they reside.
 
 ## shadow-cljs in full stack projects
 

--- a/docs/site/customizing-jack-in-and-connect.md
+++ b/docs/site/customizing-jack-in-and-connect.md
@@ -17,21 +17,31 @@ You can have Calva evaluate code whenever a REPL has been connected via the `cal
 
 - `clj`: "Code to evaluate when the **Clojure** REPL has been connected.
     - The default is code that refer in the `repl-requires`/REPL utilities (like `source`, `doc`, etcetera). (Note that there is also a command to do this on demand.).
+    - Overriding the default replaces it. If you want to add code to be evaluated on connect this way, and keep the behaviour of auto-refering REPL utilities, you need to provide code for the latter (copy/pasting the default code will do). See also note below about concatenation of configurations.
     - The code will be evaluated *before* the `afterCLJReplJackInCode` in any [connect sequence](https://calva.io/connect-sequences/) used.
-    - Set to `null` to disable this feature. (The Settings linter will complain, but it works.)
 - `cljs`: Code to evaluate when the **ClojureScript** REPL has been connected.
     - The default is code that refer in the `repl-requires`/REPL utilities (like `source`, `doc`, etcetera). (Note that there is also a command to do this on demand.).
-    - Set to `null` to disable this feature.
+    - Same deal with overriding the default as with `clj`.
 
-NB: There are two mechanisms for evaluating code when a Clojure REPL is connected. The `afterCLJReplJackInCode` setting of custom connect sequences, and this `calva.autoEvaluateCode.onConnect.clj` setting. There is no fundamental difference between them. This one has a default function of auto-refering in the Clojure REPL utilities. And it will be run *before* the connect sequence after-Jack-in code.
+Set either of these to `null` to disable the feature for that REPL type. (The Settings linter will complain, but it works.)
+
+!!! Note "For Clojure this is in addition to `afterCLJReplJackInCode`"
+
+    There are two mechanisms for evaluating code when a Clojure REPL is connected. The `afterCLJReplJackInCode` setting of custom connect sequences, and this `calva.autoEvaluateCode.onConnect.clj` setting. There is no _fundamental_ difference between them. This one has a default function of auto-refering in the Clojure REPL utilities. And it will be run *before* the connect sequence after-Jack-in code.
+
+!!! Note "All configured code is concatenated"
+    If you configure this both in User/global settings and in a Workspace, the workspace configured code will be concatenated on the user level code. Meaning both code snippets will be evaluated, first the User level code, then the Workspace level code. Also `null` disables the feature:
+
+    - If you use `null` in the User level code, you will disable the onConnect code evaluation for all workspaces that do not configure code for this.
+    - If you configure code on the User level it will be evaluated in all workspaces, except those that disable the feature by configuring `null`. 
 
 ## Auto-evaluate Code at file/namespace load/evaluation
 
-You can also make Calva auto-evaluate code when a file has been loaded (manually using the Calva command for it) in the REPL. You add code for this via the `calva.autoEvaluateCode.onFileLoaded` setting. It also has two entries: `clj` and `cljs`, for the **Clojure** and **ClojureScript** REPL, respectively.
+You can also make Calva auto-evaluate code when a file has been loaded in the REPL (via the Calva command for loading files). You add code for this via the `calva.autoEvaluateCode.onFileLoaded` setting. Like with `onConnect` you provide code for `clj` and `cljs` separately.
 
-Note that the same substitution variables as with [custom commands](https://calva.io/custom-commands/) can be used here.
-
-Calva's does not provide defaults for this setting.
+* Note that [custom commands](https://calva.io/custom-commands/) substitutions are in play here as well.
+* Calva's does not provide defaults for this setting.
+* Merging works the same as with `onConnect`.
 
 ## Customizing Connect
 

--- a/docs/site/customizing-jack-in-and-connect.md
+++ b/docs/site/customizing-jack-in-and-connect.md
@@ -1,0 +1,146 @@
+---
+title: Customize Jack-in and Connect
+description: Calva's connecting of the REPL is highly customizable
+search:
+  boost: 7
+---
+
+# Customize Jack-in and Connect
+
+ Since Jack-in and connect both are about connecting the REPL, and only differ in how the REPL is started, many settings and configuration points are shared between the two concepts. A major customization point is [Custom Connect Sequences](connect-sequences.md), which are relevant for both Jack-in and Standalone Connect scenarios.
+
+This page lists some more Jack-in and Connect configuration options.
+
+## Auto-evaluate Code on Connect
+
+You can have Calva evaluate code whenever a REPL has been connected via the `calva.autoEvaluateCode.onConnect` setting. It has two entries `clj` and `cljs`:
+
+- `clj`: "Code to evaluate when the **Clojure** REPL has been connected.
+    - The default is code that refer in the `repl-requires`/REPL utilities (like `source`, `doc`, etcetera). (Note that there is also a command to do this on demand.).
+    - The code will be evaluated *before* the `afterCLJReplJackInCode` in any [connect sequence](https://calva.io/connect-sequences/) used.
+    - Set to `null` to disable this feature. (The Settings linter will complain, but it works.)
+- `cljs`: Code to evaluate when the **ClojureScript** REPL has been connected.
+    - The default is code that refer in the `repl-requires`/REPL utilities (like `source`, `doc`, etcetera). (Note that there is also a command to do this on demand.).
+    - Set to `null` to disable this feature.
+
+NB: There are two mechanisms for evaluating code when a Clojure REPL is connected. The `afterCLJReplJackInCode` setting of custom connect sequences, and this `calva.autoEvaluateCode.onConnect.clj` setting. There is no fundamental difference between them. This one has a default function of auto-refering in the Clojure REPL utilities. And it will be run *before* the connect sequence after-Jack-in code.
+
+## Auto-evaluate Code at file/namespace load/evaluation
+
+You can also make Calva auto-evaluate code when a file has been loaded (manually using the Calva command for it) in the REPL. You add code for this via the `calva.autoEvaluateCode.onFileLoaded` setting. It also has two entries: `clj` and `cljs`, for the **Clojure** and **ClojureScript** REPL, respectively.
+
+Note that the same substitution variables as with [custom commands](https://calva.io/custom-commands/) can be used here.
+
+Calva's does not provide defaults for this setting.
+
+## Customizing Connect
+
+If there is an nRepl port file, Calva will use it and not prompt for `host:port` when connecting. You can make Calva prompt for this by setting the boolean config `calva.autoSelectNReplPortFromPortFile` to `false`.
+
+With the setting `calva.autoConnectRepl` you can make Calva automatically connect the REPL if there is an nRepl port file present when the project is opened.
+
+With this and the below mentioned auto-select options you can make connect a prompt-less experience. See: [Connect Sequences](connect-sequences.md).
+
+#### Options for the Connect Command 
+
+The `calva.connect` command takes an optional options argument defined like so:
+
+```typescript
+  options?: {
+    host?: string;
+    port?: string;
+    connectSequence?: string | ReplConnectSequence;
+    disableAutoSelect?: boolean;
+  }
+```
+
+Where `ReplConnectSequence` is a [Connect Sequences](connect-sequences.md). If you provide a string it needs to match against a built-in or custom connect sequence. With `disableAutoSelect` you can force the connect menus to be provided even if a custom connect sequence is set to be autoSelected.
+
+You can provide these options from keyboard shortcuts or from [Joyride](https://github.com/BetterThanTomorrow/joyride) scripts.
+
+Here's a keyboard shortcut for connecting to a running REPL bypassing any connect sequence with `autoSelectForConnect`.
+
+```json
+    {
+        "command": "calva.connect",
+        "args": {"disableAutoSelect": true},
+        "key": "ctrl+alt+c shift+c",
+    },
+```
+
+A Joyride command for connecting to a REPL on port 55555, without being asked for project type:
+
+```clojure
+(vscode/commands.executeCommand "calva.connect" (clj->js {:port "55555" :connectSequence "Generic"}))
+```
+
+## Customizing Jack-in
+The main mechanism for customizing your Jack-in, including automating menu selections, and custom CLJS REPL types is [Custom Connect Sequences](connect-sequences.md).
+
+There are also these settings:
+
+* `calva.jackInEnv`: An object with environment variables that will be added to the environment of the Jack-in process.
+* `calva.myCljAliases`: An array of `deps.edn` aliases not found in the project file. Use this to tell Calva Jack-in to launch your REPL using your user defined aliases.
+* `calva.myLeinProfiles`: An array of Leiningen profiles not found in `project.clj`. Use this to tell Calva Jack-in to launch your REPL using your user defined profiles.
+* `calva.openBrowserWhenFigwheelStarted`: _For Legacy Figwheel only._ A boolean controlling if Calva should automatically launch your ClojureScript app, once it is compiled by Figwheel. Defaults to `true`.
+* `calva.depsEdnJackInExecutable`: A string which should either be `clojure` or `deps.clj`, or `clojure or deps.clj` (default). It determines which executable Calva Jack-in should use for starting a `deps.edn` project. With this setting at its default, `clojure or deps.clj`, Calva will test if the `clojure` executable works, and use it if it does, otherwise `deps.clj` will be used, which is bundled with Calva.
+
+!!! Note
+    When processing the `calva.jackInEnv` setting you can refer to existing ENV variables with `${env:VARIABLE}`.
+
+### Options for the Jack-in Command 
+
+The `calva.jackIn` command takes an optional options argument defined like so:
+
+```typescript
+  options?: {
+    connectSequence?: string | ReplConnectSequence;
+    disableAutoSelect?: boolean;
+  }
+```
+
+Where `ReplConnectSequence` is a [Connect Sequences](connect-sequences.md). If you provide a string it needs to match against a built-in or custom connect sequence. With `disableAutoSelect` you can force the jack-in menus to be provided even if a custom connect sequence is set to be autoSelected.
+
+You can provide these options from keyboard shortcuts or from [Joyride](https://github.com/BetterThanTomorrow/joyride) scripts.
+
+Here's a keyboard shortcut for connecting to a running REPL bypassing any connect sequence with `autoSelectForConnect`.
+
+```json
+    {
+        "command": "calva.jackIn",
+        "args": {"disableAutoSelect": true},
+        "key": "ctrl+alt+c shift+j",
+    },
+```
+
+A Joyride command for starting a `deps.edn` REPL for a project in the root of the workspace.
+
+```clojure
+(vscode/commands.executeCommand
+ "calva.jackIn"
+ (clj->js {:connectSequence {:projectType "deps.edn"
+                             :projectRootPath ["."]}}))
+```
+
+It will prompt for any aliases it finds in the `deps.edn` file.    
+
+## Starting the REPL from application code?
+
+If your project is setup so that the REPL server is started by the application code, you will need to get the cider-nrepl middleware in place. See the cider-nrepl docs about [embedding nREPL in your application](https://docs.cider.mx/cider-nrepl/usage.html#via-embedding-nrepl-in-your-application).
+
+## Auto-select Project Type and Project Root
+
+You can make both Jack-in and Connect stop prompting you for project type and project root path in projects where you always want to use the same. See [Connect Sequences](connect-sequences.md).
+
+## Project roots search globing
+
+When searching for project roots in your workspace, Calva will glob for all files matching `project.clj`, `deps.edn`, or `shadow-cljs.edn`. This is done using VS Code's workspace search engine, and is very efficient. However, in a large monorepo, it is still a substantial task. In order to not waste resources Calva will exclude any directories in the setting `calva.projectRootsSearchExclude`. 
+
+![calva.projectRootsSearchExclude setting](images/calva-project-roots-search-exclude.png)
+
+!!! Note "Exclude entry globs"
+    Each entry is a partial *glob* and will be part of a resulting *glob* of the form `**/{glob1,glob2,...,globN}`. This means that all directories in the workspace matching an entry will be excluded, regardless of where in the workspace they reside.
+
+## Viewing the Communication Between nREPL and Calva
+
+It may be helpful to view the messages sent between nREPL and Calva when troubleshooting an issue related to the REPL. See how to do that [here](../nrepl_and_cider-nrepl/#viewing-the-communication-between-calva-and-nrepl).

--- a/docs/site/customizing.md
+++ b/docs/site/customizing.md
@@ -72,7 +72,7 @@ To have the hints automatically pop up when you are typing, set `editor.paramete
 
 See [Formatting](formatting.md) for information on how to configure this.
 
-## Jack-in and Connect Sequences
+## Jack-in and Connect
 
 Jack-in and Connect are very customizable through [Custom Connect Sequences](connect-sequences.md).
 

--- a/docs/site/when-clauses.md
+++ b/docs/site/when-clauses.md
@@ -1,0 +1,22 @@
+---
+title: Calva When Clause Contexts
+description: Calva comes with batteries included and preconfigured, and if you don't like the defaults, you can customize
+---
+
+# Calva When Clause Contexts
+
+[When clause contexts](https://code.visualstudio.com/api/references/when-clause-contexts) is a powerful customization mechanism in VS Code. The most common use for end users is with keyboard shortcut bindings. Extensions can provide their own. The following contexts are available with Calva:
+
+* `calva:keybindingsEnabled`: a master switch that you find in the settings
+* `paredit:keyMap`: `strict`, `original`, or `none` from the corresponding Calva setting (see [Paredit](paredit.md))
+* `calva:connected`: `true` when Calva is connected to a REPL (there is also `calva:connecting` || `calva:launching`)
+* `calva:outputWindowActive`: `true` when the [Output/REPL window](output.md) has input focus
+* `calva:replHistoryCommandsActive`: `true` when the cursor is in the Output/REPL window at the top level after the last prompt
+* `calva:outputWindowSubmitOnEnter`: `true` when the cursor is adjacent after the last top level form in the Output/REPL window
+* `calva:cursorInString`: `true` when the cursor/caret is in a string or a regexp
+* `calva:cursorInComment`: `true` when the cursor is in, or adjacent to a line comment
+* `calva:cursorBeforeComment`: `true` when the cursor is adjacent before a line comment
+* `calva:cursorAfterComment`: `true` when the cursor is adjacent after a line comment
+* `calva:cursorAtStartOfLine`: `true` when the cursor is at the start of a line including any leading whitespace
+* `calva:cursorAtEndOfLine`: `true` when the cursor is at the end of a line including any trailing whitespace
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,9 +68,12 @@ nav:
     - namespace-form-auto-creation.md
     - notebooks.md
     - hiccup.md
+  - Customizing Calva:
+    - customizing.md
+    - customizing-jack-in-and-connect.md
+    - when-clauses.md
   - clojure-lsp.md
   - nrepl_and_cider-nrepl.md
-  - customizing.md
   - Using Calva with ...:
     - wsl.md
     - remote-development.md

--- a/package.json
+++ b/package.json
@@ -838,20 +838,49 @@
               }
             }
           },
-          "calva.autoReferReplUtilities": {
-            "type": "string",
-            "markdownDescription": "Should Calva automatically refer in the `repl-requires`/REPL utilities (like `source`, `doc`, etcetera), and when should it do that? (There is also a command to do this on demand.)",
-            "enum": [
-              "on-connect",
-              "always",
-              "never"
-            ],
-            "default": "on-connect",
-            "markdownEnumDescriptions": [
-              "Auto-refer the REPL utilities only in the initial namespace immediately after connecting the REPL.",
-              "Auto-refer the REPL utilities in all namespaces.",
-              "Never auto-refer the REPL utilities."
-            ]
+          "calva.autoEvaluateCode": {
+            "type": "object",
+            "markdownDescription": "Code to automatically evaluate when a REPL has been connected, or a file/namespace has been loaded/evaluated.",
+            "properties": {
+              "onConnect": {
+                "type": "object",
+                "markdownDescription": "When a REPL has been connected.",
+                "properties": {
+                  "clj": {
+                    "type": "string",
+                    "markdownDescription": "Code to evaluate when the **Clojure** REPL has been connected. The default is code that refer in the `repl-requires`/REPL utilities (like `source`, `doc`, etcetera). (Note that there is also a command to do this on demand.). The code will be evaluated *before* the `afterCLJReplJackInCode` in any [connect sequence](https://calva.io/connect-sequences/) used. Set to `null` to disable this feature."
+                  },
+                  "cljs": {
+                    "type": "string",
+                    "markdownDescription": "Code to evaluate when the **ClojureScript** REPL has been connected. The default is code that refer in the `repl-requires`/REPL utilities (like `source`, `doc`, etcetera). (Note that there is also a command to do this on demand.). Set to `null` to disable this feature."
+                  }
+                },
+                "onFileLoaded": {
+                  "type": "object",
+                  "markdownDescription": "When a file/namespace has been loaded/evaluated.",
+                  "properties": {
+                    "clj": {
+                      "type": "string",
+                      "markdownDescription": "Code to evaluate when the current file/namespace has been loaded/evaluated (via the command for this), in the **Clojure** REPL. The same substitution variables as with [custom commands](https://calva.io/custom-commands/) can be used here. Set to `null` to disable this feature."
+                    },
+                    "cljs": {
+                      "type": "string",
+                      "markdownDescription": "Code to evaluate when the current file/namespace has been loaded/evaluated (via the command for this), in the **ClojureScript** REPL. The same substitution variables as with [custom commands](https://calva.io/custom-commands/) can be used here. Set to `null` to disable this feature."
+                    }
+                  }
+                }
+              }
+            },
+            "default": {
+              "onConnect": {
+                "clj": "(when-let [requires (resolve 'clojure.main/repl-requires)] (clojure.core/apply clojure.core/require @requires))",
+                "cljs": "(try (require '[cljs.repl :refer [apropos dir doc find-doc print-doc pst source]]) (catch :default e (js/console.warn \"Failed to require cljs.repl utilities:\" (.-message e))))"
+              },
+              "onFileLoaded": {
+                "clj": null,
+                "cljs": null
+              }
+            }
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -840,7 +840,7 @@
           },
           "calva.autoEvaluateCode": {
             "type": "object",
-            "markdownDescription": "Code to automatically evaluate when a REPL has been connected, or a file/namespace has been loaded/evaluated.",
+            "markdownDescription": "Code to automatically evaluate when a REPL has been connected, or a file/namespace has been loaded/evaluated. See https://calva.io/customizing-jack-in-and-connect/ for details.",
             "properties": {
               "onConnect": {
                 "type": "object",
@@ -861,11 +861,11 @@
                   "properties": {
                     "clj": {
                       "type": "string",
-                      "markdownDescription": "Code to evaluate when the current file/namespace has been loaded/evaluated (via the command for this), in the **Clojure** REPL. The same substitution variables as with [custom commands](https://calva.io/custom-commands/) can be used here. Set to `null` to disable this feature."
+                      "markdownDescription": "Code to evaluate when the current file/namespace has been loaded/evaluated (via the command for this), in the **Clojure** REPL. The same substitution variables as with [custom commands](https://calva.io/custom-commands/) can be used here."
                     },
                     "cljs": {
                       "type": "string",
-                      "markdownDescription": "Code to evaluate when the current file/namespace has been loaded/evaluated (via the command for this), in the **ClojureScript** REPL. The same substitution variables as with [custom commands](https://calva.io/custom-commands/) can be used here. Set to `null` to disable this feature."
+                      "markdownDescription": "Code to evaluate when the current file/namespace has been loaded/evaluated (via the command for this), in the **ClojureScript** REPL. The same substitution variables as with [custom commands](https://calva.io/custom-commands/) can be used here."
                     }
                   }
                 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -225,8 +225,7 @@ function getConfig() {
     autoSelectNReplPortFromPortFile: configOptions.get<boolean>('autoSelectNReplPortFromPortFile'),
     autoConnectRepl: configOptions.get<boolean>('autoConnectRepl'),
     html2HiccupOptions: configOptions.get<converters.HiccupOptions>('html2HiccupOptions'),
-    autoReferReplUtilities:
-      configOptions.get<nrepl.AutoReferReplUtilities>('autoReferReplUtilities'),
+    autoEvaluateCode: configOptions.get<nrepl.AutoEvaluateCodeConfig>('autoEvaluateCode'),
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -174,6 +174,8 @@ function getConfig() {
     []
   ).concat((state.getProjectConfig()?.customREPLHoverSnippets as customREPLCommandSnippet[]) ?? []);
 
+  const autoEvaluateCode = configOptions.inspect<nrepl.AutoEvaluateCodeConfig>('autoEvaluateCode');
+
   return {
     formatOnSave: configOptions.get('formatOnSave'),
     evalOnSave: configOptions.get('evalOnSave'),
@@ -225,7 +227,14 @@ function getConfig() {
     autoSelectNReplPortFromPortFile: configOptions.get<boolean>('autoSelectNReplPortFromPortFile'),
     autoConnectRepl: configOptions.get<boolean>('autoConnectRepl'),
     html2HiccupOptions: configOptions.get<converters.HiccupOptions>('html2HiccupOptions'),
-    autoEvaluateCode: configOptions.get<nrepl.AutoEvaluateCodeConfig>('autoEvaluateCode'),
+    autoEvaluateCode: nrepl.mergeAutoEvaluateConfigs(
+      [
+        autoEvaluateCode.globalValue,
+        autoEvaluateCode.workspaceValue,
+        autoEvaluateCode.workspaceFolderValue,
+      ],
+      autoEvaluateCode.defaultValue
+    ),
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ import * as state from './state';
 import _ = require('lodash');
 import { isDefined } from './utilities';
 import * as converters from './converters';
-import * as nrepl from './nrepl/index';
+import * as nreplUtil from './nrepl/util';
 
 const REPL_FILE_EXT = 'calva-repl';
 const KEYBINDINGS_ENABLED_CONFIG_KEY = 'calva.keybindingsEnabled';
@@ -174,7 +174,8 @@ function getConfig() {
     []
   ).concat((state.getProjectConfig()?.customREPLHoverSnippets as customREPLCommandSnippet[]) ?? []);
 
-  const autoEvaluateCode = configOptions.inspect<nrepl.AutoEvaluateCodeConfig>('autoEvaluateCode');
+  const autoEvaluateCode =
+    configOptions.inspect<nreplUtil.AutoEvaluateCodeConfig>('autoEvaluateCode');
 
   return {
     formatOnSave: configOptions.get('formatOnSave'),
@@ -227,7 +228,7 @@ function getConfig() {
     autoSelectNReplPortFromPortFile: configOptions.get<boolean>('autoSelectNReplPortFromPortFile'),
     autoConnectRepl: configOptions.get<boolean>('autoConnectRepl'),
     html2HiccupOptions: configOptions.get<converters.HiccupOptions>('html2HiccupOptions'),
-    autoEvaluateCode: nrepl.mergeAutoEvaluateConfigs(
+    autoEvaluateCode: nreplUtil.mergeAutoEvaluateConfigs(
       [
         autoEvaluateCode.globalValue,
         autoEvaluateCode.workspaceValue,

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -138,7 +138,7 @@ async function getSnippetDefinition(codeOrKey: string, editorNS: string, editorR
   return pick !== undefined ? snippetsDict[pick] : { snippet: codeOrKey };
 }
 
-function makeContext(editor: vscode.TextEditor, ns: string, editorNS: string, repl: string) {
+export function makeContext(editor: vscode.TextEditor, ns: string, editorNS: string, repl: string) {
   return {
     currentLine: editor.selection.active.line,
     currentColumn: editor.selection.active.character,

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -106,9 +106,6 @@ async function evaluateCodeUpdatingUI(
 
     if (outputWindow.getNs() !== ns) {
       await session.switchNS(ns);
-      if (getConfig().autoReferReplUtilities === 'always') {
-        await session.requireREPLUtilities();
-      }
     }
 
     const context: NReplEvaluation = session.eval(code, ns, {
@@ -434,8 +431,17 @@ async function loadFile(
     outputWindow.appendLine(`; Evaluating file: ${fileName}`);
 
     await session.switchNS(ns);
-    if (getConfig().autoReferReplUtilities === 'always') {
-      await session.requireREPLUtilities();
+    if (getConfig().autoEvaluateCode.onFileLoaded[fileType]) {
+      if (getConfig().autoEvaluateCode.onConnect.cljs) {
+        outputWindow.appendLine(`; Evaluating 'autoEvaluateCode.onFileLoaded.${fileType}'`);
+        await evaluateInOutputWindow(
+          getConfig().autoEvaluateCode.onConnect.cljs,
+          fileType,
+          outputWindow.getNs(),
+          {}
+        );
+        outputWindow.appendPrompt();
+      }
     }
 
     const errorMessages = [];
@@ -588,9 +594,6 @@ export async function evaluateInOutputWindow(
     replSession.updateReplSessionType();
     if (outputWindow.getNs() !== ns) {
       await session.switchNS(ns);
-      if (getConfig().autoReferReplUtilities === 'always') {
-        await session.requireREPLUtilities();
-      }
       outputWindow.setSession(session, ns);
       if (options.evaluationSendCodeToOutputWindow !== false) {
         outputWindow.appendPrompt();

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -15,6 +15,7 @@ import { getStateValue } from '../out/cljs-lib/cljs-lib';
 import { getConfig } from './config';
 import * as replSession from './nrepl/repl-session';
 import * as getText from './util/get-text';
+import * as customSnippets from './custom-snippets';
 
 function interruptAllEvaluations() {
   if (util.getConnectedState()) {
@@ -432,16 +433,13 @@ async function loadFile(
 
     await session.switchNS(ns);
     if (getConfig().autoEvaluateCode.onFileLoaded[fileType]) {
-      if (getConfig().autoEvaluateCode.onConnect.cljs) {
-        outputWindow.appendLine(`; Evaluating 'autoEvaluateCode.onFileLoaded.${fileType}'`);
-        await evaluateInOutputWindow(
-          getConfig().autoEvaluateCode.onConnect.cljs,
-          fileType,
-          outputWindow.getNs(),
-          {}
-        );
-        outputWindow.appendPrompt();
-      }
+      outputWindow.appendLine(`; Evaluating 'autoEvaluateCode.onFileLoaded.${fileType}'`);
+      const context = customSnippets.makeContext(vscode.window.activeTextEditor, ns, ns, fileType);
+      await customSnippets.evaluateSnippet(
+        getConfig().autoEvaluateCode.onFileLoaded[fileType],
+        context,
+        {}
+      );
     }
 
     const errorMessages = [];

--- a/src/extension-test/unit/nrepl/util-test.ts
+++ b/src/extension-test/unit/nrepl/util-test.ts
@@ -81,7 +81,7 @@ describe('config', () => {
       ];
       const expectedResult: nreplUtil.AutoEvaluateCodeConfig = {
         ...defaults,
-        onFileLoaded: { clj: 'custom1', cljs: 'custom2' },
+        onFileLoaded: { clj: null, cljs: 'custom2' },
       };
       expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults)).toStrictEqual(expectedResult);
     });
@@ -94,7 +94,7 @@ describe('config', () => {
 
       const expectedResult: nreplUtil.AutoEvaluateCodeConfig = {
         ...defaults,
-        onFileLoaded: { clj: 'custom1', cljs: null },
+        onFileLoaded: { clj: null, cljs: null },
       };
 
       expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults)).toStrictEqual(expectedResult);

--- a/src/extension-test/unit/nrepl/util-test.ts
+++ b/src/extension-test/unit/nrepl/util-test.ts
@@ -1,0 +1,133 @@
+import * as expect from 'expect';
+import * as fc from 'fast-check';
+import * as nreplUtil from '../../../../src/nrepl/util';
+
+const defaults: nreplUtil.AutoEvaluateCodeConfig = {
+  onConnect: {
+    clj: 'clj',
+    cljs: 'cljs',
+  },
+  onFileLoaded: {
+    clj: null,
+    cljs: null,
+  },
+};
+
+const createCustomConfig = (custom: string): nreplUtil.AutoEvaluateCodeConfig => ({
+  onConnect: {
+    clj: custom,
+    cljs: custom,
+  },
+  onFileLoaded: {
+    clj: custom,
+    cljs: custom,
+  },
+});
+
+describe('config', () => {
+  describe('mergeAutoEvaluateConfigs', () => {
+    it('Keeps defaults if no config overrides', () => {
+      expect(
+        nreplUtil.mergeAutoEvaluateConfigs([defaults, defaults, defaults], defaults)
+      ).toStrictEqual(defaults);
+    });
+
+    it('Keeps defaults if no config overrides, also if a config is undefined', () => {
+      expect(
+        nreplUtil.mergeAutoEvaluateConfigs([defaults, defaults, undefined], defaults)
+      ).toStrictEqual(defaults);
+    });
+
+    it('Overrides default string with null value', () => {
+      const configs: nreplUtil.AutoEvaluateCodeConfig[] = [
+        { ...defaults, onConnect: { clj: null, cljs: null } },
+        { ...defaults, onConnect: { clj: null, cljs: null } },
+      ];
+      const expectedResult: nreplUtil.AutoEvaluateCodeConfig = {
+        ...defaults,
+        onConnect: { clj: null, cljs: null },
+      };
+      expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults)).toStrictEqual(expectedResult);
+    });
+
+    it('Concatenates non-default strings and disregards default strings', () => {
+      const configs: nreplUtil.AutoEvaluateCodeConfig[] = [
+        { ...defaults, onConnect: { clj: 'custom1', cljs: 'custom1' } },
+        { ...defaults, onConnect: { clj: 'clj', cljs: 'custom2' } },
+      ];
+      const expectedResult: nreplUtil.AutoEvaluateCodeConfig = {
+        ...defaults,
+        onConnect: { clj: 'custom1', cljs: 'custom1\ncustom2' },
+      };
+      expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults)).toStrictEqual(expectedResult);
+    });
+
+    it('Concatenates all strings when default value is null', () => {
+      const configs: nreplUtil.AutoEvaluateCodeConfig[] = [
+        { ...defaults, onFileLoaded: { clj: 'custom1', cljs: 'custom1' } },
+        { ...defaults, onFileLoaded: { clj: 'custom2', cljs: 'custom2' } },
+      ];
+      const expectedResult: nreplUtil.AutoEvaluateCodeConfig = {
+        ...defaults,
+        onFileLoaded: { clj: 'custom1\ncustom2', cljs: 'custom1\ncustom2' },
+      };
+      expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults)).toStrictEqual(expectedResult);
+    });
+
+    it('Overrides null default value with string value', () => {
+      const configs: nreplUtil.AutoEvaluateCodeConfig[] = [
+        { ...defaults, onFileLoaded: { clj: 'custom1', cljs: null } },
+        { ...defaults, onFileLoaded: { clj: null, cljs: 'custom2' } },
+      ];
+      const expectedResult: nreplUtil.AutoEvaluateCodeConfig = {
+        ...defaults,
+        onFileLoaded: { clj: 'custom1', cljs: 'custom2' },
+      };
+      expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults)).toStrictEqual(expectedResult);
+    });
+
+    it('Ignores null values when default value is null', () => {
+      const configs: nreplUtil.AutoEvaluateCodeConfig[] = [
+        { ...defaults, onFileLoaded: { clj: 'custom1', cljs: null } },
+        { ...defaults, onFileLoaded: { clj: null, cljs: null } },
+      ];
+
+      const expectedResult: nreplUtil.AutoEvaluateCodeConfig = {
+        ...defaults,
+        onFileLoaded: { clj: 'custom1', cljs: null },
+      };
+
+      expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults)).toStrictEqual(expectedResult);
+    });
+
+    it('Concatenates all non-default strings, generated', () => {
+      const nonDefaultString = (defaultString: string) =>
+        fc.string().filter((s) => s !== defaultString);
+      fc.assert(
+        fc.property(
+          nonDefaultString(defaults.onConnect.clj),
+          nonDefaultString(defaults.onConnect.cljs),
+          nonDefaultString(defaults.onFileLoaded.clj),
+          (custom1, custom2, custom3) => {
+            const config1 = createCustomConfig(custom1);
+            const config2 = createCustomConfig(custom2);
+            const config3 = createCustomConfig(custom3);
+
+            const merged = nreplUtil.mergeAutoEvaluateConfigs(
+              [config1, config2, config3],
+              defaults
+            );
+
+            const expectedOnFileLoaded = [custom1, custom2, custom3].join('\n');
+            const expectedOnConnectClj = [custom1, custom2, custom3].join('\n');
+            const expectedOnConnectCljs = [custom1, custom2, custom3].join('\n');
+            expect(merged.onFileLoaded.clj).toEqual(expectedOnFileLoaded);
+            expect(merged.onFileLoaded.cljs).toEqual(expectedOnFileLoaded);
+            expect(merged.onConnect.clj).toEqual(expectedOnConnectClj);
+            expect(merged.onConnect.cljs).toEqual(expectedOnConnectCljs);
+          }
+        )
+      );
+    });
+  });
+});

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -14,54 +14,6 @@ import { getStateValue, prettyPrint } from '../../out/cljs-lib/cljs-lib';
 import { getConfig } from '../config';
 import { log, Direction } from './logging';
 
-export interface AutoEvaluateCodeConfig {
-  onConnect: {
-    clj: string | null;
-    cljs: string | null;
-  };
-  onFileLoaded: {
-    clj: string | null;
-    cljs: string | null;
-  };
-}
-
-export function mergeAutoEvaluateConfigs(
-  configs: AutoEvaluateCodeConfig[],
-  defaultConfig: AutoEvaluateCodeConfig
-): AutoEvaluateCodeConfig {
-  return configs.reduce<AutoEvaluateCodeConfig>(
-    (merged, config) => {
-      if (config) {
-        for (const key of ['onConnect', 'onFileLoaded'] as const) {
-          for (const lang of ['clj', 'cljs'] as const) {
-            const defaultValue = defaultConfig[key][lang];
-            const currentValue = config[key][lang];
-            const mergedValue = merged[key][lang];
-
-            if (defaultValue === null) {
-              if (currentValue !== null) {
-                merged[key][lang] =
-                  mergedValue === null ? currentValue : `${mergedValue}\n${currentValue}`;
-              }
-            } else {
-              if (currentValue === null) {
-                merged[key][lang] = null;
-              } else if (currentValue !== defaultValue) {
-                merged[key][lang] =
-                  mergedValue === null || mergedValue === defaultValue
-                    ? currentValue
-                    : `${mergedValue}\n${currentValue}`;
-              }
-            }
-          }
-        }
-      }
-      return merged;
-    },
-    { ...defaultConfig }
-  );
-}
-
 function hasStatus(res: any, status: string): boolean {
   return res.status && res.status.indexOf(status) > -1;
 }

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -25,6 +25,43 @@ export interface AutoEvaluateCodeConfig {
   };
 }
 
+export function mergeAutoEvaluateConfigs(
+  configs: AutoEvaluateCodeConfig[],
+  defaultConfig: AutoEvaluateCodeConfig
+): AutoEvaluateCodeConfig {
+  return configs.reduce<AutoEvaluateCodeConfig>(
+    (merged, config) => {
+      if (config) {
+        for (const key of ['onConnect', 'onFileLoaded'] as const) {
+          for (const lang of ['clj', 'cljs'] as const) {
+            const defaultValue = defaultConfig[key][lang];
+            const currentValue = config[key][lang];
+            const mergedValue = merged[key][lang];
+
+            if (defaultValue === null) {
+              if (currentValue !== null) {
+                merged[key][lang] =
+                  mergedValue === null ? currentValue : `${mergedValue}\n${currentValue}`;
+              }
+            } else {
+              if (currentValue === null) {
+                merged[key][lang] = null;
+              } else if (currentValue !== defaultValue) {
+                merged[key][lang] =
+                  mergedValue === null || mergedValue === defaultValue
+                    ? currentValue
+                    : `${mergedValue}\n${currentValue}`;
+              }
+            }
+          }
+        }
+      }
+      return merged;
+    },
+    { ...defaultConfig }
+  );
+}
+
 function hasStatus(res: any, status: string): boolean {
   return res.status && res.status.indexOf(status) > -1;
 }

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -14,7 +14,16 @@ import { getStateValue, prettyPrint } from '../../out/cljs-lib/cljs-lib';
 import { getConfig } from '../config';
 import { log, Direction } from './logging';
 
-export type AutoReferReplUtilities = 'on-connect' | 'always' | 'never';
+export interface AutoEvaluateCodeConfig {
+  onConnect: {
+    clj: string | null;
+    cljs: string | null;
+  };
+  onFileLoaded: {
+    clj: string | null;
+    cljs: string | null;
+  };
+}
 
 function hasStatus(res: any, status: string): boolean {
   return res.status && res.status.indexOf(status) > -1;

--- a/src/nrepl/util.ts
+++ b/src/nrepl/util.ts
@@ -1,0 +1,62 @@
+export interface AutoEvaluateCodeConfig {
+  onConnect: {
+    clj: string | null;
+    cljs: string | null;
+  };
+  onFileLoaded: {
+    clj: string | null;
+    cljs: string | null;
+  };
+}
+
+/**
+ * Merges an array of AutoEvaluateCodeConfig objects, respecting their default values and overriding rules.
+ *
+ * The function takes the following rules into account when merging configurations:
+ *
+ * 1. If the default value is a string:
+ *    a. A `null` value in a config should override the merged value, essentially setting the merged value to `null`.
+ *    b. If the config value is a non-null string and not equal to the default value, it should be concatenated to the merged value.
+ *    c. If the config value is equal to the default value, it should be disregarded and not concatenated.
+ *
+ * 2. If the default value is `null`:
+ *    a. A `null` value in a config should be disregarded.
+ *    b. A non-null string value in a config should be concatenated to the merged value.
+ *
+ * @param configs An array of AutoEvaluateCodeConfig objects to be merged.
+ * @param defaultConfig The default AutoEvaluateCodeConfig object containing default values for each property.
+ * @returns The merged AutoEvaluateCodeConfig object resulting from the combination of the provided configs and default config.
+ */
+export function mergeAutoEvaluateConfigs(
+  configs: AutoEvaluateCodeConfig[],
+  defaultConfig: AutoEvaluateCodeConfig
+): AutoEvaluateCodeConfig {
+  return configs.reduce<AutoEvaluateCodeConfig>((merged, config) => {
+    if (config) {
+      for (const key of ['onConnect', 'onFileLoaded'] as const) {
+        for (const lang of ['clj', 'cljs'] as const) {
+          const defaultValue = defaultConfig[key][lang];
+          const currentValue = config[key][lang];
+          const mergedValue = merged[key][lang];
+
+          if (defaultValue === null) {
+            if (currentValue !== null) {
+              merged[key][lang] =
+                mergedValue === null ? currentValue : `${mergedValue}\n${currentValue}`;
+            }
+          } else {
+            if (currentValue === null) {
+              merged[key][lang] = null;
+            } else if (currentValue !== defaultValue) {
+              merged[key][lang] =
+                mergedValue === null || mergedValue === defaultValue
+                  ? currentValue
+                  : `${mergedValue}\n${currentValue}`;
+            }
+          }
+        }
+      }
+    }
+    return merged;
+  }, JSON.parse(JSON.stringify(defaultConfig)));
+}

--- a/src/nrepl/util.ts
+++ b/src/nrepl/util.ts
@@ -11,6 +11,8 @@ export interface AutoEvaluateCodeConfig {
 
 /**
  * Merges an array of AutoEvaluateCodeConfig objects, respecting their default values and overriding rules.
+ * Generally we want to evaluate all code that is configured, so we generally concatenate all non-null strings.
+ * However, we also want the allow disabling the evaluation all together by setting the value to `null`.
  *
  * The function takes the following rules into account when merging configurations:
  *

--- a/src/nrepl/util.ts
+++ b/src/nrepl/util.ts
@@ -14,17 +14,6 @@ export interface AutoEvaluateCodeConfig {
  * Generally we want to evaluate all code that is configured, so we generally concatenate all non-null strings.
  * However, we also want the allow disabling the evaluation all together by setting the value to `null`.
  *
- * The function takes the following rules into account when merging configurations:
- *
- * 1. If the default value is a string:
- *    a. A `null` value in a config should override the merged value, essentially setting the merged value to `null`.
- *    b. If the config value is a non-null string and not equal to the default value, it should be concatenated to the merged value.
- *    c. If the config value is equal to the default value, it should be disregarded and not concatenated.
- *
- * 2. If the default value is `null`:
- *    a. A `null` value in a config should be disregarded.
- *    b. A non-null string value in a config should be concatenated to the merged value.
- *
  * @param configs An array of AutoEvaluateCodeConfig objects to be merged.
  * @param defaultConfig The default AutoEvaluateCodeConfig object containing default values for each property.
  * @returns The merged AutoEvaluateCodeConfig object resulting from the combination of the provided configs and default config.
@@ -40,21 +29,13 @@ export function mergeAutoEvaluateConfigs(
           const defaultValue = defaultConfig[key][lang];
           const currentValue = config[key][lang];
           const mergedValue = merged[key][lang];
-
-          if (defaultValue === null) {
-            if (currentValue !== null) {
-              merged[key][lang] =
-                mergedValue === null ? currentValue : `${mergedValue}\n${currentValue}`;
-            }
-          } else {
-            if (currentValue === null) {
-              merged[key][lang] = null;
-            } else if (currentValue !== defaultValue) {
-              merged[key][lang] =
-                mergedValue === null || mergedValue === defaultValue
-                  ? currentValue
-                  : `${mergedValue}\n${currentValue}`;
-            }
+          if (currentValue === null) {
+            merged[key][lang] = null;
+          } else if (currentValue !== defaultValue) {
+            merged[key][lang] =
+              mergedValue === null || mergedValue === defaultValue
+                ? currentValue
+                : `${mergedValue}\n${currentValue}`;
           }
         }
       }

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -233,9 +233,6 @@ export async function setNamespaceFromCurrentFile() {
   const ns = namespace.getNamespace(util.tryToGetDocument({}));
   if (getNs() !== ns && util.isDefined(ns)) {
     await session.switchNS(ns);
-    if (config.getConfig().autoReferReplUtilities === 'always') {
-      await session.requireREPLUtilities();
-    }
   }
   setSession(session, ns);
   replSession.updateReplSessionType();
@@ -258,9 +255,6 @@ async function appendFormGrabbingSessionAndNS(topLevel: boolean) {
   if (code != '') {
     if (getNs() !== ns) {
       await session.switchNS(ns);
-      if (config.getConfig().autoReferReplUtilities === 'always') {
-        await session.requireREPLUtilities();
-      }
     }
     setSession(session, ns);
     appendLine(code, (_) => revealResultsDoc(false));

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import { https } from 'follow-redirects';
-import axios from 'axios';
 import * as _ from 'lodash';
 import * as state from './state';
 import * as path from 'path';


### PR DESCRIPTION
## What has changed?

* Fixes #2180

In that issue @sindhubb suggests adding a config for evaluating code when a file is loaded in the REPL. I was a bit reluctant at first, but then decided that we can replace the setting for `autoReferReplUtilities` with a setting for evaluating code after connecting the repl and provide default code that requires the REPL utilities. And then also settings for auto-evaluating code when a file is loaded/evaluated. The settings looks like so:

```json
          "calva.autoEvaluateCode": {
            "type": "object",
            "markdownDescription": "Code to automatically evaluate when a REPL has been connected, or a file/namespace has been loaded/evaluated.",
            "properties": {
              "onConnect": {
                "type": "object",
                "markdownDescription": "When a REPL has been connected.",
                "properties": {
                  "clj": {
                    "type": "string",
                    "markdownDescription": "Code to evaluate when the **Clojure** REPL has been connected. The default is code that refer in the `repl-requires`/REPL utilities (like `source`, `doc`, etcetera). (Note that there is also a command to do this on demand.). The code will be evaluated *before* the `afterCLJReplJackInCode` in any [connect sequence](https://calva.io/connect-sequences/) used. Set to `null` to disable this feature."
                  },
                  "cljs": {
                    "type": "string",
                    "markdownDescription": "Code to evaluate when the **ClojureScript** REPL has been connected. The default is code that refer in the `repl-requires`/REPL utilities (like `source`, `doc`, etcetera). (Note that there is also a command to do this on demand.). Set to `null` to disable this feature."
                  }
                },
                "onFileLoaded": {
                  "type": "object",
                  "markdownDescription": "When a file/namespace has been loaded/evaluated.",
                  "properties": {
                    "clj": {
                      "type": "string",
                      "markdownDescription": "Code to evaluate when the current file/namespace has been loaded/evaluated (via the command for this), in the **Clojure** REPL. The same substitution variables as with [custom commands](https://calva.io/custom-commands/) can be used here. Set to `null` to disable this feature."
                    },
                    "cljs": {
                      "type": "string",
                      "markdownDescription": "Code to evaluate when the current file/namespace has been loaded/evaluated (via the command for this), in the **ClojureScript** REPL. The same substitution variables as with [custom commands](https://calva.io/custom-commands/) can be used here. Set to `null` to disable this feature."
                    }
                  }
                }
              }
            },
            "default": {
              "onConnect": {
                "clj": "(when-let [requires (resolve 'clojure.main/repl-requires)] (clojure.core/apply clojure.core/require @requires))",
                "cljs": "(try (require '[cljs.repl :refer [apropos dir doc find-doc print-doc pst source]]) (catch :default e (js/console.warn \"Failed to require cljs.repl utilities:\" (.-message e))))"
              },
              "onFileLoaded": {
                "clj": null,
                "cljs": null
              }
            }
          }
```

This is WIP, and works, except that I haven't added the interpolations yet. I think those will make this worthwhile and more usable.

NB: When adding the auto-evel code for when the ClojureScript REPL is connected I ran against the problem that Calva doesn't know when the shadow-cljs REPL is connected. So I fixed a solution to that. Using the shadow-cljs API to wait for a CLJS runtime and only continuing the connect sequence when a runtime is available. Basically fixing the old:
* #1027 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
