### PR TITLE
Escape file paths in custom snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Escape backslashes in $file in customREPLCommands on windows](https://github.com/BetterThanTomorrow/calva/issues/2184)
+
 ## [2.0.357] - 2023-05-08
 
 - Fix: [Extension manifest misconfiguration, `autoEvaluateCode` nests `onFileEvaluated` inside `onConnect`](https://github.com/BetterThanTomorrow/calva/issues/2182)

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -165,12 +165,12 @@ function interpolateCode(code: string, context): string {
     .replace(/\$column/g, context.currentColumn)
     .replace(/\$hover-column/g, context.hoverColumn)
     .replace(/\$file-text/g, context.currentFileText[1])
-    .replace(/\$file/g, context.currentFilename)
+    .replace(/\$file/g, context.currentFilename.replace(/\\/g, '\\\\'))
     .replace(
       /\$hover-file-text/g,
       context.hovercurrentFileText ? context.hovercurrentFileText[1] : ''
     )
-    .replace(/\$hover-file/g, context.hoverFilename)
+    .replace(/\$hover-file/g, context.hoverFilename?.replace(/\\/g, '\\\\') ?? '')
     .replace(/\$ns/g, context.ns)
     .replace(/\$editor-ns/g, context.editorNS)
     .replace(/\$repl/g, context.repl)

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -165,11 +165,8 @@ function interpolateCode(code: string, context): string {
     .replace(/\$column/g, context.currentColumn)
     .replace(/\$hover-column/g, context.hoverColumn)
     .replace(/\$file-text/g, context.currentFileText[1])
-    .replace(/\$file/g, context.currentFilename.replace(/\\/g, '\\\\'))
-    .replace(
-      /\$hover-file-text/g,
-      context.hovercurrentFileText ? context.hovercurrentFileText[1] : ''
-    )
+    .replace(/\$file/g, context.currentFilename?.replace(/\\/g, '\\\\') ?? '')
+    .replace(/\$hover-file-text/g, context.hovercurrentFileText?.[1] ?? '')
     .replace(/\$hover-file/g, context.hoverFilename?.replace(/\\/g, '\\\\') ?? '')
     .replace(/\$ns/g, context.ns)
     .replace(/\$editor-ns/g, context.editorNS)
@@ -182,25 +179,16 @@ function interpolateCode(code: string, context): string {
     .replace(/\$top-level-form/g, context.topLevelForm[1])
     .replace(/\$current-fn/g, context.currentFn[1])
     .replace(/\$top-level-fn/g, context.topLevelFn[1])
-    .replace(/\$top-level-defined-symbol/g, context.topLevelDefinedForm[1])
+    .replace(/\$top-level-defined-symbol/g, context.topLevelDefinedForm?.[1] ?? '')
     .replace(/\$head/g, context.head[1])
     .replace(/\$tail/g, context.tail[1])
-    .replace(/\$hover-current-form/g, context.hovercurrentForm ? context.hovercurrentForm[1] : '')
-    .replace(/\$hover-current-pair/g, context.hovercurrentPair ? context.hovercurrentPair[1] : '')
-    .replace(
-      /\$hover-enclosing-form/g,
-      context.hoverenclosingForm ? context.hoverenclosingForm[1] : ''
-    )
-    .replace(
-      /\$hover-top-level-form/g,
-      context.hovertopLevelForm ? context.hovertopLevelForm[1] : ''
-    )
-    .replace(/\$hover-current-fn/g, context.hovercurrentFn ? context.hovercurrentFn[1] : '')
-    .replace(/\$hover-current-fn/g, context.hovertopLevelFn ? context.hovertopLevelFn[1] : '')
-    .replace(
-      /\$hover-top-level-defined-symbol/g,
-      context.hovertopLevelDefinedForm ? context.hovertopLevelDefinedForm[1] : ''
-    )
-    .replace(/\$hover-head/g, context.hoverhead ? context.hoverhead[1] : '')
-    .replace(/\$hover-tail/g, context.hovertail ? context.hovertail[1] : '');
+    .replace(/\$hover-current-form/g, context.hovercurrentForm?.[1] ?? '')
+    .replace(/\$hover-current-pair/g, context.hovercurrentPair?.[1] ?? '')
+    .replace(/\$hover-enclosing-form/g, context.hoverenclosingForm?.[1] ?? '')
+    .replace(/\$hover-top-level-form/g, context.hovertopLevelForm?.[1] ?? '')
+    .replace(/\$hover-current-fn/g, context.hovercurrentFn?.[1] ?? '')
+    .replace(/\$hover-current-fn/g, context.hovertopLevelFn?.[1] ?? '')
+    .replace(/\$hover-top-level-defined-symbol/g, context.hovertopLevelDefinedForm?.[1] ?? '')
+    .replace(/\$hover-head/g, context.hoverhead?.[1] ?? '')
+    .replace(/\$hover-tail/g, context.hovertail?.[1] ?? '');
 }


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

Using `$file` in custom snippets fails on Windows, because backslashes. This PR fixes.

* Fixes #2184

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Tests
  - [ ] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
