### PR TITLE
Fix windows auto jack in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [autoSelectForJackIn makes the jack-in fail on Windows](https://github.com/BetterThanTomorrow/calva/issues/2190)
+
 ## [2.0.358] - 2023-05-08
 
-- Fix: [Error connecting to the shadow.cljs REPL, introduced in v2.0.356](https://github.com/BetterThanTomorrow/calva/issues/2185)
 - [Escape backslashes in $file in customREPLCommands on windows](https://github.com/BetterThanTomorrow/calva/issues/2184)
 
 ## [2.0.357] - 2023-05-08

--- a/src/state.ts
+++ b/src/state.ts
@@ -215,11 +215,9 @@ export async function initProjectDir(
       );
 
   const projectRootPath: vscode.Uri = defaultSequence
-    ? vscode.Uri.parse(
-        path.resolve(
-          vscode.workspace.workspaceFolders[0].uri.fsPath,
-          ...(defaultSequence?.projectRootPath ? defaultSequence.projectRootPath : [])
-        )
+    ? vscode.Uri.joinPath(
+        vscode.workspace.workspaceFolders[0].uri,
+        ...(defaultSequence?.projectRootPath ? defaultSequence.projectRootPath : [])
       )
     : await projectRoot.pickProjectRoot(candidatePaths, closestRootPath, connectType);
   if (projectRootPath) {


### PR DESCRIPTION
## What has changed?

I don't know why, but the way we initialize the projectRoot when there is a default connect sequence, seems to walk some unnecessary extra mile, involving `path`. On Windows it creates a path Uri that is slightly different from creating it with the `Uri.joinPath()` function directly. And this then can't be used to join working Windows paths with this project root path.

I've changed so that we now go straight at the joinPath. I really can't see why we shouldn't. And it fixes the issue.

* Fixes #2190 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
