### PR TITLE
Custom project type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Support custom connect sequences that are not based on built in types](https://github.com/BetterThanTomorrow/calva/issues/2192)
 - Fix: [autoSelectForJackIn makes the jack-in fail on Windows](https://github.com/BetterThanTomorrow/calva/issues/2190)
+- Remove configuration and handling of `calva.autoSelectReplConnectProjectType` (replaced by connect sequence settings)
 
 ## [2.0.358] - 2023-05-08
 

--- a/docs/site/connect-sequences.md
+++ b/docs/site/connect-sequences.md
@@ -19,7 +19,7 @@ NB: _Connect sequence configuration affects Calva's Jack-in menu in the followin
 A connect sequence configures the following:
 
 * `name`: (required) This will show up in the Jack-in quick-pick menu when you start Jack-in (see above).
-* `projectType`: (required) This is either "Leiningen”, ”deps.edn”, ”shadow-cljs”, ”lein-shadow”, "Gradle", or ”generic".
+* `projectType`: (required) This is either "Leiningen”, "deps.edn", "shadow-cljs", "lein-shadow", "Gradle", ”generic”, or  "custom".
 * `autoSelectForJackIn`: A boolean. If true, this sequence will be automatically selected at **Jack-in**, suppressing the Project Type. Use together with `projectRootPath` to also suppress the Project Root menu. Add usage of `menuSelections` to go for a prompt-less REPL Jack-in. If you have more than one sequence with `autoSelectForJackIn` set to true, the first one will be used.
 * `autoSelectForConnect`: A boolean. If true, this sequence will be automatically selected at **Connect**, suppressing the Project Type menu. Use together with `projectRootPath` to also suppress the Project Root menu. If you have more than one sequence with `autoSelectForConnect` set to true, the first one will be used.
 * `projectRootPath`: An array of path segments leading to the root of the project to which this connect sequence corresponds. Use together with `autoSelectForJackIn`/`autoSelectForConnect` to suppress the Project Root menu. The path can be absolute or relative to the workspace root. If there are several Workspace Folders, the workspace root is the path of the first folder, so relative paths will only work for this first folder.
@@ -63,6 +63,8 @@ Custom command lines are there to bridge the gap to those situations where stand
 4. Any other reason...
 
 A custom command line is executed from same directory as the REPL project root (See `projectRootPath`, above), and can be as simple as `my-repl-jack-in-command`. You  can use a relative or absolute path to your command line.
+
+If your custom command line starts a REPL of a project type that is not ”known”/built-in to Calva, use `custom` as the `projectType` for the connect sequence.
 
 ### Custom Command Line Substitutions/Placeholders/Environment variables
 

--- a/package.json
+++ b/package.json
@@ -379,12 +379,6 @@
             "default": {},
             "description": "Specifies any environment variables your project needs. (Probably mostly for your Workspace Settings.)"
           },
-          "calva.autoSelectReplConnectProjectType": {
-            "deprecationMessage": "Deprecated in favour of `autoSelectForJackIn`/`autoSelectForConnect` in `calva.replConnectSequences`",
-            "type": "string",
-            "default": null,
-            "markdownDescription": "Use `autoSelectForJackIn`/`autoSelectForConnect` in `calva.replConnectSequences` instead of this setting."
-          },
           "calva.autoSelectNReplPortFromPortFile": {
             "type": "boolean",
             "default": true,

--- a/package.json
+++ b/package.json
@@ -561,7 +561,8 @@
                     "deps.edn",
                     "shadow-cljs",
                     "lein-shadow",
-                    "generic"
+                    "generic",
+                    "custom"
                   ]
                 },
                 "autoSelectForJackIn": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -224,7 +224,6 @@ function getConfig() {
     definitionProviderPriority: configOptions.get<string[]>('definitionProviderPriority'),
     depsEdnJackInExecutable: configOptions.get<string>('depsEdnJackInExecutable'),
     depsCljPath: configOptions.get<string>('depsCljPath'),
-    autoSelectReplConnectProjectType: configOptions.get<string>('autoSelectReplConnectProjectType'),
     autoSelectNReplPortFromPortFile: configOptions.get<boolean>('autoSelectNReplPortFromPortFile'),
     autoConnectRepl: configOptions.get<boolean>('autoConnectRepl'),
     html2HiccupOptions: configOptions.get<converters.HiccupOptions>('html2HiccupOptions'),

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -17,6 +17,7 @@ enum ProjectTypes {
   'nbb' = 'nbb',
   'joyride' = 'joyride',
   'generic' = 'generic',
+  'custom' = 'custom',
   'cljs-only' = 'cljs-only',
 }
 
@@ -180,6 +181,15 @@ const genericDefaults: ReplConnectSequence[] = [
   },
 ];
 
+const customDefaults: ReplConnectSequence[] = [
+  {
+    name: 'Custom',
+    projectType: ProjectTypes['custom'],
+    cljsType: CljsTypes.none,
+    nReplPortFile: ['.nrepl-port'],
+  },
+];
+
 const cljsOnlyDefaults: ReplConnectSequence[] = [
   {
     name: 'ClojureScript nREPL Server',
@@ -222,6 +232,7 @@ const defaultSequences = {
   'lein-shadow': leinShadowDefaults,
   gradle: gradleDefaults,
   generic: genericDefaults,
+  custom: customDefaults,
   babashka: babashkaDefaults,
   nbb: nbbDefaults,
   joyride: joyrideDefaults,
@@ -437,9 +448,9 @@ async function askForConnectSequence(
     defaultSequence?.name ??
     (await utilities.quickPickSingle({
       title: `${menuTitleType}: Project Type/Connect Sequence`,
-      values: sequences.map((s) => {
-        return s.name;
-      }),
+      values: sequences
+        .filter((s) => !(s.projectType === 'custom' && !s.customJackInCommandLine))
+        .map((s) => s.name),
       placeHolder: 'Please select a project type',
       saveAs: saveAsPath,
       autoSelect: true,

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -302,9 +302,6 @@ const defaultCljsTypes: { [id: string]: CljsTypeConfig } = {
   },
 };
 
-const autoSelectProjectTypeSetting: `calva.${keyof Config}` =
-  'calva.autoSelectReplConnectProjectType';
-
 const connectSequencesDocLink = `  - See https://calva.io/connect-sequences/`;
 
 const defaultProjectSettingMsg = (project: string) =>
@@ -374,26 +371,12 @@ function getUserSpecifiedSequence(
   connectType: ConnectType,
   disableAutoSelect: boolean
 ): ReplConnectSequence | undefined {
-  if (getConfig().autoSelectReplConnectProjectType) {
-    outputWindow.appendLine(
-      formatAsLineComments(
-        [
-          `Note: The config "${autoSelectProjectTypeSetting}" is deprecated.`,
-          connectSequencesDocLink,
-          '\n',
-        ].join('\n')
-      )
-    );
-  }
-
   const autoSelectedSequence = disableAutoSelect
     ? undefined
     : sequences.find((s) =>
         connectType === ConnectType.Connect ? s.autoSelectForConnect : s.autoSelectForJackIn
       );
-  const userSpecifiedProjectType = autoSelectedSequence
-    ? autoSelectedSequence.name
-    : getConfig().autoSelectReplConnectProjectType;
+  const userSpecifiedProjectType = autoSelectedSequence?.name;
 
   if (userSpecifiedProjectType) {
     const defaultSequence = sequences.find(

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -204,7 +204,7 @@ async function getJackInTerminalOptions(
 
   const projectType = projectTypes.getProjectTypeForName(projectTypeName);
 
-  const commandLineInfo = await projectType.commandLine(projectConnectSequence, selectedCljsType);
+  const commandLineInfo = await projectType.commandLine?.(projectConnectSequence, selectedCljsType);
 
   let args: string[] = commandLineInfo.args;
   let cmd: string[];

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -204,7 +204,11 @@ async function getJackInTerminalOptions(
 
   const projectType = projectTypes.getProjectTypeForName(projectTypeName);
 
-  const commandLineInfo = await projectType.commandLine?.(projectConnectSequence, selectedCljsType);
+  if (!projectType?.commandLine) {
+    throw new Error(`Project type ${projectTypeName} does not support Jack-in.`);
+  }
+
+  const commandLineInfo = await projectType.commandLine(projectConnectSequence, selectedCljsType);
 
   let args: string[] = commandLineInfo.args;
   let cmd: string[];

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -500,6 +500,20 @@ const projectTypes: { [id: string]: ProjectType } = {
       return cljCommandLine(connectSequence, CljsTypes.none);
     },
   },
+  custom: {
+    name: 'custom',
+    processShellUnix: true,
+    processShellWin: true,
+    useWhenExists: [],
+    nReplPortFile: ['.nrepl-port'],
+    commandLine: async (_connectSequence: ReplConnectSequence, _cljsType: CljsTypes) => {
+      const port = await getPort();
+      return {
+        args: [],
+        substitutions: { 'NREPL-PORT': port.toString() },
+      };
+    },
+  },
   babashka: {
     name: 'babashka',
     cljsTypes: [],
@@ -791,7 +805,7 @@ export function getProjectTypeForName(name: string) {
 
 export async function detectProjectTypes(): Promise<string[]> {
   const rootUri = state.getProjectRootUri();
-  const cljProjTypes = ['generic', 'cljs-only', 'babashka', 'nbb', 'joyride'];
+  const cljProjTypes = ['custom', 'generic', 'cljs-only', 'babashka', 'nbb', 'joyride'];
   for (const clj in projectTypes) {
     for (const projectFileName of projectTypes[clj].useWhenExists) {
       try {


### PR DESCRIPTION
## What has changed?

Adding a `custom` project type that never shows up in the project type selection menu and is only meant to be used together with connect sequences that provide a custom command line. Some such configurations will not be ”based” on deps.edn, Leiningen or any other built-in project type. I considered making `generic` the type to use for this, but it is (possibly by mistake) based on `deps.edn`.

* Fixes #2192 

Also removing the global and deprecated `calva.autoSelectConnectSequence` setting, as the code it adds to support it confused me a bit when trying to figure out how to properly support the `custom` project type.

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
