### PR TITLE
Fix shadow cljs connect regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Bump bundled deps.clj to v1.11.1.1273-4
+- Fix regression: [Cannot start a shadow-cljs REPL with non-keyword build id:s since version 2.0.355](https://github.com/BetterThanTomorrow/calva/issues/2200)
 
 ## [2.0.361] - 2023-05-16
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -413,8 +413,8 @@ function createCLJSReplType(
         'cljsReplTypeHasBuilds',
         cljsType.buildsRequired
       );
-      let initCode = cljsType.connectCode,
-        build: string = null;
+      let initCode = cljsType.connectCode;
+      let build: string = null;
       if (menuSelections && menuSelections.cljsDefaultBuild && useDefaultBuild) {
         build = menuSelections.cljsDefaultBuild;
         useDefaultBuild = false;
@@ -445,6 +445,7 @@ function createCLJSReplType(
         return;
       }
 
+      build = build.startsWith(':') ? build : `:${build}`;
       connectToBuild = build;
       setStateValue('cljsBuild', build);
 
@@ -464,7 +465,6 @@ function createCLJSReplType(
 
   async function waitForShadowCljsRuntimes() {
     const cljSession = replSession.getSession('clj');
-    console.log(connectToBuild);
     const getRuntimesCode = `(count (shadow.cljs.devtools.api/repl-runtimes ${connectToBuild}))`;
     const checkForRuntimes = async () => {
       const runtimes = await cljSession.eval(getRuntimesCode, 'shadow.user').value;

--- a/test-data/projects/minimal-shadow-only/.gitignore
+++ b/test-data/projects/minimal-shadow-only/.gitignore
@@ -1,0 +1,9 @@
+**/public/js/
+**/target/
+package-lock.json
+**/node_modules
+**/.cache
+**/.portal
+**/.shadow-cljs
+.lein*
+.nrepl-port

--- a/test-data/projects/minimal-shadow-only/.vscode/settings.json
+++ b/test-data/projects/minimal-shadow-only/.vscode/settings.json
@@ -1,0 +1,27 @@
+{
+  "calva.autoOpenJackInTerminal": true,
+  "calva.autoConnectRepl": true,
+  "calva.replConnectSequences": [
+    {
+      "projectType": "shadow-cljs",
+      "name": "Start ShadowCLJS REPL",
+      //"autoSelectForJackIn": true,
+      "projectRootPath": ["."],
+      "cljsType": "shadow-cljs",
+      "menuSelections": {
+        "cljsLaunchBuilds": ["app"],
+        "cljsDefaultBuild": "app"
+      }
+    },
+    {
+      "projectType": "deps.edn",
+      "name": "Connect ShadowCLJS REPL",
+      "autoSelectForConnect": true,
+      "projectRootPath": ["."],
+      "cljsType": "shadow-cljs",
+      "menuSelections": {
+        "cljsDefaultBuild": "frontend"
+      }
+    }
+  ]
+}

--- a/test-data/projects/minimal-shadow-only/deps.edn
+++ b/test-data/projects/minimal-shadow-only/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        org.clojure/clojurescript {:mvn/version "1.11.60"}
+        thheller/shadow-cljs {:mvn/version "2.19.9"}
+        binaryage/devtools {:mvn/version "1.0.6"}
+        reagent/reagent {:mvn/version "1.1.1"}}
+}

--- a/test-data/projects/minimal-shadow-only/package.json
+++ b/test-data/projects/minimal-shadow-only/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "shadow-cljs": "^2.19.9"
+  }
+}

--- a/test-data/projects/minimal-shadow-only/public/css/style.css
+++ b/test-data/projects/minimal-shadow-only/public/css/style.css
@@ -1,0 +1,1 @@
+/* some style */

--- a/test-data/projects/minimal-shadow-only/public/index.html
+++ b/test-data/projects/minimal-shadow-only/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="/css/style.css" rel="stylesheet" type="text/css">
+    <link rel="icon" href="https://clojurescript.org/images/cljs-logo-icon-32.png">
+  </head>
+  <body>
+    <div id="app">
+      The app should replace this. Have you started the app?
+    </div>
+    <script src="/js/compiled/main.js" type="text/javascript"></script>
+  </body>
+</html>

--- a/test-data/projects/minimal-shadow-only/shadow-cljs.edn
+++ b/test-data/projects/minimal-shadow-only/shadow-cljs.edn
@@ -1,0 +1,13 @@
+{;:deps true
+ :source-paths ["src"]
+ :dependencies [[binaryage/devtools "1.0.6"]
+                #_[ org.clojure/clojurescript {:mvn/version "1.11.60"}]
+                #_[ thheller/shadow-cljs "2.19.9"]
+                [ binaryage/devtools "1.0.6"]
+                [ reagent/reagent "1.1.1"]]
+ :dev-http {8700 "public"}
+ :builds
+ {:app {:target :browser
+        :output-dir "public/js/compiled"
+        :asset-path "/js/compiled"
+        :modules {:main {:init-fn main.core/init}}}}}

--- a/test-data/projects/minimal-shadow-only/src/main/core.cljs
+++ b/test-data/projects/minimal-shadow-only/src/main/core.cljs
@@ -1,0 +1,22 @@
+(ns main.core
+  (:require [reagent.core :as r]
+            [reagent.dom :as rdom]))
+
+(defonce app-state (r/atom {:text "Hello world!"}))
+
+(defn hello-world []
+  [:div
+   [:h1 (:text @app-state)]
+   [:h3 "Edit this and watch it change!"]])
+
+(defn ^:dev/after-load start []
+  (js/console.log "start")
+  (rdom/render [hello-world]
+               (. js/document (getElementById "app"))))
+
+(defn ^:export init []
+  (js/console.log "init")
+  (start))
+
+(defn ^:dev/before-load stop []
+  (js/console.log "stop"))


### PR DESCRIPTION
## What has changed?

With version 2.0.356 we introduced a wait for shadow-cljs runtimes before connecting/attaching to the build. In the code for checking this, the build id was not ensured to start with a `:` making the call croak. So, with connect sequences where the config set `cljsDefaultBuild` to something that already looks like a keyword the, the connect works, but without the `:` it doesn't work.

Now we are ensuring that the build id is prepended with a `:` before using it in calls to the shadow-cljs API.

* Fixes #2200

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
