### PR TITLE
Filter rich comments on Notebook Run All

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Stop Run All in Clojure Notebooks from evaluating `comment` forms](https://github.com/BetterThanTomorrow/calva/issues/2210)
+
 ## [2.0.364] - 2023-05-26
 
 - [Enable Custom REPL Commands in non-Clojure files](https://github.com/BetterThanTomorrow/calva/issues/2208)

--- a/src/NotebookProvider.ts
+++ b/src/NotebookProvider.ts
@@ -163,12 +163,16 @@ export class NotebookKernel {
   }
 }
 
+// TODO: Why is this called also when executing a single cell?
 async function executeAll(
   cells: vscode.NotebookCell[],
   _notebook: vscode.NotebookDocument,
   controller: vscode.NotebookController
 ) {
   for (const cell of cells) {
+    if (cell.metadata?.richComment && cells.length > 1) {
+      return;
+    }
     await doExecution(cell, controller);
   }
 }

--- a/src/NotebookProvider.ts
+++ b/src/NotebookProvider.ts
@@ -171,7 +171,7 @@ async function executeAll(
 ) {
   for (const cell of cells) {
     if (cell.metadata?.richComment && cells.length > 1) {
-      return;
+      continue;
     }
     await doExecution(cell, controller);
   }


### PR DESCRIPTION
## What has changed?

Implementing @djblue's suggestion of filtering rich comments when **Run All** is called on a Notebook.

**NB**: Even though the function is called `executeAll`, it is also called when evaluating/running a single cell. So we check that the cell count is larger than 1 before we decide to filter a comment form/cell.

* Fixes #2210

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
