### PR TITLE
Remove config disabling trim trailing newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Trailing whitespace not being stripped](https://github.com/BetterThanTomorrow/calva/issues/1258)
 - Bump bundled deps.clj to v1.11.1.1347
 
 ## [2.0.369] - 2023-06-02

--- a/docs/site/customizing.md
+++ b/docs/site/customizing.md
@@ -29,7 +29,6 @@ Calva sets some VS Code settings for all Clojure files. Some of these are needed
         "editor.formatOnType": true,
         "editor.autoIndent": "full",
         "editor.formatOnPaste": true,
-        "files.trimTrailingWhitespace": false,
         "editor.matchBrackets": "never",
         "editor.renderIndentGuides": false,
         "editor.parameterHints.enabled": false
@@ -47,7 +46,7 @@ Calva's pretty printing mode can be configured a bit. See [Pretty Printing](ppri
 
 This is highly customizable. See [Syntax highlighting](syntax-highlighting.md)
 
-## Color customizations 
+## Color customizations
 
 Calva defines a set of themable colors which can be provided by the user using [workbench.colorCustomizations](https://code.visualstudio.com/docs/getstarted/themes#_customize-a-color-theme).
 
@@ -88,7 +87,7 @@ The versions used are configurable via the VS Code settings `calva.jackInDepende
 
 ## Key bindings
 
-Most of Calva's commands have default keybindings. They are only defaults, though, and you can change keybindings as you wish. To facilitate precision in binding keys Calva keeps some [when clause contexts](https://code.visualstudio.com/api/references/when-clause-contexts) updated. 
+Most of Calva's commands have default keybindings. They are only defaults, though, and you can change keybindings as you wish. To facilitate precision in binding keys Calva keeps some [when clause contexts](https://code.visualstudio.com/api/references/when-clause-contexts) updated.
 
 ### When Clause Contexts
 
@@ -107,7 +106,7 @@ The following contexts are available with Calva:
 * `calva:cursorAtStartOfLine`: `true` when the cursor is at the start of a line including any leading whitespace
 * `calva:cursorAtEndOfLine`: `true` when the cursor is at the end of a line including any trailing whitespace
 
-### Some Custom Bindings 
+### Some Custom Bindings
 
 Here is a collection of custom keybindings from here and there.
 

--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
         "editor.formatOnType": true,
         "editor.autoIndent": "full",
         "editor.formatOnPaste": true,
-        "files.trimTrailingWhitespace": false,
         "editor.matchBrackets": "never",
         "editor.guides.indentation": false,
         "editor.parameterHints.enabled": false,


### PR DESCRIPTION
Calva ships with some default settings that take effect on Clojure files. One of them is:

```json
"files.trimTrailingWhitespace": false,
```

I vaguely remember there being a reason for this, but I think that the reason does not exist any longer. So removing that config with this PR.

* Fixes #1258

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
