### PR TITLE
Show main-opts info with the alias item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Improve Jack-in Ux around deps.edn aliases with :main-opts](https://github.com/BetterThanTomorrow/calva/issues/2223)
+
 ## [2.0.370] - 2023-06-15
 
 - Fix: [Trailing whitespace not being stripped](https://github.com/BetterThanTomorrow/calva/issues/1258)

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -423,7 +423,9 @@ function createCLJSReplType(
       } else {
         if (typeof initCode === 'object' || initCode.includes('%BUILD%')) {
           build = await util.quickPickSingle({
-            values: startedBuilds ? startedBuilds : await figwheelOrShadowBuilds(cljsTypeName),
+            values: startedBuilds
+              ? startedBuilds.map((a) => ({ label: a }))
+              : (await figwheelOrShadowBuilds(cljsTypeName)).map((a) => ({ label: a })),
             placeHolder: 'Select which build to connect to',
             saveAs: `${state.getProjectRootUri().toString()}/${cljsTypeName.replace(
               ' ',
@@ -531,7 +533,7 @@ function createCLJSReplType(
               allBuilds.length <= 1
                 ? allBuilds
                 : await util.quickPickMulti({
-                    values: allBuilds,
+                    values: allBuilds.map((a) => ({ label: a })),
                     placeHolder: 'Please select which builds to start',
                     saveAs: `${state.getProjectRootUri().toString()}/${cljsTypeName.replace(
                       ' ',

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -121,7 +121,7 @@ async function getSnippetDefinition(codeOrKey: string, editorNS: string, editorR
     if (snippetsMenuItems.length > 0) {
       try {
         pick = await util.quickPickSingle({
-          values: snippetsMenuItems,
+          values: snippetsMenuItems.map((a) => ({ label: a })),
           placeHolder: 'Choose a command to run at the REPL',
           saveAs: 'runCustomREPLCommand',
         });

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -433,7 +433,8 @@ async function askForConnectSequence(
       title: `${menuTitleType}: Project Type/Connect Sequence`,
       values: sequences
         .filter((s) => !(s.projectType === 'custom' && !s.customJackInCommandLine))
-        .map((s) => s.name),
+        .map((s) => s.name)
+        .map((a) => ({ label: a })),
       placeHolder: 'Please select a project type',
       saveAs: saveAsPath,
       autoSelect: true,


### PR DESCRIPTION
Removing the pop-up warning about main-opts and replacing it with some info attached to the `:main-opts` alias.

<img width="600" alt="image" src="https://github.com/BetterThanTomorrow/calva/assets/30010/fd051671-4028-4877-bbe0-1e6f9b37cea1">

* Fixes #2223

In order to provide the extra info with the alias, I changed so that our custom quick-pick menu expects `vscode.QuickPickItem`s, instead of strings.

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
