### PR TITLE
Format enclosing on paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [When pasting something with trailing space, it gets removed](https://github.com/BetterThanTomorrow/calva/issues/2229)
+
 ## [2.0.371] - 2023-06-17
 
 - [Improve Jack-in Ux around deps.edn aliases with :main-opts](https://github.com/BetterThanTomorrow/calva/issues/2223)

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -13,6 +13,7 @@ import { isUndefined, cloneDeep } from 'lodash';
 import { LispTokenCursor } from '../../cursor-doc/token-cursor';
 import { formatIndex } from './format-index';
 import * as state from '../../state';
+import * as getText from '../../util/get-text';
 
 const FormatDepthDefaults = {
   deftype: 2,
@@ -55,9 +56,12 @@ export async function indentPosition(position: vscode.Position, document: vscode
 
 export async function formatRangeEdits(
   document: vscode.TextDocument,
-  range: vscode.Range
+  originalRange: vscode.Range
 ): Promise<vscode.TextEdit[] | undefined> {
-  const text: string = document.getText(range);
+  const originalText = document.getText(originalRange);
+  const [range, text]: [vscode.Range, string] = originalText.match(/[\])}]/)
+    ? [originalRange, originalText]
+    : getText.currentEnclosingFormText(document, originalRange.end);
   const mirroredDoc: MirroredDocument = getDocument(document);
   const startIndex = document.offsetAt(range.start);
   const endIndex = document.offsetAt(range.end);


### PR DESCRIPTION
## What has changed?

The range format provider (which is used by VS Code when text is pasted) is updated to select the enclosing form if the range does not correspond to a list-ish form. This to avoid trimming the separating space when formatting something like `a (b |c |d) e`. (We instead format `a |(b c d)| e` in this case.

* Fixes #2229

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
