### PR TITLE
Selection closing bracket fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Selection, closing brackets, fails in mysterious ways](https://github.com/BetterThanTomorrow/calva/issues/2232)
+
 ## [2.0.372] - 2023-06-23
 
 - Fix: [Trailing space is removed unconditionally from pasted text](https://github.com/BetterThanTomorrow/calva/issues/2229)

--- a/src/util/cursor-get-text.ts
+++ b/src/util/cursor-get-text.ts
@@ -82,7 +82,7 @@ export function startOfFileToCursor(doc: EditableDocument): RangeAndText {
 }
 
 export function selectionAddingBrackets(doc: EditableDocument): RangeAndText {
-  const [left, right] = [doc.selection.anchor, doc.selection.active].sort();
+  const [left, right] = [doc.selection.anchor, doc.selection.active].sort((a, b) => a - b);
   const cursor = doc.getTokenCursor(left);
   cursor.forwardSexp(true, true, true);
   const rangeEnd = cursor.offsetStart;

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -15,9 +15,17 @@
     {
       "name": "Current file text",
       "snippet": "'($file-text)"
+    },
+    {
+      "name": "Selection, closing brackets",
+      "snippet": "$selection-closing-brackets"
     }
   ],
   "calva.customREPLHoverSnippets": [
+    {
+      "name": "Selection, closing brackets",
+      "snippet": "$selection-closing-brackets"
+    },
     {
       "name": "edn hover hover-text",
       "snippet": "(str \"**JSON hover hover-text** \" \"$hover-text\")"

--- a/test-data/hiccup.clj
+++ b/test-data/hiccup.clj
@@ -1,0 +1,10 @@
+(defonce Stack (rnn-stack/createNativeStackNavigator))
+
+(r/with-let [counter (rf/subscribe [:get-counter])
+               tap-enabled? (rf/subscribe [:counter-tappable?])
+               remaining-time (rf/subscribe [:timer/remaining-time])]
+    [:> rn/View {:style {:flex 1
+                         :padding-vertical 50
+                         :justify-content :space-between
+                         :align-items :center
+                         :background-color :white}}])


### PR DESCRIPTION
## What has changed?

See: https://twitter.com/pappapez/status/1672265204036452353 😄 

* Fixes #2232

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
