### PR TITLE
Format incomplete on paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Re-indent non-complete code, when pasting or formatting selection](https://github.com/BetterThanTomorrow/calva/issues/1709)
 - Fix: [Selection, closing brackets, fails in mysterious ways](https://github.com/BetterThanTomorrow/calva/issues/2232)
 
 ## [2.0.372] - 2023-06-23

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -63,10 +63,16 @@ export async function formatRangeEdits(
     const missingTexts = cursorDocUtils.getMissingBrackets(originalText);
     const healedText = `${missingTexts.prepend}${originalText}${missingTexts.append}`;
     const formattedHealedText = await formatCode(healedText, document.eol);
-    const formattedText = formattedHealedText.substring(
-      missingTexts.prepend.length,
-      missingTexts.prepend.length + formattedHealedText.length - missingTexts.append.length
-    );
+    const formattedText = formattedHealedText
+      .substring(
+        missingTexts.prepend.length,
+        missingTexts.prepend.length + formattedHealedText.length - missingTexts.append.length
+      )
+      .split(_convertEolNumToStringNotation(document.eol))
+      .map((line: string, i: number) =>
+        i === 0 ? line : `${' '.repeat(originalRange.start.character)}${line}`
+      )
+      .join(_convertEolNumToStringNotation(document.eol));
     const endIndex = startIndex + formattedText.length;
     const allText =
       document.getText(new vscode.Range(document.positionAt(0), originalRange.start)) +

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -58,20 +58,15 @@ export async function formatRangeEdits(
   const cursor = mirrorDoc.getTokenCursor(startIndex);
   if (!cursor.withinString() && !cursor.withinComment()) {
     const originalText = document.getText(originalRange);
-    console.log(`originalText:\n${originalText}`);
     const leadingWs = originalText.match(/^\s*/)[0];
     const trailingWs = originalText.match(/\s*$/)[0];
     const missingTexts = cursorDocUtils.getMissingBrackets(originalText);
-    console.log(`missingTexts:\n${missingTexts}`);
     const healedText = `${missingTexts.prepend}${originalText}${missingTexts.append}`;
-    console.log(`healedText:\n${healedText}`);
     const formattedHealedText = await formatCode(healedText, document.eol);
-    console.log(`formattedHealedText:\n${formattedHealedText}`);
     const formattedText = formattedHealedText.substring(
       missingTexts.prepend.length,
       missingTexts.prepend.length + formattedHealedText.length - missingTexts.append.length
     );
-    console.log('formattedText:\n', formattedText);
     const endIndex = startIndex + formattedText.length;
     const allText =
       document.getText(new vscode.Range(document.positionAt(0), originalRange.start)) +

--- a/src/cursor-doc/clojure-lexer.ts
+++ b/src/cursor-doc/clojure-lexer.ts
@@ -168,7 +168,7 @@ export interface ScannerState {
 export class Scanner {
   state: ScannerState = { inString: false };
 
-  constructor(private maxLength: number) {}
+  constructor(public maxLength: number) {}
 
   processLine(line: string, state: ScannerState = this.state) {
     const tks: Token[] = [];

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -559,6 +559,7 @@ export class StringDocument implements EditableDocument {
 
   insertString(text: string) {
     this.model.insertString(0, text);
+    initScanner(scanner.maxLength);
   }
 
   getSelectionText: () => string;

--- a/src/cursor-doc/utilities.ts
+++ b/src/cursor-doc/utilities.ts
@@ -1,6 +1,11 @@
 import * as model from './model';
 
-export function addMissingBrackets(text: string): { append: string; prepend: string } {
+export type MissingTexts = {
+  append: string;
+  prepend: string;
+};
+
+export function getMissingBrackets(text: string): MissingTexts {
   const doc = new model.StringDocument(text);
   const cursor = doc.getTokenCursor(0);
   const stack: string[] = [];

--- a/src/cursor-doc/utilities.ts
+++ b/src/cursor-doc/utilities.ts
@@ -1,0 +1,32 @@
+import * as model from './model';
+
+export function addMissingBrackets(text: string): string {
+  const doc = new model.StringDocument(text);
+  const cursor = doc.getTokenCursor(0);
+  const stack: string[] = [];
+  const missingOpens = [];
+  do {
+    const token = cursor.getToken();
+    if (token.type === 'open') {
+      stack.push(token.raw[token.raw.length - 1]);
+    } else if (token.type === 'close') {
+      if (stack.length === 0) {
+        missingOpens.unshift({ ')': '(', ']': '[', '}': '{', '"': '"' }[token.raw]);
+      } else {
+        stack.pop();
+      }
+    }
+    cursor.next();
+  } while (!cursor.atEnd());
+  if (stack.length === 0) {
+    return `${missingOpens.join('')}${text}`;
+  } else {
+    stack.reverse();
+    const missingCloses = stack
+      .map((bracket) => {
+        return { '{': '}', '[': ']', '(': ')', '"': '"' }[bracket];
+      })
+      .join('');
+    return `${missingOpens.join('')}${text}${missingCloses}`;
+  }
+}

--- a/src/cursor-doc/utilities.ts
+++ b/src/cursor-doc/utilities.ts
@@ -1,6 +1,6 @@
 import * as model from './model';
 
-export function addMissingBrackets(text: string): string {
+export function addMissingBrackets(text: string): { append: string; prepend: string } {
   const doc = new model.StringDocument(text);
   const cursor = doc.getTokenCursor(0);
   const stack: string[] = [];
@@ -19,14 +19,12 @@ export function addMissingBrackets(text: string): string {
     cursor.next();
   } while (!cursor.atEnd());
   if (stack.length === 0) {
-    return `${missingOpens.join('')}${text}`;
+    return { append: '', prepend: missingOpens.join('') };
   } else {
     stack.reverse();
-    const missingCloses = stack
-      .map((bracket) => {
-        return { '{': '}', '[': ']', '(': ')', '"': '"' }[bracket];
-      })
-      .join('');
-    return `${missingOpens.join('')}${text}${missingCloses}`;
+    const missingCloses = stack.map((bracket) => {
+      return { '{': '}', '[': ']', '(': ')', '"': '"' }[bracket];
+    });
+    return { prepend: missingOpens.join(''), append: missingCloses.join('') };
   }
 }

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1080,9 +1080,7 @@ describe('paredit', () => {
         await paredit.rewrapSexpr(a, '{', '}');
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      // TODO: Something is broken in Peredit or the test utilities
-      //       this test make a lot of other tests fail
-      xit('Rewraps #{} -> ""', async () => {
+      it('Rewraps #{} -> ""', async () => {
         const a = docFromTextNotation('a #{b c|} d');
         const b = docFromTextNotation('a "b c|" d');
         await paredit.rewrapSexpr(a, '"', '"');
@@ -1182,9 +1180,7 @@ describe('paredit', () => {
       });
 
       describe('Slurping backwards', () => {
-        // TODO: Figure out why this test makes the following test fail
-        //       It's something with in-string navigation...
-        it.skip('slurps form before string', async () => {
+        it('slurps form before string', async () => {
           const a = docFromTextNotation('(str) "fo|o"');
           const b = docFromTextNotation('"(str) fo|o"');
           await paredit.backwardSlurpSexp(a);
@@ -1668,7 +1664,7 @@ describe('paredit', () => {
 
       // NB: enabling this breaks bunch of other tests.
       //     Not sure why, but it can be run successfully by itself.
-      it.skip('splice string', async () => {
+      xit('splice string', async () => {
         const a = docFromTextNotation('"h|ello"');
         await paredit.spliceSexp(a);
         expect(text(a)).toEqual('hello');

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -140,13 +140,13 @@ describe('Token Cursor', () => {
       cursor.forwardSexp(true, true, true);
       expect(cursor.offsetStart).toBe(b.selection.anchor);
     });
-    it.skip('Does not move past unbalanced top level form', () => {
+    xit('Does not move past unbalanced top level form', () => {
       //TODO: Figure out why this doesn't work
-      //TODO: Figure out why this breaks some tests run after this one
       const d = docFromTextNotation('|(foo "bar"');
       const cursor: LispTokenCursor = d.getTokenCursor(d.selection.anchor);
+      const offsetStart = cursor.offsetStart;
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(d.selection.anchor);
+      expect(cursor.offsetStart).toBe(offsetStart);
     });
   });
 

--- a/src/extension-test/unit/cursor-doc/utilities-test.ts
+++ b/src/extension-test/unit/cursor-doc/utilities-test.ts
@@ -9,6 +9,11 @@ describe('Utilities that need cursor doc things', () => {
       const trail = ']})';
       expect(utilities.addMissingBrackets(text)).toEqual(`${text}${trail}`);
     });
+    it('Closes strings', () => {
+      const text = '(a b) (c {:d [1 2 3 "four';
+      const trail = '"]})';
+      expect(utilities.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+    });
     it('Leaves non-broken structure alone', () => {
       const text = '(a b) (c {:d [1 2 3 "four"] :e :f} g) h';
       expect(utilities.addMissingBrackets(text)).toEqual(text);
@@ -26,12 +31,6 @@ describe('Utilities that need cursor doc things', () => {
     it('Ignores brackets in line comments', () => {
       const text = '(a b) (c {:d \n; ( [ ( {\n[1 2 3 "four"';
       const trail = ']})';
-      expect(utilities.addMissingBrackets(text)).toEqual(`${text}${trail}`);
-    });
-    xit('Closes strings', () => {
-      // TODO: Fix the scanner or whatever it is that makes this crash everything else
-      const text = '(a b) (c {:d [1 2 3 "four';
-      const trail = '"]})';
       expect(utilities.addMissingBrackets(text)).toEqual(`${text}${trail}`);
     });
   });

--- a/src/extension-test/unit/cursor-doc/utilities-test.ts
+++ b/src/extension-test/unit/cursor-doc/utilities-test.ts
@@ -6,32 +6,32 @@ describe('Utilities that need cursor doc things', () => {
   describe('addMissingBrackets', () => {
     it('Adds missing brackets', () => {
       const text = '(a b) (c {:d [1 2 3 "four"';
-      const trail = ']})';
-      expect(utilities.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+      const append = ']})';
+      expect(utilities.addMissingBrackets(text)).toEqual({ append: append, prepend: '' });
     });
     it('Closes strings', () => {
       const text = '(a b) (c {:d [1 2 3 "four';
-      const trail = '"]})';
-      expect(utilities.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+      const append = '"]})';
+      expect(utilities.addMissingBrackets(text)).toEqual({ append: append, prepend: '' });
     });
     it('Leaves non-broken structure alone', () => {
       const text = '(a b) (c {:d [1 2 3 "four"] :e :f} g) h';
-      expect(utilities.addMissingBrackets(text)).toEqual(text);
+      expect(utilities.addMissingBrackets(text)).toEqual({ append: '', prepend: '' });
     });
     it('Adds missing opening brackets', () => {
       const text = '(a b) (c {:d [1 2 3 "four"]}) extra ] closing } brackets)';
-      const head = '({[';
-      expect(utilities.addMissingBrackets(text)).toEqual(`${head}${text}`);
+      const prepend = '({[';
+      expect(utilities.addMissingBrackets(text)).toEqual({ append: '', prepend: prepend });
     });
     it('Ignores brackets in strings', () => {
       const text = '(a b) "{{" (c {:d [1 2 3 "four([{" [';
-      const trail = ']]})';
-      expect(utilities.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+      const append = ']]})';
+      expect(utilities.addMissingBrackets(text)).toEqual({ append: append, prepend: '' });
     });
     it('Ignores brackets in line comments', () => {
       const text = '(a b) (c {:d \n; ( [ ( {\n[1 2 3 "four"';
-      const trail = ']})';
-      expect(utilities.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+      const append = ']})';
+      expect(utilities.addMissingBrackets(text)).toEqual({ append: append, prepend: '' });
     });
   });
 });

--- a/src/extension-test/unit/cursor-doc/utilities-test.ts
+++ b/src/extension-test/unit/cursor-doc/utilities-test.ts
@@ -7,31 +7,31 @@ describe('Utilities that need cursor doc things', () => {
     it('Adds missing brackets', () => {
       const text = '(a b) (c {:d [1 2 3 "four"';
       const append = ']})';
-      expect(utilities.addMissingBrackets(text)).toEqual({ append: append, prepend: '' });
+      expect(utilities.getMissingBrackets(text)).toEqual({ append: append, prepend: '' });
     });
     it('Closes strings', () => {
       const text = '(a b) (c {:d [1 2 3 "four';
       const append = '"]})';
-      expect(utilities.addMissingBrackets(text)).toEqual({ append: append, prepend: '' });
+      expect(utilities.getMissingBrackets(text)).toEqual({ append: append, prepend: '' });
     });
     it('Leaves non-broken structure alone', () => {
       const text = '(a b) (c {:d [1 2 3 "four"] :e :f} g) h';
-      expect(utilities.addMissingBrackets(text)).toEqual({ append: '', prepend: '' });
+      expect(utilities.getMissingBrackets(text)).toEqual({ append: '', prepend: '' });
     });
     it('Adds missing opening brackets', () => {
       const text = '(a b) (c {:d [1 2 3 "four"]}) extra ] closing } brackets)';
       const prepend = '({[';
-      expect(utilities.addMissingBrackets(text)).toEqual({ append: '', prepend: prepend });
+      expect(utilities.getMissingBrackets(text)).toEqual({ append: '', prepend: prepend });
     });
     it('Ignores brackets in strings', () => {
       const text = '(a b) "{{" (c {:d [1 2 3 "four([{" [';
       const append = ']]})';
-      expect(utilities.addMissingBrackets(text)).toEqual({ append: append, prepend: '' });
+      expect(utilities.getMissingBrackets(text)).toEqual({ append: append, prepend: '' });
     });
     it('Ignores brackets in line comments', () => {
       const text = '(a b) (c {:d \n; ( [ ( {\n[1 2 3 "four"';
       const append = ']})';
-      expect(utilities.addMissingBrackets(text)).toEqual({ append: append, prepend: '' });
+      expect(utilities.getMissingBrackets(text)).toEqual({ append: append, prepend: '' });
     });
   });
 });

--- a/src/extension-test/unit/cursor-doc/utilities-test.ts
+++ b/src/extension-test/unit/cursor-doc/utilities-test.ts
@@ -1,0 +1,38 @@
+import * as expect from 'expect';
+import * as utilities from '../../../cursor-doc/utilities';
+//import { docFromTextNotation, textAndSelection } from '../common/text-notation';
+
+describe('Utilities that need cursor doc things', () => {
+  describe('addMissingBrackets', () => {
+    it('Adds missing brackets', () => {
+      const text = '(a b) (c {:d [1 2 3 "four"';
+      const trail = ']})';
+      expect(utilities.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+    });
+    it('Leaves non-broken structure alone', () => {
+      const text = '(a b) (c {:d [1 2 3 "four"] :e :f} g) h';
+      expect(utilities.addMissingBrackets(text)).toEqual(text);
+    });
+    it('Adds missing opening brackets', () => {
+      const text = '(a b) (c {:d [1 2 3 "four"]}) extra ] closing } brackets)';
+      const head = '({[';
+      expect(utilities.addMissingBrackets(text)).toEqual(`${head}${text}`);
+    });
+    it('Ignores brackets in strings', () => {
+      const text = '(a b) "{{" (c {:d [1 2 3 "four([{" [';
+      const trail = ']]})';
+      expect(utilities.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+    });
+    it('Ignores brackets in line comments', () => {
+      const text = '(a b) (c {:d \n; ( [ ( {\n[1 2 3 "four"';
+      const trail = ']})';
+      expect(utilities.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+    });
+    xit('Closes strings', () => {
+      // TODO: Fix the scanner or whatever it is that makes this crash everything else
+      const text = '(a b) (c {:d [1 2 3 "four';
+      const trail = '"]})';
+      expect(utilities.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+    });
+  });
+});

--- a/src/extension-test/unit/util/cursor-get-text-test.ts
+++ b/src/extension-test/unit/util/cursor-get-text-test.ts
@@ -121,36 +121,4 @@ describe('get text', () => {
       ]);
     });
   });
-
-  describe('addMissingBrackets', () => {
-    it('Adds missing brackets', () => {
-      const text = '(a b) (c {:d [1 2 3 "four"';
-      const trail = ']})';
-      expect(getText.addMissingBrackets(text)).toEqual(`${text}${trail}`);
-    });
-    it('Leaves non-broken structure alone', () => {
-      const text = '(a b) (c {:d [1 2 3 "four"] :e :f} g) h';
-      expect(getText.addMissingBrackets(text)).toEqual(text);
-    });
-    it('Adds missing opening brackets', () => {
-      const text = '(a b) (c {:d [1 2 3 "four"]}) extra ] closing } brackets)';
-      const head = '({[';
-      expect(getText.addMissingBrackets(text)).toEqual(`${head}${text}`);
-    });
-    it('Ignores brackets in strings', () => {
-      const text = '(a b) "{{" (c {:d [1 2 3 "four([{" [';
-      const trail = ']]})';
-      expect(getText.addMissingBrackets(text)).toEqual(`${text}${trail}`);
-    });
-    it('Ignores brackets in line comments', () => {
-      const text = '(a b) (c {:d \n; ( [ ( {\n[1 2 3 "four"';
-      const trail = ']})';
-      expect(getText.addMissingBrackets(text)).toEqual(`${text}${trail}`);
-    });
-    it('Closes strings', () => {
-      const text = '(a b) (c {:d [1 2 3 "four';
-      const trail = '"]})';
-      expect(getText.addMissingBrackets(text)).toEqual(`${text}${trail}`);
-    });
-  });
 });

--- a/src/extension-test/unit/util/cursor-get-text-test.ts
+++ b/src/extension-test/unit/util/cursor-get-text-test.ts
@@ -121,4 +121,36 @@ describe('get text', () => {
       ]);
     });
   });
+
+  describe('addMissingBrackets', () => {
+    it('Adds missing brackets', () => {
+      const text = '(a b) (c {:d [1 2 3 "four"';
+      const trail = ']})';
+      expect(getText.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+    });
+    it('Leaves non-broken structure alone', () => {
+      const text = '(a b) (c {:d [1 2 3 "four"] :e :f} g) h';
+      expect(getText.addMissingBrackets(text)).toEqual(text);
+    });
+    it('Does not attempt to fix missing brackets', () => {
+      const text = '(a b) (c {:d [1 2 3 "four"]}) extra ]})';
+      const trail = '';
+      expect(getText.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+    });
+    it('Ignores brackets in strings', () => {
+      const text = '(a b) "{{" (c {:d [1 2 3 "four([{" [';
+      const trail = ']]})';
+      expect(getText.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+    });
+    it('Ignores brackets in line comments', () => {
+      const text = '(a b) (c {:d \n; ( [ ( {\n[1 2 3 "four"';
+      const trail = ']})';
+      expect(getText.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+    });
+    it('Closes strings', () => {
+      const text = '(a b) (c {:d [1 2 3 "four';
+      const trail = '"]})';
+      expect(getText.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+    });
+  });
 });

--- a/src/extension-test/unit/util/cursor-get-text-test.ts
+++ b/src/extension-test/unit/util/cursor-get-text-test.ts
@@ -132,10 +132,10 @@ describe('get text', () => {
       const text = '(a b) (c {:d [1 2 3 "four"] :e :f} g) h';
       expect(getText.addMissingBrackets(text)).toEqual(text);
     });
-    it('Does not attempt to fix missing brackets', () => {
-      const text = '(a b) (c {:d [1 2 3 "four"]}) extra ]})';
-      const trail = '';
-      expect(getText.addMissingBrackets(text)).toEqual(`${text}${trail}`);
+    it('Adds missing opening brackets', () => {
+      const text = '(a b) (c {:d [1 2 3 "four"]}) extra ] closing } brackets)';
+      const head = '({[';
+      expect(getText.addMissingBrackets(text)).toEqual(`${head}${text}`);
     });
     it('Ignores brackets in strings', () => {
       const text = '(a b) "{{" (c {:d [1 2 3 "four([{" [';

--- a/src/util/cursor-get-text.ts
+++ b/src/util/cursor-get-text.ts
@@ -2,7 +2,7 @@
  * Can be unit tested since vscode and stuff is not imported
  */
 
-import { EditableDocument } from '../cursor-doc/model';
+import { EditableDocument, StringDocument } from '../cursor-doc/model';
 
 export type RangeAndText = [[number, number], string] | [undefined, ''];
 
@@ -87,4 +87,30 @@ export function selectionAddingBrackets(doc: EditableDocument): RangeAndText {
   cursor.forwardSexp(true, true, true);
   const rangeEnd = cursor.offsetStart;
   return rangeToCursor(doc, [left, rangeEnd], left, right);
+}
+
+export function addMissingBrackets(text: string): string {
+  const doc = new StringDocument(text);
+  const cursor = doc.getTokenCursor(0);
+  const stack: string[] = [];
+  do {
+    const token = cursor.getToken();
+    if (token.type === 'open') {
+      stack.push(token.raw[token.raw.length - 1]);
+    } else if (token.type === 'close') {
+      stack.pop();
+    }
+    cursor.next();
+  } while (!cursor.atEnd());
+  if (stack.length === 0) {
+    return text;
+  } else {
+    stack.reverse();
+    const trail = stack
+      .map((bracket) => {
+        return { '{': '}', '[': ']', '(': ')', '"': '"' }[bracket];
+      })
+      .join('');
+    return `${text}${trail}`;
+  }
 }

--- a/src/util/cursor-get-text.ts
+++ b/src/util/cursor-get-text.ts
@@ -88,34 +88,3 @@ export function selectionAddingBrackets(doc: EditableDocument): RangeAndText {
   const rangeEnd = cursor.offsetStart;
   return rangeToCursor(doc, [left, rangeEnd], left, right);
 }
-
-export function addMissingBrackets(text: string): string {
-  const doc = new StringDocument(text);
-  const cursor = doc.getTokenCursor(0);
-  const stack: string[] = [];
-  const missingOpens = [];
-  do {
-    const token = cursor.getToken();
-    if (token.type === 'open') {
-      stack.push(token.raw[token.raw.length - 1]);
-    } else if (token.type === 'close') {
-      if (stack.length === 0) {
-        missingOpens.unshift({ ')': '(', ']': '[', '}': '{', '"': '"' }[token.raw]);
-      } else {
-        stack.pop();
-      }
-    }
-    cursor.next();
-  } while (!cursor.atEnd());
-  if (stack.length === 0) {
-    return `${missingOpens.join('')}${text}`;
-  } else {
-    stack.reverse();
-    const missingCloses = stack
-      .map((bracket) => {
-        return { '{': '}', '[': ']', '(': ')', '"': '"' }[bracket];
-      })
-      .join('');
-    return `${missingOpens.join('')}${text}${missingCloses}`;
-  }
-}

--- a/src/util/cursor-get-text.ts
+++ b/src/util/cursor-get-text.ts
@@ -93,24 +93,29 @@ export function addMissingBrackets(text: string): string {
   const doc = new StringDocument(text);
   const cursor = doc.getTokenCursor(0);
   const stack: string[] = [];
+  const missingOpens = [];
   do {
     const token = cursor.getToken();
     if (token.type === 'open') {
       stack.push(token.raw[token.raw.length - 1]);
     } else if (token.type === 'close') {
-      stack.pop();
+      if (stack.length === 0) {
+        missingOpens.unshift({ ')': '(', ']': '[', '}': '{', '"': '"' }[token.raw]);
+      } else {
+        stack.pop();
+      }
     }
     cursor.next();
   } while (!cursor.atEnd());
   if (stack.length === 0) {
-    return text;
+    return `${missingOpens.join('')}${text}`;
   } else {
     stack.reverse();
-    const trail = stack
+    const missingCloses = stack
       .map((bracket) => {
         return { '{': '}', '[': ']', '(': ')', '"': '"' }[bracket];
       })
       .join('');
-    return `${text}${trail}`;
+    return `${missingOpens.join('')}${text}${missingCloses}`;
   }
 }


### PR DESCRIPTION
## What has changed?

1. The range format function used by the range format provider (used for format-on-paste and format selection, and more) now attempts to ”heal” a broken structure before formatting. Previously formatting would fail on a broken structure, because cljfmt can't format code that lacks structural integrity.
   **Note**: The healing only attempts to add missing brackets at the start or end of the range. Which is likely to be enough for when the selection just misses some bracket.
1. I've also changed the way that we avoid trimming trailing space from the pasted text (or from a formatted selection). Now we check if the whitespace has been trimmed, and restore it if so.
   * See: #2229

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1709

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
