### PR TITLE
Add special indent for leading `eol` text when pasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Pasting text with leading whitespace increases the leading whitespace](https://github.com/BetterThanTomorrow/calva/issues/2236)
+
 ## [2.0.373] - 2023-06-27
 
 - [Re-indent non-complete code, when pasting or formatting selection](https://github.com/BetterThanTomorrow/calva/issues/1709)

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -59,21 +59,27 @@ export async function formatRangeEdits(
   if (!cursor.withinString() && !cursor.withinComment()) {
     const eol = _convertEolNumToStringNotation(document.eol);
     const originalText = document.getText(originalRange);
+    const leadingWs = originalText.match(/^\s*/)[0];
     const trailingWs = originalText.match(/\s*$/)[0];
     const missingTexts = cursorDocUtils.getMissingBrackets(originalText);
-    const healedText = `${missingTexts.prepend}${originalText}${missingTexts.append}`;
+    const healedText = `${missingTexts.prepend}${originalText.trim()}${missingTexts.append}`;
     const formattedHealedText = await formatCode(healedText, document.eol);
+    const leadingEolPos = leadingWs.lastIndexOf(eol);
+    const startIndent =
+      leadingEolPos === -1
+        ? originalRange.start.character
+        : leadingWs.length - leadingEolPos - eol.length;
     const formattedText = formattedHealedText
       .substring(
         missingTexts.prepend.length,
         missingTexts.prepend.length + formattedHealedText.length - missingTexts.append.length
       )
       .split(eol)
-      .map((line: string, i: number) =>
-        i === 0 ? line : `${' '.repeat(originalRange.start.character)}${line}`
-      )
+      .map((line: string, i: number) => (i === 0 ? line : `${' '.repeat(startIndent)}${line}`))
       .join(eol);
-    const newText = `${formattedText}${formattedText.endsWith(trailingWs) ? '' : trailingWs}`;
+    const newText = `${formattedText.startsWith(leadingWs) ? '' : leadingWs}${formattedText}${
+      formattedText.endsWith(trailingWs) ? '' : trailingWs
+    }`;
     return [vscode.TextEdit.replace(originalRange, newText)];
   }
 }

--- a/test-data/paste-formatted.clj
+++ b/test-data/paste-formatted.clj
@@ -1,0 +1,11 @@
+(fn a []
+  (b c
+     d)
+  (b c
+     d
+     (e f
+        (g h
+           i))))
+
+(fn j []
+  k)


### PR DESCRIPTION
When the leading text contains newlines we are sometimes duplicating the leading indents, which is sometimes a bit too unhelpful. Trying to add some logic for that case here, without making things all too complicated... See:

* Fixes #2236


## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
