### PR TITLE
If calva.fmt.configPath not set, look in default config locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [If calva.fmt.configPath not set, look in default config locations](https://github.com/BetterThanTomorrow/calva/issues/2243)
+
 ## [2.0.374] - 2023-06-29
 
 - Fix: [Pasting text with leading whitespace increases the leading whitespace](https://github.com/BetterThanTomorrow/calva/issues/2236)

--- a/docs/site/formatting.md
+++ b/docs/site/formatting.md
@@ -72,7 +72,7 @@ Unlike with the ”real” Calva Formatter, which never breaks up lines, this on
 
 ## Configuration
 
-You configure Calva's formatting using [cljfmt's configuration EDN](https://github.com/weavejester/cljfmt#configuration). This means that you can adjust the above mentioned defaults, including the indenting.
+You configure Calva's formatting using [cljfmt's configuration EDN](https://github.com/weavejester/cljfmt#configuration). This means that you can adjust the above mentioned defaults, including the indenting. If you have a config file defined in your repo in one of cljfmt's default locations. If calva.fmt.configPath not set, look in default config locations, it will be automatically used.
 
 This configuration can either be provided via a file or via clojure-lsp (see [Clojure LSP Settings](https://clojure-lsp.io/settings/)).
 

--- a/package.json
+++ b/package.json
@@ -920,7 +920,7 @@
         "properties": {
           "calva.fmt.configPath": {
             "type": "string",
-            "markdownDescription": "Path to [cljfmt](https://github.com/weavejester/cljfmt#configuration) configuration file. Absolute or relative to the project root directory. To provide the config via [clojure-lsp](https://clojure-lsp.io), set this to `CLOJURE-LSP` (case sensitive)."
+            "markdownDescription": "Path to [cljfmt](https://github.com/weavejester/cljfmt#configuration) configuration file. Absolute or relative to the project root directory. To provide the config via [clojure-lsp](https://clojure-lsp.io), set this to `CLOJURE-LSP` (case sensitive). If left blank and a config file with a [default name]( is used, the file will be automatically loaded."
           },
           "calva.fmt.newIndentEngine": {
             "type": "boolean",

--- a/src/formatter-config.ts
+++ b/src/formatter-config.ts
@@ -35,6 +35,18 @@ function configuration(workspaceConfig: vscode.WorkspaceConfiguration, cljfmt: s
   };
 }
 
+function getConfigPath(workspaceConfig: vscode.WorkspaceConfiguration): string | undefined {
+  const pathFromSettings = workspaceConfig.get<string>('configPath');
+  if (pathFromSettings) {
+    return pathFromSettings;
+  }
+  // if not set, check default cljfmt paths (https://github.com/weavejester/cljfmt#configuration)
+  const configFileNames = ['.cljfmt.edn', '.cljfmt.clj', 'cljfmt.edn', 'cljfmt.clj'];
+  return configFileNames.find((configPath) => {
+    return filesCache.content(configPath);
+  });
+}
+
 export type FormatterConfig = Partial<Awaited<ReturnType<typeof getConfig>>>;
 
 export async function getConfig(
@@ -46,7 +58,7 @@ export async function getConfig(
   'cljfmt-options': object;
 }> {
   const workspaceConfig = vscode.workspace.getConfiguration('calva.fmt');
-  const configPath: string | undefined = workspaceConfig.get('configPath');
+  const configPath: string | undefined = getConfigPath(workspaceConfig);
 
   if (configPath === LSP_CONFIG_KEY && document) {
     const clientProvider = lsp.getClientProvider();


### PR DESCRIPTION
## What has changed?

In order to make initial setup of Calva a little easier for repos with cljfmt config files, attempt to read in the config file from the default paths (https://github.com/weavejester/cljfmt#configuration) if `calva.fmt.configPath` is not explicitly set.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2243

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
        - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
