### PR TITLE
Update how we determine the namespace of evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Support `in-ns` forms to provide the ns for evaluations, and use the closest `ns/in-ns` before the cursor](https://github.com/BetterThanTomorrow/calva/issues/2245)
+
 ## [2.0.376] - 2023-07-12
 
 - [Add “Fiddle” files Support](https://github.com/BetterThanTomorrow/calva/issues/2199)

--- a/src/clojuredocs.ts
+++ b/src/clojuredocs.ts
@@ -177,7 +177,7 @@ async function clojureDocsLookup(
   const doc = d ? d : util.getDocument({});
   const position = p ? p : util.getActiveTextEditor().selection.active;
   const symbol = util.getWordAtPosition(doc, position);
-  const ns = namespace.getNamespace(doc);
+  const ns = namespace.getNamespace(doc, p);
   const session = replSession.getSession(util.getFileType(doc));
 
   const docsFromCider = await clojureDocsCiderNReplLookup(session, symbol, ns);

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -39,7 +39,7 @@ async function evaluateCodeOrKeyOrSnippet(codeOrKeyOrSnippet?: string | SnippetD
   const editor = util.getActiveTextEditor();
   const editorNS =
     editor && editor.document && editor.document.languageId === 'clojure'
-      ? namespace.getNamespace(editor.document)
+      ? namespace.getNamespace(editor.document, editor.selection.active)
       : undefined;
   const editorRepl =
     editor && editor.document && editor.document.languageId === 'clojure'

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -235,7 +235,7 @@ async function evaluateSelection(document = {}, options) {
     [codeSelection, code]; //TODO: What's this doing here?
 
     const doc = util.getDocument(document);
-    const ns = namespace.getNamespace(doc);
+    const ns = namespace.getNamespace(doc, codeSelection.end);
     const line = codeSelection.start.line;
     const column = codeSelection.start.character;
     const filePath = doc.fileName;
@@ -421,7 +421,7 @@ async function loadDocument(
 
   const doc = util.tryToGetDocument(document);
   const fileType = util.getFileType(doc);
-  const ns = namespace.getNamespace(doc);
+  const ns = namespace.getNamespace(doc, doc.positionAt(0));
   const session = replSession.getSession(util.getFileType(doc));
 
   if (doc && doc.languageId == 'clojure' && fileType != 'edn' && getStateValue('connected')) {

--- a/src/extension-test/unit/util/ns-form-test.ts
+++ b/src/extension-test/unit/util/ns-form-test.ts
@@ -138,5 +138,8 @@ describe('ns-form util', () => {
     it('defaults to `null`', function () {
       expect(nsFormUtil.nsFromText('(no-ns a-b.c-d)\nfoo')).toBe(null);
     });
+    it('defaults to start from end', function () {
+      expect(nsFormUtil.nsFromText('(ns a)\nfoo (ns b) bar')).toBe('b');
+    });
   });
 });

--- a/src/extension-test/unit/util/ns-form-test.ts
+++ b/src/extension-test/unit/util/ns-form-test.ts
@@ -132,6 +132,17 @@ describe('ns-form util', () => {
         )
       ).toBe('b');
     });
+    it('finds first ns form if at start of document', function () {
+      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('|(ns a) (a b c) (ns b)'))).toBe('a');
+      expect(
+        nsFormUtil.nsFromCursorDoc(docFromTextNotation('|(no-ns a) (a b c) (ns b) x (ns c) y'))
+      ).toBe('b');
+    });
+    it('returns `null` if at start of document without ns form', function () {
+      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('|(no-ns a) (a b c) (no-ns b)'))).toBe(
+        null
+      );
+    });
   });
 
   describe('nsFromText', function () {

--- a/src/extension-test/unit/util/ns-form-test.ts
+++ b/src/extension-test/unit/util/ns-form-test.ts
@@ -46,6 +46,12 @@ describe('ns-form util', () => {
         'a-b.c-d'
       );
     });
+    it('returns `null` if ns form does not contain a namespace symbol', function () {
+      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns) (a b c)|'))).toBe(null);
+    });
+    it('returns `null` if ns form does contains non-symbol', function () {
+      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns [a]) (a b c)|'))).toBe(null);
+    });
     it('returns null if current enclosing form is ns form', function () {
       expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-|d) (a b c)'))).toBe(null);
     });
@@ -60,7 +66,7 @@ describe('ns-form util', () => {
       );
     });
 
-    it('Last ns at top level wins', function () {
+    it('Closest ns at top level wins', function () {
       expect(
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation('(ns a) (fn [] {:rcf (comment\n(ns a-b.c-d))}|)')
@@ -71,6 +77,11 @@ describe('ns-form util', () => {
           docFromTextNotation('(ns a) (ns b) (fn [] {:rcf (comment\n(ns a-b.c-d))|})')
         )
       ).toBe('b');
+      expect(
+        nsFormUtil.nsFromCursorDoc(
+          docFromTextNotation('(ns a) (ns b) (fn [] {:rcf (comment\n(ns a-b.c-d)|)})')
+        )
+      ).toBe('a-b.c-d');
       expect(
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation('(fn [] {:rcf (comment\n(ns a-b.c-d))}) (ns a)|')

--- a/src/extension-test/unit/util/ns-form-test.ts
+++ b/src/extension-test/unit/util/ns-form-test.ts
@@ -41,8 +41,13 @@ describe('ns-form util', () => {
     it('defaults to `null`', function () {
       expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(no-ns a-b.c-d)\nfoo|'))).toBe(null);
     });
-    it('finds ns in simple form', function () {
+    it('finds ns', function () {
       expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-d) (a b c)|'))).toBe(
+        'a-b.c-d'
+      );
+    });
+    it('finds in-ns', function () {
+      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation("(in-ns 'a-b.c-d) (a b c)|"))).toBe(
         'a-b.c-d'
       );
     });
@@ -90,6 +95,34 @@ describe('ns-form util', () => {
       expect(
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation('(fn [] {:rcf (comment\n(ns a-b.c-d))}) (ns a|)')
+        )
+      ).toBe(null);
+    });
+
+    it('Closest ns or in-ns at top level wins', function () {
+      expect(
+        nsFormUtil.nsFromCursorDoc(
+          docFromTextNotation("(ns a) (in-ns 'b) (fn [] {:rcf (comment\n(ns a-b.c-d))}|)")
+        )
+      ).toBe('b');
+      expect(
+        nsFormUtil.nsFromCursorDoc(
+          docFromTextNotation("(in-ns 'a) (ns b) (fn [] {:rcf (comment\n(ns a-b.c-d))|})")
+        )
+      ).toBe('b');
+      expect(
+        nsFormUtil.nsFromCursorDoc(
+          docFromTextNotation("(ns a) (ns b) (fn [] {:rcf (comment\n(ns c) x (in-ns 'a-b.c-d)|)})")
+        )
+      ).toBe('a-b.c-d');
+      expect(
+        nsFormUtil.nsFromCursorDoc(
+          docFromTextNotation("(fn [] {:rcf (comment\n(ns a-b.c-d))}) (in-ns 'a)|")
+        )
+      ).toBe('a');
+      expect(
+        nsFormUtil.nsFromCursorDoc(
+          docFromTextNotation("(fn [] {:rcf (comment\n(ns a-b.c-d))}) (in-ns 'a|)")
         )
       ).toBe(null);
     });

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -7,7 +7,7 @@ import * as replSession from './nrepl/repl-session';
 import { NReplSession } from './nrepl';
 import * as nsUtil from './util/ns-form';
 
-export function getNamespace(doc?: vscode.TextDocument) {
+export function getNamespace(doc: vscode.TextDocument, position: vscode.Position = null) {
   if (outputWindow.isResultsDoc(doc)) {
     const outputWindowNs = outputWindow.getNs();
     utilities.assertIsDefined(outputWindowNs, 'Expected output window to have a namespace!');
@@ -16,7 +16,12 @@ export function getNamespace(doc?: vscode.TextDocument) {
   if (doc && doc.languageId == 'clojure') {
     try {
       const cursorDoc = docMirror.getDocument(doc);
-      return nsUtil.nsFromCursorDoc(cursorDoc) ?? 'user';
+      return (
+        nsUtil.nsFromCursorDoc(
+          cursorDoc,
+          position ? doc.offsetAt(position) : doc.getText().length
+        ) ?? 'user'
+      );
     } catch (e) {
       console.log(
         'Error getting ns form of this file using docMirror, trying with cljs.reader: ' + e

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -191,7 +191,7 @@ async function replCompletions(
     contextEnd = toplevel.substring(wordEndLocalOffset),
     replContext = `${contextStart}__prefix__${contextEnd}`,
     toplevelIsValidForm = toplevelStartCursor.withinValidList() && replContext != '__prefix__',
-    ns = namespace.getNamespace(document),
+    ns = namespace.getNamespace(document, position),
     client = replSession.getSession(util.getFileType(document)),
     res = await client.complete(ns, text, toplevelIsValidForm ? replContext : undefined),
     results = res.completions || [];

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -26,7 +26,7 @@ async function provideClojureDefinition(
     const client = replSession.getSession(util.getFileType(document));
     if (client?.supports('info')) {
       const text = util.getWordAtPosition(document, position);
-      const info = await client.info(namespace.getNamespace(document), text);
+      const info = await client.info(namespace.getNamespace(document, position), text);
       if (info.file && info.file.length > 0) {
         const pos = new vscode.Position(info.line - 1, info.column || 0);
         try {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -17,7 +17,7 @@ export async function provideHover(
 ) {
   if (util.getConnectedState()) {
     const text = util.getWordAtPosition(document, position);
-    const ns = namespace.getNamespace(document);
+    const ns = namespace.getNamespace(document, position);
     const client = replSession.getSession(util.getFileType(document));
     if (client && client.supports('info')) {
       await namespace.createNamespaceFromDocumentIfNotExists(document);

--- a/src/providers/signature.ts
+++ b/src/providers/signature.ts
@@ -30,7 +30,7 @@ export async function provideSignatureHelp(
   _token: CancellationToken
 ): Promise<SignatureHelp | undefined> {
   if (util.getConnectedState()) {
-    const ns = namespace.getNamespace(document),
+    const ns = namespace.getNamespace(document, position),
       idx = document.offsetAt(position),
       symbol = getSymbol(document, idx);
     if (symbol) {

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -230,7 +230,10 @@ export async function revealDocForCurrentNS(preserveFocus: boolean = true) {
 
 export async function setNamespaceFromCurrentFile() {
   const session = replSession.getSession();
-  const ns = namespace.getNamespace(util.tryToGetDocument({}));
+  const ns = namespace.getNamespace(
+    util.tryToGetDocument({}),
+    vscode.window.activeTextEditor?.selection?.active
+  );
   if (getNs() !== ns && util.isDefined(ns)) {
     await session.switchNS(ns);
   }
@@ -241,7 +244,10 @@ export async function setNamespaceFromCurrentFile() {
 
 async function appendFormGrabbingSessionAndNS(topLevel: boolean) {
   const session = replSession.getSession();
-  const ns = namespace.getNamespace(util.tryToGetDocument({}));
+  const ns = namespace.getNamespace(
+    util.tryToGetDocument({}),
+    vscode.window.activeTextEditor?.selection?.active
+  );
   const editor = util.getActiveTextEditor();
   const doc = editor.document;
   const selection = editor.selection;

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -319,7 +319,10 @@ async function runNamespaceTests(controller: vscode.TestController, document: vs
     return;
   }
   const session = getSession(util.getFileType(document));
-  const currentDocNs = namespace.getNamespace(doc);
+  const currentDocNs = namespace.getNamespace(
+    doc,
+    vscode.window.activeTextEditor?.selection?.active
+  );
   await loadTestNS(currentDocNs, session);
   const namespacesToRunTestsFor = [
     currentDocNs,
@@ -338,7 +341,7 @@ function getTestUnderCursor() {
 async function runTestUnderCursor(controller: vscode.TestController) {
   const doc = util.tryToGetDocument({});
   const session = getSession(util.getFileType(doc));
-  const ns = namespace.getNamespace(doc);
+  const ns = namespace.getNamespace(doc, vscode.window.activeTextEditor?.selection?.active);
   const test = getTestUnderCursor();
 
   if (test) {

--- a/src/util/ns-form.ts
+++ b/src/util/ns-form.ts
@@ -43,9 +43,9 @@ export function nsFromCursorDoc(
       if (token.type === 'id' && token.raw == 'ns') {
         nsCheckCursor.forwardSexp(true, true, true);
         nsCheckCursor.forwardWhitespace(true);
-        const ns = nsCheckCursor.getToken().raw;
-        if (ns) {
-          return ns;
+        const nsToken = nsCheckCursor.getToken();
+        if (nsToken.type === 'id') {
+          return nsToken.raw;
         }
       }
     }

--- a/src/util/ns-form.ts
+++ b/src/util/ns-form.ts
@@ -36,13 +36,13 @@ function nsSymbolOfCurrentForm(
   nsCheckCursor[downList]();
   nsCheckCursor.backwardList();
   nsCheckCursor.forwardWhitespace(true);
-  const token = nsCheckCursor.getToken();
-  if (token.type === 'id' && token.raw == 'ns') {
+  const formToken = nsCheckCursor.getToken();
+  if (formToken.type === 'id' && ['ns', 'in-ns'].includes(formToken.raw)) {
     nsCheckCursor.forwardSexp(true, true, true);
     nsCheckCursor.forwardWhitespace(true);
     const nsToken = nsCheckCursor.getToken();
     if (nsToken.type === 'id') {
-      return nsToken.raw;
+      return formToken.raw === 'ns' ? nsToken.raw : nsToken.raw.substring(1);
     }
   }
 }


### PR DESCRIPTION
## What has changed?

To find the namespace of a document we now look for both `ns` and `in-ns` forms, and we do it with the context of the cursor, looking for the closest ns/in-ns form before. This is in contrast to looking for the first `ns` form in the document, disregarding where the cursor is.

There's a special case when loading the file, where we use the old scheme of looking from the start and finding the first ns form.

* Fixes #2245

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
