### PR TITLE
Continue upward when top level context lacks ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Rich comments broken by 2.0.377](https://github.com/BetterThanTomorrow/calva/issues/2249)
+
 ## [2.0.377] - 2023-07-13
 
 - [Support `in-ns` forms to provide the ns for evaluations, and use the closest `ns/in-ns` before the cursor](https://github.com/BetterThanTomorrow/calva/issues/2245)

--- a/src/extension-test/unit/util/ns-form-test.ts
+++ b/src/extension-test/unit/util/ns-form-test.ts
@@ -176,6 +176,13 @@ describe('ns-form util', () => {
         null
       );
     });
+
+    // https://github.com/BetterThanTomorrow/calva/issues/2249
+    it('returns outer ns if rich comment lacks ns', function () {
+      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a) (a b c) (comment b|)'))).toBe(
+        'a'
+      );
+    });
   });
 
   describe('nsFromText', function () {

--- a/src/util/ns-form.ts
+++ b/src/util/ns-form.ts
@@ -72,17 +72,15 @@ export function nsFromCursorDoc(
         return ns;
       }
     }
-  } else {
-    cursor.backwardList();
-    cursor.backwardUpList();
-    cursor.backwardWhitespace(true);
-    if (cursor.atStart()) {
-      return null;
-    } else {
-      return nsFromCursorDoc(cursorDoc, cursor.offsetStart);
-    }
   }
-  return null;
+  cursor.backwardList();
+  cursor.backwardUpList();
+  cursor.backwardWhitespace(true);
+  if (cursor.atStart()) {
+    return null;
+  } else {
+    return nsFromCursorDoc(cursorDoc, cursor.offsetStart);
+  }
 }
 
 export function nsFromText(text: string, p = text.length): string | null {


### PR DESCRIPTION
## What has changed?

In #2247 rich comments lacking an `ns` or `in-ns` form (almost any rich comment out there) got evaluated in the `user` namespace, because the search for an namespace form was cut short when a top level context lacked such a form. Now the search continues backwards, upwards until we're at the start of the document, and only then we throw in the towel and default to `user`.

* Fixes #2249

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
