### PR TITLE
Update documentation with missing cljfmt link

### DIFF
--- a/package.json
+++ b/package.json
@@ -949,7 +949,7 @@
         "properties": {
           "calva.fmt.configPath": {
             "type": "string",
-            "markdownDescription": "Path to [cljfmt](https://github.com/weavejester/cljfmt#configuration) configuration file. Absolute or relative to the project root directory. To provide the config via [clojure-lsp](https://clojure-lsp.io), set this to `CLOJURE-LSP` (case sensitive). If left blank and a config file with a [default name]( is used, the file will be automatically loaded."
+            "markdownDescription": "Path to [cljfmt](https://github.com/weavejester/cljfmt#configuration) configuration file. Absolute or relative to the project root directory. To provide the config via [clojure-lsp](https://clojure-lsp.io), set this to `CLOJURE-LSP` (case sensitive). If left blank and a config file with a [default name](https://github.com/weavejester/cljfmt#configuration) is used, the file will be automatically loaded."
           },
           "calva.fmt.newIndentEngine": {
             "type": "boolean",


### PR DESCRIPTION
## What has Changed?

Update documentation with missing cljfmt link

https://github.com/BetterThanTomorrow/calva/pull/2246#discussion_r1263243807

I have:

- [x] Read [Editing Documentation](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Hack-on-Calva#editing-documentation)
- [x] Directed this pull request at the `published` branch.
- [x] Built the site locally (if the changes were more involved than simple typo fixes), and verified that the site is presented as expected.
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_ (if there was is an issue for the documentation change)
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik

