### PR TITLE
2248 cljfmt config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Calva structural editing fails if cljfmt parsing fails](https://github.com/BetterThanTomorrow/calva/issues/2248)
+
 ## [2.0.379] - 2023-07-15
 
 - Fix: [shadow-cljs jack-in with cljAliases fails on Windows](https://github.com/BetterThanTomorrow/calva/issues/2239)

--- a/src/cljs-lib/src/calva/fmt/formatter.cljs
+++ b/src/cljs-lib/src/calva/fmt/formatter.cljs
@@ -44,7 +44,9 @@
       (parse-clj-edn $)
       (merge-cljfmt $))
     (catch js/Error e
-      {:error (.-message e)})))
+      (merge default-fmt
+             {:error (.-message e)
+              :indents cljfmt/default-indents}))))
 
 (defn- reformat-string [range-text {:keys [align-associative?
                                            remove-multiple-non-indenting-spaces?] :as config}]

--- a/src/cljs-lib/src/calva/parse.cljs
+++ b/src/cljs-lib/src/calva/parse.cljs
@@ -38,14 +38,11 @@
   (parse-forms-js s))
 
 (defn parse-clj-edn
-  "Reads edn (with regexp tags)"
-  ; https://ask.clojure.org/index.php/8675/cljs-reader-read-string-fails-input-clojure-string-accepts
+  "Reads edn (with regexp tags or regexes)"
   [s]
-  (def s s)
-  #_(if (re-find #"#re" s)
+  (if (re-find #"#re" (or s ""))
     (edn/read-string {:readers {'re re-pattern}} s)
-    (tr/read-string s))
-  (tr/read-string s))
+    (tr/read-string s)))
 
 ;[[ar gu ment] {:as extras, :keys [d e :s t r u c t u r e d]}]
 (comment

--- a/src/cljs-lib/src/calva/parse.cljs
+++ b/src/cljs-lib/src/calva/parse.cljs
@@ -1,6 +1,7 @@
 (ns calva.parse
   (:require [cljs.reader]
             [cljs.tools.reader :as tr]
+            [clojure.edn :as edn]
             [cljs.tools.reader.reader-types :as rt]
             [clojure.string :as str]
             [calva.js-utils :refer [jsify]]))
@@ -39,7 +40,12 @@
 (defn parse-clj-edn
   "Reads edn (with regexp tags)"
   ; https://ask.clojure.org/index.php/8675/cljs-reader-read-string-fails-input-clojure-string-accepts
-  [s] (tr/read-string s))
+  [s]
+  (def s s)
+  #_(if (re-find #"#re" s)
+    (edn/read-string {:readers {'re re-pattern}} s)
+    (tr/read-string s))
+  (tr/read-string s))
 
 ;[[ar gu ment] {:as extras, :keys [d e :s t r u c t u r e d]}]
 (comment

--- a/test-data/cljfmt.edn
+++ b/test-data/cljfmt.edn
@@ -1,2 +1,10 @@
 {:indents {inner-0-form [[:inner 0]]
-           #re "foo" [[:inner 0]]}}
+           #re "^foo" [[:inner 0]]}
+ :test [(foo []
+          x)
+        (foobar []
+          x)
+        (bar []
+             x)
+        (barfoo []
+                x)]}

--- a/test-data/cljfmt.edn
+++ b/test-data/cljfmt.edn
@@ -1,1 +1,2 @@
-{:indents {inner-0-form [[:inner 0]]}}
+{:indents {inner-0-form [[:inner 0]]
+           #re "foo" [[:inner 0]]}}


### PR DESCRIPTION
## What has changed?

1. We were not falling back on defaults when parsing of cljfmt-config fails. We are now.
2. If cljfmt-config is in a proper EDN format, regex strings can't be used. Now we do what clojure-lsp does then and support `#re` tagged strings instead. (And we use `clojure.edn/read-string` then, instead of `tools.reader/read-string` which doesn't seem to support reader tags.

* Fixes #2248

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
