### PR TITLE
Update fiddle files doc

### DIFF
--- a/docs/site/fiddle-files.md
+++ b/docs/site/fiddle-files.md
@@ -5,15 +5,15 @@ search:
   boost: 5
 ---
 
-# Fiddle Files support
+# Fiddle Files Support
 
-In the podcast **Functional Design in Clojure**, [Episode 014: Fiddle with the REPL](https://clojuredesign.club/episode/014-fiddle-with-the-repl/), they discuss a workflow where you keep some of your exploratory code in separate files, which they call **Fiddle Files**. It's like [Rich Comments](rich-comments.md), and the files often consist of such comments. The **Fiddle** files are typically not on the classpath, and are only loaded in the REPL by you when you are developing on your project. Some developers keep personal fiddle files, in some project they are meant to be shared, and in other projects its a combination.
+In the podcast **Functional Design in Clojure**, [Episode 014: Fiddle with the REPL](https://clojuredesign.club/episode/014-fiddle-with-the-repl/), they discuss a workflow in which you keep some of your exploratory code in separate files, which they call **Fiddle Files**. It's like [Rich Comments](rich-comments.md), and the files often consist of such comments. The **Fiddle** files are typically not on the classpath, and are only loaded in the REPL by you when you are developing your project. Some developers keep personal fiddle files. In some projects they are meant to be shared, and in other projects it's a combination.
 
-Calva has some extra support for the fiddle file workflow, beyond what VS Code offers in terms of navigating between files. The support comes in the form of three commands supported by some little configuration.
+Calva has some extra support for the fiddle file workflow, beyond what VS Code offers in terms of navigating between files. The support comes in the form of three commands supported by a little configuration.
 
-## The three Fiddle File commands
+## The Three Fiddle File Commands
 
-The commands let you quickly navigate between your implementation code (called **Source** here) and your **Fiddle** fle, and to evaluate the **Fiddle** file without leaving the **Source** file.
+The commands let you quickly navigate between your implementation code (called **Source** here) and your **Fiddle** file, and to evaluate the **Fiddle** file without leaving the **Source** file.
 
 | Command | Action | Shortcut | Active |
 |---------|--------|----------|--------|
@@ -23,9 +23,9 @@ The commands let you quickly navigate between your implementation code (called *
 
 The commands for opening and evaluating corresponding **Fiddle** files will offer to Create the **Fiddle** file if it does not already exist. But the **Calva: Open Source File for Current Fiddle File** command will _not_ offer to create the target file.
 
-What does **corresponding** mean here? Without any configuration Calva will look for “sibling” files, where files with Clojure file extensions (E.g. `.clj`, `.cljs`, `.bb`) will be treated as **Source** files, and files with the `.fiddle` extension will be treated as **Fiddle** files. Sibling file here means residing side by side in the file system. If this default behaviour is not your cup of tea, there is some flexibility added by configuration.
+What does **corresponding** mean here? Without any configuration Calva will look for “sibling” files, where files with Clojure file extensions (E.g. `.clj`, `.cljs`, `.bb`) will be treated as **Source** files, and files with the `.fiddle` extension will be treated as **Fiddle** files. "Sibling file" here means residing side by side in the file system. If this default behaviour is not your cup of tea, there is some flexibility added by configuration.
 
-## The Fiddle File configuration
+## The Fiddle File Configuration
 
 To know how to map between **Fiddle** <-> **Source** files, Calva has three different modes of operation:
 
@@ -43,15 +43,15 @@ To know how to map between **Fiddle** <-> **Source** files, Calva has three diff
 The setting is named `calva.fiddleFilePaths` and is an array of `source` and `fiddle` root paths, _relative to the project root_.
 
 !!! Note "The Project Root"
-    It is important to note that the **project root** depends on wether you are connected to a REPL or not, and to which project you are connected, in case the workspace contains several projects.
+    It is important to note that the **project root** depends on whether you are connected to a REPL or not, and to which project you are connected, in case the workspace contains several projects.
 
-    **Without** a REPL connection (disregarding that fiddle files are not very interesting then) the project root is the same as the first Workspace root. And if you have a regular VS Code window open, it is the root of the folder you have opened in that window.
+    **Without** a REPL connection (disregarding that fiddle files are not very interesting then) the project root is the same as the first workspace root. And if you have a regular VS Code window open, it is the root of the folder you have opened in that window.
 
     **With** a REPL connection, the project root will be the root of the project, i.e. where the project file (`deps.edn`, `project.clj`, `shadow-cljs.edn`) is.
 
-### Example configurations
+### Example Configurations
 
-#### Single parallel directory structure
+#### Single Parallel Directory Structure
 
 ```json
 "calva.fiddleFilePaths": [
@@ -67,7 +67,7 @@ This will make any file in the `src` directory tree correspond to a matching fil
 * `src/a/b/c.clj` -> `env/dev/fiddles/a/b/c.clj`, for both the **open** and **evaluate** commands
 * `env/dev/fiddles/a/b/c.clj` -> `src/a/b/c.clj`
 
-#### Single dedicated Fiddle file
+#### Single Dedicated Fiddle File
 
 If you generally work with one **Fiddle** file at a time, you can configure a mapping to a **Dedicated Fiddle** file. E.g.:
 
@@ -88,11 +88,11 @@ This will make any file in the `src` directory tree correspond to the same **Fid
 * `env/dev/fiddle.clj` -> Won't correspond to a **Source** file in this case
 
 !!! Note "Jumping from a dedicated fiddle to a source file"
-    Calva's command for opening the corresponding source file won't work in this case because it is one->many situation. If you want to open the last file you worked with before using doing **Open Fiddle File for Current File**, consider using the VS Code command: **Go Previous**.
+    Calva's command for opening the corresponding source file won't work in this case because it is a one->many situation. If you want to open the last file you worked with before using **Open Fiddle File for Current File**, consider using the VS Code command: **Go Previous**.
 
-#### Multiple mappings
+#### Multiple Mappings
 
-The configuration is an array so that you can configure different mappings for different **Source** directories. Given several mappings with overlapping **Source**, the longest mapping will win. Given several mappings with the _same_ **Source**, the first one will win, _unless_ one of them is a _Dedicated_ **Fiddle**, in which case that one will win.
+The configuration is an array so that you can configure different mappings for different **Source** directories. Given several mappings with overlapping **Source**, the longest mapping will win. Given several mappings with the _same_ **Source**, the first one will win, _unless_ one of them is a _dedicated_ **Fiddle**, in which case that one will win.
 
 ```json
 "calva.fiddleFilePaths": [
@@ -128,14 +128,14 @@ With this configuration we would get a behaviour like so:
 
 ## Tips
 
-Organize your **Fiddle** files such that they do not get automatically loaded as part of your application. This can lead to strange errors and hard-to-detect bugs. Most often it should only be you, manually, loading the fiddle file, not **clj/clojure**, or **Leiningen** or any such system which loads your application.
+Organize your **Fiddle** files such that they do not get automatically loaded as part of your application. This can lead to strange errors and hard-to-detect bugs. Most often it should only be you manually loading the fiddle file, not **clj/clojure** or **Leiningen** or any such system which loads your application.
 
 When you want your fiddle code to be evaluated in the same workspace as its corresponding **Source** file, you can use the same namespace declaration for both files. The linter might complain, but the REPL will happily comply.
 
 If you primarily evaluate the fiddle file using the provided command for it, from the **Source** files, you can omit the namespace declaration, and Calva will evaluate it in the namespace of the **Source** file.
 
 !!! Note "The linter and fiddle files"
-    For some fiddle files you will get a lot of linter warnings, because clj-kondo doesn't know about fiddle files, and they are often not on the classpath, making. You might find yourself wanting to silence some linters for some fiddle files. E.g. like this:
+    For some fiddle files you will get a lot of linter warnings, because clj-kondo doesn't know about fiddle files, and they are often not on the classpath. You might find yourself wanting to silence some linters for some fiddle files. E.g. like this:
 
     ``` clojure
     (ns main.core
@@ -145,8 +145,8 @@ If you primarily evaluate the fiddle file using the provided command for it, fro
 
      See [clj-kondo Configuration](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md) for more on what options you have for this.
 
-## See also
+## See Also
 
 * [Rich Comments](rich-comments.md)
 * **Functional Design in Clojure** [Episode 014: Fiddle with the REPL](https://clojuredesign.club/episode/014-fiddle-with-the-repl/)
-* The Polylith [Development](https://polylith.gitbook.io/poly/architecture/development) page mentions good practice for where to put your fiddle files (not called fiddle files there, but it is the same concept).
+* The [Polylith Development](https://polylith.gitbook.io/poly/architecture/development) page mentions good practice for where to put your fiddle files (not called fiddle files there, but it is the same concept).

--- a/package-lock.json
+++ b/package-lock.json
@@ -11290,9 +11290,9 @@
       "dev": true
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -20240,9 +20240,9 @@
       "dev": true
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true
     },
     "workerpool": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calva",
-  "version": "2.0.381",
+  "version": "2.0.382",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calva",
-      "version": "2.0.381",
+      "version": "2.0.382",
       "license": "MIT",
       "dependencies": {
         "@types/axios": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Calva: Clojure & ClojureScript Interactive Programming",
   "description": "Integrated REPL, formatter, Paredit, and more. Powered by cider-nrepl and clojure-lsp.",
   "icon": "assets/calva.png",
-  "version": "2.0.381",
+  "version": "2.0.382",
   "publisher": "betterthantomorrow",
   "author": {
     "name": "Better Than Tomorrow",


### PR DESCRIPTION
@PEZ, I tried to use the docs PR template, but updating the URL as described in the default PR template didn't work as expected.

> If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

I did the above, resulting in:

> https://github.com/BetterThanTomorrow/calva/compare/docs_updates?expand=1&template=docs.md

but that brought me to the same default template.

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
