### PR TITLE
Add instructions to open the command palette to the getting started doc

### DIFF
--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -65,8 +65,6 @@ The browser REPL app looks like so:
 
 ![ClojureScript Quick Start Browser REPL](images/howto/clojurescript-quick-start.png "clojurescript-quick-start")
 
-
-
 ## You have a Project?
 
 If you are new to Calva, please consider the above option first. Then when it will be time to get [Calva connected to the REPL of your project](connect.md).

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -25,17 +25,17 @@ The demo tells you about the command (and some about the Clojure Beginner's mate
 
 ??? Note "I am completely new to Clojure"
     The ”Getting Started” REPL below introduces you to Clojure as well as to Calva. You might however, not want to start with installing the right version of Java and such to run the guide. If so you should definitely check the [Get Started with Clojure](get-started-with-clojure.md) guide on this site.
-    
+
     Three clicks will have you running Calva in your browser with the REPL ready to serve.
 
 ??? Note "I don't have Java installed"
     If you like, you can defer installing anything at all and still get started with Calva (not kidding).
-    
+
     See [Get Started with Clojure](get-started-with-clojure.md).
 
 ### There's a ”Getting Started” REPL
 
-If you are new to Calva, a good place to start is using the command **Fire up the ”Getting Started” REPL**. Demo:
+If you are new to Calva, a good place to start is using the command **Fire up the ”Getting Started” REPL**. (You can open the command palette using the VS Code top menu by going to `View -> Command Palette...` or by running the associated keyboard shortcut for your OS.) Demo:
 
 ![Command Palette Start Standalone REPL](images/howto/start-hello-repl.png "Fire up the ”Getting Started” REPL")
 
@@ -46,7 +46,6 @@ It will open up a three files in a temporary directory, and start and connect a 
 - `welcome_to_clojure.clj` - The very basics of the Clojure language
 
 ![Hello REPL](images/howto/hello-repl.png "hello-repl.clj")
-
 
 The only prerequisite here is that you have Java installed. _No pre-installed clojure tools required._ (You will want to install these tools later, of course.)
 
@@ -83,7 +82,7 @@ There are also many great books on Clojure. [Clojure for the Brave and True](htt
 
 ## There is also Standalone REPL
 
-When you are more familiar with Calva, and want a standalone REPL, there is a separate command: **Start a standalone REPL (not in project)**. It will open up a `user.clj` in a temporary directory, containing only an `(ns user)` form, and start and connect the REPL. 
+When you are more familiar with Calva, and want a standalone REPL, there is a separate command: **Start a standalone REPL (not in project)**. It will open up a `user.clj` in a temporary directory, containing only an `(ns user)` form, and start and connect the REPL.
 
 ## Dram - Where the Guides Live
 


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

If you have updated only the documentation, including README and GitHub templates, then we most often want those changes directed to the `published` branch (which is the default, so you probably don't have to do anything.
-->

## What has Changed?
<!-- Please tell us what the change is about and why and such. For simple typos, just say that. 😄 -->

<!-- Please consider creating an issue for your documentation update, if there isn't one already. Tell us which issue you are fixing. -->

Fixes #2271

<!-- Also include `Fixes #12345` in the commit message. -->

## My Calva Documentation Only PR Checklist

<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [Editing Documentation](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Hack-on-Calva#editing-documentation)
- [x] Directed this pull request at the `published` branch.
- ~[ ] Built the site locally (if the changes were more involved than simple typo fixes), and verified that the site is presented as expected.~
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_ (if there was is an issue for the documentation change)
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - ~[ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik

