### PR TITLE
Add `-str` substitution variables to custom REPL commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+[Add `-str` substitution variables to custom REPL commands](https://github.com/BetterThanTomorrow/calva/issues/2282)
+
 ## [2.0.384] - 2023-08-14
 
 - [Improve clojure-lsp download error handling](https://github.com/BetterThanTomorrow/calva/issues/2278)

--- a/docs/site/custom-commands.md
+++ b/docs/site/custom-commands.md
@@ -42,6 +42,17 @@ There are also substitutions available, which will take elements from the curren
 * `$head`: The text between the start of the current list to the cursor
 * `$tail`: The text between the cursor and the end of the current list
 
+The following are quoted string variable of the above variables:
+
+* `$file-text-str`
+* `$selection-str`
+* `$current-form-str`
+* `$current-pair-str`
+* `$enclosing-form-str`
+* `$top-level-form-str`
+* `$head-str`
+* `$tail-str`
+
 ## User and Workspace Settings
 
 Settings from your User (global) level and the workspace are merged.

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -188,6 +188,7 @@ function interpolateCode(editor: vscode.TextEditor, code: string, context): stri
     .replace(/\$hover-line/g, context.hoverLine)
     .replace(/\$column/g, context.currentColumn)
     .replace(/\$hover-column/g, context.hoverColumn)
+    .replace(/\$file-text-str/g, JSON.stringify(context.currentFileText[1]))
     .replace(/\$file-text/g, context.currentFileText[1])
     .replace(/\$file/g, context.currentFilename?.replace(/\\/g, '\\\\') ?? '')
     .replace(/\$hover-file-text/g, context.hovercurrentFileText?.[1] ?? '')
@@ -196,20 +197,27 @@ function interpolateCode(editor: vscode.TextEditor, code: string, context): stri
     .replace(/\$editor-ns/g, context.editorNS)
     .replace(/\$repl/g, context.repl)
     .replace(/\$selection-closing-brackets/g, context.selectionWithBracketTrail?.[1])
+    .replace(/\$selection-str/g, JSON.stringify(context.selection))
     .replace(/\$selection/g, context.selection)
     .replace(/\$hover-text/g, context.hoverText);
   if (editor.document.languageId !== 'clojure') {
     return interpolateCode;
   } else {
     return interpolateCode
+      .replace(/\$current-form-str/g, JSON.stringify(context.currentForm[1]))
       .replace(/\$current-form/g, context.currentForm[1])
+      .replace(/\$current-pair-str/g, JSON.stringify(context.currentPair[1]))
       .replace(/\$current-pair/g, context.currentPair[1])
+      .replace(/\$enclosing-form-str/g, JSON.stringify(context.enclosingForm[1]))
       .replace(/\$enclosing-form/g, context.enclosingForm[1])
+      .replace(/\$top-level-form-str/g, JSON.stringify(context.topLevelForm[1]))
       .replace(/\$top-level-form/g, context.topLevelForm[1])
       .replace(/\$current-fn/g, context.currentFn[1])
       .replace(/\$top-level-fn/g, context.topLevelFn[1])
       .replace(/\$top-level-defined-symbol/g, context.topLevelDefinedForm?.[1] ?? '')
+      .replace(/\$head-str/g, JSON.stringify(context.head[1]))
       .replace(/\$head/g, context.head[1])
+      .replace(/\$tail-str/g, JSON.stringify(context.tail[1]))
       .replace(/\$tail/g, context.tail[1])
       .replace(/\$hover-current-form/g, context.hovercurrentForm?.[1] ?? '')
       .replace(/\$hover-current-pair/g, context.hovercurrentPair?.[1] ?? '')

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -17,6 +17,10 @@
       "snippet": "'($file-text)"
     },
     {
+      "name": "Current file text as string",
+      "snippet": "(println $file-text-str)"
+    },
+    {
       "name": "Selection, closing brackets",
       "snippet": "$selection-closing-brackets"
     }


### PR DESCRIPTION
The current `$file-text` substitution is of limited use since string composition always involves worrying about escaping.

<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Addition of a new substitution `$file-text-str` variable.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #

Some context: https://clojurians.slack.com/archives/CBE668G4R/p1684570174713629

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [ ] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
        - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [ ] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [ ] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
