### PR TITLE
Use array instead of object for indent rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- fix: [Can't override default cljfmt config since 2.0.383](https://github.com/BetterThanTomorrow/calva/issues/2284)
+
 ## [2.0.384] - 2023-08-14
 
 - [Improve clojure-lsp download error handling](https://github.com/BetterThanTomorrow/calva/issues/2278)

--- a/src/extension-test/unit/cursor-doc/indent-test.ts
+++ b/src/extension-test/unit/cursor-doc/indent-test.ts
@@ -81,6 +81,18 @@ describe('indent', () => {
           )
         ).toEqual(2);
       });
+      it('custom config does not override indents for default `defn`', () => {
+        const doc = docFromTextNotation('(defn foo [] |x)');
+        expect(
+          indent.getIndent(
+            doc.model,
+            textAndSelection(doc)[1][0],
+            mkConfig({
+              foo: [['block', 0]],
+            })
+          )
+        ).toEqual(2);
+      });
     });
 
     describe('vectors', () => {
@@ -210,6 +222,7 @@ describe('indent', () => {
     });
     describe('cljfmt defaults', () => {
       const doc = docFromTextNotation('(let []\n|x)');
+      const defndoc = docFromTextNotation('(defn []\n|x)');
       const p = textAndSelection(doc)[1][0];
       const emptyConfig = mkConfig({});
       it('with empty config, uses the built-in rule for the `let` body', () => {
@@ -224,8 +237,17 @@ describe('indent', () => {
       const blockConfig = mkConfig({
         '/\\S+/': [['block', 0]],
       });
-      it('overrides the built-in rule for the `let` body', () => {
+      it('catch-all overrides the built-in rule for the `let` body', () => {
         expect(indent.getIndent(doc.model, p, blockConfig)).toEqual(5);
+      });
+      const letBlockConfig = mkConfig({
+        let: [['block', 0]],
+      });
+      it('overrides the built-in rule for the `let` body', () => {
+        expect(indent.getIndent(doc.model, p, letBlockConfig)).toEqual(5);
+      });
+      it('does not overrides the built-in rule for the `defn` body', () => {
+        expect(indent.getIndent(defndoc.model, p, letBlockConfig)).toEqual(2);
       });
     });
   });


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Use array instead of object for indent rules. The earlier method of spreading objects and then combining them overwrote existing keys in the provided configuration.


<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

* Fixes #2284 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [X] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [X] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [X] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [X] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [X] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [X] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [X] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [X] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [X] Tests
  - [X] Tested the particular change
  - [X] Figured if the change might have some side effects and tested those as well.
- [X] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [X] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
