### PR TITLE
cljfmt 11.0.x extra indents fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Can't override default cljfmt config since 2.0.383](https://github.com/BetterThanTomorrow/calva/issues/2284)
+- Fix: [Update the indenter to handle the cljfmt `0.11.x` breaking config update since version 2.0.383](https://github.com/BetterThanTomorrow/calva/issues/2280)
 - Bump bundled deps.clj to v1.11.1.1403
 
 ## [2.0.384] - 2023-08-14

--- a/docs/site/formatting.md
+++ b/docs/site/formatting.md
@@ -117,7 +117,7 @@ The `cljfmt` indents are highly configurable. They, and the rest of the configur
 
     > The `:indents` key has been split into `:indents` and :extra-indents. The `:indents` key **replaces** all default indents, while the `:extra-indents` key will append to the default indents.
 
-    And the docs also says to use `:legacy/merge-indents true` to get the legacy behaviour, [but this doesn't work with Calva](https://github.com/weavejester/cljfmt/issues/318). So, _if you want to add your rules to the defaults, use `:extra-indents`_.
+    If something prevents you from using a config with `:extra-indents`, there's an escape hatch to keep using the `:indents` key as before, by adding `:legacy/merge-indents true` to the config map.
 
 Calva is an extra good tool for experimenting with these settings. `cljfmt` doesn't care about keys in the map that it doesn't know about so you can sneak in test code there to quickly see how it will get formatted by certain rules. Try this, for instance:
 

--- a/docs/site/formatting.md
+++ b/docs/site/formatting.md
@@ -74,7 +74,7 @@ Unlike with the ”real” Calva Formatter, which never breaks up lines, this on
 
 You can adjust the above mentioned defaults, and the default indents, by configuring the formatting using [cljfmt's configuration EDN](https://github.com/weavejester/cljfmt#configuration).
 
-This configuration can either be provided via a file or via clojure-lsp (see [Clojure LSP Settings](https://clojure-lsp.io/settings/)).
+This configuration can either be provided via a file or via clojure-lsp. See [Providing configuration via clojure-lsp](#providing-configuration-via-clojure-lsp) below.
 
 ### Providing configuration via a config file
 
@@ -104,7 +104,7 @@ If the file is in the workspace, you can quickly test how different settings aff
 
 ### Providing configuration via clojure-lsp
 
-If you work in a team where some members use clojure-lsp for formatting, you can make Calva format using the same configuration by telling setting `calva.fmt.configPath` to `CLOJURE-LSP` (case sensitive).
+If you work in a team where some members use clojure-lsp for formatting, you can make Calva format using the same configuration by telling setting `calva.fmt.configPath` to `CLOJURE-LSP` (case sensitive). See [Clojure LSP Settings](https://clojure-lsp.io/settings/)) for how to provide the configuration. (It might not be provided from where you think it is, specifically check clojure-lsp's global config in you user home directory.) Use the command **Calva Diagnostics: Clojure-lsp Server Info** to see what cljfmt configuration is being used (under the `cljfmt-raw` key).
 
 Note that doing this you will not have hot reload of the formatting configuration, and of course you will be depending on that clojure-lsp is running and functioning.
 

--- a/src/cljs-lib/src/calva/fmt/formatter.cljs
+++ b/src/cljs-lib/src/calva/fmt/formatter.cljs
@@ -20,11 +20,18 @@
   (as-> fmt $
     (merge default-fmt $)))
 
+(defn- convert-legacy-keys [config]
+       (cond-> config
+               (:legacy/merge-indents? config)
+               (-> (assoc :extra-indents (:indents config))
+                   (dissoc :indents))))
+
 (defn- read-cljfmt
   [s]
   (try
-    (as-> s $
-      (parse-clj-edn $))
+    (-> s
+        parse-clj-edn
+        convert-legacy-keys)
     (catch js/Error e
       (merge default-fmt
              {:error (.-message e)
@@ -41,6 +48,7 @@
                                                  (assoc :align-associative? true)
                                                  (dissoc :remove-multiple-non-indenting-spaces?)))
       (cljfmt/reformat-string range-text (-> cljfmt-options
+                                             convert-legacy-keys
                                              (assoc :remove-multiple-non-indenting-spaces?
                                                     trim-space-between?))))))
 

--- a/src/cursor-doc/indent.ts
+++ b/src/cursor-doc/indent.ts
@@ -63,11 +63,14 @@ export function collectIndents(
   let lastLine = cursor.line;
   let lastIndent = 0;
   const indents: IndentInformation[] = [];
+  const replaceIndents = config['cljfmt-options']['indents'];
   const defaultIndents = cljsLib.defaultIndents();
-  const extraIndents = config['cljfmt-options']['indents'];
-  const defaultRules = Object.keys(defaultIndents).map((k) => [k, defaultIndents[k]]);
-  const extraRules = Object.keys(extraIndents).map((k) => [k, extraIndents[k]]);
-  const rules = [...extraRules, ...defaultRules];
+  const extraIndents = config['cljfmt-options']['extra-indents'];
+  const replaceRules = replaceIndents
+    ? Object.keys(replaceIndents).map((k) => [k, replaceIndents[k]])
+    : Object.keys(defaultIndents).map((k) => [k, defaultIndents[k]]);
+  const extraRules = extraIndents ? Object.keys(extraIndents).map((k) => [k, extraIndents[k]]) : [];
+  const rules = [...extraRules, ...replaceRules];
 
   do {
     if (!cursor.backwardSexp()) {

--- a/src/extension-test/unit/cursor-doc/indent-test.ts
+++ b/src/extension-test/unit/cursor-doc/indent-test.ts
@@ -402,9 +402,7 @@ describe('indent', () => {
 function mkConfig(extraRules: indent.IndentRules, replaceRules?: indent.IndentRules) {
   return {
     'cljfmt-options': {
-      ...{
-        'extra-indents': extraRules,
-      },
+      'extra-indents': extraRules,
       ...(replaceRules ? { indents: replaceRules } : {}),
     },
   };

--- a/src/extension-test/unit/cursor-doc/indent-test.ts
+++ b/src/extension-test/unit/cursor-doc/indent-test.ts
@@ -250,6 +250,24 @@ describe('indent', () => {
         expect(indent.getIndent(defndoc.model, p, letBlockConfig)).toEqual(2);
       });
     });
+    describe('replacing cljfmt defaults', () => {
+      const doc = docFromTextNotation('(let []\n|x)');
+      const defndoc = docFromTextNotation('(defn []\n|x)');
+      const p = textAndSelection(doc)[1][0];
+      const emptyConfig = mkConfig({}, {});
+      it('with empty replace config, does not use the built-in rule for the `let` body', () => {
+        expect(indent.getIndent(doc.model, p, emptyConfig)).toEqual(5);
+      });
+      const someConfig = mkConfig(
+        {
+          '/foo+/': [['inner', 0]],
+        },
+        {}
+      );
+      it('with some config, still uses the built-in the built-in rule for the `let` body', () => {
+        expect(indent.getIndent(doc.model, p, someConfig)).toEqual(5);
+      });
+    });
   });
 
   describe('collectIndents', () => {
@@ -380,10 +398,13 @@ describe('indent', () => {
   });
 });
 
-function mkConfig(rules: indent.IndentRules) {
+function mkConfig(extraRules: indent.IndentRules, replaceRules?: indent.IndentRules) {
   return {
     'cljfmt-options': {
-      indents: rules,
+      ...{
+        'extra-indents': extraRules,
+      },
+      ...(replaceRules ? { indents: replaceRules } : {}),
     },
   };
 }

--- a/src/extension-test/unit/cursor-doc/indent-test.ts
+++ b/src/extension-test/unit/cursor-doc/indent-test.ts
@@ -231,7 +231,7 @@ describe('indent', () => {
       const someConfig = mkConfig({
         '/foo+/': [['inner', 0]],
       });
-      it('with some config, still uses the built-in the built-in rule for the `let` body', () => {
+      it('with some config, still uses the built-in rule for the `let` body', () => {
         expect(indent.getIndent(doc.model, p, someConfig)).toEqual(2);
       });
       const blockConfig = mkConfig({
@@ -251,6 +251,7 @@ describe('indent', () => {
       });
     });
     describe('replacing cljfmt defaults', () => {
+      // TODO: We probably need more test cases here
       const doc = docFromTextNotation('(let []\n|x)');
       const defndoc = docFromTextNotation('(defn []\n|x)');
       const p = textAndSelection(doc)[1][0];

--- a/src/formatter-config.ts
+++ b/src/formatter-config.ts
@@ -14,18 +14,8 @@ const defaultCljfmtContent =
 const LSP_CONFIG_KEY = 'CLOJURE-LSP';
 let lspFormatConfig: string | undefined;
 
-function cljfmtOptionsFromString(cljfmt: string) {
-  const options = cljsLib.cljfmtOptionsFromString(cljfmt);
-  return options.error
-    ? options
-    : {
-        ...options,
-        indents: options['indents'],
-      };
-}
-
 function configuration(workspaceConfig: vscode.WorkspaceConfiguration, cljfmt: string) {
-  const cljfmtOptions = cljfmtOptionsFromString(cljfmt);
+  const cljfmtOptions = cljsLib.cljfmtOptionsFromString(cljfmt);
   return {
     'format-as-you-type': !!formatOnTypeEnabled(),
     'keep-comment-forms-trail-paren-on-own-line?': !!workspaceConfig.get<boolean>(

--- a/test-data/cljfmt.edn
+++ b/test-data/cljfmt.edn
@@ -1,6 +1,7 @@
 {:extra-indents {inner-0-form [[:inner 0]]
-                 #re "^le[^t]" [[:block 0]]
                  #re "^foo" [[:inner 0]]}
+;;  :legacy/merge-indents? true
+;;  :indents {}
  :test [(let [] x)
         (lex [] x)
         (foo [] x)

--- a/test-data/cljfmt.edn
+++ b/test-data/cljfmt.edn
@@ -1,15 +1,9 @@
-{:indents {inner-0-form [[:inner 0]]
-           #re "^le[^t]" [[:block 0]]
-           #re "^foo" [[:inner 0]]}
- :test [(let []
-          x)
-        (lex []
-             x)
-        (foo []
-          x)
-        (foobar []
-          x)
-        (bar []
-             x)
-        (barfoo []
-                x)]}
+{:extra-indents {inner-0-form [[:inner 0]]
+                 #re "^le[^t]" [[:block 0]]
+                 #re "^foo" [[:inner 0]]}
+ :test [(let [] x)
+        (lex [] x)
+        (foo [] x)
+        (foobar [] x)
+        (bar [] x)
+        (barfoo [] x)]}


### PR DESCRIPTION
## What has changed?

* Makes the indenter read `:extra-indents` and `:indents` from the cljfmt configuration, and merge in cljfmt/default-indent:
    * if `:indents` is not used, or
    * if `:indents` are used and `:legacy/merge-indents?` is true.
* Fixes a bug with #2285 (not released yet) where the lack of an `:indent` map in the config made the indenter fail to parse the config completely.

This

* Fixes #2280 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
