### PR TITLE
In clojure-lsp server downloader, use `platform` instead of `arch` to determine if running on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Failing to download clojure-lsp server](https://github.com/BetterThanTomorrow/calva/issues/2287)
+
 ## [2.0.385] - 2023-08-15
 
 - Fix: [Can't override default cljfmt config since 2.0.383](https://github.com/BetterThanTomorrow/calva/issues/2284)

--- a/src/lsp/client/downloader.ts
+++ b/src/lsp/client/downloader.ts
@@ -36,7 +36,7 @@ export function getClojureLspPath(
 ): string {
   let name = getArtifactDownloadName(platform, arch);
   if (path.extname(name).toLowerCase() !== '.jar') {
-    name = arch === 'win32' ? 'clojure-lsp.exe' : 'clojure-lsp';
+    name = platform === 'win32' ? 'clojure-lsp.exe' : 'clojure-lsp';
   }
   return path.join(extensionPath, name);
 }


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- In the `getClojureLspPath` function in `src/lsp/client/downloader.ts`, the current code uses `process.arch` to determine if the OS is running on Windows. I've changed this to use `process.platform` instead. [Here's a StackOverflow](https://stackoverflow.com/questions/8683895/how-do-i-determine-the-current-operating-system-with-node-js?rq=4) that even says to use `process.platform` to determine the current operating system.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2287

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [X] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [X] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [X] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [X] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [X] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [X] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [X] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [X] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
    - **Note**: I have tested this on the following operating systems:
         - Windows 11 Pro 10.0.22621
         - Windows 10 Home 10.0.19045
         - macOS Ventura 13.5
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [X] Tests
  - [X] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [X] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [X] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
