### PR TITLE
Format aligned legacy merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Difference between regular formatting and formatting with alignment](https://github.com/BetterThanTomorrow/calva/issues/2289)
+
 ## [2.0.386] - 2023-08-17
 
 - Fix: [Failing to download clojure-lsp server on Windows](https://github.com/BetterThanTomorrow/calva/issues/2287)

--- a/cljfmt.edn
+++ b/cljfmt.edn
@@ -5,7 +5,7 @@
 
  :insert-missing-whitespace? true
  :align-associative? false
- :indents {foo [[:inner 0]]}
+ :extra-indents {foo [[:inner 0]]}
  :test (foo 1
             2
             {:a a

--- a/src/cljs-lib/src/calva/fmt/formatter.cljs
+++ b/src/cljs-lib/src/calva/fmt/formatter.cljs
@@ -296,37 +296,37 @@
         (cljify)
         (assoc-in [:config :cljfmt-options] (parse-clj-edn edn)))))
 
-(defn format-text-bridge
+(defn ^:export format-text-bridge
   [^js m]
   (-> m
       (parse-cljfmt-options-string)
       (format-text)))
 
-(defn format-text-at-range-bridge
+(defn ^:export format-text-at-range-bridge
   [^js m]
   (-> m
       (parse-cljfmt-options-string)
       (format-text-at-range)))
 
-(defn format-text-at-idx-bridge
+(defn ^:export format-text-at-idx-bridge
   [^js m]
   (-> m
       (parse-cljfmt-options-string)
       (format-text-at-idx)))
 
-(defn format-text-at-idx-on-type-bridge
+(defn ^:export format-text-at-idx-on-type-bridge
   [^js m]
   (-> m
       (parse-cljfmt-options-string)
       (format-text-at-idx-on-type)))
 
-(defn cljfmt-from-string-js-bridge
+(defn ^:export cljfmt-from-string-js-bridge
   [^js s]
   (-> s
       read-cljfmt
       jsify))
 
-(defn get-default-indents-js-bridge
+(defn ^:export get-default-indents-js-bridge
   []
   (jsify cljfmt/default-indents))
 

--- a/src/cljs-lib/src/pez_cljfmt/core.cljs
+++ b/src/cljs-lib/src/pez_cljfmt/core.cljs
@@ -468,7 +468,7 @@
       (cond-> (:remove-trailing-whitespace? opts true)
         remove-trailing-whitespace))))
 
-    
+
 (defn reformat-string
   ([form-string]
    (reformat-string form-string {}))
@@ -479,4 +479,3 @@
          (reformat-form (cond-> options
                           alias-map (assoc :alias-map alias-map)))
          (n/string)))))
-

--- a/test-data/cljfmt.edn
+++ b/test-data/cljfmt.edn
@@ -1,10 +1,18 @@
-{:extra-indents {inner-0-form [[:inner 0]]
-                 #re "^foo" [[:inner 0]]}
-;;  :legacy/merge-indents? true
+{:indents {inner-0-form [[:inner 0]]
+           #re "^foo" [[:inner 0]]
+                 let [[:block 0]]}
+ :legacy/merge-indents? true
 ;;  :indents {}
- :test [(let [] x)
-        (lex [] x)
-        (foo [] x)
-        (foobar [] x)
-        (bar [] x)
-        (barfoo [] x)]}
+ :test    [(let [x 1
+                 yyyyy 2]
+                    x)
+      (defn f []
+                                  x)
+           (lex []
+                     x)
+           (foo []
+        x)
+           (foobar []
+                      x)
+           (bar [] x)
+           (barfoo [] x)]}


### PR DESCRIPTION
## What has changed?

When fixing the issue with new cljfmt using a new configuration format, I forgot about how we are using an old cljfmt for the **Format and Align Current Form** command/mode. That cljfmt of course uses the old configuration format. It all gets quite confusing already before this fact, with the backward compatibility ket `:legacy/merge-indents?` key... I tried to ease the extra confusion a bit by:

1. first adapting to the new configuration format, honoring the `:legacy/merge-indents?` key, and
2. then converting to the old configuration format, merging default-indents.

The case we don't handle (which i am not sure we ever handled) is align-formatting using the legacy format and the `^:replace` metadata. That can only be achieved by using the new configuration format (and not specifying legacy merge). Haha, I don't know if this is possible to follow, but anyway, the (hopefully small) slice of the user base, that want aligned formatting, and that can't use the new configuration format, won't be able to.

I don't think I can express how much I long for this PR to be merged into cljfmt:

* https://github.com/weavejester/cljfmt/pull/299

😄 

Also in this PR is an update of Calva's own cljfmt.edn config to use the new configuration format, as well as some fixes to the formatting that had become weird because we had forgotten about this. Oh, the irony...

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

* Fixes #2289

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
