### PR TITLE
rcf top level non-function fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Evaluate a non-list top level form from inside a form evaluates the wrong form when in a rich comment](https://github.com/BetterThanTomorrow/calva/issues/2290)
+
 ## [2.0.386] - 2023-08-17
 
 - Fix: [Failing to download clojure-lsp server on Windows](https://github.com/BetterThanTomorrow/calva/issues/2287)

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -781,103 +781,156 @@ describe('Token Cursor', () => {
       const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
       expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
     });
-    it('Finds range for a top level form inside a comment', () => {
-      const a = docFromTextNotation('aaa (comment (comment [bbb cc|c]  ddd))');
-      const b = docFromTextNotation('aaa (comment (comment |[bbb ccc]|  ddd))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
-      expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
-    });
-    it('Finds range for a top level form inside a comment inside a form', () => {
-      const a = docFromTextNotation('a (b (comment [c |d] e))');
-      const b = docFromTextNotation('a (b (comment |[c d]| e))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
-      expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
-    });
-    it('Finds top level comment range if comment special treatment is disabled', () => {
-      const a = docFromTextNotation(
-        'aaa (comment (ccc •#foo•(#bar •#baz•[:a :b| :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) (ddd eee)'
-      );
-      const b = docFromTextNotation(
-        'aaa |(comment (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar))| (ddd eee)'
-      );
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
-      expect(cursor.rangeForDefun(a.selection.active, false)).toEqual(textAndSelection(b)[1]);
-    });
-    it('Finds comment range for empty comment form', () => {
-      // Unimportant use case, just documenting how it behaves
-      const a = docFromTextNotation('aaa (comment |  ) bbb');
-      const b = docFromTextNotation('aaa (|comment|   ) bbb');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
-      expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
-    });
-    it('Does not find comment range when comments are nested', () => {
-      const a = docFromTextNotation('aaa (comment (comment [bbb ccc] | ddd))');
-      const b = docFromTextNotation('aaa (comment (comment |[bbb ccc]|  ddd))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
-      expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
-    });
-    it('Finds comment range when current form is top level comment form', () => {
-      const a = docFromTextNotation(
-        'aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) |(comment eee)'
-      );
-      const b = docFromTextNotation(
-        'aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) |(comment eee)|'
-      );
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
-      expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
-    });
-    it('Includes reader tag', () => {
-      const a = docFromTextNotation('aaa (comment #r [bbb ccc|]  ddd)');
-      const b = docFromTextNotation('aaa (comment |#r [bbb ccc]|  ddd)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
-      expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
-    });
-    it('Finds the preceding range when cursor is between to forms on the same line', () => {
-      const a = docFromTextNotation('aaa (comment [bbb ccc] | ddd)');
-      const b = docFromTextNotation('aaa (comment |[bbb ccc]|  ddd)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
-      expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
-    });
-    it('Finds the succeeding range when cursor is at the start of the line', () => {
-      const a = docFromTextNotation('aaa (comment [bbb ccc]• | ddd)');
-      const b = docFromTextNotation('aaa (comment [bbb ccc]•  |ddd|)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
-      expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
-    });
-    it('Finds the preceding comment symbol range when cursor is between that and something else on the same line', () => {
-      // This is a bit funny, but is not an important use case
-      const a = docFromTextNotation('aaa (comment  | [bbb ccc]  ddd)');
-      const b = docFromTextNotation('aaa (|comment|   [bbb ccc]  ddd)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
-      expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
-    });
-    it('Can find the comment range for a top level form inside a comment', () => {
-      const a = docFromTextNotation(
-        'aaa (comment (ccc •#foo•(#bar •#baz•[:a :b| :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) (ddd eee)'
-      );
-      const b = docFromTextNotation(
-        'aaa |(comment (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar))| (ddd eee)'
-      );
-      const cursor: LispTokenCursor = a.getTokenCursor(0);
-      expect(cursor.rangeForDefun(a.selection.anchor, false)).toEqual(textAndSelection(b)[1]);
-    });
-    it('Finds closest form inside multiple nested comments', () => {
-      const a = docFromTextNotation('aaa (comment (comment [bbb ccc] | ddd))');
-      const b = docFromTextNotation('aaa (comment (comment |[bbb ccc]|  ddd))');
-      const cursor: LispTokenCursor = a.getTokenCursor(0);
-      expect(cursor.rangeForDefun(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
-    });
-    it('Finds the preceding range when cursor is between two forms on the same line', () => {
-      const a = docFromTextNotation('aaa (comment [bbb ccc] | ddd)');
-      const b = docFromTextNotation('aaa (comment |[bbb ccc]|  ddd)');
-      const cursor: LispTokenCursor = a.getTokenCursor(0);
-      expect(cursor.rangeForDefun(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
-    });
-    it('Finds top level form when deref in comment', () => {
-      const a = docFromTextNotation('(comment @(foo [bar|]))');
-      const b = docFromTextNotation('(comment |@(foo [bar])|)');
-      const cursor: LispTokenCursor = a.getTokenCursor(0);
-      expect(cursor.rangeForDefun(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
+    describe('Rich Comment Form top level context', () => {
+      it('Finds range for a top level form inside a comment', () => {
+        const a = docFromTextNotation('aaa (comment [bbb cc|c]  ddd)');
+        const b = docFromTextNotation('aaa (comment |[bbb ccc]|  ddd)');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+        expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+      });
+      it('Finds range for a top level map inside a comment', () => {
+        const a = docFromTextNotation('aaa (comment {bbb cc|c}  ddd)');
+        const b = docFromTextNotation('aaa (comment |{bbb ccc}|  ddd)');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+        expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+      });
+      // https://github.com/BetterThanTomorrow/calva/issues/2290
+      describe('Rich Comment Form top level context from inside form', () => {
+        it('Finds range for a top level function call inside a comment from inside a string', () => {
+          const a = docFromTextNotation('aaa (comment (bbb "cc|c")  ddd)');
+          const b = docFromTextNotation('aaa (comment |(bbb "ccc")|  ddd)');
+          const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+          expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+        });
+        it('Finds range for a top level shortcut lambda function inside a comment from inside a string', () => {
+          const a = docFromTextNotation('aaa (comment #(bbb "cc|c")  ddd)');
+          const b = docFromTextNotation('aaa (comment |#(bbb "ccc")|  ddd)');
+          const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+          expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+        });
+        it('Finds range for a top level quoted list inside a comment from inside a string', () => {
+          const a = docFromTextNotation(`aaa (comment '(bbb "cc|c")  ddd)`);
+          const b = docFromTextNotation(`aaa (comment |'(bbb "ccc")|  ddd)`);
+          const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+          expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+        });
+        it('Finds range for a top level map inside a comment from inside a string', () => {
+          const a = docFromTextNotation('aaa (comment {bbb "cc|c"}  ddd)');
+          const b = docFromTextNotation('aaa (comment |{bbb "ccc"}|  ddd)');
+          const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+          expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+        });
+        it('Finds range for a top level map inside a comment from inside a form', () => {
+          const a = docFromTextNotation('aaa (comment {bbb [cc|c]}  ddd)');
+          const b = docFromTextNotation('aaa (comment |{bbb [ccc]}|  ddd)');
+          const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+          expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+        });
+        it('Finds range for a top level set inside a comment from inside a string', () => {
+          const a = docFromTextNotation('aaa (comment #{bbb "cc|c"}  ddd)');
+          const b = docFromTextNotation('aaa (comment |#{bbb "ccc"}|  ddd)');
+          const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+          expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+        });
+        it('Finds range for a top level vector inside a comment from inside a string', () => {
+          const a = docFromTextNotation('aaa (comment [bbb "cc|c"]  ddd)');
+          const b = docFromTextNotation('aaa (comment |[bbb "ccc"]|  ddd)');
+          const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+          expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+        });
+      });
+      it('Finds range for a top level form inside a comment inside a form', () => {
+        const a = docFromTextNotation('a (b (comment [c |d] e))');
+        const b = docFromTextNotation('a (b (comment |[c d]| e))');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+        expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+      });
+      it('Finds top level comment range if comment special treatment is disabled', () => {
+        const a = docFromTextNotation(
+          'aaa (comment (ccc •#foo•(#bar •#baz•[:a :b| :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) (ddd eee)'
+        );
+        const b = docFromTextNotation(
+          'aaa |(comment (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar))| (ddd eee)'
+        );
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+        expect(cursor.rangeForDefun(a.selection.active, false)).toEqual(textAndSelection(b)[1]);
+      });
+      it('Finds comment range for empty comment form', () => {
+        // Unimportant use case, just documenting how it behaves
+        const a = docFromTextNotation('aaa (comment |  ) bbb');
+        const b = docFromTextNotation('aaa (|comment|   ) bbb');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+        expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+      });
+      it('Does not find comment range when comments are nested', () => {
+        const a = docFromTextNotation('aaa (comment (comment [bbb ccc] | ddd))');
+        const b = docFromTextNotation('aaa (comment (comment |[bbb ccc]|  ddd))');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+        expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+      });
+      it('Finds comment range when current form is top level comment form', () => {
+        const a = docFromTextNotation(
+          'aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) |(comment eee)'
+        );
+        const b = docFromTextNotation(
+          'aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) |(comment eee)|'
+        );
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+        expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+      });
+      it('Includes reader tag', () => {
+        const a = docFromTextNotation('aaa (comment #r [bbb ccc|]  ddd)');
+        const b = docFromTextNotation('aaa (comment |#r [bbb ccc]|  ddd)');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+        expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+      });
+      it('Finds the preceding range when cursor is between to forms on the same line', () => {
+        const a = docFromTextNotation('aaa (comment [bbb ccc] | ddd)');
+        const b = docFromTextNotation('aaa (comment |[bbb ccc]|  ddd)');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+        expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+      });
+      it('Finds the succeeding range when cursor is at the start of the line', () => {
+        const a = docFromTextNotation('aaa (comment [bbb ccc]• | ddd)');
+        const b = docFromTextNotation('aaa (comment [bbb ccc]•  |ddd|)');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+        expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+      });
+      it('Finds the preceding comment symbol range when cursor is between that and something else on the same line', () => {
+        // This is a bit funny, but is not an important use case
+        const a = docFromTextNotation('aaa (comment  | [bbb ccc]  ddd)');
+        const b = docFromTextNotation('aaa (|comment|   [bbb ccc]  ddd)');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+        expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+      });
+      it('Can find the comment range for a top level form inside a comment', () => {
+        const a = docFromTextNotation(
+          'aaa (comment (ccc •#foo•(#bar •#baz•[:a :b| :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) (ddd eee)'
+        );
+        const b = docFromTextNotation(
+          'aaa |(comment (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar))| (ddd eee)'
+        );
+        const cursor: LispTokenCursor = a.getTokenCursor(0);
+        expect(cursor.rangeForDefun(a.selection.anchor, false)).toEqual(textAndSelection(b)[1]);
+      });
+      it('Finds closest form inside multiple nested comments', () => {
+        const a = docFromTextNotation('aaa (comment (comment [bbb ccc] | ddd))');
+        const b = docFromTextNotation('aaa (comment (comment |[bbb ccc]|  ddd))');
+        const cursor: LispTokenCursor = a.getTokenCursor(0);
+        expect(cursor.rangeForDefun(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
+      });
+      it('Finds the preceding range when cursor is between two forms on the same line', () => {
+        const a = docFromTextNotation('aaa (comment [bbb ccc] | ddd)');
+        const b = docFromTextNotation('aaa (comment |[bbb ccc]|  ddd)');
+        const cursor: LispTokenCursor = a.getTokenCursor(0);
+        expect(cursor.rangeForDefun(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
+      });
+      it('Finds top level form when deref in comment', () => {
+        const a = docFromTextNotation('(comment @(foo [bar|]))');
+        const b = docFromTextNotation('(comment |@(foo [bar])|)');
+        const cursor: LispTokenCursor = a.getTokenCursor(0);
+        expect(cursor.rangeForDefun(a.selection.anchor)).toEqual(textAndSelection(b)[1]);
+      });
     });
   });
 
@@ -919,10 +972,20 @@ describe('Token Cursor', () => {
         const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
         expect(cursor.atTopLevel(true)).toEqual(true);
       });
+      it('Returns true when at a top level map in rich comment if instructed so', () => {
+        const a = docFromTextNotation('( comment (foo []) |{bar :baz})');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+        expect(cursor.atTopLevel(true)).toEqual(true);
+      });
       // TODO: Figure out if this should be how it works
       // Related to: https://github.com/BetterThanTomorrow/calva/issues/2109
       it('Returns true when at top level in rich comment if instructed so, even if comment is not at top level', () => {
         const a = docFromTextNotation('(a ( comment (foo []) |(bar :baz)))');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+        expect(cursor.atTopLevel(true)).toEqual(true);
+      });
+      it('Returns true when at a top level map in rich comment if instructed so, even if comment is not at top level', () => {
+        const a = docFromTextNotation('(a ( comment (foo []) |{bar :baz}))');
         const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
         expect(cursor.atTopLevel(true)).toEqual(true);
       });

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -1000,6 +1000,44 @@ describe('Token Cursor', () => {
         expect(cursor.atTopLevel()).toEqual(false);
       });
     });
+
+    describe('backwardFunction', () => {
+      it('Finds current function start', () => {
+        const a = docFromTextNotation('(a b |c)');
+        const b = docFromTextNotation('(|a b c)');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+        expect(cursor.backwardFunction()).toBe(true);
+        expect(cursor.offsetStart).toBe(b.selection.anchor);
+      });
+      it('Finds current function start when nested', () => {
+        const a = docFromTextNotation('(a b (c d|))');
+        const b = docFromTextNotation('(a b (|c d))');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+        expect(cursor.backwardFunction()).toBe(true);
+        expect(cursor.offsetStart).toBe(b.selection.anchor);
+      });
+      it('Finds current function start when nested and inside non-function', () => {
+        const a = docFromTextNotation('(a b (c d [e f|]))');
+        const b = docFromTextNotation('(a b (|c d [e f]))');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+        expect(cursor.backwardFunction()).toBe(true);
+        expect(cursor.offsetStart).toBe(b.selection.anchor);
+      });
+      it('Finds current function start when nested in rich comment', () => {
+        const a = docFromTextNotation('(comment a b (c d|))');
+        const b = docFromTextNotation('(comment a b (|c d))');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+        expect(cursor.backwardFunction()).toBe(true);
+        expect(cursor.offsetStart).toBe(b.selection.anchor);
+      });
+      it('Finds parent function start', () => {
+        const a = docFromTextNotation('(a b (c d|))');
+        const b = docFromTextNotation('(|a b (c d))');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selection.anchor);
+        expect(cursor.backwardFunction(1)).toBe(true);
+        expect(cursor.offsetStart).toBe(b.selection.anchor);
+      });
+    });
   });
 
   describe('Location State', () => {

--- a/test-data/projects/pirate-lang/env/dev/fiddles/pez/pirate_lang.clj
+++ b/test-data/projects/pirate-lang/env/dev/fiddles/pez/pirate_lang.clj
@@ -1,0 +1,9 @@
+(ns pez.pirate-lang)
+
+{:hello "world"}
+
+(comment
+  {:hello "world"}
+  {:hello ["world"]}
+  {:hello ['world]}
+  :rcf)


### PR DESCRIPTION
## What has changed?

The problem (for me) here was the semantics of `cursor.getFunctionName(levels)`, where `levels` is levels of *functions*. So when we where checking if the current function name is `comment` we shouldn't be using that function. I instead:

1. Wrote a local/nested function in `rangeForDefun` which only checks the symbol at function position of the current form.
2. Added some documentation notes to `cursor.getFunctionName` and `cursor.backwardFunction` (the latter of which is the function where the function semantics is assumed)
3. Added tests to document the expected behaviour

There is probably a solution where we clean up the semantics and naming and figure out how to not get confused by the code, but I fail to see how right now, and I think that at least I have improved the situation a bit now. 🤷 


* Fixes #2290

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
