### PR TITLE
Subscribe repl process stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [stdout from sub threads is not printed in the terminal](https://github.com/BetterThanTomorrow/calva/issues/2300)
+
 ## [2.0.387] - 2023-08-20
 
 - Fix: [Evaluating a non-list top level form from inside a form evaluates the wrong form when in a rich comment](https://github.com/BetterThanTomorrow/calva/issues/2290)

--- a/docs/site/output.md
+++ b/docs/site/output.md
@@ -136,6 +136,10 @@ In full stack projects, you will probably use the window as a REPL for both `clj
 
 ![Toggle CLJC](images/howto/cljc-toggle-button.png)
 
+## REPL process output (stdout and stderr)
+
+When evaluating code, `stdout`, and `stderr` stemming from `(println ...)` et al is captured by Calva and sent to the Output window. By default this includes output from threads spawned by the evaluated code as well as a lot of other output from the repl process. You can opt out of the “this includes” behaviour with the `calva.redirectServerOutputToRepl` setting.
+
 ## Known Quirks
 
 Due to limitations in the VS Code API it is hard for Calva to know if the output file is opened, and also if it is opened more than once. Make it a habit to leave this window opened. And if it is opened in several tabs, expect evaluation printouts to be a bit unpredictable.

--- a/docs/site/output.md
+++ b/docs/site/output.md
@@ -138,7 +138,15 @@ In full stack projects, you will probably use the window as a REPL for both `clj
 
 ## REPL process output (stdout and stderr)
 
-When evaluating code, `stdout`, and `stderr` stemming from `(println ...)` et al is captured by Calva and sent to the Output window. By default this includes output from threads spawned by the evaluated code as well as a lot of other output from the repl process. You can opt out of this behavior by setting the `calva.redirectServerOutputToRepl` setting to `false`.
+When Calva is connected to the REPL, the Output window will by default print not only results of evaluations, but also:
+
+1. Things printed to `stdout` and `stderr` in the **main thread** of the evaluations
+2. Things printed to `stdout` and `stderr` from **child threads** of the evaluations
+3. Anything printed to `stdout` and `stderr` by the REPL process
+
+You can control the default via the `calva.redirectServerOutputToRepl` setting. It defaults to `true`. Setting it to `false` before connecting the REPL will result in that **2.** and **3.** will not get printed in the Output window. It will then instead be printed wherever the REPL process is printing its messages, usually the terminal from where it was started (the **Jack-in terminal** if Calva started the REPL).
+
+The main reason for keeping the default is that all output from an evaluation is kept together, instead of some of it in the Output window and some of it in the REPL process terminal. It comes with the side effect that all REPL process output will also be printed in the Output window. There is currently no way to separate these. If you are working mostly in ClojureScript, you might want to disable `calva.redirectServerOutputToRepl`, since there are no child threads there anyway.
 
 ## Known Quirks
 

--- a/docs/site/output.md
+++ b/docs/site/output.md
@@ -138,7 +138,7 @@ In full stack projects, you will probably use the window as a REPL for both `clj
 
 ## REPL process output (stdout and stderr)
 
-When evaluating code, `stdout`, and `stderr` stemming from `(println ...)` et al is captured by Calva and sent to the Output window. By default this includes output from threads spawned by the evaluated code as well as a lot of other output from the repl process. You can opt out of the “this includes” behaviour with the `calva.redirectServerOutputToRepl` setting.
+When evaluating code, `stdout`, and `stderr` stemming from `(println ...)` et al is captured by Calva and sent to the Output window. By default this includes output from threads spawned by the evaluated code as well as a lot of other output from the repl process. You can opt out of this behavior by setting the `calva.redirectServerOutputToRepl` setting to `false`.
 
 ## Known Quirks
 

--- a/package.json
+++ b/package.json
@@ -909,7 +909,7 @@
           },
           "calva.redirectServerOutputToRepl": {
             "type": "boolean",
-            "markdownDescription": "Redirect the output from the REPL server process to the REPL/Output window. With this disabled output from child threads of evaluations will not be shown in the REPL/Output window, but instead in the terminal where the repl is started. (The Jack-in terminal if Calva started the repl).",
+            "markdownDescription": "Redirect the output from the REPL server process to the REPL/Output window. With this disabled output from child threads of evaluations will not be shown in the REPL/Output window, but instead in the terminal where the REPL is started (the jack-in terminal if Calva started the REPL).",
             "default": true
           }
         }

--- a/package.json
+++ b/package.json
@@ -906,6 +906,11 @@
                 "cljs": null
               }
             }
+          },
+          "calva.redirectServerOutputToRepl": {
+            "type": "boolean",
+            "markdownDescription": "Redirect the output from the REPL server process to the REPL/Output window. With this disabled output from child threads of evaluations will not be shown in the REPL/Output window, but instead in the terminal where the repl is started. (The Jack-in terminal if Calva started the repl).",
+            "default": true
           }
         }
       },

--- a/src/config.ts
+++ b/src/config.ts
@@ -243,6 +243,7 @@ function getConfig() {
       ],
       autoEvaluateCode.defaultValue
     ),
+    redirectServerOutputToRepl: configOptions.get<boolean>('redirectServerOutputToRepl'),
     fiddleFilePaths: configOptions.get<fiddleFilesUtil.FiddleFilePaths>('fiddleFilePaths'),
   };
 }

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -744,6 +744,9 @@ export async function connect(
       console.error(`Basic cider-nrepl dependencies not met (no 'info' op)`);
     }
   }
+  if (nClient.session.supports('out-subscribe')) {
+    void nClient.session.outSubscribe();
+  }
   return true;
 }
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -744,7 +744,7 @@ export async function connect(
       console.error(`Basic cider-nrepl dependencies not met (no 'info' op)`);
     }
   }
-  if (nClient.session.supports('out-subscribe')) {
+  if (getConfig().redirectServerOutputToRepl && nClient.session.supports('out-subscribe')) {
     void nClient.session.outSubscribe();
   }
   return true;

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -316,6 +316,19 @@ export class NReplSession {
     });
   }
 
+  outSubscribe(verbose?: boolean) {
+    return new Promise<any>((resolve, reject) => {
+      const id = this.client.nextId;
+      this.messageHandlers[id] = resultHandler(resolve, reject);
+      this.client.write({
+        op: 'out-subscribe',
+        id: id,
+        session: this.sessionId,
+        verbose,
+      });
+    });
+  }
+
   listSessions() {
     return new Promise<any>((resolve, reject) => {
       const id = this.client.nextId;


### PR DESCRIPTION
## What has changed?

As part of the Clojure REPL connect process we now check the setting `calva.redirectServerOutputToRepl`, and if it is `true` (the default) we send the `out-subscribe` message to the nREPL server. This makes the server rebind stuff in there catching output that would otherwise be printed by the repl server, sending it as `out` and `err` messages to the the Calva nREPL client.

* Fixes #2300

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
