### PR TITLE
Return open repl window promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [The command `calva.showOutputWindow` is not awaitable](https://github.com/BetterThanTomorrow/calva/issues/2305)
+
 ## [2.0.387] - 2023-08-20
 
 - Fix: [Evaluating a non-list top level form from inside a form evaluates the wrong form when in a rich comment](https://github.com/BetterThanTomorrow/calva/issues/2290)

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -214,8 +214,8 @@ export async function openResultsDoc(): Promise<vscode.TextDocument> {
 }
 
 export function revealResultsDoc(preserveFocus: boolean = true) {
-  void openResultsDoc().then((doc) => {
-    void vscode.window.showTextDocument(doc, getViewColumn(), preserveFocus);
+  return openResultsDoc().then((doc) => {
+    return vscode.window.showTextDocument(doc, getViewColumn(), preserveFocus);
   });
 }
 

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -221,7 +221,7 @@ export function revealResultsDoc(preserveFocus: boolean = true) {
 
 export async function revealDocForCurrentNS(preserveFocus: boolean = true) {
   const uri = await getUriForCurrentNamespace();
-  void vscode.workspace.openTextDocument(uri).then((doc) =>
+  return vscode.workspace.openTextDocument(uri).then((doc) =>
     vscode.window.showTextDocument(doc, {
       preserveFocus,
     })


### PR DESCRIPTION
## What has changed?

What the title says. Instead of “fire and forget” we now return the promise from the `calva.showOutputWindow` command, so that anyone using that command can now await it.

* Fixes #2305

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
