### PR TITLE
2309 find ns from inside ns form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Command to run tests for namespace uses user and user-test namespaces when cursor is in ns form](https://github.com/BetterThanTomorrow/calva/issues/2309)
+
 ## [2.0.388] - 2023-08-31
 
 - Fix: [stdout from sub threads is not printed in the terminal](https://github.com/BetterThanTomorrow/calva/issues/2300)

--- a/src/extension-test/unit/util/ns-form-test.ts
+++ b/src/extension-test/unit/util/ns-form-test.ts
@@ -189,6 +189,12 @@ describe('ns-form util', () => {
         nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns ^:no-doc a-b.c-d) (a b c)|'))
       ).toBe('a-b.c-d');
     });
+    // https://github.com/BetterThanTomorrow/calva/issues/2309
+    it('finds ns from inside ns form', function () {
+      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns |a-b.c-d) (a b c)'))).toBe(
+        'a-b.c-d'
+      );
+    });
   });
 
   describe('nsFromText', function () {

--- a/src/extension-test/unit/util/ns-form-test.ts
+++ b/src/extension-test/unit/util/ns-form-test.ts
@@ -57,9 +57,6 @@ describe('ns-form util', () => {
     it('returns `null` if ns form does contains non-symbol', function () {
       expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns [a]) (a b c)|'))).toBe(null);
     });
-    it('returns null if current enclosing form is ns form', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-|d) (a b c)'))).toBe(null);
-    });
     it('finds ns in form with line comment', function () {
       expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-d ; comment\n)|'))).toBe(
         'a-b.c-d'
@@ -96,7 +93,7 @@ describe('ns-form util', () => {
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation('(fn [] {:rcf (comment\n(ns a-b.c-d))}) (ns a|)')
         )
-      ).toBe(null);
+      ).toBe('a');
     });
 
     it('Closest ns or in-ns at top level wins', function () {
@@ -124,7 +121,7 @@ describe('ns-form util', () => {
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation("(fn [] {:rcf (comment\n(ns a-b.c-d))}) (in-ns 'a|)")
         )
-      ).toBe(null);
+      ).toBe('a');
     });
 
     // TODO: Figure what to do with ignored forms
@@ -170,6 +167,7 @@ describe('ns-form util', () => {
       expect(
         nsFormUtil.nsFromCursorDoc(docFromTextNotation('|(no-ns a) (a b c) (ns b) x (ns c) y'))
       ).toBe('b');
+      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation(' |(ns a) (a b c) (ns b)'))).toBe('a');
     });
     it('returns `null` if at start of document without ns form', function () {
       expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('|(no-ns a) (a b c) (no-ns b)'))).toBe(


### PR DESCRIPTION
## What has changed?

Added a check for if the current top level form is an ns form, and if so uses that ns.

* Fixes #2309

A strange thing was that we were actually testing that we were not doing this before. I'm not sure if that was more for being explicit, or for some legit reason to not consider the form we're in... Can't really see that legit reason, but anyway.

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
