### PR TITLE
Fix for ClojureScript Quick Start path bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Changes to Calva.
 
+## [Unreleased]
+
 ## [2.0.391] - 2023-10-11
 
 - Fix: [Allowing dram download to fail vocally for user. Fixing a JS join path error](https://github.com/BetterThanTomorrow/calva/issues/2325)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 Changes to Calva.
 
-## [Unreleased]
+## [2.0.391] - 2023-10-11
+
+- Fix: [Allowing dram download to fail vocally for user. Fixing a JS join path error](https://github.com/BetterThanTomorrow/calva/issues/2325)
 
 ## [2.0.390] - 2023-10-11
 

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -69,7 +69,8 @@ async function fetchConfig(configName: string): Promise<DramConfig> {
 
 async function downloadDram(storageUri: vscode.Uri, configPath: string, filePath: string) {
   const downloadUrl = `${dramsBaseUrl()}/${configPath}/${filePath}`;
-  const dirUri = vscode.Uri.joinPath(storageUri, path.join(...path.dirname(filePath).split(/\//)));
+  const directoryPath = path.dirname(filePath).split(/\//);
+  const dirUri = vscode.Uri.joinPath(storageUri, ...directoryPath);
   await vscode.workspace.fs.createDirectory(dirUri);
   const storeFileUri = vscode.Uri.joinPath(storageUri, path.join(...filePath.split(/\//)));
   return await utilities.downloadFromUrl(downloadUrl, storeFileUri.fsPath).catch((err) => {
@@ -84,13 +85,12 @@ export async function downloadDrams(
 ) {
   await Promise.all(
     filePaths.map(async (filePath) => {
-      await downloadDram(storageUri, configPath, filePath)
-        .then(() => {
-          console.log(`Downloaded ${filePath}`);
-        })
-        .catch((err) => {
-          console.error(err);
-        });
+      await downloadDram(storageUri, configPath, filePath).then(() => {
+        console.log(`Downloaded ${filePath}`);
+      });
+      // .catch((err) => {
+      //   console.error(err);
+      // });
     })
   );
 }

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -88,9 +88,6 @@ export async function downloadDrams(
       await downloadDram(storageUri, configPath, filePath).then(() => {
         console.log(`Downloaded ${filePath}`);
       });
-      // .catch((err) => {
-      //   console.error(err);
-      // });
     })
   );
 }


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- I have removed a catch that was silently hiding an exception that can cause calva to not display an error to the user
- I have added a fix to the code where an exception is thrown via a problematic file path join. Instead of doing path.join on an array spread, we remove that join and do joinPath on the array that we were trying to join on. 

More explanation is provided below the checklist. 

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2325

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
        - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [x] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik

## Why is this happening? 

This issue was uncovered in a huddle session less than an hour ago at time of writing. Explanations to follow. 

### Why isn't it showing an error to the user? 

It's not showing an error to the user because the exception that is (presumably) thrown is being caught and silently logged to a console that (I think) isn't exposed to the user. Specifically, this line. 

https://github.com/BetterThanTomorrow/calva/blob/57a24c859b07a0ed6786dbe285a1add7f0727ddb/src/nrepl/repl-start.ts#L91

### Why isn't the command behaving as expected?

The command isn't working because of nuances with javascript's join behavior. Look at this line. 
https://github.com/BetterThanTomorrow/calva/blob/57a24c859b07a0ed6786dbe285a1add7f0727ddb/src/nrepl/repl-start.ts#L72

When javascript joins these lines it results in code such as `src\\hello_world` instead of the desired `src/hello_world`. This is an invalid directory format, so the directory cannot be created! Thus when trying to act on these assumed created files, the function will throw an exception that is silently caught. 

## What is the solution? 

The solution is twofold. First, remove the catch so that this error bubbles up and notifies the user. Second, remove the join since it's not needed to build the path connection for the file creation location; as follows. 

```
  const directoryPath = path.dirname(filePath).split(/\//);
  const dirUri = vscode.Uri.joinPath(storageUri, ...directoryPath);
```

