### PR TITLE
Fix structural edit hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changes to Calva.
 ## [Unreleased]
 
 - Bump bundled deps.clj to v1.11.1.1413
+- Add timestamps to nREPL message log diagnostics
+- Fix: [Backspace (structural editing) occasionally hangs](https://github.com/BetterThanTomorrow/calva/issues/2299)
 
 ## [2.0.391] - 2023-10-12
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -778,15 +778,6 @@ export function open(
   }
 }
 
-function docIsBalanced(doc: EditableDocument, start: number = doc.selection.active): boolean {
-  const cursor = doc.getTokenCursor(0);
-  while (cursor.forwardSexp(true, true, true)) {
-    // move forward until the cursor cannot move forward anymore
-  }
-  cursor.forwardWhitespace(true);
-  return cursor.atEnd();
-}
-
 export async function close(
   doc: EditableDocument,
   close: string,
@@ -798,7 +789,7 @@ export async function close(
   if (cursor.getToken().raw === close) {
     doc.selection = new ModelEditSelection(cursor.offsetEnd);
   } else {
-    if (!inString && docIsBalanced(doc)) {
+    if (!inString && cursor.docIsBalanced()) {
       // Do nothing when there is balance
     } else {
       return doc.model.edit([new ModelEdit('insertString', [start, close])], {
@@ -876,7 +867,7 @@ export async function backspace(
     } else if (!isTopLevel && !cursor.withinString() && onlyWhitespaceLeftOfCursor(doc, cursor)) {
       return backspaceOnWhitespaceEdit(doc, cursor, config);
     } else {
-      if (['open', 'close'].includes(prevToken.type) && docIsBalanced(doc)) {
+      if (['open', 'close'].includes(prevToken.type) && cursor.docIsBalanced()) {
         doc.selection = new ModelEditSelection(p - prevToken.raw.length);
         return new Promise<boolean>((resolve) => resolve(true));
       } else {
@@ -910,7 +901,7 @@ export async function deleteForward(
         }
       );
     } else {
-      if (['open', 'close'].includes(nextToken.type) && docIsBalanced(doc)) {
+      if (['open', 'close'].includes(nextToken.type) && cursor.docIsBalanced()) {
         doc.selection = new ModelEditSelection(p + 1);
         return new Promise<boolean>((resolve) => resolve(true));
       } else {

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -965,6 +965,16 @@ export class LispTokenCursor extends TokenCursor {
     }
     return true;
   }
+
+  docIsBalanced(): boolean {
+    const cursor = this.clone();
+    cursor.set(new TokenCursor(this.doc, 0, 0));
+    while (cursor.forwardSexp(true, true, true)) {
+      // move forward until the cursor cannot move forward anymore
+    }
+    cursor.forwardWhitespace(true);
+    return cursor.atEnd();
+  }
 }
 
 /**

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -781,6 +781,16 @@ describe('Token Cursor', () => {
       const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
       expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
     });
+    it('Finds something when there is unbalance', () => {
+      const a = docFromTextNotation(
+        '(ns xxx)•(def xxx|•{()"#"\\$" #"(?!\\w)"))))))))))))))))))))))))))))))))))))))))'
+      );
+      const b = docFromTextNotation(
+        '(ns xxx)•(def xxx•|{()"#"\\$" #"(?!\\w)"))))))))))))))))))))))))))))))))))))))))|'
+      );
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selection.active);
+      expect(cursor.rangeForDefun(a.selection.active)).toEqual(textAndSelection(b)[1]);
+    });
     describe('Rich Comment Form top level context', () => {
       it('Finds range for a top level form inside a comment', () => {
         const a = docFromTextNotation('aaa (comment [bbb cc|c]  ddd)');

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -1011,6 +1011,31 @@ describe('Token Cursor', () => {
       });
     });
 
+    describe('docIsBalanced', () => {
+      it('Reports balance for balanced structure', () => {
+        const doc = docFromTextNotation('(a)•|(b)');
+        const cursor: LispTokenCursor = doc.getTokenCursor(doc.selection.active);
+        expect(cursor.docIsBalanced()).toBe(true);
+      });
+      it('Detects unbalance when lacking opening brackets', () => {
+        const doc = docFromTextNotation('(a)•|(b))');
+        const cursor: LispTokenCursor = doc.getTokenCursor(doc.selection.active);
+        expect(cursor.docIsBalanced()).toBe(false);
+      });
+      // TODO: Fix this
+      xit('Detects unbalance when lacking closing brackets', () => {
+        const doc = docFromTextNotation('(a)•|(b');
+        const cursor: LispTokenCursor = doc.getTokenCursor(doc.selection.active);
+        expect(cursor.docIsBalanced()).toBe(false);
+      });
+      // TODO: Fix this too
+      xit('Detects unbalance when lacking man closing brackets', () => {
+        const doc = docFromTextNotation('(a)•|([{((((b)');
+        const cursor: LispTokenCursor = doc.getTokenCursor(doc.selection.active);
+        expect(cursor.docIsBalanced()).toBe(false);
+      });
+    });
+
     describe('backwardFunction', () => {
       it('Finds current function start', () => {
         const a = docFromTextNotation('(a b |c)');

--- a/src/extension-test/unit/util/ns-form-test.ts
+++ b/src/extension-test/unit/util/ns-form-test.ts
@@ -2,6 +2,7 @@ import * as expect from 'expect';
 import { docFromTextNotation } from '../common/text-notation';
 import * as nsFormUtil from '../../../util/ns-form';
 import { resolveNsName, pathToNs, isPrefix } from '../../../util/ns-form';
+import { fail } from 'assert';
 
 describe('ns-form util', () => {
   describe('isPrefix', function () {
@@ -192,6 +193,19 @@ describe('ns-form util', () => {
       expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns |a-b.c-d) (a b c)'))).toBe(
         'a-b.c-d'
       );
+    });
+    it('finds ns from unbalanced form', function () {
+      try {
+        expect(
+          nsFormUtil.nsFromCursorDoc(
+            docFromTextNotation(
+              '(ns xxx)•(def xxx|•{()"#"\\$" #"(?!\\w)"))))))))))))))))))))))))))))))))))))))))'
+            )
+          )
+        ).toBe('xxx');
+      } catch (error) {
+        fail(`Expected no error to be thrown, but got ${error}`);
+      }
     });
   });
 

--- a/src/extension-test/unit/util/ns-form-test.ts
+++ b/src/extension-test/unit/util/ns-form-test.ts
@@ -194,7 +194,8 @@ describe('ns-form util', () => {
         'a-b.c-d'
       );
     });
-    it('finds ns from unbalanced form', function () {
+    // https://github.com/BetterThanTomorrow/calva/issues/2299
+    it('finds ns from unbalanced form, lacking opening brackets', function () {
       try {
         expect(
           nsFormUtil.nsFromCursorDoc(
@@ -202,6 +203,15 @@ describe('ns-form util', () => {
               '(ns xxx)•(def xxx|•{()"#"\\$" #"(?!\\w)"))))))))))))))))))))))))))))))))))))))))'
             )
           )
+        ).toBe('xxx');
+      } catch (error) {
+        fail(`Expected no error to be thrown, but got ${error}`);
+      }
+    });
+    it('finds ns from unbalanced form lacking closing brackets', function () {
+      try {
+        expect(
+          nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns xxx]))]]]]]])))•(def xxx|•{})'))
         ).toBe('xxx');
       } catch (error) {
         fail(`Expected no error to be thrown, but got ${error}`);

--- a/src/nrepl/logging.ts
+++ b/src/nrepl/logging.ts
@@ -26,11 +26,19 @@ function formatNreplMessage(message: any): string {
   return nodeUtil.inspect(message, false, 2, false);
 }
 
+const lastSeenTimes = {};
 export function log(message: any, direction: Direction): void {
   if (NREPL_LOGGING_ENABLED) {
     const channel = getMessageChannel();
     if (channel) {
-      const formattedMessage = `${direction}\n${formatNreplMessage(message)}\n`;
+      const lastSeenKey = `${message.session}:${message.id}`;
+      const currentTime = Date.now();
+      const lastSeenTime = lastSeenTimes[lastSeenKey];
+      const timeSinceLastSeen = lastSeenTime ? `${currentTime - lastSeenTime}ms` : '';
+      lastSeenTimes[lastSeenKey] = currentTime;
+      const formattedMessage = `${Date.now()} ${direction} ${timeSinceLastSeen}\n${formatNreplMessage(
+        message
+      )}\n`;
       channel.appendLine(formattedMessage);
     }
   }

--- a/src/util/ns-form.ts
+++ b/src/util/ns-form.ts
@@ -91,9 +91,12 @@ export function nsFromCursorDoc(
   if (cursor.atStart()) {
     return null;
   } else {
+    // Special case 3, the structure of the document is unbalanced
+    // We try to find the ns from the start of the document
     if (!cursor.docIsBalanced()) {
       return nsFromCursorDoc(cursorDoc, 0);
     }
+    // General case, continue look for ns form closest before p
     return nsFromCursorDoc(cursorDoc, cursor.offsetStart);
   }
 }

--- a/src/util/ns-form.ts
+++ b/src/util/ns-form.ts
@@ -91,6 +91,9 @@ export function nsFromCursorDoc(
   if (cursor.atStart()) {
     return null;
   } else {
+    if (!cursor.docIsBalanced()) {
+      return nsFromCursorDoc(cursorDoc, 0);
+    }
     return nsFromCursorDoc(cursorDoc, cursor.offsetStart);
   }
 }


### PR DESCRIPTION
## What has changed?

I seems it was my changes to how we find the `ns` from the current cursor position that caused a stack overflow in unbalanced structure and thus #2299.

I've added a check for this kind of unbalance and stop the recursion by letting the search for the ns continue from the start of the document in these cases.

I've also added some tests for the unbalance-check, and while doing so notice that it doesn't actually find unbalance if it is from a lack of closing brackets, only lack of opening brackets. I couldn't immediately fix it, so left some disabled tests, and added TODOs. We've been living with this bug for long, (I don't even remember when I added the code for unbalance check). Besides, I think the real way to check for unbalance is to piggy back on the highlighter's work, which does a much better job at it, and also, since it is doing the job, we shouldn't be doing it over and over again at other places.

* Fixes #2299

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
