### PR TITLE
2336 completion merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Namespace alias shadows local variables](https://github.com/BetterThanTomorrow/calva/issues/2336)
+
 ## [2.0.392] - 2023-10-22
 
 - Bump bundled deps.clj to v1.11.1.1413

--- a/src/extension-test/unit/completion-test.ts
+++ b/src/extension-test/unit/completion-test.ts
@@ -1,7 +1,10 @@
 import * as expect from 'expect';
 import * as completionUtil from '../../../src/providers/completion-util';
 
-describe('Merging arrays', () => {
+describe('Merging completion arrays', () => {
+  it('it merges two empty arrays or completions', function () {
+    expect(completionUtil.mergeCompletions([], [])).toStrictEqual([]);
+  });
   it('it merges an empty and a populated array or completions', function () {
     const completions = [
       { label: 'a', kind: 1 },
@@ -37,15 +40,18 @@ describe('Merging arrays', () => {
   it('it merges two populated arrays or completions, the higher score wins', function () {
     const completions1 = [
       { label: 'a', kind: 1, detail: 'foo', score: 1 },
-      { label: 'b', kind: 2 },
+      { label: 'b', kind: 2, detail: 'foo', score: 0 },
+      { label: 'd', kind: 4 },
     ];
     const completions2 = [
       { label: 'a', kind: 1, detail: 'bar', score: 0 },
+      { label: 'b', kind: 2, detail: 'bar', score: 0 },
       { label: 'c', kind: 3 },
     ];
     const mergedCompletions = [
       { label: 'a', kind: 1, detail: 'foo', score: 1 },
-      { label: 'b', kind: 2 },
+      { label: 'b', kind: 2, detail: 'bar', score: 0 },
+      { label: 'd', kind: 4 },
       { label: 'c', kind: 3 },
     ];
     expect(completionUtil.mergeCompletions(completions1, completions2)).toStrictEqual(

--- a/src/extension-test/unit/completion-test.ts
+++ b/src/extension-test/unit/completion-test.ts
@@ -1,38 +1,6 @@
 import * as expect from 'expect';
 import * as completionUtil from '../../../src/providers/completion-util';
 
-describe('Padding arrays', () => {
-  it('it pads an empty array to a length', function () {
-    const length = 2;
-    const aMap2 = Array.from({ length: length }).map(() => new Map());
-    expect(completionUtil._padArray([], length)).toStrictEqual(aMap2);
-  });
-  it('it pads an arrays of one completion objects to a length', function () {
-    const length = 2;
-    const populatedMap = new Map([[['a', 1], { label: 'a', kind: 1 }]]);
-    const expectedArray = [populatedMap, new Map()];
-    expect(completionUtil._padArray([{ label: 'a', kind: 1 }], length)).toStrictEqual(
-      expectedArray
-    );
-  });
-  it('it leaves a arrays of length completion objects alone', function () {
-    const length = 2;
-    const expectedArray = [
-      new Map([[['a', 1], { label: 'a', kind: 1 }]]),
-      new Map([[['b', 2], { label: 'b', kind: 2 }]]),
-    ];
-    expect(
-      completionUtil._padArray(
-        [
-          { label: 'a', kind: 1 },
-          { label: 'b', kind: 2 },
-        ],
-        length
-      )
-    ).toStrictEqual(expectedArray);
-  });
-});
-
 describe('Merging arrays', () => {
   it('it merges an empty and a populated array or completions', function () {
     const completions = [

--- a/src/extension-test/unit/completion-test.ts
+++ b/src/extension-test/unit/completion-test.ts
@@ -1,0 +1,69 @@
+import * as expect from 'expect';
+import * as completionUtil from '../../../src/providers/completion-util';
+
+describe('Padding arrays', () => {
+  it('it pads an empty array to a length', function () {
+    const length = 2;
+    const aMap2 = Array.from({ length: length }).map(() => new Map());
+    expect(completionUtil._padArray([], length)).toStrictEqual(aMap2);
+  });
+  it('it pads an arrays of one completion objects to a length', function () {
+    const length = 2;
+    const populatedMap = new Map([[['a', 1], { label: 'a', kind: 1 }]]);
+    const expectedArray = [populatedMap, new Map()];
+    expect(completionUtil._padArray([{ label: 'a', kind: 1 }], length)).toStrictEqual(
+      expectedArray
+    );
+  });
+  it('it leaves a arrays of length completion objects alone', function () {
+    const length = 2;
+    const expectedArray = [
+      new Map([[['a', 1], { label: 'a', kind: 1 }]]),
+      new Map([[['b', 2], { label: 'b', kind: 2 }]]),
+    ];
+    expect(
+      completionUtil._padArray(
+        [
+          { label: 'a', kind: 1 },
+          { label: 'b', kind: 2 },
+        ],
+        length
+      )
+    ).toStrictEqual(expectedArray);
+  });
+});
+
+describe('Merging arrays', () => {
+  it('it merges an empty and a populated array or completions', function () {
+    const completions = [
+      { label: 'a', kind: 1 },
+      { label: 'b', kind: 2 },
+    ];
+    expect(completionUtil.mergeCompletions([], completions)).toStrictEqual(completions);
+  });
+  it('it merges a populated and empty array or completions', function () {
+    const completions = [
+      { label: 'a', kind: 1 },
+      { label: 'b', kind: 2 },
+    ];
+    expect(completionUtil.mergeCompletions(completions, [])).toStrictEqual(completions);
+  });
+  it('it merges two populated arrays or completions', function () {
+    const completions1 = [
+      { label: 'a', kind: 1, detail: 'foo' },
+      { label: 'b', kind: 2 },
+    ];
+    const completions2 = [
+      { label: 'a', kind: 1, detail: 'bar' },
+      { label: 'c', kind: 3 },
+    ];
+    const mergedCompletions = [
+      { label: 'a', kind: 1, detail: 'bar' },
+      { label: 'b', kind: 2 },
+      { label: 'c', kind: 3 },
+    ];
+    expect(completionUtil.mergeCompletions(completions1, completions2)).toStrictEqual(
+      mergedCompletions
+    );
+  });
+});

--- a/src/extension-test/unit/completion-test.ts
+++ b/src/extension-test/unit/completion-test.ts
@@ -16,17 +16,35 @@ describe('Merging arrays', () => {
     ];
     expect(completionUtil.mergeCompletions(completions, [])).toStrictEqual(completions);
   });
-  it('it merges two populated arrays or completions', function () {
+  it('it merges two populated arrays or completions, the second array wins with equal scores', function () {
     const completions1 = [
-      { label: 'a', kind: 1, detail: 'foo' },
+      { label: 'a', kind: 1, detail: 'foo', score: 0 },
       { label: 'b', kind: 2 },
     ];
     const completions2 = [
-      { label: 'a', kind: 1, detail: 'bar' },
+      { label: 'a', kind: 1, detail: 'bar', score: 0 },
       { label: 'c', kind: 3 },
     ];
     const mergedCompletions = [
-      { label: 'a', kind: 1, detail: 'bar' },
+      { label: 'a', kind: 1, detail: 'bar', score: 0 },
+      { label: 'b', kind: 2 },
+      { label: 'c', kind: 3 },
+    ];
+    expect(completionUtil.mergeCompletions(completions1, completions2)).toStrictEqual(
+      mergedCompletions
+    );
+  });
+  it('it merges two populated arrays or completions, the higher score wins', function () {
+    const completions1 = [
+      { label: 'a', kind: 1, detail: 'foo', score: 1 },
+      { label: 'b', kind: 2 },
+    ];
+    const completions2 = [
+      { label: 'a', kind: 1, detail: 'bar', score: 0 },
+      { label: 'c', kind: 3 },
+    ];
+    const mergedCompletions = [
+      { label: 'a', kind: 1, detail: 'foo', score: 1 },
       { label: 'b', kind: 2 },
       { label: 'c', kind: 3 },
     ];

--- a/src/providers/completion-util.ts
+++ b/src/providers/completion-util.ts
@@ -1,0 +1,39 @@
+import { CompletionItem, CompletionItemKind, CompletionItemLabel } from 'vscode';
+
+type CompletionKey = [string | CompletionItemLabel, CompletionItemKind | number];
+type CompletionMap = Map<CompletionKey, CompletionItem>;
+
+type CompletionObject = {
+  label: string | CompletionItemLabel;
+  kind: CompletionItemKind | number;
+  [key: string]: any;
+};
+
+const objectToMap = (obj: CompletionObject[]): CompletionMap => {
+  return new Map(
+    obj.map((item) => {
+      const completionKey: CompletionKey = [item.label, item.kind];
+      return [completionKey, item];
+    })
+  );
+};
+
+export const _padArray = (arr: CompletionObject[], length: number): CompletionMap[] => {
+  const maps = arr.map((obj) => objectToMap([obj])); // Create a new CompletionMap for each CompletionObject
+  const padding = Array.from({ length: length - maps.length }, () => new Map());
+  return maps.concat(padding);
+};
+
+export function mergeCompletions(a: CompletionObject[], b: CompletionObject[]): CompletionObject[] {
+  const mergeMap = new Map<string, CompletionObject>();
+
+  const addToMergeMap = (obj: CompletionObject) => {
+    const key = `${obj.label},${obj.kind}`;
+    mergeMap.set(key, obj);
+  };
+
+  a.forEach(addToMergeMap);
+  b.forEach(addToMergeMap);
+
+  return Array.from(mergeMap.values());
+}

--- a/src/providers/completion-util.ts
+++ b/src/providers/completion-util.ts
@@ -11,7 +11,10 @@ export function mergeCompletions(a: CompletionObject[], b: CompletionObject[]): 
 
   const addToMergeMap = (obj: CompletionObject) => {
     const key = `${obj.label},${obj.kind}`;
-    mergeMap.set(key, obj);
+    const existingObj = mergeMap.get(key);
+    if (!existingObj || obj.score >= existingObj.score) {
+      mergeMap.set(key, obj);
+    }
   };
 
   a.forEach(addToMergeMap);

--- a/src/providers/completion-util.ts
+++ b/src/providers/completion-util.ts
@@ -7,18 +7,16 @@ type CompletionObject = {
 };
 
 export function mergeCompletions(a: CompletionObject[], b: CompletionObject[]): CompletionObject[] {
-  const mergeMap = new Map<string, CompletionObject>();
-
-  const addToMergeMap = (obj: CompletionObject) => {
+  const merge = (map: Map<string, CompletionObject>, obj: CompletionObject) => {
     const key = `${obj.label},${obj.kind}`;
-    const existingObj = mergeMap.get(key);
+    const existingObj = map.get(key);
     if (!existingObj || obj.score >= existingObj.score) {
-      mergeMap.set(key, obj);
+      map.set(key, obj);
     }
+    return map;
   };
 
-  a.forEach(addToMergeMap);
-  b.forEach(addToMergeMap);
+  const mergedMap = [...a, ...b].reduce(merge, new Map<string, CompletionObject>());
 
-  return Array.from(mergeMap.values());
+  return Array.from(mergedMap.values());
 }

--- a/src/providers/completion-util.ts
+++ b/src/providers/completion-util.ts
@@ -1,27 +1,9 @@
-import { CompletionItem, CompletionItemKind, CompletionItemLabel } from 'vscode';
-
-type CompletionKey = [string | CompletionItemLabel, CompletionItemKind | number];
-type CompletionMap = Map<CompletionKey, CompletionItem>;
+import { CompletionItemKind, CompletionItemLabel } from 'vscode';
 
 type CompletionObject = {
   label: string | CompletionItemLabel;
   kind: CompletionItemKind | number;
   [key: string]: any;
-};
-
-const objectToMap = (obj: CompletionObject[]): CompletionMap => {
-  return new Map(
-    obj.map((item) => {
-      const completionKey: CompletionKey = [item.label, item.kind];
-      return [completionKey, item];
-    })
-  );
-};
-
-export const _padArray = (arr: CompletionObject[], length: number): CompletionMap[] => {
-  const maps = arr.map((obj) => objectToMap([obj])); // Create a new CompletionMap for each CompletionObject
-  const padding = Array.from({ length: length - maps.length }, () => new Map());
-  return maps.concat(padding);
 };
 
 export function mergeCompletions(a: CompletionObject[], b: CompletionObject[]): CompletionObject[] {

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -8,7 +8,6 @@ import {
   CompletionList,
   CompletionItemProvider,
   CompletionItem,
-  CompletionItemLabel,
   Uri,
 } from 'vscode';
 import * as util from '../utilities';
@@ -32,6 +31,7 @@ const mappings = {
   function: CompletionItemKind.Function,
   'special-form': CompletionItemKind.Keyword,
   var: CompletionItemKind.Variable,
+  local: CompletionItemKind.Variable,
   method: CompletionItemKind.Method,
 };
 
@@ -204,9 +204,12 @@ async function replCompletions(
     }
   });
   return results.map((item) => {
+    console.log('nrepl item', item);
     const result = new CompletionItem(
       item.candidate,
-      mappings[item.type] || CompletionItemKind.Text
+      // +1 because the LSP CompletionItemKind enum starts at 1
+      // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemKind
+      (mappings[item.type] || CompletionItemKind.Text) + 1
     );
     const data = item[0] === '.' ? item.slice(1) : item;
     data['provider'] = 'repl';


### PR DESCRIPTION
## What has changed?

The merge of lsp and nrepl completion items wasn't working as we intended. So I fixed that and added some tests for it.

Also, while merging the LSP `CompletionItemKind`s are used, which are off by one from VS Code's. This made our mapping from nREPL completion `type`s off by one as well. I fixed that too. No tests here, though, as I think maybe the comment I added where I add one to the mappings is enough?

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

* Fixes #2336

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
