### PR TITLE
Use last active client when serving jar files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Definition lookup in dependency files is broken](https://github.com/BetterThanTomorrow/calva/issues/2339)
+
 ## [2.0.392] - 2023-10-22
 
 - Bump bundled deps.clj to v1.11.1.1413

--- a/src/lsp/api.ts
+++ b/src/lsp/api.ts
@@ -46,6 +46,11 @@ export const getActiveClientForUri = (clients: defs.LspClientStore, uri: vscode.
   }
 };
 
+// Temporary hack to pick the last active client when no active client matches the current file Uri
+// Such as when serving jar files
+// TODO: Figure out the proper way to handle this
+let lastActiveClient: defs.LspClient | undefined;
+
 /**
  * Similar to `getActiveClientForUri` except this only returns the client if it is in a running state. This API
  * should be used by systems wanting to interact with the LSP client.
@@ -53,7 +58,10 @@ export const getActiveClientForUri = (clients: defs.LspClientStore, uri: vscode.
 export const getClientForDocumentUri = (clients: defs.LspClientStore, uri: vscode.Uri) => {
   const client = getActiveClientForUri(clients, uri);
   if (client && client.status === defs.LspStatus.Running) {
+    lastActiveClient = client;
     return client.client;
+  } else {
+    return lastActiveClient?.client;
   }
 };
 


### PR DESCRIPTION
## What has changed?

When selecting the lsp client to serve a definition lookup, we index the clients based on the project root, and use the current file's associated project root for this. With dependency files, such as jars in the local maven cache, this breaks, because:

1. There is no project root for those files
2. Only the lsp client serving the file that brought the user to a particular dependency file, can be relied on to have the analysis necessary to serve definition lookups from that dependency file.

Tbh, I don't know the proper way to solve this. But as a temporary fix, that probably works in 99.99% of cases, we now just keep track of the last active client and fall back on that if the current file has no corresponding client.

* Fixes #2339

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
