### PR TITLE
LSP client check if nrepl is providing a hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Calva shows two hover definitions for user-defined vars when a repl is connected](https://github.com/BetterThanTomorrow/calva/issues/2091)
+
 ## [2.0.393] - 2023-11-05
 
 - Fix: [Namespace alias shadows local variables](https://github.com/BetterThanTomorrow/calva/issues/2336)

--- a/src/lsp/client/client.ts
+++ b/src/lsp/client/client.ts
@@ -1,5 +1,6 @@
 import * as messages from './messages';
 import { provideSignatureHelp } from '../../providers/signature';
+import { provideHover } from '../../providers/hover';
 import { isResultsDoc } from '../../results-output/results-doc';
 import * as vscode_lsp from 'vscode-languageclient/node';
 import * as defs from '../definitions';
@@ -7,6 +8,7 @@ import * as config from '../../config';
 import * as utils from '../utils';
 import * as vscode from 'vscode';
 import * as path from 'path';
+import { getClientProvider } from '../state';
 
 /**
  * This can potentially be used to replace or alter the automatic command instrumentation performed by the
@@ -171,6 +173,14 @@ export const createClient = (params: CreateClientParams): defs.LspClient => {
         },
         provideLinkedEditingRange: (_document, _position, _token, _next): null => {
           return null;
+        },
+        async provideHover(document, position, token, next) {
+          const hovers = await provideHover(getClientProvider(), document, position);
+          if (hovers) {
+            return null;
+          } else {
+            return next(document, position, token);
+          }
         },
         handleDiagnostics(uri, diagnostics, next) {
           if (uri.path.endsWith(config.REPL_FILE_EXT)) {


### PR DESCRIPTION
## What has changed?

I added middleware to the lsp client so that it checks if there is already hovers provided before going ahead providing them.

This is a bit inefficient, because now nrepl gets asked twice to provide hovers, where one of them is only a check. But it is the simplest way to accommodate for nrepl servers that do not provide the `info` op.

* Fixes #2091

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
