### PR TITLE
2343 squint nrepl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Make Calva's nrepl client squint-cljs compatible](https://github.com/BetterThanTomorrow/calva/issues/2343)
+
 ## [2.0.394] - 2023-11-06
 
 - Fix: [Calva shows two hover definitions for user-defined vars when a repl is connected](https://github.com/BetterThanTomorrow/calva/issues/2091)

--- a/src/clojuredocs.ts
+++ b/src/clojuredocs.ts
@@ -177,7 +177,7 @@ async function clojureDocsLookup(
   const doc = d ? d : util.getDocument({});
   const position = p ? p : util.getActiveTextEditor().selection.active;
   const symbol = util.getWordAtPosition(doc, position);
-  const ns = namespace.getNamespace(doc, p);
+  const [ns, _] = namespace.getNamespace(doc, p);
   const session = replSession.getSession(util.getFileType(doc));
 
   const docsFromCider = await clojureDocsCiderNReplLookup(session, symbol, ns);

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -37,7 +37,7 @@ async function evaluateCodeOrKeyOrSnippet(codeOrKeyOrSnippet?: string | SnippetD
     return;
   }
   const editor = util.getActiveTextEditor();
-  const editorNS =
+  const [editorNS, _] =
     editor && editor.document && editor.document.languageId === 'clojure'
       ? namespace.getNamespace(editor.document, editor.selection.active)
       : undefined;

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -105,7 +105,7 @@ async function evaluateCodeUpdatingUI(
     const err: string[] = [];
 
     if (outputWindow.getNs() !== ns) {
-      await session.evaluateInCurrentNs(options.nsForm);
+      await session.evaluateInNs(options.nsForm, outputWindow.getNs());
     }
 
     const context: NReplEvaluation = session.eval(code, ns, {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -104,10 +104,6 @@ async function evaluateCodeUpdatingUI(
 
     const err: string[] = [];
 
-    if (outputWindow.getNs() !== ns) {
-      await session.switchNS(ns);
-    }
-
     const context: NReplEvaluation = session.eval(code, ns, {
       file: filePath,
       line: line + 1,
@@ -446,8 +442,6 @@ async function loadFile(
 
   outputWindow.appendLine(`; Evaluating file: ${fileName}`);
 
-  await session.switchNS(ns);
-
   const errorMessages = [];
   const res = session.loadFile(fileContents, {
     fileName,
@@ -533,7 +527,6 @@ async function requireREPLUtilitiesCommand() {
     if (session) {
       try {
         await namespace.createNamespaceFromDocumentIfNotExists(util.tryToGetDocument({}));
-        await session.switchNS(ns);
         await session.requireREPLUtilities();
         chan.appendLine(`REPL utilities are now available in namespace ${ns}.`);
       } catch (e) {
@@ -602,7 +595,6 @@ async function evaluateInOutputWindow(code: string, sessionType: string, ns: str
     const session = replSession.getSession(sessionType);
     replSession.updateReplSessionType();
     if (outputWindow.getNs() !== ns) {
-      await session.switchNS(ns);
       outputWindow.setSession(session, ns);
       if (options.evaluationSendCodeToOutputWindow !== false) {
         outputWindow.appendPrompt();

--- a/src/extension-test/unit/util/ns-form-test.ts
+++ b/src/extension-test/unit/util/ns-form-test.ts
@@ -43,14 +43,14 @@ describe('ns-form util', () => {
       expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(no-ns a-b.c-d)\nfoo|'))).toBe(null);
     });
     it('finds ns', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-d) (a b c)|'))).toBe(
-        'a-b.c-d'
-      );
+      expect(
+        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-d) (a b c)|'))
+      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
     });
     it('finds in-ns', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation("(in-ns 'a-b.c-d) (a b c)|"))).toBe(
-        'a-b.c-d'
-      );
+      expect(
+        nsFormUtil.nsFromCursorDoc(docFromTextNotation("(in-ns 'a-b.c-d) (a b c)|"))
+      ).toStrictEqual(['a-b.c-d', "(in-ns 'a-b.c-d)"]);
     });
     it('returns `null` if ns form does not contain a namespace symbol', function () {
       expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns) (a b c)|'))).toBe(null);
@@ -59,14 +59,14 @@ describe('ns-form util', () => {
       expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns [a]) (a b c)|'))).toBe(null);
     });
     it('finds ns in form with line comment', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-d ; comment\n)|'))).toBe(
-        'a-b.c-d'
-      );
+      expect(
+        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-d ; comment\n)|'))
+      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d ; comment\n)']);
     });
     it('finds ns in form after line comments', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('; comment\n(ns a-b.c-d)|'))).toBe(
-        'a-b.c-d'
-      );
+      expect(
+        nsFormUtil.nsFromCursorDoc(docFromTextNotation('; comment\n(ns a-b.c-d)|'))
+      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
     });
 
     it('Closest ns at top level wins', function () {
@@ -74,27 +74,27 @@ describe('ns-form util', () => {
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation('(ns a) (fn [] {:rcf (comment\n(ns a-b.c-d))}|)')
         )
-      ).toBe('a');
+      ).toStrictEqual(['a', '(ns a)']);
       expect(
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation('(ns a) (ns b) (fn [] {:rcf (comment\n(ns a-b.c-d))|})')
         )
-      ).toBe('b');
+      ).toStrictEqual(['b', '(ns b)']);
       expect(
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation('(ns a) (ns b) (fn [] {:rcf (comment\n(ns a-b.c-d)|)})')
         )
-      ).toBe('a-b.c-d');
+      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
       expect(
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation('(fn [] {:rcf (comment\n(ns a-b.c-d))}) (ns a)|')
         )
-      ).toBe('a');
+      ).toStrictEqual(['a', '(ns a)']);
       expect(
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation('(fn [] {:rcf (comment\n(ns a-b.c-d))}) (ns a|)')
         )
-      ).toBe('a');
+      ).toStrictEqual(['a', '(ns a)']);
     });
 
     it('Closest ns or in-ns at top level wins', function () {
@@ -102,73 +102,80 @@ describe('ns-form util', () => {
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation("(ns a) (in-ns 'b) (fn [] {:rcf (comment\n(ns a-b.c-d))}|)")
         )
-      ).toBe('b');
+      ).toStrictEqual(['b', "(in-ns 'b)"]);
       expect(
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation("(in-ns 'a) (ns b) (fn [] {:rcf (comment\n(ns a-b.c-d))|})")
         )
-      ).toBe('b');
+      ).toStrictEqual(['b', '(ns b)']);
       expect(
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation("(ns a) (ns b) (fn [] {:rcf (comment\n(ns c) x (in-ns 'a-b.c-d)|)})")
         )
-      ).toBe('a-b.c-d');
+      ).toStrictEqual(['a-b.c-d', "(in-ns 'a-b.c-d)"]);
       expect(
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation("(fn [] {:rcf (comment\n(ns a-b.c-d))}) (in-ns 'a)|")
         )
-      ).toBe('a');
+      ).toStrictEqual(['a', "(in-ns 'a)"]);
       expect(
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation("(fn [] {:rcf (comment\n(ns a-b.c-d))}) (in-ns 'a|)")
         )
-      ).toBe('a');
+      ).toStrictEqual(['a', "(in-ns 'a)"]);
     });
 
     // TODO: Figure what to do with ignored forms
     //       For now, this is what they do (nothing)
     it('Finds ns in top level ignored form', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('#_ (ns a-b.c-d)|'))).toBe('a-b.c-d');
+      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('#_ (ns a-b.c-d)|'))).toStrictEqual([
+        'a-b.c-d',
+        '(ns a-b.c-d)',
+      ]);
     });
     it('Finds ns in ignored rich comments', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('#_ (comment\n(ns a-b.c-d)|)'))).toBe(
-        'a-b.c-d'
-      );
+      expect(
+        nsFormUtil.nsFromCursorDoc(docFromTextNotation('#_ (comment\n(ns a-b.c-d)|)'))
+      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
     });
 
     it('finds ns past top level id tokens', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-d) (a b c) d e (f)|'))).toBe(
-        'a-b.c-d'
-      );
+      expect(
+        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-d) (a b c) d e (f)|'))
+      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
     });
     it('finds ns past top level id tokens from nested form', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-d) (a b c) d e (f|)'))).toBe(
-        'a-b.c-d'
-      );
+      expect(
+        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-d) (a b c) d e (f|)'))
+      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
     });
     it('finds ns also when not first form', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(foo bar)\n\n(ns a-b.c-d)|'))).toBe(
-        'a-b.c-d'
-      );
+      expect(
+        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(foo bar)\n\n(ns a-b.c-d)|'))
+      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
     });
     it('finds ns in rich comments', function () {
       expect(
         nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a) (comment\n(ns b) (d e)|)'))
-      ).toBe('b');
+      ).toStrictEqual(['b', '(ns b)']);
     });
     it('finds ns in nested rich comments', function () {
       expect(
         nsFormUtil.nsFromCursorDoc(
           docFromTextNotation('(ns a) (fn [] {:rcf (comment\n(ns b) (c| d))})')
         )
-      ).toBe('b');
+      ).toStrictEqual(['b', '(ns b)']);
     });
     it('finds first ns form if at start of document', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('|(ns a) (a b c) (ns b)'))).toBe('a');
+      expect(
+        nsFormUtil.nsFromCursorDoc(docFromTextNotation('|(ns a) (a b c) (ns b)'))
+      ).toStrictEqual(['a', '(ns a)']);
       expect(
         nsFormUtil.nsFromCursorDoc(docFromTextNotation('|(no-ns a) (a b c) (ns b) x (ns c) y'))
-      ).toBe('b');
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation(' |(ns a) (a b c) (ns b)'))).toBe('a');
+      ).toStrictEqual(['b', '(ns b)']);
+      expect(
+        nsFormUtil.nsFromCursorDoc(docFromTextNotation(' |(ns a) (a b c) (ns b)'))
+      ).toStrictEqual(['a', '(ns a)']);
     });
     it('returns `null` if at start of document without ns form', function () {
       expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('|(no-ns a) (a b c) (no-ns b)'))).toBe(
@@ -178,21 +185,21 @@ describe('ns-form util', () => {
 
     // https://github.com/BetterThanTomorrow/calva/issues/2249
     it('returns outer ns if rich comment lacks ns', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a) (a b c) (comment b|)'))).toBe(
-        'a'
-      );
+      expect(
+        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a) (a b c) (comment b|)'))
+      ).toStrictEqual(['a', '(ns a)']);
     });
     // https://github.com/BetterThanTomorrow/calva/issues/2266
     it('finds ns when symbol has metadata', function () {
       expect(
         nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns ^:no-doc a-b.c-d) (a b c)|'))
-      ).toBe('a-b.c-d');
+      ).toStrictEqual(['a-b.c-d', '(ns ^:no-doc a-b.c-d)']);
     });
     // https://github.com/BetterThanTomorrow/calva/issues/2309
     it('finds ns from inside ns form', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns |a-b.c-d) (a b c)'))).toBe(
-        'a-b.c-d'
-      );
+      expect(
+        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns |a-b.c-d) (a b c)'))
+      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
     });
     // https://github.com/BetterThanTomorrow/calva/issues/2299
     it('finds ns from unbalanced form, lacking opening brackets', function () {
@@ -203,7 +210,7 @@ describe('ns-form util', () => {
               '(ns xxx)•(def xxx|•{()"#"\\$" #"(?!\\w)"))))))))))))))))))))))))))))))))))))))))'
             )
           )
-        ).toBe('xxx');
+        ).toStrictEqual(['xxx', '(ns xxx)']);
       } catch (error) {
         fail(`Expected no error to be thrown, but got ${error}`);
       }
@@ -212,7 +219,7 @@ describe('ns-form util', () => {
       try {
         expect(
           nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns xxx]))]]]]]])))•(def xxx|•{})'))
-        ).toBe('xxx');
+        ).toStrictEqual(['xxx', '(ns xxx]']);
       } catch (error) {
         fail(`Expected no error to be thrown, but got ${error}`);
       }
@@ -224,7 +231,7 @@ describe('ns-form util', () => {
       expect(nsFormUtil.nsFromText('(no-ns a-b.c-d)\nfoo')).toBe(null);
     });
     it('defaults to start from end', function () {
-      expect(nsFormUtil.nsFromText('(ns a)\nfoo (ns b) bar')).toBe('b');
+      expect(nsFormUtil.nsFromText('(ns a)\nfoo (ns b) bar')).toStrictEqual(['b', '(ns b)']);
     });
   });
 });

--- a/src/fiddle-files.ts
+++ b/src/fiddle-files.ts
@@ -142,14 +142,11 @@ export async function evaluateFiddleForSourceFile() {
     const code = doc.getText();
     const fiddleSelection = filePathToSelection.get(fiddleFilePath);
     const p = fiddleSelection ? doc.offsetAt(fiddleSelection.active) : 0;
-    const ns = nsUtil.nsFromText(code, p) || namespace.getDocumentNamespace();
+    const [ns, nsForm] = nsUtil.nsFromText(code, p) || namespace.getDocumentNamespace();
     outputWindow.appendLine(`; Evaluating fiddle: ${relativeFiddleFilePath}`);
-    await eval.evaluateInOutputWindow(
-      code,
-      path.extname(fiddleFilePath).replace(/^\./, ''),
-      ns,
-      {}
-    );
+    await eval.evaluateInOutputWindow(code, path.extname(fiddleFilePath).replace(/^\./, ''), ns, {
+      nsForm,
+    });
     return new Promise((resolve) => {
       outputWindow.appendPrompt(resolve);
     });

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -11,7 +11,7 @@ export function getNamespace(doc: vscode.TextDocument, position: vscode.Position
   if (outputWindow.isResultsDoc(doc)) {
     const outputWindowNs = outputWindow.getNs();
     utilities.assertIsDefined(outputWindowNs, 'Expected output window to have a namespace!');
-    return outputWindowNs;
+    return [outputWindowNs, `(in-ns '${outputWindowNs})`];
   }
   if (doc && doc.languageId == 'clojure') {
     try {

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -20,7 +20,7 @@ export function getNamespace(doc: vscode.TextDocument, position: vscode.Position
         nsUtil.nsFromCursorDoc(
           cursorDoc,
           position ? doc.offsetAt(position) : doc.getText().length
-        ) ?? 'user'
+        ) ?? ['user', "(in-ns 'user)"]
       );
     } catch (e) {
       console.log(
@@ -33,7 +33,7 @@ export function getNamespace(doc: vscode.TextDocument, position: vscode.Position
           if (nsFormArray != undefined && nsFormArray.length > 0) {
             const nsForm = nsFormArray[0].filter((x) => typeof x == 'string');
             if (nsForm != undefined) {
-              return nsForm[1];
+              return [nsForm[1], `(in-ns '${nsForm[1]})`];
             }
           }
         }
@@ -42,7 +42,7 @@ export function getNamespace(doc: vscode.TextDocument, position: vscode.Position
       }
     }
   }
-  return 'user';
+  return ['user', "(in-ns 'user)"];
 }
 
 export async function createNamespaceFromDocumentIfNotExists(doc) {

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -297,8 +297,8 @@ const defaultCljsTypes: { [id: string]: CljsTypeConfig } = {
     name: 'ClojureScript nREPL',
     buildsRequired: false,
     isStarted: true,
-    connectCode: '"fake-it"',
-    isConnectedRegExp: '"fake-it"',
+    connectCode: '42',
+    isConnectedRegExp: '42',
   },
 };
 

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -297,8 +297,8 @@ const defaultCljsTypes: { [id: string]: CljsTypeConfig } = {
     name: 'ClojureScript nREPL',
     buildsRequired: false,
     isStarted: true,
-    connectCode: '42',
-    isConnectedRegExp: '42',
+    connectCode: ':always-succeeding-connect-code',
+    isConnectedRegExp: 'always-succeeding-connect-code',
   },
 };
 

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -297,8 +297,8 @@ const defaultCljsTypes: { [id: string]: CljsTypeConfig } = {
     name: 'ClojureScript nREPL',
     buildsRequired: false,
     isStarted: true,
-    connectCode: ':fake-it',
-    isConnectedRegExp: ':fake-it',
+    connectCode: '"fake-it"',
+    isConnectedRegExp: '"fake-it"',
   },
 };
 

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -372,10 +372,9 @@ export class NReplSession {
     });
   }
 
-  async evaluateInCurrentNs(nsForm: string) {
+  async evaluateInNs(nsForm: string, ns: string) {
     try {
-      console.log('Evaluating in current ns: ', nsForm, this.client.ns);
-      await this.eval(nsForm, this.client.ns).value;
+      await this.eval(nsForm, ns).value;
     } catch (e) {
       console.error(e);
     }

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -372,6 +372,15 @@ export class NReplSession {
     });
   }
 
+  async evaluateInCurrentNs(nsForm: string) {
+    try {
+      console.log('Evaluating in current ns: ', nsForm, this.client.ns);
+      await this.eval(nsForm, this.client.ns).value;
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
   async requireREPLUtilities() {
     const CLJS_FORM = `(try
                          (require '[cljs.repl :refer [apropos dir doc find-doc print-doc pst source]])

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -373,7 +373,12 @@ export class NReplSession {
   }
 
   async switchNS(ns: any) {
-    await this.eval(`(in-ns '${ns})`, this.client.ns).value;
+    try {
+      await this.eval(`(in-ns '${ns})`, this.client.ns).value;
+    } catch (e) {
+      //await this.eval(`(symbol "${ns}")`, this.client.ns).value;
+      console.error(e);
+    }
   }
 
   async requireREPLUtilities() {

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -372,15 +372,6 @@ export class NReplSession {
     });
   }
 
-  async switchNS(ns: any) {
-    try {
-      await this.eval(`(in-ns '${ns})`, this.client.ns).value;
-    } catch (e) {
-      //await this.eval(`(symbol "${ns}")`, this.client.ns).value;
-      console.error(e);
-    }
-  }
-
   async requireREPLUtilities() {
     const CLJS_FORM = `(try
                          (require '[cljs.repl :refer [apropos dir doc find-doc print-doc pst source]])
@@ -403,6 +394,7 @@ export class NReplSession {
         .send();
       return {
         id: debugResponse.id,
+        ns,
         session: this.sessionId,
         op: 'debug-input',
         input: `{:response :eval, :code ${code}}`,
@@ -413,6 +405,7 @@ export class NReplSession {
       return {
         id: this.client.nextId,
         op: 'eval',
+        ns,
         session: this.sessionId,
         code,
         ...opts,

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -102,7 +102,7 @@ export default class CalvaCompletionItemProvider implements CompletionItemProvid
       const client = replSession.getSession(util.getFileType(activeTextEditor.document));
       if (client) {
         await namespace.createNamespaceFromDocumentIfNotExists(activeTextEditor.document);
-        const ns = namespace.getDocumentNamespace();
+        const [ns, _] = namespace.getDocumentNamespace();
         const result = await client.info(
           ns,
           typeof item.label === 'string' ? item.label : item['data'].label
@@ -188,7 +188,7 @@ async function replCompletions(
     contextEnd = toplevel.substring(wordEndLocalOffset),
     replContext = `${contextStart}__prefix__${contextEnd}`,
     toplevelIsValidForm = toplevelStartCursor.withinValidList() && replContext != '__prefix__',
-    ns = namespace.getNamespace(document, position),
+    [ns, _] = namespace.getNamespace(document, position),
     client = replSession.getSession(util.getFileType(document)),
     res = await client.complete(ns, text, toplevelIsValidForm ? replContext : undefined),
     results = res.completions || [];

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -69,11 +69,8 @@ async function provideCompletionItems(
     ).catch((err) => {
       console.log(`Failed to get results from completions provider '${provider}'`, err);
     });
-    console.log('completions', provider, completions);
-    console.log('results before merge', provider, results);
     if (completions) {
       results = mergeCompletions(results, completions);
-      console.log('results after merge', provider, results);
     }
   }
 
@@ -204,7 +201,6 @@ async function replCompletions(
     }
   });
   return results.map((item) => {
-    console.log('nrepl item', item);
     const result = new CompletionItem(
       item.candidate,
       // +1 because the LSP CompletionItemKind enum starts at 1

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -26,7 +26,7 @@ async function provideClojureDefinition(
     const client = replSession.getSession(util.getFileType(document));
     if (client?.supports('info')) {
       const text = util.getWordAtPosition(document, position);
-      const info = await client.info(namespace.getNamespace(document, position), text);
+      const info = await client.info(namespace.getNamespace(document, position)[0], text);
       if (info.file && info.file.length > 0) {
         const pos = new vscode.Position(info.line - 1, info.column || 0);
         try {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -17,7 +17,7 @@ export async function provideHover(
 ) {
   if (util.getConnectedState()) {
     const text = util.getWordAtPosition(document, position);
-    const ns = namespace.getNamespace(document, position);
+    const [ns, _] = namespace.getNamespace(document, position);
     const client = replSession.getSession(util.getFileType(document));
     if (client && client.supports('info')) {
       await namespace.createNamespaceFromDocumentIfNotExists(document);

--- a/src/providers/signature.ts
+++ b/src/providers/signature.ts
@@ -30,7 +30,7 @@ export async function provideSignatureHelp(
   _token: CancellationToken
 ): Promise<SignatureHelp | undefined> {
   if (util.getConnectedState()) {
-    const ns = namespace.getNamespace(document, position),
+    const [ns, _] = namespace.getNamespace(document, position),
       idx = document.offsetAt(position),
       symbol = getSymbol(document, idx);
     if (symbol) {

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -228,15 +228,12 @@ export async function revealDocForCurrentNS(preserveFocus: boolean = true) {
   );
 }
 
-export async function setNamespaceFromCurrentFile() {
+export function setNamespaceFromCurrentFile() {
   const session = replSession.getSession();
   const ns = namespace.getNamespace(
     util.tryToGetDocument({}),
     vscode.window.activeTextEditor?.selection?.active
   );
-  if (getNs() !== ns && util.isDefined(ns)) {
-    await session.switchNS(ns);
-  }
   setSession(session, ns);
   replSession.updateReplSessionType();
   appendPrompt();
@@ -259,9 +256,6 @@ async function appendFormGrabbingSessionAndNS(topLevel: boolean) {
     code = await formatCode(doc.getText(selection), doc.eol);
   }
   if (code != '') {
-    if (getNs() !== ns) {
-      await session.switchNS(ns);
-    }
     setSession(session, ns);
     appendLine(code, (_) => revealResultsDoc(false));
   }

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -230,7 +230,7 @@ export async function revealDocForCurrentNS(preserveFocus: boolean = true) {
 
 export function setNamespaceFromCurrentFile() {
   const session = replSession.getSession();
-  const ns = namespace.getNamespace(
+  const [ns, _] = namespace.getNamespace(
     util.tryToGetDocument({}),
     vscode.window.activeTextEditor?.selection?.active
   );
@@ -241,7 +241,7 @@ export function setNamespaceFromCurrentFile() {
 
 async function appendFormGrabbingSessionAndNS(topLevel: boolean) {
   const session = replSession.getSession();
-  const ns = namespace.getNamespace(
+  const [ns, _] = namespace.getNamespace(
     util.tryToGetDocument({}),
     vscode.window.activeTextEditor?.selection?.active
   );

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -319,7 +319,7 @@ async function runNamespaceTests(controller: vscode.TestController, document: vs
     return;
   }
   const session = getSession(util.getFileType(document));
-  const currentDocNs = namespace.getNamespace(
+  const [currentDocNs, _] = namespace.getNamespace(
     doc,
     vscode.window.activeTextEditor?.selection?.active
   );
@@ -341,7 +341,7 @@ function getTestUnderCursor() {
 async function runTestUnderCursor(controller: vscode.TestController) {
   const doc = util.tryToGetDocument({});
   const session = getSession(util.getFileType(doc));
-  const ns = namespace.getNamespace(doc, vscode.window.activeTextEditor?.selection?.active);
+  const [ns, _] = namespace.getNamespace(doc, vscode.window.activeTextEditor?.selection?.active);
   const test = getTestUnderCursor();
 
   if (test) {

--- a/src/util/ns-form.ts
+++ b/src/util/ns-form.ts
@@ -53,7 +53,7 @@ export function nsFromCursorDoc(
   p: number = cursorDoc.selection.active,
   _maxRecursionDepth: number = 100, // used internally for recursion
   _depth: number = 0 // used internally for recursion
-): string | null {
+): [string, string] | null {
   if (_depth > _maxRecursionDepth) {
     console.error(`nsFromCursorDoc: recursion depth, ${_maxRecursionDepth} , exceeded`);
     return null;
@@ -65,7 +65,7 @@ export function nsFromCursorDoc(
     const topLevelRangeCursor = cursorDoc.getTokenCursor(topLevelRange[0]);
     const ns = nsSymbolOfCurrentForm(topLevelRangeCursor, 'downList');
     if (ns) {
-      return ns;
+      return [ns, cursorDoc.model.getText(...topLevelRange)];
     }
   }
   // Special case 2, find ns form from start of document
@@ -76,7 +76,7 @@ export function nsFromCursorDoc(
     while (cursor.forwardSexp(true, true, true)) {
       const ns = nsSymbolOfCurrentForm(cursor, 'backwardDownList');
       if (ns) {
-        return ns;
+        return [ns, cursorDoc.model.getText(...cursor.rangeForCurrentForm(cursor.offsetEnd))];
       }
     }
     return null;
@@ -87,7 +87,7 @@ export function nsFromCursorDoc(
     while (cursor.backwardSexp()) {
       const ns = nsSymbolOfCurrentForm(cursor, 'downList');
       if (ns) {
-        return ns;
+        return [ns, cursorDoc.model.getText(...cursor.rangeForCurrentForm(cursor.offsetStart))];
       }
     }
   }
@@ -106,7 +106,7 @@ export function nsFromCursorDoc(
   return nsFromCursorDoc(cursorDoc, cursor.offsetStart, _maxRecursionDepth, _depth + 1);
 }
 
-export function nsFromText(text: string, p = text.length): string | null {
+export function nsFromText(text: string, p = text.length): [string, string] | null {
   const stringDoc: model.StringDocument = new model.StringDocument(text);
   return nsFromCursorDoc(stringDoc, p);
 }


### PR DESCRIPTION
## What has changed?

The way we handle ClojureScript-only repls should really be fixed. I think the proper fix is to fix the way we handle nREPL sessions all together, and that it is not meaningful to do a fix that only addresses the ClojureScript-only question. Anyway, the way we handle it is to:
1. connect the ClojureScript REPL as a CLJ session,
2. clone the session as a CLJS-to-be session (although it already is)
3. Fake that we upgrade it to a CLJS session

When that is done there are two sessions, CLJ and CLJS, both connected to the same REPL. But the user will probably only interact with one, so it works suprisingly well.


However, the squint-cljs REPL evaluates keywords to string, so our fake upgrade evaluation failed. We are now evaluating the number `42` instead, which should stay consistent even with crazy future REPLs.

While at it I also realized that we were not using the `ns` field of the `eval` op, and that that was the reason we had to do all those switchNS shenanigans. I have therefore now removed the switchNS calls, and replaced it with an evaluation of the current file's `ns` form when the current ns changes.

For this I choose to change the return type of the function that finds the ns of the current file. Now it returns both the ns and the form text.

I've tested it with a bunch of different projects. Will ask in the Calva channel for help with more testing.


<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

* Fixes #2343

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
