### PR TITLE
Fix 2345 nrepl hovers broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Docstring tooltip not shown while connected to REPL](https://github.com/BetterThanTomorrow/calva/issues/2345)
+
 ## [2.0.395] - 2023-11-12
 
 - [Make Calva's nrepl client squint-cljs compatible](https://github.com/BetterThanTomorrow/calva/issues/2343)

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -524,7 +524,7 @@ async function evaluateUser(code: string) {
 async function requireREPLUtilitiesCommand() {
   if (util.getConnectedState()) {
     const chan = state.outputChannel(),
-      ns = namespace.getDocumentNamespace(util.tryToGetDocument({})),
+      [ns, _nsForm] = namespace.getDocumentNamespace(util.tryToGetDocument({})),
       fileType = util.getFileType(util.tryToGetDocument({})),
       session = replSession.getSession(fileType);
 

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -49,14 +49,14 @@ export async function createNamespaceFromDocumentIfNotExists(doc) {
   if (utilities.getConnectedState()) {
     const document = utilities.tryToGetDocument(doc);
     if (document) {
-      const ns = getNamespace(document);
+      const [ns, nsForm] = getNamespace(document);
       const client = replSession.getSession(utilities.getFileType(document));
       if (client) {
         const nsList = await client.listNamespaces([]);
         if (nsList && nsList['ns-list'] && nsList['ns-list'].includes(ns)) {
           return;
         }
-        await client.eval('(ns ' + ns + ')', client.client.ns).value;
+        await client.evaluateInNs(nsForm, outputWindow.getNs());
       }
     }
   }

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -7,7 +7,12 @@ import * as replSession from './nrepl/repl-session';
 import { NReplSession } from './nrepl';
 import * as nsUtil from './util/ns-form';
 
-export function getNamespace(doc: vscode.TextDocument, position: vscode.Position = null) {
+export type NsAndNsForm = [string, string];
+
+export function getNamespace(
+  doc: vscode.TextDocument,
+  position: vscode.Position = null
+): NsAndNsForm {
   if (outputWindow.isResultsDoc(doc)) {
     const outputWindowNs = outputWindow.getNs();
     utilities.assertIsDefined(outputWindowNs, 'Expected output window to have a namespace!');


### PR DESCRIPTION
## What has changed?

I had missed a place, in hover.ts, where the results of finding the document namespace was not destructured, now that it is a tuple of `[ns, nsForm]`. Making hovers fail.

Not sure why TypeScript, or our various checks is not helping me with this. Tried now to also introduce an explicit type, but even so, a file search found me another place where I had missed to adjust for the new return type...

Anyway:

* Fixes #2345

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
