### PR TITLE
2349 nrepl fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Standalone connect of shadow-cljs repl fails in some projects](https://github.com/BetterThanTomorrow/calva/issues/2349)
+
 ## [2.0.396] - 2023-11-13
 
 - Fix: [Docstring tooltip not shown while connected to REPL](https://github.com/BetterThanTomorrow/calva/issues/2345)

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -212,7 +212,7 @@ async function setUpCljsRepl(session, build) {
       outputWindow.CLJS_CONNECT_GREETINGS
     )}`
   );
-  outputWindow.setSession(session, 'cljs.user');
+  outputWindow.setSession(session, 'user');
   if (getConfig().autoEvaluateCode.onConnect.cljs) {
     outputWindow.appendLine(
       `; Evaluating code from settings: 'calva.autoEvaluateCode.onConnect.cljs'`
@@ -474,7 +474,7 @@ function createCLJSReplType(
     const cljSession = replSession.getSession('clj');
     const getRuntimesCode = `(count (shadow.cljs.devtools.api/repl-runtimes ${connectToBuild}))`;
     const checkForRuntimes = async () => {
-      const runtimes = await cljSession.eval(getRuntimesCode, 'shadow.user').value;
+      const runtimes = await cljSession.eval(getRuntimesCode, 'user').value;
       return runtimes && parseInt(runtimes) > 0;
     };
     const hasRuntimes = await checkForRuntimes();

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -430,7 +430,7 @@ async function loadDocument(
       ? await namespace.getUriForNamespace(session, ns)
       : doc.uri;
     const filePath = docUri.path;
-    await loadFile(filePath, ns, pprintOptions, fileType);
+    return await loadFile(filePath, ns, pprintOptions, fileType);
   }
 }
 
@@ -491,7 +491,7 @@ async function loadFile(
         });
     }
   } finally {
-    outputWindow.setSession(session, res.ns || ns);
+    outputWindow.setSession(session, ns);
     replSession.updateReplSessionType();
     if (getConfig().autoEvaluateCode.onFileLoaded[fileType]) {
       outputWindow.appendLine(`; Evaluating 'autoEvaluateCode.onFileLoaded.${fileType}'`);


### PR DESCRIPTION
## What has changed?

When we started to send `ns` with our `eval` ops (as one should) we stirred up some bugs resulting from faulty assumptions about cljs name spaces.

* Fixes #2349 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
