### PR TITLE
Prevent formatting when breaking line comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Connecting to an external REPL does not work when local nrepl port exists](https://github.com/BetterThanTomorrow/calva/issues/2303)
+- [Avoid formatting when breaking up line comments](https://github.com/BetterThanTomorrow/calva/issues/2296)
 
 ## [2.0.397] - 2023-11-17
 

--- a/src/calva-fmt/src/providers/ontype_formatter.ts
+++ b/src/calva-fmt/src/providers/ontype_formatter.ts
@@ -6,10 +6,22 @@ import * as paredit from '../../../cursor-doc/paredit';
 import { getConfig } from '../../../config';
 import * as util from '../../../utilities';
 import * as formatterConfig from '../../../formatter-config';
+import * as whenContexts from '../../../when-contexts';
 
 // TODO: Make this provider return a proper edit instead of performing it.
 // Errors like that of https://github.com/BetterThanTomorrow/calva/issues/2071
 // probably happens because of this.
+
+function isNewLineInComment(ch: string): boolean {
+  return (
+    ch === '\n' &&
+    whenContexts.lastContexts.includes('calva:cursorInComment') &&
+    !(
+      whenContexts.lastContexts.includes('calva:cursorBeforeComment') ||
+      whenContexts.lastContexts.includes('calva:cursorAfterComment')
+    )
+  );
+}
 
 export class FormatOnTypeEditProvider implements vscode.OnTypeFormattingEditProvider {
   async provideOnTypeFormattingEdits(
@@ -18,6 +30,9 @@ export class FormatOnTypeEditProvider implements vscode.OnTypeFormattingEditProv
     ch: string,
     _options
   ): Promise<vscode.TextEdit[] | undefined> {
+    if (isNewLineInComment(ch)) {
+      return undefined;
+    }
     let keyMap = vscode.workspace.getConfiguration().get('calva.paredit.defaultKeyMap');
     keyMap = String(keyMap).trim().toLowerCase();
     if ([')', ']', '}'].includes(ch)) {

--- a/src/extension-test/unit/cursor-doc/cursor-context-test.ts
+++ b/src/extension-test/unit/cursor-doc/cursor-context-test.ts
@@ -84,9 +84,21 @@ describe('Cursor Contexts', () => {
       );
       expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
     });
-    it('is true adjacent before comment', () => {
+    it('is true adjacent before comment starting a line', () => {
       const contexts = context.determineContexts(
         docFromTextNotation('|;; foo•   ;; bar•  ;; baz  •gaz')
+      );
+      expect(contexts.includes('calva:cursorBeforeComment')).toBe(true);
+    });
+    it('is true adjacent before comment with space before', () => {
+      const contexts = context.determineContexts(
+        docFromTextNotation(' |;; foo•   ;; bar•  ;; baz  •gaz')
+      );
+      expect(contexts.includes('calva:cursorBeforeComment')).toBe(true);
+    });
+    it('is false before comment with space between', () => {
+      const contexts = context.determineContexts(
+        docFromTextNotation('| ;; foo•   ;; bar•  ;; baz  •gaz')
       );
       expect(contexts.includes('calva:cursorBeforeComment')).toBe(true);
     });

--- a/src/when-contexts.ts
+++ b/src/when-contexts.ts
@@ -4,7 +4,8 @@ import * as docMirror from './doc-mirror';
 import * as context from './cursor-doc/cursor-context';
 import * as util from './utilities';
 
-let lastContexts: context.CursorContext[] = [];
+export let lastContexts: context.CursorContext[] = [];
+export let currentContexts: context.CursorContext[] = [];
 
 export function setCursorContextIfChanged(editor: vscode.TextEditor) {
   if (
@@ -15,10 +16,8 @@ export function setCursorContextIfChanged(editor: vscode.TextEditor) {
   ) {
     return;
   }
-  const currentContexts = determineCursorContexts(editor.document, editor.selection.active);
-  if (!deepEqual(lastContexts, currentContexts)) {
-    setCursorContexts(currentContexts);
-  }
+  const contexts = determineCursorContexts(editor.document, editor.selection.active);
+  setCursorContexts(contexts);
 }
 
 function determineCursorContexts(
@@ -29,13 +28,10 @@ function determineCursorContexts(
   return context.determineContexts(mirrorDoc, document.offsetAt(position));
 }
 
-function setCursorContexts(currentContexts: context.CursorContext[]) {
+function setCursorContexts(contexts: context.CursorContext[]) {
   lastContexts = currentContexts;
+  currentContexts = contexts;
   context.allCursorContexts.forEach((context) => {
-    void vscode.commands.executeCommand(
-      'setContext',
-      context,
-      currentContexts.indexOf(context) > -1
-    );
+    void vscode.commands.executeCommand('setContext', context, contexts.indexOf(context) > -1);
   });
 }


### PR DESCRIPTION
## What has changed?

When hitting enter in a line comment, chances are there is parens and quotes there that will break the document structure. Currently the on-type formatter follows up with formatting, which can get extra weird. So this PR prevents formatting if we determine that the new line was entered in a line comment.

* Fixes #2296

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR. _(I haven't tested on Windows, but it really should work there too, but otherwise no big deal, things will continue to work as they work today on Windows.)_
- [ ] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
