### PR TITLE
2334 populate project types from cold

### DIFF
--- a/.joyride/deps.edn
+++ b/.joyride/deps.edn
@@ -1,0 +1,13 @@
+;; clojure-lsp needs this config to analyze Joyride code
+;; To tell clojure-lsp about this file:
+;; 1. Add a source-alias to `.lsp/config.edn`. Minimal config file content:
+;;    {:source-aliases #{:joyride}}
+;; 2. Add a `:joyride` alias to the project root deps.edn file.
+;;    Minimal file content:
+;;    {:aliases {:joyride {:extra-deps {joyride/workspace {:local/root ".joyride"}}}}}
+
+{:deps {org.clojure/clojurescript {:mvn/version "1.11.54"}
+        funcool/promesa {:mvn/version "9.0.471"}
+        rewrite-clj/rewrite-clj {:mvn/version "1.1.46"}
+        joyride/user {:local/root "/Users/pez/.config/joyride"}}
+ :paths ["src" "scripts"]}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes to Calva.
 
 - Fix: [Connecting to an external REPL does not work when local nrepl port exists](https://github.com/BetterThanTomorrow/calva/issues/2303)
 - [Avoid formatting when breaking up line comments](https://github.com/BetterThanTomorrow/calva/issues/2296)
+- Fix: [The Jack-in/Connect Project Type menu is not always fully populated on first use](https://github.com/BetterThanTomorrow/calva/issues/2334)
 
 ## [2.0.397] - 2023-11-17
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -827,7 +827,6 @@ export default {
   }) => {
     const host = options && options.host ? options.host : undefined;
     const port = options && options.port ? options.port : undefined;
-    const cljTypes = await projectTypes.detectProjectTypes();
     let connectSequence: ReplConnectSequence;
     if (options && typeof options.connectSequence === 'string') {
       connectSequence = getConnectSequences(projectTypes.getAllProjectTypes()).find(
@@ -841,6 +840,7 @@ export default {
       .catch((e) => {
         void vscode.window.showErrorMessage('Failed initializing project root directory: ', e);
       });
+    const cljTypes = await projectTypes.detectProjectTypes();
     if (!connectSequence) {
       try {
         connectSequence = await askForConnectSequence(

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -793,7 +793,8 @@ export function getProjectTypeForName(name: string) {
 export async function detectProjectTypes(): Promise<string[]> {
   const rootUri = state.getProjectRootUri();
   const cljProjTypes = ['custom', 'generic', 'cljs-only', 'babashka', 'nbb', 'joyride'];
-  for (const clj in projectTypes) {
+
+  const promises = Object.keys(projectTypes).map(async (clj) => {
     for (const projectFileName of projectTypes[clj].useWhenExists) {
       try {
         const uri = vscode.Uri.joinPath(rootUri, projectFileName);
@@ -804,7 +805,9 @@ export async function detectProjectTypes(): Promise<string[]> {
         // continue regardless of error
       }
     }
-  }
+  });
+
+  await Promise.all(promises);
   return cljProjTypes;
 }
 

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -793,8 +793,7 @@ export function getProjectTypeForName(name: string) {
 export async function detectProjectTypes(): Promise<string[]> {
   const rootUri = state.getProjectRootUri();
   const cljProjTypes = ['custom', 'generic', 'cljs-only', 'babashka', 'nbb', 'joyride'];
-
-  const promises = Object.keys(projectTypes).map(async (clj) => {
+  for (const clj in projectTypes) {
     for (const projectFileName of projectTypes[clj].useWhenExists) {
       try {
         const uri = vscode.Uri.joinPath(rootUri, projectFileName);
@@ -802,12 +801,10 @@ export async function detectProjectTypes(): Promise<string[]> {
         cljProjTypes.push(clj);
         break;
       } catch {
-        // continue regardless of error
+        // this just means the file doesn't exist
       }
     }
-  });
-
-  await Promise.all(promises);
+  }
   return cljProjTypes;
 }
 


### PR DESCRIPTION
## What has changed?

I can't reproduce the issue reported with project type menu not being populated on first connect attempt after a VS Code start. But I think it is because we don't wait for all promises checking for project files. So now using Promise.all() and hopefully that fixes it. I'm waiting for tests from people with the issue.

* Fixes #2334

(Maybe, that's why this is in draft still.)

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
