### PR TITLE
2263 indenter regex rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ Changes to Calva.
 ## [Unreleased]
 
 - Bump deps.clj version: v1.11.1.1429
+- Fix: [Indenter treating symbols as regex](https://github.com/BetterThanTomorrow/calva/issues/2263)
 
 ## [2.0.402] - 2023-12-15
 
-- Fix audit warnings, bump some deps, clean out some depsn
-- [Update to cljfmt v0.12.0 ](https://github.com/BetterThanTomorrow/calva/issues/2365)
+- Fix audit warnings, bump some deps, clean out some deps
+- [Update to cljfmt v0.12.0](https://github.com/BetterThanTomorrow/calva/issues/2365)
 - Fix: [Selecting words forward and backwards when in line comments selects to next sexpression](https://github.com/BetterThanTomorrow/calva/issues/2368)
 
 ## [2.0.401] - 2023-12-03

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as _ from 'lodash';
 import * as state from './state';
 import * as util from './utilities';
+import * as string from './util/string';
 import * as open from 'open';
 import status from './status';
 import * as projectTypes from './nrepl/project-types';
@@ -58,7 +59,7 @@ async function readRuntimeConfigs() {
 
     // maybe we don't need to keep uri -> edn association, but it would make showing errors easier later
     return files
-      .filter(([_, config]) => util.isNonEmptyString(config))
+      .filter(([_, config]) => string.isNonEmptyString(config))
       .map(([_, config]) => addEdnConfig(config));
   }
 }

--- a/src/extension-test/unit/cursor-doc/indent-test.ts
+++ b/src/extension-test/unit/cursor-doc/indent-test.ts
@@ -237,13 +237,13 @@ describe('indent', () => {
       const blockConfig = mkConfig({
         '/\\S+/': [['block', 0]],
       });
-      it('catch-all overrides the built-in rule for the `let` body', () => {
-        expect(indent.getIndent(doc.model, p, blockConfig)).toEqual(5);
+      it('catch-all does not override the built-in rule for the `let` body', () => {
+        expect(indent.getIndent(doc.model, p, blockConfig)).toEqual(2);
       });
       const letBlockConfig = mkConfig({
         let: [['block', 0]],
       });
-      it('overrides the built-in rule for the `let` body', () => {
+      it('symbol let overrides the built-in rule for the `let` body', () => {
         expect(indent.getIndent(doc.model, p, letBlockConfig)).toEqual(5);
       });
       it('does not overrides the built-in rule for the `defn` body', () => {

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -13,6 +13,7 @@ import type { ReplSessionType } from '../config';
 import { getStateValue, prettyPrint } from '../../out/cljs-lib/cljs-lib';
 import { getConfig } from '../config';
 import { log, Direction } from './logging';
+import * as string from '../util/string';
 
 function hasStatus(res: any, status: string): boolean {
   return res.status && res.status.indexOf(status) > -1;
@@ -659,7 +660,7 @@ export class NReplSession {
       'ns-query': {
         exactly: [ns],
       },
-      search: util.escapeStringRegexp(test),
+      search: string.escapeStringRegexp(test),
       'test?': true,
     });
   }

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as util from './utilities';
+import * as string from './util/string';
 import * as outputWindow from './results-output/results-doc';
 import { NReplSession } from './nrepl';
 import * as cider from './nrepl/cider';
@@ -66,7 +67,7 @@ function upsertTest(
 // Cider 0.26 and 0.27 have an issue where context can be an empty array.
 // https://github.com/clojure-emacs/cider-nrepl/issues/728#issuecomment-996002988
 export function assertionName(result: cider.TestResult): string {
-  if (util.isNonEmptyString(result.context)) {
+  if (string.isNonEmptyString(result.context)) {
     return result.context;
   }
   return 'assertion';

--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -36,6 +36,14 @@ function getTextAfterLastOccurrenceOfSubstring(
   return text.substring(indexOfEndOfPrompt);
 }
 
+export function escapeStringRegexp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function isNonEmptyString(value: any): value is string {
+  return typeof value == 'string' && value.length > 0;
+}
+
 export {
   keywordize,
   unKeywordize,

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -42,14 +42,6 @@ export function assertIsDefined<T>(
   }
 }
 
-export function escapeStringRegexp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-export function isNonEmptyString(value: any): value is string {
-  return typeof value == 'string' && value.length > 0;
-}
-
 async function quickPickSingle(opts: {
   title?: string;
   values: vscode.QuickPickItem[];


### PR DESCRIPTION
## What has changed?

The indenter was treating all rules as regexes, which worked surprisingly well, but of course breaks if a rule has a regular symbol with regex characters in it. Like the `+` symbol as in #2263.

So now we're escaping the symbols.

* Fixes 2263

I've also added a sort of the rules such that regex rules are sorted last. This way a rule like `#"^le" [[:block 0]]` won't override the built-in `let` rule, but an explicit `let [[:block 0]]` will, which is how cljfmt works.

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
