### PR TITLE
433 require repl utils ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Require REPL Utilities only works for `user`` namespace](https://github.com/BetterThanTomorrow/calva/issues/433)
+
 ## [2.0.403] - 2023-12-18
 
 - Bump deps.clj version: v1.11.1.1429

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -536,7 +536,7 @@ async function requireREPLUtilitiesCommand() {
     if (session) {
       try {
         await namespace.createNamespaceFromDocumentIfNotExists(util.tryToGetDocument({}));
-        await session.requireREPLUtilities();
+        await session.requireREPLUtilities(ns);
         chan.appendLine(`REPL utilities are now available in namespace ${ns}.`);
       } catch (e) {
         chan.appendLine(`REPL utilities could not be acquired for namespace ${ns}: ${e}`);

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -381,14 +381,14 @@ export class NReplSession {
     }
   }
 
-  async requireREPLUtilities() {
+  async requireREPLUtilities(ns: string) {
     const CLJS_FORM = `(try
                          (require '[cljs.repl :refer [apropos dir doc find-doc print-doc pst source]])
                          (catch :default e
                            (js/console.warn "Failed to require cljs.repl utilities:" (.-message e))))`;
     const CLJ_FORM = `(when-let [requires (resolve 'clojure.main/repl-requires)]
                         (clojure.core/apply clojure.core/require @requires))`;
-    await this.eval(this.replType === 'clj' ? CLJ_FORM : CLJS_FORM, this.client.ns).value;
+    await this.eval(this.replType === 'clj' ? CLJ_FORM : CLJS_FORM, ns).value;
   }
 
   private _createEvalOperationMessage(code: string, ns: string, opts: any) {


### PR DESCRIPTION
## What has changed?

Since the update of the eval op to send along the `ns` parameter, the **Require REPL Utilities** command has been broken. This is now fixed by properly sending the ns param along as we should.

* Fixes #433

(Actually, this has been fixed for a while, but the issue mentions how the command is the way to do it.)

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
