### PR TITLE
Eval `(in-ns ..)` when connecting cljs repl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Require REPL Utilities only works for `user`` namespace](https://github.com/BetterThanTomorrow/calva/issues/433)
+- Fix: [NullPointerException evaluating calva.autoEvaluateCode.onConnect.cljs when using Krell](https://github.com/BetterThanTomorrow/calva/issues/2372)
 
 ## [2.0.403] - 2023-12-18
 

--- a/package.json
+++ b/package.json
@@ -899,7 +899,7 @@
             "default": {
               "onConnect": {
                 "clj": "(when-let [requires (resolve 'clojure.main/repl-requires)] (clojure.core/apply clojure.core/require @requires))",
-                "cljs": "(try (require '[cljs.repl :refer [apropos dir doc find-doc print-doc pst source]]) (catch :default e (js/console.warn \"Failed to require cljs.repl utilities:\" (.-message e))))"
+                "cljs": "(require '[cljs.repl :refer [apropos dir doc find-doc print-doc pst source]])"
               },
               "onFileLoaded": {
                 "clj": null,

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -204,7 +204,7 @@ function cleanUpAfterError(e: any) {
   return false;
 }
 
-async function setUpCljsRepl(session, build) {
+async function setUpCljsRepl(session: NReplSession, build) {
   setStateValue('cljs', session);
   setStateValue('cljc', session);
   status.update();
@@ -213,7 +213,10 @@ async function setUpCljsRepl(session, build) {
       outputWindow.CLJS_CONNECT_GREETINGS
     )}`
   );
-  outputWindow.setSession(session, 'user');
+  const description = await session.describe(true);
+  const ns = description.aux?.['current-ns'] || 'user';
+  await session.eval(`(in-ns '${ns})`, 'user').value;
+  outputWindow.setSession(session, ns);
   if (getConfig().autoEvaluateCode.onConnect.cljs) {
     outputWindow.appendLine(
       `; Evaluating code from settings: 'calva.autoEvaluateCode.onConnect.cljs'`
@@ -221,7 +224,7 @@ async function setUpCljsRepl(session, build) {
     await evaluate.evaluateInOutputWindow(
       getConfig().autoEvaluateCode.onConnect.cljs,
       'cljs',
-      outputWindow.getNs(),
+      ns,
       {}
     );
     outputWindow.appendPrompt();

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -382,10 +382,7 @@ export class NReplSession {
   }
 
   async requireREPLUtilities(ns: string) {
-    const CLJS_FORM = `(try
-                         (require '[cljs.repl :refer [apropos dir doc find-doc print-doc pst source]])
-                         (catch :default e
-                           (js/console.warn "Failed to require cljs.repl utilities:" (.-message e))))`;
+    const CLJS_FORM = `(require '[cljs.repl :refer [apropos dir doc find-doc print-doc pst source]])`;
     const CLJ_FORM = `(when-let [requires (resolve 'clojure.main/repl-requires)]
                         (clojure.core/apply clojure.core/require @requires))`;
     await this.eval(this.replType === 'clj' ? CLJ_FORM : CLJS_FORM, ns).value;


### PR DESCRIPTION
* Fixes #2372
* Stop wrapping cljs repl requires in `try`

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
