### PR TITLE
Evaluation commands handle case when the repl is not connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Offer to connect when evaluating forms while disconnected](https://github.com/BetterThanTomorrow/calva/issues/1490)
+
 ## [2.0.406] - 2024-01-08
 
 - Calva development: Fix: [Fiddle-file-unit-tests fails on windows](https://github.com/BetterThanTomorrow/calva/issues/2378)

--- a/package.json
+++ b/package.json
@@ -1180,13 +1180,12 @@
         "command": "calva.debug.instrument",
         "title": "Instrument Top Level Form for Debugging",
         "category": "Calva Debug",
-        "enablement": "editorLangId == clojure && calva:connected"
+        "enablement": "editorLangId == clojure"
       },
       {
         "command": "calva.togglePrettyPrint",
         "title": "Toggle Pretty Printing for All Evaluations",
-        "category": "Calva",
-        "enablement": "calva:connected"
+        "category": "Calva"
       },
       {
         "command": "calva.toggleEvaluationSendCodeToOutputWindow",
@@ -1285,25 +1284,23 @@
       {
         "command": "calva.evaluateToCursor",
         "title": "Evaluate From Start of List to Cursor, Closing Brackets",
-        "enablement": "calva:connected && !editorHasSelection",
+        "enablement": "!editorHasSelection",
         "category": "Calva"
       },
       {
         "command": "calva.evaluateSelectionToSelectionEnd",
         "title": "Evaluate Selection, Closing Brackets",
-        "enablement": "calva:connected && editorHasSelection",
+        "enablement": "editorHasSelection",
         "category": "Calva"
       },
       {
         "command": "calva.evaluateTopLevelFormToCursor",
         "title": "Evaluate From Start of Top Level Form to Cursor, Closing Brackets",
-        "enablement": "calva:connected",
         "category": "Calva"
       },
       {
         "command": "calva.evaluateStartOfFileToCursor",
         "title": "Evaluate From Start of File to Cursor, Closing Brackets",
-        "enablement": "calva:connected",
         "category": "Calva"
       },
       {
@@ -1326,19 +1323,16 @@
       {
         "command": "calva.evaluateSelectionReplace",
         "title": "Evaluate Current Form and Replace it with the Result",
-        "enablement": "calva:connected",
         "category": "Calva"
       },
       {
         "command": "calva.evaluateSelectionAsComment",
         "title": "Evaluate Current Form to Comment",
-        "enablement": "calva:connected",
         "category": "Calva"
       },
       {
         "command": "calva.evaluateTopLevelFormAsComment",
         "title": "Evaluate Top Level Form (defun) to Comment",
-        "enablement": "calva:connected",
         "category": "Calva"
       },
       {
@@ -1356,7 +1350,6 @@
       {
         "command": "calva.loadFile",
         "title": "Load/Evaluate Current File and its Requires/Dependencies",
-        "enablement": "calva:connected",
         "category": "Calva"
       },
       {
@@ -2015,7 +2008,7 @@
       {
         "command": "calva.debug.instrument",
         "key": "ctrl+alt+c i",
-        "when": "calva:keybindingsEnabled && editorLangId == clojure && calva:connected"
+        "when": "calva:keybindingsEnabled && editorLangId == clojure"
       },
       {
         "command": "calva.jackIn",
@@ -2139,7 +2132,7 @@
       {
         "command": "calva.loadFile",
         "key": "ctrl+alt+c enter",
-        "when": "editorLangId == clojure && calva:connected && calva:keybindingsEnabled"
+        "when": "editorLangId == clojure && calva:keybindingsEnabled"
       },
       {
         "command": "calva.togglePrettyPrint",
@@ -2888,7 +2881,7 @@
         },
         {
           "command": "calva.debug.instrument",
-          "when": "editorLangId == clojure && calva:connected"
+          "when": "editorLangId == clojure"
         },
         {
           "command": "calva.showPreviousReplHistoryEntry",

--- a/package.json
+++ b/package.json
@@ -1275,7 +1275,6 @@
       {
         "command": "calva.evaluateSelection",
         "title": "Evaluate Current Form  (or selection, if any)",
-        "enablement": "calva:connected",
         "category": "Calva"
       },
       {

--- a/package.json
+++ b/package.json
@@ -1280,7 +1280,6 @@
       {
         "command": "calva.evaluateEnclosingForm",
         "title": "Evaluate Current Enclosing Form",
-        "enablement": "calva:connected",
         "category": "Calva"
       },
       {

--- a/package.json
+++ b/package.json
@@ -1317,7 +1317,6 @@
       {
         "command": "calva.evaluateCurrentTopLevelForm",
         "title": "Evaluate Top Level Form (defun)",
-        "enablement": "calva:connected",
         "category": "Calva"
       },
       {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -385,13 +385,17 @@ function evaluateCurrentForm(document = {}, options = {}) {
 }
 
 function evaluateEnclosingForm(document = {}, options = {}) {
-  evaluateSelection(
-    document,
-    Object.assign({}, options, {
-      pprintOptions: getConfig().prettyPrintingOptions,
-      selectionFn: _currentEnclosingFormText,
-    })
-  ).catch(printWarningForError);
+  if (util.getConnectedState()) {
+    evaluateSelection(
+      document,
+      Object.assign({}, options, {
+        pprintOptions: getConfig().prettyPrintingOptions,
+        selectionFn: _currentEnclosingFormText,
+      })
+    ).catch(printWarningForError);
+  } else {
+    offerToConnect();
+  }
 }
 
 function evaluateUsingTextAndSelectionGetter(

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -330,13 +330,28 @@ function evaluateTopLevelFormAsComment(document = {}, options = {}) {
 }
 
 function evaluateTopLevelForm(document = {}, options = {}) {
-  evaluateSelection(
-    document,
-    Object.assign({}, options, {
-      pprintOptions: getConfig().prettyPrintingOptions,
-      selectionFn: _currentTopLevelFormText,
-    })
-  ).catch(printWarningForError);
+  if (util.getConnectedState()) {
+    evaluateSelection(
+      document,
+      Object.assign({}, options, {
+        pprintOptions: getConfig().prettyPrintingOptions,
+        selectionFn: _currentTopLevelFormText,
+      })
+    ).catch(printWarningForError);
+  } else {
+    void vscode.window
+      .showInformationMessage('The editor is not connected to a REPL server', 'Connect')
+      .then(
+        (choice) => {
+          if (choice === 'Connect') {
+            void vscode.commands.executeCommand('calva.startOrConnectRepl');
+          }
+        },
+        (reason) => {
+          console.log('Rejected because: ', reason);
+        }
+      );
+  }
 }
 
 function evaluateOutputWindowForm(document = {}, options = {}) {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -329,6 +329,21 @@ function evaluateTopLevelFormAsComment(document = {}, options = {}) {
   ).catch(printWarningForError);
 }
 
+function offerToConnect() {
+  vscode.window
+    .showInformationMessage('The editor is not connected to a REPL server', 'Connect')
+    .then(
+      (choice) => {
+        if (choice === 'Connect') {
+          void vscode.commands.executeCommand('calva.startOrConnectRepl');
+        }
+      },
+      (reason) => {
+        console.log('Rejected because: ', reason);
+      }
+    );
+}
+
 function evaluateTopLevelForm(document = {}, options = {}) {
   if (util.getConnectedState()) {
     evaluateSelection(
@@ -339,18 +354,7 @@ function evaluateTopLevelForm(document = {}, options = {}) {
       })
     ).catch(printWarningForError);
   } else {
-    void vscode.window
-      .showInformationMessage('The editor is not connected to a REPL server', 'Connect')
-      .then(
-        (choice) => {
-          if (choice === 'Connect') {
-            void vscode.commands.executeCommand('calva.startOrConnectRepl');
-          }
-        },
-        (reason) => {
-          console.log('Rejected because: ', reason);
-        }
-      );
+    offerToConnect();
   }
 }
 
@@ -367,13 +371,17 @@ function evaluateOutputWindowForm(document = {}, options = {}) {
 }
 
 function evaluateCurrentForm(document = {}, options = {}) {
-  evaluateSelection(
-    document,
-    Object.assign({}, options, {
-      pprintOptions: getConfig().prettyPrintingOptions,
-      selectionFn: _currentSelectionElseCurrentForm,
-    })
-  ).catch(printWarningForError);
+  if (util.getConnectedState()) {
+    evaluateSelection(
+      document,
+      Object.assign({}, options, {
+        pprintOptions: getConfig().prettyPrintingOptions,
+        selectionFn: _currentSelectionElseCurrentForm,
+      })
+    ).catch(printWarningForError);
+  } else {
+    offerToConnect();
+  }
 }
 
 function evaluateEnclosingForm(document = {}, options = {}) {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -297,36 +297,48 @@ function _currentEnclosingFormText(editor: vscode.TextEditor): getText.Selection
 }
 
 function evaluateSelectionReplace(document = {}, options = {}) {
-  evaluateSelection(
-    document,
-    Object.assign({}, options, {
-      replace: true,
-      pprintOptions: getConfig().prettyPrintingOptions,
-      selectionFn: _currentSelectionElseCurrentForm,
-    })
-  ).catch(printWarningForError);
+  if (util.getConnectedState()) {
+    evaluateSelection(
+      document,
+      Object.assign({}, options, {
+        replace: true,
+        pprintOptions: getConfig().prettyPrintingOptions,
+        selectionFn: _currentSelectionElseCurrentForm,
+      })
+    ).catch(printWarningForError);
+  } else {
+    offerToConnect();
+  }
 }
 
 function evaluateSelectionAsComment(document = {}, options = {}) {
-  evaluateSelection(
-    document,
-    Object.assign({}, options, {
-      comment: true,
-      pprintOptions: getConfig().prettyPrintingOptions,
-      selectionFn: _currentSelectionElseCurrentForm,
-    })
-  ).catch(printWarningForError);
+  if (util.getConnectedState()) {
+    evaluateSelection(
+      document,
+      Object.assign({}, options, {
+        comment: true,
+        pprintOptions: getConfig().prettyPrintingOptions,
+        selectionFn: _currentSelectionElseCurrentForm,
+      })
+    ).catch(printWarningForError);
+  } else {
+    offerToConnect();
+  }
 }
 
 function evaluateTopLevelFormAsComment(document = {}, options = {}) {
-  evaluateSelection(
-    document,
-    Object.assign({}, options, {
-      comment: true,
-      pprintOptions: getConfig().prettyPrintingOptions,
-      selectionFn: _currentTopLevelFormText,
-    })
-  ).catch(printWarningForError);
+  if (util.getConnectedState()) {
+    evaluateSelection(
+      document,
+      Object.assign({}, options, {
+        comment: true,
+        pprintOptions: getConfig().prettyPrintingOptions,
+        selectionFn: _currentTopLevelFormText,
+      })
+    ).catch(printWarningForError);
+  } else {
+    offerToConnect();
+  }
 }
 
 function offerToConnect() {
@@ -359,15 +371,19 @@ function evaluateTopLevelForm(document = {}, options = {}) {
 }
 
 function evaluateOutputWindowForm(document = {}, options = {}) {
-  evaluateSelection(
-    document,
-    Object.assign({}, options, {
-      pprintOptions: getConfig().prettyPrintingOptions,
-      selectionFn: _currentTopLevelFormText,
-      evaluationSendCodeToOutputWindow: false,
-      addToHistory: true,
-    })
-  ).catch(printWarningForError);
+  if (util.getConnectedState()) {
+    evaluateSelection(
+      document,
+      Object.assign({}, options, {
+        pprintOptions: getConfig().prettyPrintingOptions,
+        selectionFn: _currentTopLevelFormText,
+        evaluationSendCodeToOutputWindow: false,
+        addToHistory: true,
+      })
+    ).catch(printWarningForError);
+  } else {
+    offerToConnect();
+  }
 }
 
 function evaluateCurrentForm(document = {}, options = {}) {
@@ -417,32 +433,44 @@ function evaluateUsingTextAndSelectionGetter(
 }
 
 function evaluateToCursor(document = {}, options = {}) {
-  evaluateUsingTextAndSelectionGetter(
-    vscode.window.activeTextEditor.selection.isEmpty
-      ? getText.currentEnclosingFormToCursor
-      : getText.selectionAddingBrackets,
-    (code) => `${code}`,
-    document,
-    options
-  );
+  if (util.getConnectedState()) {
+    evaluateUsingTextAndSelectionGetter(
+      vscode.window.activeTextEditor.selection.isEmpty
+        ? getText.currentEnclosingFormToCursor
+        : getText.selectionAddingBrackets,
+      (code) => `${code}`,
+      document,
+      options
+    );
+  } else {
+    offerToConnect();
+  }
 }
 
 function evaluateTopLevelFormToCursor(document = {}, options = {}) {
-  evaluateUsingTextAndSelectionGetter(
-    getText.currentTopLevelFormToCursor,
-    (code) => `${code}`,
-    document,
-    options
-  );
+  if (util.getConnectedState()) {
+    evaluateUsingTextAndSelectionGetter(
+      getText.currentTopLevelFormToCursor,
+      (code) => `${code}`,
+      document,
+      options
+    );
+  } else {
+    offerToConnect();
+  }
 }
 
 function evaluateStartOfFileToCursor(document = {}, options = {}) {
-  evaluateUsingTextAndSelectionGetter(
-    getText.startOFileToCursor,
-    (code) => `${code}`,
-    document,
-    options
-  );
+  if (util.getConnectedState()) {
+    evaluateUsingTextAndSelectionGetter(
+      getText.startOFileToCursor,
+      (code) => `${code}`,
+      document,
+      options
+    );
+  } else {
+    offerToConnect();
+  }
 }
 
 async function loadDocument(
@@ -463,6 +491,17 @@ async function loadDocument(
       : doc.uri;
     const filePath = docUri.path;
     return await loadFile(filePath, ns, pprintOptions, fileType);
+  }
+}
+
+async function loadFileCommand() {
+  if (util.getConnectedState()) {
+    await loadDocument({}, getConfig().prettyPrintingOptions);
+    return new Promise((resolve) => {
+      outputWindow.appendPrompt(resolve);
+    });
+  } else {
+    offerToConnect();
   }
 }
 
@@ -610,18 +649,22 @@ async function toggleEvaluationSendCodeToOutputWindow() {
 }
 
 function instrumentTopLevelForm() {
-  evaluateSelection(
-    {},
-    {
-      pprintOptions: getConfig().prettyPrintingOptions,
-      debug: true,
-      selectionFn: _currentTopLevelFormText,
-    }
-  ).catch(printWarningForError);
-  state
-    .analytics()
-    .logEvent(DEBUG_ANALYTICS.CATEGORY, DEBUG_ANALYTICS.EVENT_ACTIONS.INSTRUMENT_FORM)
-    .send();
+  if (util.getConnectedState()) {
+    evaluateSelection(
+      {},
+      {
+        pprintOptions: getConfig().prettyPrintingOptions,
+        debug: true,
+        selectionFn: _currentTopLevelFormText,
+      }
+    ).catch(printWarningForError);
+    state
+      .analytics()
+      .logEvent(DEBUG_ANALYTICS.CATEGORY, DEBUG_ANALYTICS.EVENT_ACTIONS.INSTRUMENT_FORM)
+      .send();
+  } else {
+    offerToConnect();
+  }
 }
 
 async function evaluateInOutputWindow(code: string, sessionType: string, ns: string, options) {
@@ -654,6 +697,7 @@ async function evaluateInOutputWindow(code: string, sessionType: string, ns: str
 export default {
   interruptAllEvaluations,
   loadDocument,
+  loadFileCommand,
   loadFile,
   evaluateCurrentForm,
   evaluateEnclosingForm,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -228,12 +228,7 @@ async function activate(context: vscode.ExtensionContext) {
     interruptAllEvaluations: eval.interruptAllEvaluations,
     jackIn: jackIn.jackInCommand,
     jackOut: jackIn.jackOutCommand,
-    loadFile: async () => {
-      await eval.loadDocument({}, config.getConfig().prettyPrintingOptions);
-      return new Promise((resolve) => {
-        outputWindow.appendPrompt(resolve);
-      });
-    },
+    loadFile: eval.loadFileCommand,
     openCalvaDocs: () => {
       void context.globalState.update(VIEWED_CALVA_DOCS, true);
       open(CALVA_DOCS_URL)
@@ -322,6 +317,9 @@ async function activate(context: vscode.ExtensionContext) {
   }
 
   Object.entries(commands).forEach(registerCalvaCommand);
+
+  outputWindow.registerSubmitOnEnterHandler(context);
+  outputWindow.registerOutputWindowActiveWatcher(context);
 
   // PROVIDERS
   context.subscriptions.push(


### PR DESCRIPTION
## What has changed?

When the user tries to evaluate with a disconnected repl:
* The user gets a message about that the repl is not connected
* The message has button to connect the repl

This includes when pressing `enter` in the output window.

When the user tries to evaluate things, without realizing that the REPL is not connected, Calva is extra unhelpful because absolutely nothing happens, no error message, nothing. This despite the fact that we do have an error message prepared for this case. The reason is that all evaluation commands has `calva:connected` as a requirement in their `enablement`, in the manifest.

When adding the feature to offer to connect the repl, we saw mainly two ways to it:

1. Register two versions of each shortcut. E.g. for evaluateCurrentTopLevelForm:
   1. If the repl is connected -> evaluate
   2. If the repl is not connected -> inform and offer to connect
2. Fix the call sites for each evaluation command. E.g. for evaluateCurrentTopLevelForm:
   * Guard the evaluation with a check for if the repl is connected and if not -> inform and offer to connect

We (as in @DzePat and I) choose option two here, as it creates less noise in the manifest, and is more flexible when choosing what should happen. Also the shortcut bindings for the users gets messier if Calva has two bindings per command already.

When fixing the eval-on-enter in the output/repl window, we had to refactor the initialization of the window a bit, exposing the code for when it registered event handlers that dealt with the window contexts.


* Fixes #1490

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
        - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
