### PR TITLE
Sticky start connect repl menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Make REPL-button menu remember last item selected](https://github.com/BetterThanTomorrow/calva/issues/2382)
+- More Calva commands (especially related to connect and jack-in) are now awaitable
+
 ## [2.0.407] - 2024-01-09
 
 - [Offer to connect when evaluating forms while disconnected](https://github.com/BetterThanTomorrow/calva/issues/1490)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -200,7 +200,9 @@ async function activate(context: vscode.ExtensionContext) {
     clearInlineResults: annotations.clearAllEvaluationDecorations,
     clearReplHistory: replHistory.clearHistory,
     connect: connector.connectCommand,
-    connectNonProjectREPL: () => void connector.connectNonProjectREPLCommand(context),
+    connectNonProjectREPL: () => {
+      return connector.connectNonProjectREPLCommand(context);
+    },
     continueComment: edit.continueCommentCommand,
     convertDart2Clj: converters.dart2clj,
     convertJs2Cljs: converters.js2cljs,
@@ -229,9 +231,9 @@ async function activate(context: vscode.ExtensionContext) {
     jackIn: jackIn.jackInCommand,
     jackOut: jackIn.jackOutCommand,
     loadFile: eval.loadFileCommand,
-    openCalvaDocs: () => {
-      void context.globalState.update(VIEWED_CALVA_DOCS, true);
-      open(CALVA_DOCS_URL)
+    openCalvaDocs: async () => {
+      await context.globalState.update(VIEWED_CALVA_DOCS, true);
+      return open(CALVA_DOCS_URL)
         .then(() => {
           state.analytics().logEvent('Calva', 'Docs opened');
         })
@@ -265,38 +267,45 @@ async function activate(context: vscode.ExtensionContext) {
     openSourceFileForFiddle: fiddleFiles.openSourceFileForFiddle,
     sendCurrentTopLevelFormToOutputWindow: outputWindow.appendCurrentTopLevelForm,
     setOutputWindowNamespace: outputWindow.setNamespaceFromCurrentFile,
-    showFileForOutputWindowNS: () => void outputWindow.revealDocForCurrentNS(false),
+    showFileForOutputWindowNS: () => {
+      return outputWindow.revealDocForCurrentNS(false);
+    },
     showNextReplHistoryEntry: replHistory.showNextReplHistoryEntry,
     showOutputWindow: () => outputWindow.revealResultsDoc(false),
     showPreviousReplHistoryEntry: replHistory.showPreviousReplHistoryEntry,
     startJoyrideReplAndConnect: async () => {
       const projectDir: string = await joyride.prepareForJackingOrConnect();
       if (projectDir !== undefined) {
-        void joyride.joyrideJackIn(projectDir);
+        return joyride.joyrideJackIn(projectDir);
       }
     },
     startOrConnectRepl: replStart.startOrConnectRepl,
-    startStandaloneCljsBrowserRepl: () =>
-      void replStart.startStandaloneRepl(context, replStart.HELLO_CLJS_BROWSER_TEMPLATE, false),
-    startStandaloneCljsNodeRepl: () =>
-      void replStart.startStandaloneRepl(context, replStart.HELLO_CLJS_NODE_TEMPLATE, false),
+    startStandaloneCljsBrowserRepl: () => {
+      return replStart.startStandaloneRepl(context, replStart.HELLO_CLJS_BROWSER_TEMPLATE, false);
+    },
+    startStandaloneCljsNodeRepl: () => {
+      return replStart.startStandaloneRepl(context, replStart.HELLO_CLJS_NODE_TEMPLATE, false);
+    },
     startStandaloneHelloRepl: () => {
       return replStart.startStandaloneRepl(context, replStart.HELLO_TEMPLATE, false);
     },
-    startStandaloneRepl: () =>
-      void replStart.startStandaloneRepl(context, replStart.USER_TEMPLATE, true),
+    startStandaloneRepl: () => {
+      return replStart.startStandaloneRepl(context, replStart.USER_TEMPLATE, true);
+    },
     switchCljsBuild: connector.switchCljsBuild,
     tapCurrentTopLevelForm: () =>
       snippets.evaluateCustomCodeSnippetCommand('(tap> $top-level-form)'),
     tapSelection: () => snippets.evaluateCustomCodeSnippetCommand('(tap> $current-form)'),
-    toggleBetweenImplAndTest: () => void fileSwitcher.toggleBetweenImplAndTest(),
+    toggleBetweenImplAndTest: () => {
+      return fileSwitcher.toggleBetweenImplAndTest();
+    },
     toggleCLJCSession: connector.toggleCLJCSession,
     toggleEvaluationSendCodeToOutputWindow: eval.toggleEvaluationSendCodeToOutputWindow,
     toggleKeybindingsEnabled: () => {
       const keybindingsEnabled = vscode.workspace
         .getConfiguration()
         .get(config.KEYBINDINGS_ENABLED_CONFIG_KEY);
-      void vscode.workspace
+      return vscode.workspace
         .getConfiguration()
         .update(
           config.KEYBINDINGS_ENABLED_CONFIG_KEY,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -280,8 +280,9 @@ async function activate(context: vscode.ExtensionContext) {
       void replStart.startStandaloneRepl(context, replStart.HELLO_CLJS_BROWSER_TEMPLATE, false),
     startStandaloneCljsNodeRepl: () =>
       void replStart.startStandaloneRepl(context, replStart.HELLO_CLJS_NODE_TEMPLATE, false),
-    startStandaloneHelloRepl: () =>
-      void replStart.startStandaloneRepl(context, replStart.HELLO_TEMPLATE, false),
+    startStandaloneHelloRepl: () => {
+      return replStart.startStandaloneRepl(context, replStart.HELLO_TEMPLATE, false);
+    },
     startStandaloneRepl: () =>
       void replStart.startStandaloneRepl(context, replStart.USER_TEMPLATE, true),
     switchCljsBuild: connector.switchCljsBuild,

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -104,7 +104,11 @@ async function openStoredDoc(
       overwrite: false,
     });
   } catch (e) {
-    console.log(e);
+    if (e instanceof vscode.FileSystemError && e.code === 'FileExists') {
+      console.info(`File ${dramFile.path} already exists in temp dir, skipping copy.`);
+    } else {
+      console.log('Unexpected error:', e);
+    }
   }
   if (dramFile['open?']) {
     const doc = await vscode.workspace.openTextDocument(destUri);

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -293,9 +293,6 @@ function copyLastSavedMenuOption(lastSlug: MenuSlug, newSlug: MenuSlug) {
   const newSaveAsSlug = `${newSlug.prefix}/${newSlug.suffix}`;
   const oldSaveAsSlug = `${lastSlug.prefix}/${lastSlug.suffix}`;
   const savedValue = state.extensionContext.workspaceState.get(oldSaveAsSlug);
-  console.log(
-    `BOOM! Copying saved menu option from ${oldSaveAsSlug} to ${newSaveAsSlug}, value ${savedValue}`
-  );
   void state.extensionContext.workspaceState.update(newSaveAsSlug, savedValue);
 }
 
@@ -328,17 +325,7 @@ export async function startOrConnectRepl() {
     placeHolder: 'Start or Connect a REPL',
   });
   if (command_key) {
-    console.log(
-      `BOOM! Executing command: ${commands[command_key]}, current slug prefix: ${
-        createMenuSlugForProjectRoot().prefix
-      }`
-    );
     await vscode.commands.executeCommand(commands[command_key]);
-    console.log(
-      `BOOM! Executed command: ${commands[command_key]}, current slug prefix: ${
-        createMenuSlugForProjectRoot().prefix
-      }`
-    );
     if (lastMenuSlug) {
       const newMenuSlug = createMenuSlugForProjectRoot();
       copyLastSavedMenuOption(lastMenuSlug, {

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -188,13 +188,58 @@ export async function startStandaloneRepl(
   });
 }
 
-function composeMenu() {
-  const JACK_IN_OPTION = 'Start your project with a REPL and connect (a.k.a. Jack-in)';
-  const JACK_IN_COMMAND = 'calva.jackIn';
+function composeConnectedMenu() {
   const RE_JACK_IN_OPTION = 'Restart the Project REPL (a.k.a. Re-jack-in)';
   const RE_JACK_IN_COMMAND = 'calva.jackIn';
   const JACK_OUT_OPTION = 'Stop/Kill the Project REPL started by Calva (a.k.a. Jack-out)';
   const JACK_OUT_COMMAND = 'calva.jackOut';
+  const INTERRUPT_OPTION = 'Interrupt running Evaluations';
+  const INTERRUPT_COMMAND = 'calva.interruptAllEvaluations';
+  const DISCONNECT_OPTION = 'Disconnect from the REPL';
+  const DISCONNECT_COMMAND = 'calva.disconnect';
+  const OPEN_WINDOW_OPTION = 'Open the Output Window';
+  const OPEN_WINDOW_COMMAND = 'calva.showOutputWindow';
+  const OPEN_FIDDLE_OPTION = 'Open Fiddle for Current File';
+  const OPEN_FIDDLE_COMMAND = 'calva.openFiddleForSourceFile';
+  const EVALUATE_FIDDLE_OPTION = 'Evaluate Fiddle for Current File';
+  const EVALUATE_FIDDLE_COMMAND = 'calva.evaluateFiddleForSourceFile';
+  const OPEN_SOURCE_FOR_FIDDLE_OPTION = 'Open Source File for Current Fiddle';
+  const OPEN_SOURCE_FOR_FIDDLE_COMMAND = 'calva.openSourceFileForFiddle';
+  const PREFERRED_ORDER = [
+    INTERRUPT_OPTION,
+    OPEN_WINDOW_OPTION,
+    RE_JACK_IN_OPTION,
+    DISCONNECT_OPTION,
+    JACK_OUT_OPTION,
+    OPEN_FIDDLE_OPTION,
+    EVALUATE_FIDDLE_OPTION,
+    OPEN_SOURCE_FOR_FIDDLE_OPTION,
+  ];
+
+  const commands = {};
+  if (fiddleFiles.activeEditorIsFiddle) {
+    commands[OPEN_SOURCE_FOR_FIDDLE_OPTION] = OPEN_SOURCE_FOR_FIDDLE_COMMAND;
+  } else {
+    commands[OPEN_FIDDLE_OPTION] = OPEN_FIDDLE_COMMAND;
+  }
+  commands[INTERRUPT_OPTION] = INTERRUPT_COMMAND;
+  commands[DISCONNECT_OPTION] = DISCONNECT_COMMAND;
+  if (replSession.getSession('clj')) {
+    commands[OPEN_WINDOW_OPTION] = OPEN_WINDOW_COMMAND;
+  }
+  if (utilities.getJackedInState()) {
+    commands[RE_JACK_IN_OPTION] = RE_JACK_IN_COMMAND;
+    commands[JACK_OUT_OPTION] = JACK_OUT_COMMAND;
+  }
+  if (!fiddleFiles.activeEditorIsFiddle) {
+    commands[EVALUATE_FIDDLE_OPTION] = EVALUATE_FIDDLE_COMMAND;
+  }
+  return { commands, PREFERRED_ORDER };
+}
+
+function composeDisconnectedMenu() {
+  const JACK_IN_OPTION = 'Start your project with a REPL and connect (a.k.a. Jack-in)';
+  const JACK_IN_COMMAND = 'calva.jackIn';
   const START_REPL_OPTION = 'Start a standalone REPL';
   const START_REPL_COMMAND = 'calva.startStandaloneRepl';
   const START_JOYRIDE_REPL_OPTION = 'Start a Joyride REPL and Connect';
@@ -209,18 +254,6 @@ function composeMenu() {
   const CONNECT_PROJECT_COMMAND = 'calva.connect';
   const CONNECT_STANDALONE_OPTION = 'Connect to a running REPL, not in your project';
   const CONNECT_STANDALONE_COMMAND = 'calva.connectNonProjectREPL';
-  const INTERRUPT_OPTION = 'Interrupt running Evaluations';
-  const INTERRUPT_COMMAND = 'calva.interruptAllEvaluations';
-  const DISCONNECT_OPTION = 'Disconnect from the REPL';
-  const DISCONNECT_COMMAND = 'calva.disconnect';
-  const OPEN_WINDOW_OPTION = 'Open the Output Window';
-  const OPEN_WINDOW_COMMAND = 'calva.showOutputWindow';
-  const OPEN_FIDDLE_OPTION = 'Open Fiddle for Current File';
-  const OPEN_FIDDLE_COMMAND = 'calva.openFiddleForSourceFile';
-  const EVALUATE_FIDDLE_OPTION = 'Evaluate Fiddle for Current File';
-  const EVALUATE_FIDDLE_COMMAND = 'calva.evaluateFiddleForSourceFile';
-  const OPEN_SOURCE_FOR_FIDDLE_OPTION = 'Open Source File for Current Fiddle';
-  const OPEN_SOURCE_FOR_FIDDLE_COMMAND = 'calva.openSourceFileForFiddle';
   const PREFERRED_ORDER = [
     JACK_IN_OPTION,
     CONNECT_PROJECT_OPTION,
@@ -230,59 +263,34 @@ function composeMenu() {
     START_HELLO_REPL_OPTION,
     START_HELLO_CLJS_BROWSER_OPTION,
     START_HELLO_CLJS_NODE_OPTION,
-    INTERRUPT_OPTION,
-    OPEN_WINDOW_OPTION,
-    RE_JACK_IN_OPTION,
-    DISCONNECT_OPTION,
-    JACK_OUT_OPTION,
-    OPEN_FIDDLE_OPTION,
-    EVALUATE_FIDDLE_OPTION,
-    OPEN_SOURCE_FOR_FIDDLE_OPTION,
   ];
+
   const commands = {};
-  if (fiddleFiles.activeEditorIsFiddle) {
-    commands[OPEN_SOURCE_FOR_FIDDLE_OPTION] = OPEN_SOURCE_FOR_FIDDLE_COMMAND;
-  } else {
-    commands[OPEN_FIDDLE_OPTION] = OPEN_FIDDLE_COMMAND;
-  }
-  if (
-    !utilities.getConnectedState() &&
-    !utilities.getConnectingState() &&
-    !utilities.getLaunchingState()
-  ) {
-    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
-      if (vscode.workspace.workspaceFolders[0].uri.scheme != 'vsls') {
-        commands[JACK_IN_OPTION] = JACK_IN_COMMAND;
-        commands[CONNECT_STANDALONE_OPTION] = CONNECT_STANDALONE_COMMAND;
-      }
-      commands[CONNECT_PROJECT_OPTION] = CONNECT_PROJECT_COMMAND;
-    } else {
+  if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+    if (vscode.workspace.workspaceFolders[0].uri.scheme != 'vsls') {
+      commands[JACK_IN_OPTION] = JACK_IN_COMMAND;
       commands[CONNECT_STANDALONE_OPTION] = CONNECT_STANDALONE_COMMAND;
-      commands[START_REPL_OPTION] = START_REPL_COMMAND;
     }
-    commands[START_JOYRIDE_REPL_OPTION] = START_JOYRIDE_REPL_COMMAND;
-    commands[START_HELLO_REPL_OPTION] = START_HELLO_REPL_COMMAND;
-    commands[START_HELLO_CLJS_BROWSER_OPTION] = START_HELLO_CLJS_BROWSER_COMMAND;
-    commands[START_HELLO_CLJS_NODE_OPTION] = START_HELLO_CLJS_NODE_COMMAND;
+    commands[CONNECT_PROJECT_OPTION] = CONNECT_PROJECT_COMMAND;
   } else {
-    commands[INTERRUPT_OPTION] = INTERRUPT_COMMAND;
-    commands[DISCONNECT_OPTION] = DISCONNECT_COMMAND;
-    if (replSession.getSession('clj')) {
-      commands[OPEN_WINDOW_OPTION] = OPEN_WINDOW_COMMAND;
-    }
-    if (utilities.getJackedInState()) {
-      commands[RE_JACK_IN_OPTION] = RE_JACK_IN_COMMAND;
-      commands[JACK_OUT_OPTION] = JACK_OUT_COMMAND;
-    }
-    if (!fiddleFiles.activeEditorIsFiddle) {
-      commands[EVALUATE_FIDDLE_OPTION] = EVALUATE_FIDDLE_COMMAND;
-    }
+    commands[CONNECT_STANDALONE_OPTION] = CONNECT_STANDALONE_COMMAND;
+    commands[START_REPL_OPTION] = START_REPL_COMMAND;
   }
+  commands[START_JOYRIDE_REPL_OPTION] = START_JOYRIDE_REPL_COMMAND;
+  commands[START_HELLO_REPL_OPTION] = START_HELLO_REPL_COMMAND;
+  commands[START_HELLO_CLJS_BROWSER_OPTION] = START_HELLO_CLJS_BROWSER_COMMAND;
+  commands[START_HELLO_CLJS_NODE_OPTION] = START_HELLO_CLJS_NODE_COMMAND;
   return { commands, PREFERRED_ORDER };
 }
 
 export function startOrConnectRepl() {
-  const { commands, PREFERRED_ORDER } = composeMenu();
+  const showConnectedMenu =
+    utilities.getConnectedState() ||
+    utilities.getConnectingState() ||
+    utilities.getLaunchingState();
+  const { commands, PREFERRED_ORDER } = showConnectedMenu
+    ? composeConnectedMenu()
+    : composeDisconnectedMenu();
 
   const sortedCommands = utilities.sortByPresetOrder(Object.keys(commands), PREFERRED_ORDER);
   void vscode.window.showQuickPick(sortedCommands).then((v) => {

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -213,7 +213,7 @@ export async function startStandaloneRepl(
   const dramTemplateName =
     typeof dramTemplate.config === 'string' ? dramTemplate.config : dramTemplate.config.name;
   await state.extensionContext.workspaceState.update(
-    `${prefix}/${suffix}`,
+    `qps-${prefix}/${suffix}`,
     DRAM_TEMPLATE_TO_MENU_OPTION[dramTemplateName]
   );
 
@@ -245,7 +245,7 @@ export async function startStandaloneRepl(
   // We now have the proper project root for the REPL Menu “command palette”
   const newMenuSlug = menuSlugForProjectRoot();
   await state.extensionContext.workspaceState.update(
-    `${newMenuSlug.prefix}/${lastMenuSlug.suffix}`,
+    `qps-${newMenuSlug.prefix}/${lastMenuSlug.suffix}`,
     DRAM_TEMPLATE_TO_MENU_OPTION[dramTemplateName]
   );
 

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -188,7 +188,7 @@ export async function startStandaloneRepl(
   });
 }
 
-export function startOrConnectRepl() {
+function composeMenu() {
   const JACK_IN_OPTION = 'Start your project with a REPL and connect (a.k.a. Jack-in)';
   const JACK_IN_COMMAND = 'calva.jackIn';
   const RE_JACK_IN_OPTION = 'Restart the Project REPL (a.k.a. Re-jack-in)';
@@ -278,6 +278,11 @@ export function startOrConnectRepl() {
       commands[EVALUATE_FIDDLE_OPTION] = EVALUATE_FIDDLE_COMMAND;
     }
   }
+  return { commands, PREFERRED_ORDER };
+}
+
+export function startOrConnectRepl() {
+  const { commands, PREFERRED_ORDER } = composeMenu();
 
   const sortedCommands = utilities.sortByPresetOrder(Object.keys(commands), PREFERRED_ORDER);
   void vscode.window.showQuickPick(sortedCommands).then((v) => {

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -334,11 +334,4 @@ export async function startOrConnectRepl() {
       });
     }
   }
-
-  // const sortedCommands = utilities.sortByPresetOrder(Object.keys(commands), PREFERRED_ORDER);
-  // void vscode.window.showQuickPick(sortedCommands).then((v) => {
-  //   if (commands[v]) {
-  //     void vscode.commands.executeCommand(commands[v]);
-  //   }
-  // });
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -120,7 +120,11 @@ export function getProjectRootUri(useCache = true): vscode.Uri | undefined {
       return res;
     }
   }
-  return vscode.workspace.workspaceFolders[0]?.uri;
+  if (vscode.workspace.workspaceFolders) {
+    return vscode.workspace.workspaceFolders[0].uri;
+  } else {
+    return undefined;
+  }
 }
 
 const NON_PROJECT_DIR_KEY = 'calva.connect.nonProjectDir';

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -53,7 +53,7 @@ async function quickPickSingle(opts: {
   if (opts.values.length == 0) {
     return;
   }
-  const saveAs = `${opts.saveAs}`;
+  const saveAs = `qps-${opts.saveAs}`;
   const selected = opts.default ?? state.extensionContext.workspaceState.get<string>(saveAs);
 
   const hasOnlyOneOption = opts.autoSelect && opts.values.length == 1;
@@ -75,7 +75,7 @@ async function quickPickMulti(opts: {
   saveAs: string;
   placeHolder: string;
 }) {
-  const saveAs = `${opts.saveAs}`;
+  const saveAs = `qps-${opts.saveAs}`;
   const selected = state.extensionContext.workspaceState.get<string[]>(saveAs) || [];
   const result = await quickPick(opts.values, [], selected, {
     placeHolder: opts.placeHolder,

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -53,7 +53,7 @@ async function quickPickSingle(opts: {
   if (opts.values.length == 0) {
     return;
   }
-  const saveAs = `qps-${opts.saveAs}`;
+  const saveAs = `${opts.saveAs}`;
   const selected = opts.default ?? state.extensionContext.workspaceState.get<string>(saveAs);
 
   const hasOnlyOneOption = opts.autoSelect && opts.values.length == 1;
@@ -75,7 +75,7 @@ async function quickPickMulti(opts: {
   saveAs: string;
   placeHolder: string;
 }) {
-  const saveAs = `qps-${opts.saveAs}`;
+  const saveAs = `${opts.saveAs}`;
   const selected = state.extensionContext.workspaceState.get<string[]>(saveAs) || [];
   const result = await quickPick(opts.values, [], selected, {
     placeHolder: opts.placeHolder,


### PR DESCRIPTION
## What has changed?

Now the REPL Menu “command palette” remembers the last option selected, like the other repl connect/jack-in menus do. Special care has been taken to make this work also for Getting Started (Dram) options, which are opened from a TEMP directory and thus introduces a new/extra project root. (We use the project root for remembering the menu options selected.)

Since the REPL menu dispatches VS Code (Calva) commands, this change relies on that these commands are awaitable. So we (@DzePat and I) fixed that too. And we also found some other non-awaitable Calva commands, and fixed them too. It is a very rare exception where a command should not be awaitable.

The code for dealing with remembering the menu options for Dram things is a bit messy (or at least not super clear). We left a TODO about that, because we didn't really have a good idea for how to make it clearer, right now.

* Fixes #2382

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
