### PR TITLE
Allow `complete` middleware to return `completion-doc` optionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Enhancement: [Support cider `complete` with completions returning `completion-doc`](https://github.com/BetterThanTomorrow/calva/issues/2395)
 
 ## [2.0.411] - 2024-02-09
 

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -9,6 +9,7 @@ import {
   CompletionItemProvider,
   CompletionItem,
   Uri,
+  MarkdownString,
 } from 'vscode';
 import * as util from '../utilities';
 import * as select from '../select';
@@ -108,7 +109,10 @@ export default class CalvaCompletionItemProvider implements CompletionItemProvid
           typeof item.label === 'string' ? item.label : item['data'].label
         );
         const [doc, details] = infoparser.getCompletion(result);
-        item.documentation = doc;
+        const docFromCider = item['data']?.['completion-doc'];
+
+        item.documentation =
+          doc || docFromCider ? new MarkdownString(docFromCider, true) : undefined;
         item.detail = details;
       }
 


### PR DESCRIPTION

<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Minimal change to allow the `complete` nrepl middleware to provide `completion-doc` with completion-specific documentation. Since this is new behavior, I've made it the lowest priority completion mode to prevent unexpected behavior from current users, and this doesn't interfere with any of my usages.

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

- Fixes #2395

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
        - [~] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [~] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [~] Added to or updated docs in this branch, if appropriate
- [~] Tests
  - [~] Tested the particular change
  - [~] Figured if the change might have some side effects and tested those as well.
- [~] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [~] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
