### PR TITLE
Make eval-on-save disable preview-reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Structure editor glitch - backspace is inhibited from removing `#`](https://github.com/BetterThanTomorrow/calva/issues/2327)
+- Fix: ["Eval on save" causes files to be opened incorrectly](https://github.com/BetterThanTomorrow/calva/issues/2402)
 
 ## [2.0.412] - 2024-02-11
 

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -240,7 +240,9 @@ async function evaluateSelection(document = {}, options) {
     [codeSelection, code]; //TODO: What's this doing here?
 
     const doc = util.getDocument(document);
-    void vscode.window.showTextDocument(doc, { preview: false });
+    if (vscode.window.tabGroups?.activeTabGroup?.activeTab?.isPreview) {
+      void vscode.window.showTextDocument(doc, { preview: false });
+    }
     const [ns, nsForm] = namespace.getNamespace(doc, codeSelection.end);
     const line = codeSelection.start.line;
     const column = codeSelection.start.character;
@@ -476,12 +478,15 @@ function evaluateStartOfFileToCursor(document = {}, options = {}) {
 
 async function loadDocument(
   document: vscode.TextDocument | Record<string, never> | undefined,
-  pprintOptions: PrettyPrintingOptions
+  pprintOptions: PrettyPrintingOptions,
+  shouldResetPreview: boolean = false
 ) {
   void state.analytics().logGA4Pageview('/load-file');
 
   const doc = util.tryToGetDocument(document);
-  void vscode.window.showTextDocument(doc, { preview: false });
+  if (shouldResetPreview && vscode.window.tabGroups?.activeTabGroup?.activeTab?.isPreview) {
+    void vscode.window.showTextDocument(doc, { preview: false });
+  }
   const fileType = util.getFileType(doc);
   const [ns, _] = namespace.getNamespace(doc, doc.positionAt(0));
   const session = replSession.getSession(util.getFileType(doc));
@@ -498,7 +503,7 @@ async function loadDocument(
 
 async function loadFileCommand() {
   if (util.getConnectedState()) {
-    await loadDocument({}, getConfig().prettyPrintingOptions);
+    await loadDocument({}, getConfig().prettyPrintingOptions, true);
     return new Promise((resolve) => {
       outputWindow.appendPrompt(resolve);
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -382,7 +382,7 @@ async function activate(context: vscode.ExtensionContext) {
 
         if (evalOnSave) {
           if (!outputWindow.isResultsDoc(document)) {
-            await eval.loadDocument(document, config.getConfig().prettyPrintingOptions);
+            await eval.loadDocument(document, config.getConfig().prettyPrintingOptions, false);
             outputWindow.appendPrompt();
             state.analytics().logEvent('Calva', 'OnSaveLoad').send();
           }


### PR DESCRIPTION
Adding a check if an editor tab is in preview before resetting it (since we reset it with `showTextDocument` and that can cause side effects). Also added an option to `evaluate.loadDocument` for enabling the preview reset, defaulting to `false`.

* Fixes #2402

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
