### PR TITLE
Multicursor - Refactors - start using vscode.TextEditor.selections

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode", "hbenl.vscode-mocha-test-adapter"]
+}

--- a/src/api/ranges.ts
+++ b/src/api/ranges.ts
@@ -4,7 +4,7 @@ import * as getText from '../util/get-text';
 const wrapSelectionAndTextFunction = (
   f: (document: vscode.TextDocument, position: vscode.Position) => [vscode.Range, string]
 ) => {
-  return (editor = vscode.window.activeTextEditor, position = editor?.selection?.active) => {
+  return (editor = vscode.window.activeTextEditor, position = editor?.selections?.[0]?.active) => {
     if (editor && position && editor.document && editor.document.languageId === 'clojure') {
       return f(editor.document, position);
     } else {

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -32,7 +32,7 @@ export async function indentPosition(position: vscode.Position, document: vscode
         undoStopBefore: false,
       })
       .then((onFulfilled) => {
-        editor.selection = new vscode.Selection(newPosition, newPosition);
+        editor.selections = [new vscode.Selection(newPosition, newPosition)];
         return onFulfilled;
       });
   } else if (delta < 0) {
@@ -43,7 +43,7 @@ export async function indentPosition(position: vscode.Position, document: vscode
         undoStopBefore: false,
       })
       .then((onFulfilled) => {
-        editor.selection = new vscode.Selection(newPosition, newPosition);
+        editor.selections = [new vscode.Selection(newPosition, newPosition)];
         return onFulfilled;
       });
   }
@@ -103,7 +103,7 @@ export async function formatPositionInfo(
   extraConfig = {}
 ) {
   const doc: vscode.TextDocument = editor.document;
-  const index = doc.offsetAt(editor.selection.active);
+  const index = doc.offsetAt(editor.selections[0].active);
   const cursor = getDocument(doc).getTokenCursor(index);
 
   const formatRange = _calculateFormatRange(extraConfig, cursor, index);
@@ -208,20 +208,24 @@ export async function formatPosition(
         { undoStopAfter: false, undoStopBefore: false }
       )
       .then((onFulfilled: boolean) => {
-        editor.selection = new vscode.Selection(
-          doc.positionAt(formattedInfo.newIndex),
-          doc.positionAt(formattedInfo.newIndex)
-        );
+        editor.selections = [
+          new vscode.Selection(
+            doc.positionAt(formattedInfo.newIndex),
+            doc.positionAt(formattedInfo.newIndex)
+          ),
+        ];
         return onFulfilled;
       });
   }
   if (formattedInfo) {
     return new Promise((resolve, _reject) => {
       if (formattedInfo.newIndex != formattedInfo.previousIndex) {
-        editor.selection = new vscode.Selection(
-          doc.positionAt(formattedInfo.newIndex),
-          doc.positionAt(formattedInfo.newIndex)
-        );
+        editor.selections = [
+          new vscode.Selection(
+            doc.positionAt(formattedInfo.newIndex),
+            doc.positionAt(formattedInfo.newIndex)
+          ),
+        ];
       }
       resolve(true);
     });

--- a/src/calva-fmt/src/infer.ts
+++ b/src/calva-fmt/src/infer.ts
@@ -23,7 +23,7 @@ interface ResultOptions {
 }
 
 export function inferParensCommand(editor: vscode.TextEditor) {
-  const position: vscode.Position = editor.selection.active,
+  const position: vscode.Position = editor.selections[0].active,
     document = editor.document,
     currentText = document.getText(),
     r: ResultOptions = inferParens({
@@ -37,7 +37,7 @@ export function inferParensCommand(editor: vscode.TextEditor) {
 }
 
 export function indentCommand(editor: vscode.TextEditor, spacing: string, forward: boolean = true) {
-  const prevPosition: vscode.Position = editor.selection.active,
+  const prevPosition: vscode.Position = editor.selections[0].active,
     document = editor.document;
   let deletedText = '',
     doEdit = true;
@@ -71,7 +71,7 @@ export function indentCommand(editor: vscode.TextEditor, spacing: string, forwar
     )
     .then((_onFulfilled: boolean) => {
       if (doEdit) {
-        const position: vscode.Position = editor.selection.active,
+        const position: vscode.Position = editor.selections[0].active,
           currentText = document.getText(),
           r: ResultOptions = inferIndents({
             text: currentText,

--- a/src/calva-fmt/src/providers/ontype_formatter.ts
+++ b/src/calva-fmt/src/providers/ontype_formatter.ts
@@ -53,7 +53,7 @@ export class FormatOnTypeEditProvider implements vscode.OnTypeFormattingEditProv
     }
     const editor = util.getActiveTextEditor();
 
-    const pos = editor.selection.active;
+    const pos = editor.selections[0].active;
     if (formatterConfig.formatOnTypeEnabled()) {
       if (vscode.workspace.getConfiguration('calva.fmt').get('newIndentEngine')) {
         await formatter.indentPosition(pos, document);

--- a/src/clojuredocs.ts
+++ b/src/clojuredocs.ts
@@ -175,7 +175,7 @@ async function clojureDocsLookup(
   p?: vscode.Position
 ): Promise<DocsEntry | undefined> {
   const doc = d ? d : util.getDocument({});
-  const position = p ? p : util.getActiveTextEditor().selection.active;
+  const position = p ? p : util.getActiveTextEditor().selections[0].active;
   const symbol = util.getWordAtPosition(doc, position);
   const [ns, _] = namespace.getNamespace(doc, p);
   const session = replSession.getSession(util.getFileType(doc));

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -4,7 +4,7 @@ import * as config from './config';
 
 function getText() {
   const editor = vscode.window.activeTextEditor;
-  const selection = editor.selection;
+  const selection = editor.selections[0];
   const doc = editor.document;
   return doc.getText(
     selection.active.isEqual(selection.anchor)

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -39,7 +39,7 @@ async function evaluateCodeOrKeyOrSnippet(codeOrKeyOrSnippet?: string | SnippetD
   const editor = util.getActiveTextEditor();
   const [editorNS, _] =
     editor && editor.document && editor.document.languageId === 'clojure'
-      ? namespace.getNamespace(editor.document, editor.selection.active)
+      ? namespace.getNamespace(editor.document, editor.selections[0].active)
       : undefined;
   const editorRepl =
     editor && editor.document && editor.document.languageId === 'clojure'
@@ -157,20 +157,20 @@ async function getSnippetDefinition(codeOrKey: string, editorNS: string, editorR
 
 export function makeContext(editor: vscode.TextEditor, ns: string, editorNS: string, repl: string) {
   return {
-    currentLine: editor.selection.active.line,
-    currentColumn: editor.selection.active.character,
+    currentLine: editor.selections[0].active.line,
+    currentColumn: editor.selections[0].active.character,
     currentFilename: editor.document.fileName,
     ns,
     editorNS,
     repl,
-    selection: editor.document.getText(editor.selection),
+    selection: editor.document.getText(editor.selections[0]),
     selectionWithBracketTrail: getText.selectionAddingBrackets(
       editor.document,
-      editor.selection.active
+      editor.selections[0].active
     ),
     currentFileText: getText.currentFileText(editor.document),
     ...(editor.document.languageId === 'clojure'
-      ? getText.currentClojureContext(editor.document, editor.selection.active)
+      ? getText.currentClojureContext(editor.document, editor.selections[0].active)
       : {}),
   };
 }

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -135,13 +135,13 @@ export class MirroredDocument implements EditableDocument {
 
   public insertString(text: string) {
     const editor = utilities.getActiveTextEditor(),
-      selection = editor.selection,
+      selection = editor.selections[0],
       wsEdit = new vscode.WorkspaceEdit(),
       // TODO: prob prefer selection.active or .start
       edit = vscode.TextEdit.insert(this.document.positionAt(this.selection.anchor), text);
     wsEdit.set(this.document.uri, [edit]);
     void vscode.workspace.applyEdit(wsEdit).then((_v) => {
-      editor.selection = selection;
+      editor.selections = [selection];
     });
   }
 
@@ -150,21 +150,21 @@ export class MirroredDocument implements EditableDocument {
       document = editor.document,
       anchor = document.positionAt(selection.anchor),
       active = document.positionAt(selection.active);
-    editor.selection = new vscode.Selection(anchor, active);
+    editor.selections = [new vscode.Selection(anchor, active)];
     editor.revealRange(new vscode.Range(active, active));
   }
 
   get selection(): ModelEditSelection {
     const editor = utilities.getActiveTextEditor(),
       document = editor.document,
-      anchor = document.offsetAt(editor.selection.anchor),
-      active = document.offsetAt(editor.selection.active);
+      anchor = document.offsetAt(editor.selections[0].anchor),
+      active = document.offsetAt(editor.selections[0].active);
     return new ModelEditSelection(anchor, active);
   }
 
   public getSelectionText() {
     const editor = utilities.getActiveTextEditor(),
-      selection = editor.selection;
+      selection = editor.selections[0];
     return this.document.getText(selection);
   }
 

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -11,7 +11,7 @@ export function continueCommentCommand() {
   const document = util.tryToGetDocument({});
   if (document && document.languageId === 'clojure') {
     const editor = util.getActiveTextEditor();
-    const position = editor.selection.active;
+    const position = editor.selections[0].active;
     const cursor = docMirror.getDocument(document).getTokenCursor();
     if (cursor.getToken().type !== 'comment') {
       if (cursor.getPrevToken().type === 'comment') {
@@ -35,7 +35,7 @@ export function continueCommentCommand() {
       .then((fulfilled) => {
         if (fulfilled) {
           const newPosition = position.with(position.line + 1, newText.length);
-          editor.selection = new vscode.Selection(newPosition, newPosition);
+          editor.selections = [new vscode.Selection(newPosition, newPosition)];
         }
       });
   }
@@ -69,7 +69,7 @@ export function replace(
 export function prettyPrintReplaceCurrentForm(options = { enabled: true }) {
   const editor = util.getActiveTextEditor();
   const document = editor.document;
-  const selection = editor.selection;
+  const selection = editor.selections[0];
   const range = selection.isEmpty
     ? select.getFormSelection(document, selection.active, false)
     : selection;

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -61,7 +61,7 @@ async function addAsComment(
     wsEdit = new vscode.WorkspaceEdit();
   wsEdit.set(editor.document.uri, [edit]);
   await vscode.workspace.applyEdit(wsEdit);
-  editor.selection = selection;
+  editor.selections = [selection];
 }
 
 // TODO: Clean up this mess
@@ -141,14 +141,14 @@ async function evaluateCodeUpdatingUI(
               void vscode.workspace.applyEdit(wsEdit);
             } else {
               if (editor && options.comment) {
-                await addAsComment(c, value, selection, editor, editor.selection);
+                await addAsComment(c, value, selection, editor, editor.selections[0]);
               }
               if (editor && !outputWindow.isResultsDoc(editor.document)) {
                 annotations.decorateSelection(
                   value,
                   selection,
                   editor,
-                  editor.selection.active,
+                  editor.selections[0].active,
                   resultLocation,
                   annotations.AnnotationStatus.SUCCESS
                 );
@@ -180,14 +180,14 @@ async function evaluateCodeUpdatingUI(
         outputWindow.appendLine(outputWindowError, async (resultLocation, afterResultLocation) => {
           if (selection) {
             const editorError = util.stripAnsi(err.length ? err.join('\n') : e);
-            const currentCursorPos = editor.selection.active;
+            const currentCursorPos = editor.selections[0].active;
             if (editor && options.comment) {
               await addAsComment(
                 selection.start.character,
                 editorError,
                 selection,
                 editor,
-                editor.selection
+                editor.selections[0]
               );
             }
             if (editor && !outputWindow.isResultsDoc(editor.document)) {
@@ -284,19 +284,19 @@ function printWarningForError(e: any) {
 }
 
 function _currentSelectionElseCurrentForm(editor: vscode.TextEditor): getText.SelectionAndText {
-  if (editor.selection.isEmpty) {
-    return getText.currentFormText(editor?.document, editor.selection.active);
+  if (editor.selections[0].isEmpty) {
+    return getText.currentFormText(editor?.document, editor.selections[0].active);
   } else {
-    return [editor.selection, editor.document.getText(editor.selection)];
+    return [editor.selections[0], editor.document.getText(editor.selections[0])];
   }
 }
 
 function _currentTopLevelFormText(editor: vscode.TextEditor): getText.SelectionAndText {
-  return getText.currentTopLevelFormText(editor?.document, editor?.selection.active);
+  return getText.currentTopLevelFormText(editor?.document, editor?.selections[0].active);
 }
 
 function _currentEnclosingFormText(editor: vscode.TextEditor): getText.SelectionAndText {
-  return getText.currentEnclosingFormText(editor?.document, editor?.selection.active);
+  return getText.currentEnclosingFormText(editor?.document, editor?.selections[0].active);
 }
 
 function evaluateSelectionReplace(document = {}, options = {}) {
@@ -428,7 +428,7 @@ function evaluateUsingTextAndSelectionGetter(
     Object.assign({}, options, {
       pprintOptions: getConfig().prettyPrintingOptions,
       selectionFn: (editor: vscode.TextEditor) => {
-        const [selection, code] = getter(editor?.document, editor?.selection.active);
+        const [selection, code] = getter(editor?.document, editor?.selections[0].active);
         return [selection, formatter(code)];
       },
     })
@@ -438,7 +438,7 @@ function evaluateUsingTextAndSelectionGetter(
 function evaluateToCursor(document = {}, options = {}) {
   if (util.getConnectedState()) {
     evaluateUsingTextAndSelectionGetter(
-      vscode.window.activeTextEditor.selection.isEmpty
+      vscode.window.activeTextEditor.selections[0].isEmpty
         ? getText.currentEnclosingFormToCursor
         : getText.selectionAddingBrackets,
       (code) => `${code}`,

--- a/src/lsp/commands/lsp-commands.ts
+++ b/src/lsp/commands/lsp-commands.ts
@@ -78,8 +78,8 @@ const getLSPCommandParams = () => {
     return;
   }
 
-  const line = editor.selection.start.line;
-  const column = editor.selection.start.character;
+  const line = editor.selections[0].start.line;
+  const column = editor.selections[0].start.character;
   const doc_uri = `${document.uri.scheme}://${document.uri.path}`;
   return [doc_uri, line, column];
 };
@@ -126,12 +126,9 @@ function sendCommand(clients: defs.LspClientStore, command: string, args?: any[]
 
 const codeLensReferencesHandler: LSPCommandHandler = async (params) => {
   const [_, line, character] = params.args;
-  calva_utils.getActiveTextEditor().selection = new vscode.Selection(
-    line - 1,
-    character - 1,
-    line - 1,
-    character - 1
-  );
+  calva_utils.getActiveTextEditor().selections = [
+    new vscode.Selection(line - 1, character - 1, line - 1, character - 1),
+  ];
   await vscode.commands.executeCommand('editor.action.referenceSearch.trigger');
 };
 
@@ -139,7 +136,7 @@ const resolveMacroAsCommandHandler: LSPCommandHandler = (params) => {
   const activeTextEditor = calva_utils.tryToGetActiveTextEditor();
   if (activeTextEditor?.document?.languageId === 'clojure') {
     const documentUri = decodeURIComponent(activeTextEditor.document.uri.toString());
-    const { line, character } = activeTextEditor.selection.active;
+    const { line, character } = activeTextEditor.selections[0].active;
     sendCommandRequest(params.clients, RESOLVE_MACRO_AS_COMMAND, [
       documentUri,
       line + 1,

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -250,7 +250,7 @@ export async function startStandaloneRepl(
   );
 
   const firstPos = mainEditor.document.positionAt(0);
-  mainEditor.selection = new vscode.Selection(firstPos, firstPos);
+  mainEditor.selections = [new vscode.Selection(firstPos, firstPos)];
   mainEditor.revealRange(new vscode.Range(firstPos, firstPos));
   await vscode.window.showTextDocument(mainDoc, {
     preview: false,

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -48,12 +48,12 @@ export async function provideHover(
         hoverLine: position.line + 1,
         hoverColumn: position.character + 1,
         hoverFilename: document.fileName,
-        currentLine: editor.selection.active.line,
-        currentColumn: editor.selection.active.character,
+        currentLine: editor.selections[0].active.line,
+        currentColumn: editor.selections[0].active.character,
         currentFilename: editor.document.fileName,
-        selection: editor.document.getText(editor.selection),
+        selection: editor.document.getText(editor.selections[0]),
         currentFileText: getText.currentFileText(editor.document),
-        ...getText.currentClojureContext(editor.document, editor.selection.active),
+        ...getText.currentClojureContext(editor.document, editor.selections[0].active),
         ...getText.currentClojureContext(document, position, 'hover'),
       };
 

--- a/src/results-output/repl-history.ts
+++ b/src/results-output/repl-history.ts
@@ -17,7 +17,7 @@ let lastTextAtPrompt: string | undefined = undefined;
 function setReplHistoryCommandsActiveContext(editor: vscode.TextEditor): void {
   if (editor && util.getConnectedState() && isResultsDoc(editor.document)) {
     const document = editor.document;
-    const selection = editor.selection;
+    const selection = editor.selections[0];
     const positionAtEndOfContent = document.positionAt(
       getIndexAfterLastNonWhitespace(document.getText())
     );

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -188,7 +188,7 @@ export async function initResultsDoc(): Promise<vscode.TextDocument> {
     const resultsEditor = await vscode.window.showTextDocument(resultsDoc, getViewColumn(), true);
     const firstPos = resultsEditor.document.positionAt(0);
     const lastPos = resultsDoc.positionAt(Infinity);
-    resultsEditor.selection = new vscode.Selection(lastPos, lastPos);
+    resultsEditor.selections = [new vscode.Selection(lastPos, lastPos)];
     resultsEditor.revealRange(new vscode.Range(firstPos, firstPos));
   }
   if (isInitialized) {
@@ -238,7 +238,7 @@ export function setNamespaceFromCurrentFile() {
   const session = replSession.getSession();
   const [ns, _] = namespace.getNamespace(
     util.tryToGetDocument({}),
-    vscode.window.activeTextEditor?.selection?.active
+    vscode.window.activeTextEditor?.selections[0]?.active
   );
   setSession(session, ns);
   replSession.updateReplSessionType();
@@ -249,11 +249,11 @@ async function appendFormGrabbingSessionAndNS(topLevel: boolean) {
   const session = replSession.getSession();
   const [ns, _] = namespace.getNamespace(
     util.tryToGetDocument({}),
-    vscode.window.activeTextEditor?.selection?.active
+    vscode.window.activeTextEditor?.selections[0]?.active
   );
   const editor = util.getActiveTextEditor();
   const doc = editor.document;
-  const selection = editor.selection;
+  const selection = editor.selections[0];
   let code = '';
   if (selection.isEmpty) {
     const formSelection = select.getFormSelection(doc, selection.active, topLevel);

--- a/src/select.ts
+++ b/src/select.ts
@@ -49,12 +49,12 @@ function selectForm(
 ) {
   const editor = util.getActiveTextEditor(),
     doc = util.getDocument(document),
-    selection = editor.selection;
+    selection = editor.selections[0];
 
   if (selection.isEmpty) {
     const codeSelection = selectionFn(doc, selection.active, toplevel);
     if (codeSelection) {
-      editor.selection = codeSelection;
+      editor.selections = [codeSelection];
     }
   }
 }

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -322,7 +322,7 @@ async function runNamespaceTests(controller: vscode.TestController, document: vs
   const session = getSession(util.getFileType(document));
   const [currentDocNs, _] = namespace.getNamespace(
     doc,
-    vscode.window.activeTextEditor?.selection?.active
+    vscode.window.activeTextEditor?.selections[0]?.active
   );
   await loadTestNS(currentDocNs, session);
   const namespacesToRunTestsFor = [
@@ -335,14 +335,17 @@ async function runNamespaceTests(controller: vscode.TestController, document: vs
 function getTestUnderCursor() {
   const editor = util.tryToGetActiveTextEditor();
   if (editor) {
-    return getText.currentTopLevelDefined(editor?.document, editor?.selection.active)[1];
+    return getText.currentTopLevelDefined(editor?.document, editor?.selections[0].active)[1];
   }
 }
 
 async function runTestUnderCursor(controller: vscode.TestController) {
   const doc = util.tryToGetDocument({});
   const session = getSession(util.getFileType(doc));
-  const [ns, _] = namespace.getNamespace(doc, vscode.window.activeTextEditor?.selection?.active);
+  const [ns, _] = namespace.getNamespace(
+    doc,
+    vscode.window.activeTextEditor?.selections[0]?.active
+  );
   const test = getTestUnderCursor();
 
   if (test) {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -385,7 +385,7 @@ function filterVisibleRanges(
 
 function scrollToBottom(editor: vscode.TextEditor) {
   const lastPos = editor.document.positionAt(Infinity);
-  editor.selection = new vscode.Selection(lastPos, lastPos);
+  editor.selections = [new vscode.Selection(lastPos, lastPos)];
   editor.revealRange(new vscode.Range(lastPos, lastPos));
 }
 

--- a/src/when-contexts.ts
+++ b/src/when-contexts.ts
@@ -16,7 +16,7 @@ export function setCursorContextIfChanged(editor: vscode.TextEditor) {
   ) {
     return;
   }
-  const contexts = determineCursorContexts(editor.document, editor.selection.active);
+  const contexts = determineCursorContexts(editor.document, editor.selections[0].active);
   setCursorContexts(contexts);
 }
 


### PR DESCRIPTION
# Description

Part of multicursor work. 

This PR does the most basic things - converts explicit references to `vscode.TextEditor.selection` to `vscode.TextEditor.selections`.

Also adds something unrelated, but tiny, adding the recommended extensions that are part of the contribution/dev guide into vscode extension recommendations.
