### PR TITLE
Multicursor - Refactors - ModelEditOptions uses selections array

### DIFF
--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -36,9 +36,16 @@ export class TextLine {
 }
 
 export type ModelEditFunction = 'insertString' | 'changeRange' | 'deleteRange';
+export type ModelEditArgs<T extends ModelEditFunction> = T extends 'insertString'
+  ? Parameters<LineInputModel['insertString']>
+  : T extends 'changeRange'
+  ? Parameters<LineInputModel['changeRange']>
+  : T extends 'deleteRange'
+  ? Parameters<LineInputModel['deleteRange']>
+  : never;
 
-export class ModelEdit {
-  constructor(public editFn: ModelEditFunction, public args: any[]) {}
+export class ModelEdit<T extends ModelEditFunction> {
+  constructor(public editFn: T, public args: Readonly<ModelEditArgs<T>>) {}
 }
 
 /**
@@ -104,7 +111,7 @@ export interface EditableModel {
    * For some EditableModel's these are performed as one atomic set of edits.
    * @param edits
    */
-  edit: (edits: ModelEdit[], options: ModelEditOptions) => Thenable<boolean>;
+  edit: (edits: ModelEdit<ModelEditFunction>[], options: ModelEditOptions) => Thenable<boolean>;
 
   getText: (start: number, end: number, mustBeWithin?: boolean) => string;
   getLineText: (line: number) => string;
@@ -365,7 +372,7 @@ export class LineInputModel implements EditableModel {
    * Doesn't need to be atomic in the LineInputModel.
    * @param edits
    */
-  edit(edits: ModelEdit[], options: ModelEditOptions): Thenable<boolean> {
+  edit(edits: ModelEdit<ModelEditFunction>[], options: ModelEditOptions): Thenable<boolean> {
     return new Promise((resolve, reject) => {
       for (const edit of edits) {
         switch (edit.editFn) {

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -100,7 +100,7 @@ export type ModelEditOptions = {
   undoStopBefore?: boolean;
   formatDepth?: number;
   skipFormat?: boolean;
-  selection?: ModelEditSelection;
+  selections?: ModelEditSelection[];
 };
 
 export interface EditableModel {
@@ -395,8 +395,8 @@ export class LineInputModel implements EditableModel {
             break;
         }
       }
-      if (this.document && options.selection) {
-        this.document.selection = options.selection;
+      if (this.document && options.selections) {
+        this.document.selection = options.selections[0];
       }
       resolve(true);
     });
@@ -575,14 +575,14 @@ export class StringDocument implements EditableDocument {
   delete() {
     const p = this.selection.anchor;
     return this.model.edit([new ModelEdit('deleteRange', [p, 1])], {
-      selection: new ModelEditSelection(p),
+      selections: [new ModelEditSelection(p)],
     });
   }
 
   backspace() {
     const p = this.selection.anchor;
     return this.model.edit([new ModelEdit('deleteRange', [p - 1, 1])], {
-      selection: new ModelEditSelection(p - 1),
+      selections: [new ModelEditSelection(p - 1)],
     });
   }
 }

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -652,8 +652,8 @@ export async function forwardSlurpSexp(
       const replacedText = doc.model.getText(wsStartOffset, wsEndOffset);
       const changeArgs =
         replacedText.indexOf('\n') >= 0
-          ? [currentCloseOffset, currentCloseOffset + close.length, '']
-          : [wsStartOffset, wsEndOffset, ' '];
+          ? ([currentCloseOffset, currentCloseOffset + close.length, ''] as const)
+          : ([wsStartOffset, wsEndOffset, ' '] as const);
       return doc.model.edit(
         [
           new ModelEdit('insertString', [newCloseOffset, close]),
@@ -1336,7 +1336,7 @@ export async function dragSexprBackwardUp(doc: EditableDocument, p = doc.selecti
     const newPosOffset = p - currentRange[0];
     const newCursorPos = listStart + newPosOffset;
     const listIndent = cursor.getToken().offset;
-    let dragText: string, deleteEdit: ModelEdit;
+    let dragText: string, deleteEdit: ModelEdit<'deleteRange'>;
     if (wsInfo.hasLeftWs) {
       dragText =
         doc.model.getText(...currentRange) +

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -24,7 +24,7 @@ export async function killRange(
 ) {
   const [left, right] = [Math.min(...range), Math.max(...range)];
   return doc.model.edit([new ModelEdit('deleteRange', [left, right - left, [start, end]])], {
-    selection: new ModelEditSelection(left),
+    selections: [new ModelEditSelection(left)],
   });
 }
 
@@ -472,7 +472,7 @@ export async function wrapSexpr(
           ]),
         ],
         {
-          selection: new ModelEditSelection(start + open.length),
+          selections: [new ModelEditSelection(start + open.length)],
           skipFormat: options.skipFormat,
         }
       );
@@ -486,7 +486,7 @@ export async function wrapSexpr(
         new ModelEdit('insertString', [range[0], open]),
       ],
       {
-        selection: new ModelEditSelection(start + open.length),
+        selections: [new ModelEditSelection(start + open.length)],
         skipFormat: options.skipFormat,
       }
     );
@@ -515,7 +515,7 @@ export async function rewrapSexpr(
           new ModelEdit('changeRange', [oldCloseStart, oldCloseEnd, close]),
           new ModelEdit('changeRange', [oldOpenStart, oldOpenEnd, open]),
         ],
-        { selection: new ModelEditSelection(end + d) }
+        { selections: [new ModelEditSelection(end + d)] }
       );
     }
   }
@@ -534,7 +534,7 @@ export async function splitSexp(doc: EditableDocument, start: number = doc.selec
       return doc.model.edit(
         [new ModelEdit('changeRange', [splitPos, splitPos, `${close}${open}`])],
         {
-          selection: new ModelEditSelection(splitPos + 1),
+          selections: [new ModelEditSelection(splitPos + 1)],
         }
       );
     }
@@ -569,7 +569,7 @@ export async function joinSexp(
             [prevEnd, prevEnd],
           ]),
         ],
-        { selection: new ModelEditSelection(prevEnd), formatDepth: 2 }
+        { selections: [new ModelEditSelection(prevEnd)], formatDepth: 2 }
       );
     }
   }
@@ -596,7 +596,7 @@ export async function spliceSexp(
           new ModelEdit('changeRange', [end, end + close.raw.length, '']),
           new ModelEdit('changeRange', [beginning - open.raw.length, beginning, '']),
         ],
-        { undoStopBefore, selection: new ModelEditSelection(start - 1) }
+        { undoStopBefore, selections: [new ModelEditSelection(start - 1)] }
       );
     }
   }
@@ -606,7 +606,7 @@ export async function killBackwardList(doc: EditableDocument, [start, end]: [num
   return doc.model.edit(
     [new ModelEdit('changeRange', [start, end, '', [end, end], [start, start]])],
     {
-      selection: new ModelEditSelection(start),
+      selections: [new ModelEditSelection(start)],
     }
   );
 }
@@ -626,7 +626,7 @@ export async function killForwardList(doc: EditableDocument, [start, end]: [numb
         [start, start],
       ]),
     ],
-    { selection: new ModelEditSelection(start) }
+    { selections: [new ModelEditSelection(start)] }
   );
 }
 
@@ -726,7 +726,7 @@ export async function forwardBarfSexp(doc: EditableDocument, start: number = doc
       ],
       start >= cursor.offsetStart
         ? {
-            selection: new ModelEditSelection(cursor.offsetStart),
+            selections: [new ModelEditSelection(cursor.offsetStart)],
             formatDepth: 2,
           }
         : { formatDepth: 2 }
@@ -755,7 +755,7 @@ export async function backwardBarfSexp(
       ],
       start <= cursor.offsetStart
         ? {
-            selection: new ModelEditSelection(cursor.offsetStart),
+            selections: [new ModelEditSelection(cursor.offsetStart)],
             formatDepth: 2,
           }
         : { formatDepth: 2 }
@@ -793,7 +793,7 @@ export async function close(
       // Do nothing when there is balance
     } else {
       return doc.model.edit([new ModelEdit('insertString', [start, close])], {
-        selection: new ModelEditSelection(start + close.length),
+        selections: [new ModelEditSelection(start + close.length)],
       });
     }
   }
@@ -826,7 +826,7 @@ function backspaceOnWhitespaceEdit(
       ]),
     ],
     {
-      selection: new ModelEditSelection(changeArgs.end + changeArgs.indent),
+      selections: [new ModelEditSelection(changeArgs.end + changeArgs.indent)],
       skipFormat: true,
     }
   );
@@ -855,14 +855,14 @@ export async function backspace(
     } else if (doc.model.getText(start - 2, start, true) == '\\"') {
       // delete quoted double quote
       return doc.model.edit([new ModelEdit('deleteRange', [start - 2, 2])], {
-        selection: new ModelEditSelection(start - 2),
+        selections: [new ModelEditSelection(start - 2)],
       });
     } else if (prevToken.type === 'open' && nextToken.type === 'close') {
       // delete empty list
       return doc.model.edit(
         [new ModelEdit('deleteRange', [start - prevToken.raw.length, prevToken.raw.length + 1])],
         {
-          selection: new ModelEditSelection(start - prevToken.raw.length),
+          selections: [new ModelEditSelection(start - prevToken.raw.length)],
         }
       );
     } else if (!isTopLevel && !cursor.withinString() && onlyWhitespaceLeftOfCursor(doc, cursor)) {
@@ -893,13 +893,13 @@ export async function deleteForward(
     const p = start;
     if (doc.model.getText(p, p + 2, true) == '\\"') {
       return doc.model.edit([new ModelEdit('deleteRange', [p, 2])], {
-        selection: new ModelEditSelection(p),
+        selections: [new ModelEditSelection(p)],
       });
     } else if (prevToken.type === 'open' && nextToken.type === 'close') {
       return doc.model.edit(
         [new ModelEdit('deleteRange', [p - prevToken.raw.length, prevToken.raw.length + 1])],
         {
-          selection: new ModelEditSelection(p - prevToken.raw.length),
+          selections: [new ModelEditSelection(p - prevToken.raw.length)],
         }
       );
     } else {
@@ -927,7 +927,7 @@ export async function stringQuote(
       if (cursor.getToken().type == 'close') {
         if (doc.model.getText(0, start).endsWith('\\')) {
           return doc.model.edit([new ModelEdit('changeRange', [start, start, '"'])], {
-            selection: new ModelEditSelection(start + 1),
+            selections: [new ModelEditSelection(start + 1)],
           });
         } else {
           return close(doc, '"', start);
@@ -935,17 +935,17 @@ export async function stringQuote(
       } else {
         if (doc.model.getText(0, start).endsWith('\\')) {
           return doc.model.edit([new ModelEdit('changeRange', [start, start, '"'])], {
-            selection: new ModelEditSelection(start + 1),
+            selections: [new ModelEditSelection(start + 1)],
           });
         } else {
           return doc.model.edit([new ModelEdit('changeRange', [start, start, '\\"'])], {
-            selection: new ModelEditSelection(start + 2),
+            selections: [new ModelEditSelection(start + 2)],
           });
         }
       }
     } else {
       return doc.model.edit([new ModelEdit('changeRange', [start, start, '""'])], {
-        selection: new ModelEditSelection(start + 1),
+        selections: [new ModelEditSelection(start + 1)],
       });
     }
   }
@@ -1059,9 +1059,11 @@ export async function raiseSexp(
         return doc.model.edit(
           [new ModelEdit('changeRange', [startCursor.offsetStart, endCursor.offsetEnd, raised])],
           {
-            selection: new ModelEditSelection(
-              isCaretTrailing ? startCursor.offsetStart + raised.length : startCursor.offsetStart
-            ),
+            selections: [
+              new ModelEditSelection(
+                isCaretTrailing ? startCursor.offsetStart + raised.length : startCursor.offsetStart
+              ),
+            ],
           }
         );
       }
@@ -1152,7 +1154,7 @@ export async function transpose(
               [newCursorPos, newCursorPos],
             ]),
           ],
-          { selection: new ModelEditSelection(newCursorPos) }
+          { selections: [new ModelEditSelection(newCursorPos)] }
         );
       }
     }
@@ -1245,7 +1247,7 @@ export async function dragSexprBackward(
         new ModelEdit('changeRange', [currentRange[0], currentRange[1], leftText]),
         new ModelEdit('changeRange', [backRange[0], backRange[1], currentText]),
       ],
-      { selection: new ModelEditSelection(backRange[0] + newPosOffset) }
+      { selections: [new ModelEditSelection(backRange[0] + newPosOffset)] }
     );
   }
 }
@@ -1273,9 +1275,11 @@ export async function dragSexprForward(
         new ModelEdit('changeRange', [currentRange[0], currentRange[1], rightText]),
       ],
       {
-        selection: new ModelEditSelection(
-          currentRange[1] + (forwardRange[1] - currentRange[1]) - newPosOffset
-        ),
+        selections: [
+          new ModelEditSelection(
+            currentRange[1] + (forwardRange[1] - currentRange[1]) - newPosOffset
+          ),
+        ],
       }
     );
   }
@@ -1360,7 +1364,7 @@ export async function dragSexprBackwardUp(doc: EditableDocument, p = doc.selecti
         new ModelEdit('insertString', [listStart, dragText, [p, p], [newCursorPos, newCursorPos]]),
       ],
       {
-        selection: new ModelEditSelection(newCursorPos),
+        selections: [new ModelEditSelection(newCursorPos)],
         skipFormat: false,
         undoStopBefore: true,
       }
@@ -1394,7 +1398,7 @@ export async function dragSexprForwardDown(doc: EditableDocument, p = doc.select
           new ModelEdit('deleteRange', [currentRange[0], deleteLength]),
         ],
         {
-          selection: new ModelEditSelection(newCursorPos),
+          selections: [new ModelEditSelection(newCursorPos)],
           skipFormat: false,
           undoStopBefore: true,
         }
@@ -1426,7 +1430,7 @@ export async function dragSexprForwardUp(doc: EditableDocument, p = doc.selectio
         new ModelEdit('deleteRange', [deleteStart, deleteLength]),
       ],
       {
-        selection: new ModelEditSelection(newCursorPos),
+        selections: [new ModelEditSelection(newCursorPos)],
         skipFormat: false,
         undoStopBefore: true,
       }
@@ -1463,7 +1467,7 @@ export async function dragSexprBackwardDown(doc: EditableDocument, p = doc.selec
           ]),
         ],
         {
-          selection: new ModelEditSelection(newCursorPos),
+          selections: [new ModelEditSelection(newCursorPos)],
           skipFormat: false,
           undoStopBefore: true,
         }
@@ -1524,7 +1528,7 @@ export async function addRichComment(
           ]),
         ],
         {
-          selection: new ModelEditSelection(newCursorPos),
+          selections: [new ModelEditSelection(newCursorPos)],
           skipFormat: true,
           undoStopBefore: false,
         }
@@ -1551,7 +1555,7 @@ export async function addRichComment(
       ]),
     ],
     {
-      selection: new ModelEditSelection(newCursorPos),
+      selections: [new ModelEditSelection(newCursorPos)],
       skipFormat: false,
       undoStopBefore: true,
     }

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -10,6 +10,7 @@ import {
   ModelEditOptions,
   LineInputModel,
   ModelEditSelection,
+  ModelEditFunction,
 } from '../cursor-doc/model';
 import { isUndefined } from 'lodash';
 
@@ -24,7 +25,7 @@ export class DocumentModel implements EditableModel {
     this.lineInputModel = new LineInputModel(this.lineEndingLength);
   }
 
-  edit(modelEdits: ModelEdit[], options: ModelEditOptions): Thenable<boolean> {
+  edit(modelEdits: ModelEdit<ModelEditFunction>[], options: ModelEditOptions): Thenable<boolean> {
     const editor = utilities.getActiveTextEditor(),
       undoStopBefore = !!options.undoStopBefore;
     return editor

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -51,8 +51,8 @@ export class DocumentModel implements EditableModel {
       )
       .then((isFulfilled) => {
         if (isFulfilled) {
-          if (options.selection) {
-            this.document.selection = options.selection;
+          if (options.selections) {
+            this.document.selection = options.selections[0];
           }
           if (!options.skipFormat) {
             return formatter.formatPosition(editor, true, {


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

Part 2 of my efforts to refactor our selection/cursor related APIs to assume multiple selections without affecting existing functionality. Starting with internal APIs first, and selected this one as it's smaller impact than `EditableDocument`. Dependent on #2412 .

- make model edits use an array of selections, instead of one, tho only actually use the first.
- add more static type inference to `ModelEdit`. Eg, now `model.edit([new ModelEdit('deleteRange', [p, 1])])` will provide intellisense and checking for the range in `[p, 1]`, etc according to `deleteRange`'s arguments.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->


## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [ ] ~Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).~
    - [ ] ~Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.~
    - [ ] ~Referenced the issue I am fixing/addressing _in a commit message for the pull request_.~
        - [ ] ~If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.gi(thub.com/en/articles/closing-issues-using-keywords)~
        - [ ] ~If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] ~Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

I'm not sure if I should create issues for this renewed effort - perhaps I should look into this for tracking these PRs as they pile up.

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
