### PR TITLE
Paredit Multicursor - Testing Utils - textNotation changes and diagnostic utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Internal textNotation testing system supports multiple selections, addressing [#610](https://github.com/BetterThanTomorrow/calva/issues/610)
+- Add new Calva development utility commands to create textNotations from open buffers, and vice versa
+
 ## [2.0.415] - 2024-03-08
 
 - Refactor some internal document and selection APIs in preparation for multiple selections, addressing [#610](https://github.com/BetterThanTomorrow/calva/issues/610)

--- a/package.json
+++ b/package.json
@@ -1171,6 +1171,16 @@
         "category": "Calva Diagnostics"
       },
       {
+        "command": "calva.diagnostics.printTextNotationFromDocument",
+        "title": "Print TextNotation from the current document to Calva says",
+        "category": "Calva Diagnostics"
+      },
+      {
+        "command": "calva.diagnostics.createDocumentFromTextNotation",
+        "title": "Create a new Clojure Document from TextNotation",
+        "category": "Calva Diagnostics"
+      },
+      {
         "command": "calva.linting.resolveMacroAs",
         "title": "Resolve Macro As",
         "category": "Calva Linting",

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -150,21 +150,28 @@ export class MirroredDocument implements EditableDocument {
     });
   }
 
-  set selections(selections: ModelEditSelection[]) {
-    const editor = utilities.getActiveTextEditor(),
-      document = editor.document,
-      anchor = document.positionAt(selections[0].anchor),
-      active = document.positionAt(selections[0].active);
-    editor.selections = [new vscode.Selection(anchor, active)];
-    editor.revealRange(new vscode.Range(active, active));
-  }
-
   get selections(): ModelEditSelection[] {
     const editor = utilities.getActiveTextEditor(),
-      document = editor.document,
-      anchor = document.offsetAt(editor.selections[0].anchor),
-      active = document.offsetAt(editor.selections[0].active);
-    return [new ModelEditSelection(anchor, active)];
+      document = editor.document;
+    return editor.selections.map((sel) => {
+      const anchor = document.offsetAt(sel.anchor),
+        active = document.offsetAt(sel.active);
+      return new ModelEditSelection(anchor, active);
+    });
+  }
+
+  set selections(selections: ModelEditSelection[]) {
+    const editor = utilities.getActiveTextEditor(),
+      document = editor.document;
+    editor.selections = selections.map((selection) => {
+      const anchor = document.positionAt(selection.anchor),
+        active = document.positionAt(selection.active);
+      return new vscode.Selection(anchor, active);
+    });
+
+    const primarySelection = selections[0];
+    const active = document.positionAt(primarySelection.active);
+    editor.revealRange(new vscode.Range(active, active));
   }
 
   public getSelectionText() {

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -25,6 +25,10 @@ export class DocumentModel implements EditableModel {
     this.lineInputModel = new LineInputModel(this.lineEndingLength);
   }
 
+  get lineEnding() {
+    return this.lineEndingLength == 2 ? '\r\n' : '\n';
+  }
+
   edit(modelEdits: ModelEdit<ModelEditFunction>[], options: ModelEditOptions): Thenable<boolean> {
     const editor = utilities.getActiveTextEditor(),
       undoStopBefore = !!options.undoStopBefore;

--- a/src/extension-test/unit/common/text-notation-test.ts
+++ b/src/extension-test/unit/common/text-notation-test.ts
@@ -8,6 +8,17 @@ describe('text-notation test utils', () => {
       const doc = textNotation.docFromTextNotation(inputText);
       expect(textNotation.textNotationFromDoc(doc)).toEqual(inputText);
     });
+    it('returns the normalized version of the input text to textNotationFromDoc', () => {
+      const inputText = '<0e<0 f >1g>1';
+      const normalized = '<e< f |1g|1';
+      const doc = textNotation.docFromTextNotation(inputText);
+      expect(textNotation.textNotationFromDoc(doc)).toEqual(normalized);
+
+      const inputText1 = '|3a|3 <1b<1 >2c>2 d•>0e>0 f |4g<5<5';
+      const normalized1 = '|3a|3 <1b<1 |2c|2 d•|e| f |4g|5';
+      const doc1 = textNotation.docFromTextNotation(inputText1);
+      expect(textNotation.textNotationFromDoc(doc1)).toEqual(normalized1);
+    });
     it('has cursor at end when no trailing newline', () => {
       const inputText = '()|';
       const doc = textNotation.docFromTextNotation(inputText);

--- a/src/extension-test/unit/common/text-notation-test.ts
+++ b/src/extension-test/unit/common/text-notation-test.ts
@@ -1,0 +1,139 @@
+import * as expect from 'expect';
+import * as textNotation from '../common/text-notation';
+
+describe('text-notation test utils', () => {
+  describe('textNotationFromDoc', () => {
+    it('returns the same input text to textNotationFromDoc', () => {
+      const inputText = '(a b|1) (a b|) (a <2(b)<2)';
+      const doc = textNotation.docFromTextNotation(inputText);
+      expect(textNotation.textNotationFromDoc(doc)).toEqual(inputText);
+    });
+    it('has cursor at end when no trailing newline', () => {
+      const inputText = '()|';
+      const doc = textNotation.docFromTextNotation(inputText);
+      expect(textNotation.textNotationFromDoc(doc)).toEqual(inputText);
+    });
+  });
+  describe('docFromTextNotation', () => {
+    describe('textAndSelection - single cursors', () => {
+      it('creates single cursor position', () => {
+        const tn = '(a b|)';
+        const text = '(a b)';
+        const selection = [4, 4];
+        const doc = textNotation.docFromTextNotation(tn);
+        expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
+      });
+      it('creates single cursor position from multiple selections', () => {
+        const tn = '(|1a |2b|)';
+        const text = '(a b)';
+        const selection = [4, 4];
+        const doc = textNotation.docFromTextNotation(tn);
+        expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
+      });
+      it('creates single range/selection', () => {
+        const tn = '(a |b|)';
+        const text = '(a b)';
+        const selection = [3, 4];
+        const doc = textNotation.docFromTextNotation(tn);
+        expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
+      });
+      it('creates single range/selection from multiple selections', () => {
+        const tn = '|1(|1|2a|2 |b|)';
+        const text = '(a b)';
+        const selection = [3, 4];
+        const doc = textNotation.docFromTextNotation(tn);
+        expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
+      });
+      it('creates single directed r->l range/selection', () => {
+        const tn = '(a <b<)';
+        const text = '(a b)';
+        const selection = [4, 3];
+        const doc = textNotation.docFromTextNotation(tn);
+        expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
+      });
+      it('creates a single directed r->l range/selection from the primary cursor amongst multiple', () => {
+        const tn = '(<1a<1 <b<)';
+        const text = '(a b)';
+        const selection = [4, 3];
+        const doc = textNotation.docFromTextNotation(tn);
+        expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
+      });
+      it('creates a single cursor from the primary cursor amongst a variety of multi-cursor positions and selections', () => {
+        const tn = '|3a|3 <1b<1 >2c>2 d•>0e>0 f |4g<5<5';
+        const text = 'a b c d•e f g'.replace(/•/g, '\n');
+        const selection = [8, 9];
+        const doc = textNotation.docFromTextNotation(tn);
+        expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
+      });
+    });
+    describe('textAndSelections - multiple cursors', () => {
+      it('creates single cursor position', () => {
+        const tn = '(a b|)';
+        const text = '(a b)';
+        const selections = [[4, 4]];
+        const doc = textNotation.docFromTextNotation(tn);
+        expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
+      });
+      it('creates multiple cursor positions', () => {
+        const tn = '(|1a |2b|)';
+        const text = '(a b)';
+        const selections = [
+          [4, 4],
+          [1, 1],
+          [3, 3],
+        ];
+        const doc = textNotation.docFromTextNotation(tn);
+        expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
+      });
+      it('creates single range/selection', () => {
+        const tn = '(a |b|)';
+        const text = '(a b)';
+        const selections = [[3, 4]];
+        const doc = textNotation.docFromTextNotation(tn);
+        expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
+      });
+      it('creates multiple ranges/selections', () => {
+        const tn = '|1(|1|2a|2 |b|)';
+        const text = '(a b)';
+        const selections = [
+          [3, 4],
+          [0, 1],
+          [1, 2],
+        ];
+        const doc = textNotation.docFromTextNotation(tn);
+        expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
+      });
+      it('creates single directed r->l range/selection', () => {
+        const tn = '(a <b<)';
+        const text = '(a b)';
+        const selections = [[4, 3]];
+        const doc = textNotation.docFromTextNotation(tn);
+        expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
+      });
+      it('creates a variety directed r->l range/selection', () => {
+        const tn = '(<1a<1 <b<)';
+        const text = '(a b)';
+        const selections = [
+          [4, 3],
+          [2, 1],
+        ];
+        const doc = textNotation.docFromTextNotation(tn);
+        expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
+      });
+      it('creates a variety of multi-cursor positions and selections', () => {
+        const tn = '|3a|3 <1b<1 >2c>2 d•>0e>0 f |4g<5<5';
+        const text = 'a b c d•e f g'.replace(/•/g, '\n');
+        const selections = [
+          [8, 9],
+          [3, 2],
+          [4, 5],
+          [0, 1],
+          [12, 12],
+          [13, 13],
+        ];
+        const doc = textNotation.docFromTextNotation(tn);
+        expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
+      });
+    });
+  });
+});

--- a/src/extension-test/unit/common/text-notation.ts
+++ b/src/extension-test/unit/common/text-notation.ts
@@ -1,67 +1,171 @@
+import { clone, entries, first, last, orderBy, partialRight, toInteger } from 'lodash';
 import * as model from '../../../cursor-doc/model';
 
 /**
  * Text Notation for expressing states of a document, including
  * current text and selection.
+ * See this video for an intro: https://www.youtube.com/watch?v=Sy3arG-Degw
  * * Since JavasScript makes it clumsy with multiline strings,
  *   newlines are denoted with a middle dot character: `•`
  * * Selections are denoted like so
- *   * Single position selections are denoted with a single `|`.
- *   * Selections w/o direction are denoted with `|` at the range's boundaries.
- *   * Selections with direction left->right are denoted with `|>|` at the range boundaries
- *   * Selections with direction left->right are denoted with `|<|` at the range boundaries
+ *   * Cursors, (which are actually selections with identical start and end) are denoted with a single `|`, with <= 10 multiple cursors defined by `|1`, `|2`, ... `|9`, etc, or in regex: /\|\d/. 0-indexed, so `|` is 0, `|1` is 1, etc.
+ *   * This is however actually an alternative for the following `>\d?` notation, it has the same left->right semantics, but looks more like a cursor/caret lol, and more importantly, drops the 0 for the first cursor.
+ *   * Selections with direction left->right are denoted with `>0`, `>1`, `>2`, ... `>9` etc at the range boundaries
+ *   * Selections with direction right->left are denoted with `<0`, `<1`, `<2`, ... `<9` etc at the range boundaries
  */
+function textNotationToTextAndSelection(content: string): [string, model.ModelEditSelection[]] {
+  const cursorSymbolRegExPattern =
+    /(?<cursorType>(?:(?<selectionDirection><|>(?=\d{1})))|(?:\|))(?<cursorNumber>\d{1})?/g;
+  const text = clone(content).replace(/•/g, '\n').replace(cursorSymbolRegExPattern, '');
 
-function textNotationToTextAndSelection(s: string): [string, { anchor: number; active: number }] {
-  const text = s.replace(/•/g, '\n').replace(/\|?[<>]?\|/g, '');
-  let anchor: undefined | number = undefined;
-  let active: undefined | number = undefined;
-  anchor = s.indexOf('|>|');
-  if (anchor >= 0) {
-    active = s.lastIndexOf('|>|') - 3;
-  } else {
-    anchor = s.lastIndexOf('|<|');
-    if (anchor >= 0) {
-      anchor -= 3;
-      active = s.indexOf('|<|');
-    } else {
-      anchor = s.indexOf('|');
-      if (anchor >= 0) {
-        active = s.lastIndexOf('|');
-        if (active !== anchor) {
-          active -= 1;
-        } else {
-          active = anchor;
-        }
-      }
-    }
-  }
-  return [text, { anchor, active }];
+  /**
+   * 3 capt groups:
+   * 0 = total cursor, with number,
+   * 1 = just the cursor type, no number,
+   * 2 = only for directional selection cursors:
+   *     the > or <,
+   * 3 = only if there's a number, the number itself (eg multi cursor)
+   */
+  const matches = Array.from(content.matchAll(cursorSymbolRegExPattern));
+
+  // a map of cursor symbols (eg '>3' - including the cursor number if >1 ) to an an array of matches (for their positions mostly) in content string where that cursor is
+  // for now, we hope that there are at most two positions per symbol
+  const cursorMatchInstances = matches.reduce((acc, curr, index) => {
+    const nextAcc = { ...acc };
+
+    const sumOfPreviousCursorOffsets = Array.from(matches)
+      .slice(0, index)
+      .reduce((sum, m) => sum + m[0].length, 0);
+
+    curr.index = curr.index - sumOfPreviousCursorOffsets;
+
+    // const cursorMatchStr = curr.groups['cursorType'] ?? curr[0];
+    const cursorMatchStr = curr[0];
+    const matchesForCursor = nextAcc[cursorMatchStr] ?? [];
+    nextAcc[cursorMatchStr] = [...matchesForCursor, curr];
+    return nextAcc;
+  }, {} as { [key: string]: RegExpMatchArray[] });
+
+  const selections = [].fill(0, matches.length, undefined);
+
+  entries(cursorMatchInstances).forEach(([_, matches]) => {
+    const firstMatch = first(matches);
+    const secondMatch = last(matches) ?? firstMatch;
+
+    const isReversed =
+      (firstMatch.groups['selectionDirection'] ?? firstMatch[2] ?? '') === '<' ? true : false;
+
+    const start = firstMatch.index;
+    const end = secondMatch.index === firstMatch.index ? secondMatch.index : secondMatch.index;
+
+    const anchor = isReversed ? end : start;
+    const active = isReversed ? start : end;
+
+    const cursorNumber = toInteger(firstMatch.groups['cursorNumber'] ?? firstMatch[3] ?? '0');
+
+    selections[cursorNumber] = new model.ModelEditSelection(anchor, active, start, end, isReversed);
+  });
+
+  return [text, selections];
 }
 
 /**
  * Utility function to create a doc from text-notated strings
  */
 export function docFromTextNotation(s: string): model.StringDocument {
-  const [text, selection] = textNotationToTextAndSelection(s);
+  const [text, selections] = textNotationToTextAndSelection(s);
   const doc = new model.StringDocument(text);
-  doc.selections = [new model.ModelEditSelection(selection.anchor, selection.active)];
+  doc.selections = selections;
   return doc;
 }
+
+export function textNotationFromDoc(doc: model.EditableDocument, prettyPrint = false): string {
+  const selections = doc.selections ?? [];
+  const ranges = selections.map((s) => s.asDirectedRange);
+
+  const text = getText(doc, true);
+
+  return textNotationFromTextAndSelections(text, ranges, prettyPrint);
+}
+
+export function textNotationFromTextAndSelections(
+  text: string,
+  ranges: Array<[number, number]>,
+  prettyPrint = false
+): string {
+  let cursorSymbols: [number, string][] = [];
+  ranges.forEach((r, cursorNumber) => {
+    const [anchor, active] = r;
+    const isReversed = anchor > active;
+    const isSelection = anchor - active !== 0;
+    const start = Math.min(anchor, active);
+    const end = Math.max(anchor, active);
+
+    const cursorType = isReversed ? '<' : '|';
+    cursorSymbols.push([start, `${cursorType}${cursorNumber || ''}`]);
+    if (isSelection) {
+      cursorSymbols.push([end, `${cursorType}${cursorNumber || ''}`]);
+    }
+  });
+
+  cursorSymbols = orderBy(cursorSymbols, (c) => c[0]);
+
+  // basically split up the text into chunks separated by where they'd have had cursor symbols, and append cursor symbols after each chunk, before joining back together
+  // this way we can insert the cursor symbols in the right place without having to worry about the cumulative offsets created by appending the cursor symbols
+  const textSegments = cursorSymbols
+    .reduce(
+      (acc, [offset, symbol], index) => {
+        const lastSection = last(acc)[1];
+        const sections = acc.slice(0, -1);
+
+        const lastSectionOffset =
+          offset - sections.filter((s) => s[0]).reduce((sum, sec) => sum + sec[1].length, 0);
+        const newSectionOfText = [true, lastSection.slice(0, lastSectionOffset)];
+        const newSectionWithCursor = [false, symbol];
+        const restOfText = lastSection.slice(lastSectionOffset);
+
+        return [...sections, newSectionOfText, newSectionWithCursor, [true, restOfText]];
+      },
+      [
+        [true, text] as [
+          boolean /* is an actual text segment instead of cursor symbol? */,
+          string /* text segment or cursor symbol */
+        ],
+      ]
+    )
+    .map((s) => s[1]);
+
+  const textNotation = textSegments.join('');
+  return prettyPrint ? textNotation.replace(/•/g, '\n') : textNotation;
+}
+
+textNotationFromDoc.pretty = partialRight(textNotationFromDoc, true);
+textNotationFromTextAndSelections.pretty = partialRight(textNotationFromTextAndSelections, true);
 
 /**
  * Utility function to get the text from a document.
  * @param doc
  * @returns string
  */
-export function text(doc: model.StringDocument): string {
-  return doc.model.getText(0, Infinity);
+export function getText(doc: model.EditableDocument, replaceNewLine = false): string {
+  const text = doc.model.getText(0, Infinity);
+
+  return replaceNewLine ? text.split(doc.model.lineEnding).join('•') : text;
 }
 
 /**
  * Utility function to create a comparable structure with the text and
  * selection from a document
  */
-export function textAndSelection(doc: model.StringDocument): [string, [number, number]] {
-  return [text(doc), [doc.selections[0].anchor, doc.selections[0].active]];
+export function textAndSelection(doc: model.EditableDocument): [string, [number, number]] {
+  return [getText(doc), [doc.selections[0].anchor, doc.selections[0].active]];
+}
+
+/**
+ * Utility function to create a comparable structure with the text and
+ * selection from a document. Supports multiple cursors
+ */
+export function textAndSelections(doc: model.EditableDocument): [string, [number, number][]] {
+  // return [text(doc), [doc.selection.anchor, doc.selection.active]];
+  return [getText(doc), doc.selections.map((s) => [s.anchor, s.active])];
 }

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -78,18 +78,18 @@ describe('paredit', () => {
         expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
       });
       it('Finds next symbol, including leading space', () => {
-        const a = docFromTextNotation('(|>|def|>| foo [vec])');
-        const b = docFromTextNotation('(def|>| foo|>| [vec])');
+        const a = docFromTextNotation('(>0def>0 foo [vec])');
+        const b = docFromTextNotation('(def>0 foo>0 [vec])');
         expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
       });
       it('Finds following vector including leading space', () => {
-        const a = docFromTextNotation('(|>|def foo|>| [vec])');
-        const b = docFromTextNotation('(def foo|>| [vec]|>|)');
+        const a = docFromTextNotation('(>0def foo>0 [vec])');
+        const b = docFromTextNotation('(def foo>0 [vec]>0)');
         expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
       });
       it('Reverses direction of selection and finds next sexp', () => {
-        const a = docFromTextNotation('(|<|def foo|<| [vec])');
-        const b = docFromTextNotation('(def foo|>| [vec]|>|)');
+        const a = docFromTextNotation('(<0def foo<0 [vec])');
+        const b = docFromTextNotation('(def foo>0 [vec]>0)');
         expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
       });
     });
@@ -117,8 +117,8 @@ describe('paredit', () => {
       });
       it('Finds previous form, including space, and reverses direction', () => {
         // TODO: Should we really be reversing the direction here?
-        const a = docFromTextNotation('(def |<|foo [vec]|<|)');
-        const b = docFromTextNotation('(|>|def |>|foo [vec])');
+        const a = docFromTextNotation('(def <0foo [vec]<0)');
+        const b = docFromTextNotation('(>0def >0foo [vec])');
         expect(paredit.backwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
       });
     });
@@ -411,18 +411,18 @@ describe('paredit', () => {
         expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
       });
       it('Finds next symbol, including leading space', () => {
-        const a = docFromTextNotation('(|>|def|>| foo [vec])');
-        const b = docFromTextNotation('(def|>| foo|>| [vec])');
+        const a = docFromTextNotation('(>0def>0 foo [vec])');
+        const b = docFromTextNotation('(def>0 foo>0 [vec])');
         expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
       });
       it('Finds following vector including leading space', () => {
-        const a = docFromTextNotation('(|>|def foo|>| [vec])');
-        const b = docFromTextNotation('(def foo|>| [vec]|>|)');
+        const a = docFromTextNotation('(>0def foo>0 [vec])');
+        const b = docFromTextNotation('(def foo>0 [vec]>0)');
         expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
       });
       it('Reverses direction of selection and finds next sexp', () => {
-        const a = docFromTextNotation('(|<|def foo|<| [vec])');
-        const b = docFromTextNotation('(def foo|>| [vec]|>|)');
+        const a = docFromTextNotation('(<0def foo<0 [vec])');
+        const b = docFromTextNotation('(def foo>0 [vec]>0)');
         expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
       });
     });
@@ -450,8 +450,8 @@ describe('paredit', () => {
       });
       it('Finds previous form, including space, and reverses direction', () => {
         // TODO: Should we really be reversing the direction here?
-        const a = docFromTextNotation('(def |<|foo [vec]|<|)');
-        const b = docFromTextNotation('(|>|def |>|foo [vec])');
+        const a = docFromTextNotation('(def <0foo [vec]<0)');
+        const b = docFromTextNotation('(>0def >0foo [vec])');
         expect(paredit.backwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
       });
       it('Goes up when at front bounds', () => {
@@ -463,20 +463,20 @@ describe('paredit', () => {
 
     describe('moveToRangeRight', () => {
       it('Places cursor at the right end of the selection', () => {
-        const a = docFromTextNotation('(def |>|foo|>| [vec])');
+        const a = docFromTextNotation('(def >0foo>0 [vec])');
         const b = docFromTextNotation('(def foo| [vec])');
         paredit.moveToRangeRight(a, textAndSelection(a)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Places cursor at the right end of the selection 2', () => {
-        const a = docFromTextNotation('(|>|def foo|>| [vec])');
+        const a = docFromTextNotation('(>0def foo>0 [vec])');
         const b = docFromTextNotation('(def foo| [vec])');
         paredit.moveToRangeRight(a, textAndSelection(a)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Move to right of given range, regardless of previous selection', () => {
-        const a = docFromTextNotation('(|<|def|<| foo [vec])');
-        const b = docFromTextNotation('(def foo |>|[vec]|>|)');
+        const a = docFromTextNotation('(<0def<0 foo [vec])');
+        const b = docFromTextNotation('(def foo >0[vec]>0)');
         const c = docFromTextNotation('(def foo [vec]|)');
         paredit.moveToRangeRight(a, textAndSelection(b)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(c));
@@ -485,20 +485,20 @@ describe('paredit', () => {
 
     describe('moveToRangeLeft', () => {
       it('Places cursor at the left end of the selection', () => {
-        const a = docFromTextNotation('(def |>|foo|>| [vec])');
+        const a = docFromTextNotation('(def >0foo>0 [vec])');
         const b = docFromTextNotation('(def |foo [vec])');
         paredit.moveToRangeLeft(a, textAndSelection(a)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Places cursor at the left end of the selection 2', () => {
-        const a = docFromTextNotation('(|>|def foo|>| [vec])');
+        const a = docFromTextNotation('(>0def foo>0 [vec])');
         const b = docFromTextNotation('(|def foo [vec])');
         paredit.moveToRangeLeft(a, textAndSelection(a)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Move to left of given range, regardless of previous selection', () => {
-        const a = docFromTextNotation('(|<|def|<| foo [vec])');
-        const b = docFromTextNotation('(def foo |>|[vec]|>|)');
+        const a = docFromTextNotation('(<0def<0 foo [vec])');
+        const b = docFromTextNotation('(def foo >0[vec]>0)');
         const c = docFromTextNotation('(def foo |[vec])');
         paredit.moveToRangeLeft(a, textAndSelection(b)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(c));
@@ -615,8 +615,8 @@ describe('paredit', () => {
         doc = new model.StringDocument(docText);
       });
       it('dragSexprBackward', async () => {
-        const a = docFromTextNotation('(c•#f•(#b •[:f :b :z])•#x•#y•|1)');
-        const b = docFromTextNotation('(c•#x•#y•|1•#f•(#b •[:f :b :z]))');
+        const a = docFromTextNotation('(c•#f•(#b •[:f :b :z])•#x•#y•|:a)');
+        const b = docFromTextNotation('(c•#x•#y•|:a•#f•(#b •[:f :b :z]))');
         await paredit.dragSexprBackward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
@@ -635,7 +635,7 @@ describe('paredit', () => {
       beforeEach(() => {
         doc = new model.StringDocument(docText);
       });
-      it('dragSexprBackward: #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö => #x•#y•1•#f•(#b •[:f :b :z])•#å#ä#ö', async () => {
+      it('dragSexprBackward: #f•(#b •[:f :b :z])•#x•#y•|:a•#å#ä#ö => #x•#y•1•#f•(#b •[:f :b :z])•#å#ä#ö', async () => {
         doc.selections = [new ModelEditSelection(26, 26)];
         await paredit.dragSexprBackward(doc);
         expect(doc.model.getText(0, Infinity)).toBe('#x\n#y\n1\n#f\n(#b \n[:f :b :z])\n#å#ä#ö');
@@ -646,7 +646,7 @@ describe('paredit', () => {
         expect(doc.model.getText(0, Infinity)).toBe('#x\n#y\n1\n#f\n(#b \n[:f :b :z])\n#å#ä#ö');
         expect(doc.selections).toEqual([new ModelEditSelection(11)]);
       });
-      it('dragSexprForward: #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö => #f•(#b •[:f :b :z])•#x•#y•|1•#å#ä#ö', async () => {
+      it('dragSexprForward: #f•(#b •[:f :b :z])•#x•#y•|:a•#å#ä#ö => #f•(#b •[:f :b :z])•#x•#y•|:a•#å#ä#ö', async () => {
         doc.selections = [new ModelEditSelection(26, 26)];
         await paredit.dragSexprForward(doc);
         expect(doc.model.getText(0, Infinity)).toBe('#f\n(#b \n[:f :b :z])\n#x\n#y\n1\n#å#ä#ö');
@@ -659,16 +659,16 @@ describe('paredit', () => {
     describe('selectRangeBackward', () => {
       // TODO: Fix #498
       it('Extends backward selections backwards', () => {
-        const a = docFromTextNotation('(def foo [:foo :bar |<|:baz|<|])');
+        const a = docFromTextNotation('(def foo [:foo :bar <0:baz<0])');
         const selDoc = docFromTextNotation('(def foo [:foo |:bar| :baz])');
-        const b = docFromTextNotation('(def foo [:foo |<|:bar :baz|<|])');
+        const b = docFromTextNotation('(def foo [:foo <0:bar :baz<0])');
         paredit.selectRangeBackward(a, [selDoc.selections[0].anchor, selDoc.selections[0].active]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Contracts forward selection and extends backwards', () => {
-        const a = docFromTextNotation('(def foo [:foo :bar |>|:baz|>|])');
+        const a = docFromTextNotation('(def foo [:foo :bar >0:baz>0])');
         const selDoc = docFromTextNotation('(def foo [:foo |:bar| :baz])');
-        const b = docFromTextNotation('(def foo [:foo |<|:bar |<|:baz])');
+        const b = docFromTextNotation('(def foo [:foo <0:bar <0:baz])');
         paredit.selectRangeBackward(a, [selDoc.selections[0].anchor, selDoc.selections[0].active]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
@@ -736,7 +736,7 @@ describe('paredit', () => {
       );
     });
     it('grows selection to binding pairs', () => {
-      const a = docFromTextNotation('(a (let [b c |e| f]))');
+      const a = docFromTextNotation('(a (let [b c >0e>0 f]))');
       const aSelection = new ModelEditSelection(a.selections[0].anchor, a.selections[0].active);
       const b = docFromTextNotation('(a (let [b c |e f|]))');
       const bSelection = new ModelEditSelection(b.selections[0].anchor, b.selections[0].active);
@@ -877,8 +877,8 @@ describe('paredit', () => {
       });
 
       it('drags single sexpr backward in bound vectors', async () => {
-        const a = docFromTextNotation(`(b [x [1 2 |3]])`);
-        const b = docFromTextNotation(`(b [x [1 |3 2]])`);
+        const a = docFromTextNotation(`(b [x [1 2 |:a]])`);
+        const b = docFromTextNotation(`(b [x [1 |:a 2]])`);
         await paredit.dragSexprBackward(a, ['b']);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
@@ -891,8 +891,8 @@ describe('paredit', () => {
       });
 
       it('drags single sexpr backward in bound lists', async () => {
-        const a = docFromTextNotation(`(b [x (1 2 |3)])`);
-        const b = docFromTextNotation(`(b [x (1 |3 2)])`);
+        const a = docFromTextNotation(`(b [x (1 2 |:a)])`);
+        const b = docFromTextNotation(`(b [x (1 |:a 2)])`);
         await paredit.dragSexprBackward(a, ['b']);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
@@ -950,8 +950,8 @@ describe('paredit', () => {
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
       it('Drags up from end of indented list', async () => {
-        const b = docFromTextNotation(`((fn foo•  [x]•  [:foo•   :bar•   :baz])• |1)`);
-        const a = docFromTextNotation(`|1•((fn foo•  [x]•  [:foo•   :bar•   :baz]))`);
+        const b = docFromTextNotation(`((fn foo•  [x]•  [:foo•   :bar•   :baz])• |:a)`);
+        const a = docFromTextNotation(`|:a•((fn foo•  [x]•  [:foo•   :bar•   :baz]))`);
         await paredit.dragSexprBackwardUp(b);
         expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
       });
@@ -1553,31 +1553,31 @@ describe('paredit', () => {
 
     describe('killRange', () => {
       it('Deletes top-level range with backward direction', async () => {
-        const a = docFromTextNotation('a |<|b|<| c');
+        const a = docFromTextNotation('a <0b<0 c');
         const b = docFromTextNotation('a | c');
         await paredit.killRange(a, textAndSelection(a)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Deletes top-level range with backward direction, including space', async () => {
-        const a = docFromTextNotation('a |<|b |<|c');
+        const a = docFromTextNotation('a <0b <0c');
         const b = docFromTextNotation('a |c');
         await paredit.killRange(a, textAndSelection(a)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Deletes top-level range with forward direction', async () => {
-        const a = docFromTextNotation('a |>|b |>|c');
+        const a = docFromTextNotation('a >0b >0c');
         const b = docFromTextNotation('a |c');
         await paredit.killRange(a, textAndSelection(a)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Deletes nested range with backward direction', async () => {
-        const a = docFromTextNotation('{a |<|b |<|c}');
+        const a = docFromTextNotation('{a <0b <0c}');
         const b = docFromTextNotation('{a |c}');
         await paredit.killRange(a, textAndSelection(a)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Deletes nested range with forward direction', async () => {
-        const a = docFromTextNotation('{a |>|b |>|c}');
+        const a = docFromTextNotation('{a >0b >0c}');
         const b = docFromTextNotation('{a |c}');
         await paredit.killRange(a, textAndSelection(a)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1,7 +1,7 @@
 import * as expect from 'expect';
 import * as paredit from '../../../cursor-doc/paredit';
 import * as model from '../../../cursor-doc/model';
-import { docFromTextNotation, textAndSelection, text } from '../common/text-notation';
+import { docFromTextNotation, textAndSelection, getText } from '../common/text-notation';
 import { ModelEditSelection } from '../../../cursor-doc/model';
 
 model.initScanner(20000);
@@ -1679,7 +1679,7 @@ describe('paredit', () => {
       it('splice string', async () => {
         const a = docFromTextNotation('"h|ello"');
         await paredit.spliceSexp(a);
-        expect(text(a)).toEqual('hello');
+        expect(getText(a)).toEqual('hello');
       });
     });
   });

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -121,7 +121,7 @@ describe('Token Cursor', () => {
     });
     it('Does not skip ignored forms if skipIgnoredForms is false', () => {
       const a = docFromTextNotation('(a| #_1 #_2 3)');
-      const b = docFromTextNotation('(a #_|1 #_2 3)');
+      const b = docFromTextNotation('(a #_|a #_2 3)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp(true, true);
       expect(cursor.offsetStart).toBe(b.selections[0].anchor);
@@ -247,7 +247,7 @@ describe('Token Cursor', () => {
     });
     it('Puts cursor to the right of the following open bracket', () => {
       const a = docFromTextNotation('(a| [1 2]))');
-      const b = docFromTextNotation('(a [|1 2]))');
+      const b = docFromTextNotation('(a [|a 2]))');
       const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.downList();
       expect(cursor.offsetStart).toBe(b.selections[0].anchor);
@@ -362,21 +362,21 @@ describe('Token Cursor', () => {
 
   describe('backwardList', () => {
     it('Finds start of list', () => {
-      const a = docFromTextNotation('(((c•(#b •[:f])•#z•|1)))');
+      const a = docFromTextNotation('(((c•(#b •[:f])•#z•|a)))');
       const b = docFromTextNotation('(((|c•(#b •[:f])•#z•1)))');
       const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardList();
       expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Finds start of list through readers', () => {
-      const a = docFromTextNotation('(((c•#a• #f•(#b •[:f])•#z•|1)))');
+      const a = docFromTextNotation('(((c•#a• #f•(#b •[:f])•#z•|a)))');
       const b = docFromTextNotation('(((|c•#a• #f•(#b •[:f])•#z•1)))');
       const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardList();
       expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Finds start of list through metadata', () => {
-      const a = docFromTextNotation('(((c•^{:a c} (#b •[:f])•#z•|1)))');
+      const a = docFromTextNotation('(((c•^{:a c} (#b •[:f])•#z•|a)))');
       const b = docFromTextNotation('(((|c•^{:a c} (#b •[:f])•#z•1)))');
       const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardList();
@@ -445,7 +445,7 @@ describe('Token Cursor', () => {
       expect(result).toBe(true);
     });
     it('Finds end of map', () => {
-      const a = docFromTextNotation('({:a [(c•(#|b •[:f])•#z•|1)]})');
+      const a = docFromTextNotation('({:a [(c•(#|b •[:f])•#z•|a)]})');
       const b = docFromTextNotation('({:a [(c•(#b •[:f])•#z•1)]|})');
       const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.forwardListOfType('}');
@@ -472,7 +472,7 @@ describe('Token Cursor', () => {
 
   describe('backwardListOfType', () => {
     it('Finds start of list', () => {
-      const a = docFromTextNotation('([#{c•(#b •[:f])•#z•|1}])');
+      const a = docFromTextNotation('([#{c•(#b •[:f])•#z•|a}])');
       const b = docFromTextNotation('(|[#{c•(#b •[:f])•#z•1}])');
       const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.backwardListOfType('(');
@@ -480,7 +480,7 @@ describe('Token Cursor', () => {
       expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Finds start of vector', () => {
-      const a = docFromTextNotation('([(c•(#b •[:f])•#z•|1)])');
+      const a = docFromTextNotation('([(c•(#b •[:f])•#z•|a)])');
       const b = docFromTextNotation('([|(c•(#b •[:f])•#z•1)])');
       const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.backwardListOfType('[');
@@ -488,7 +488,7 @@ describe('Token Cursor', () => {
       expect(result).toBe(true);
     });
     it('Finds start of map', () => {
-      const a = docFromTextNotation('({:a [(c•(#b •[:f])•#z•|1)]})');
+      const a = docFromTextNotation('({:a [(c•(#b •[:f])•#z•|a)]})');
       const b = docFromTextNotation('({|:a [(c•(#b •[:f])•#z•1)]})');
       const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.backwardListOfType('{');


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

Prepares testing utilites for multiple selection tests, editing some existing tests to fit, while preserving their single-cursor semantics. (re)introduces the diagnostic Calva commands for creating textNotations from vscode buffers and vice versa.

- This requires changing the textNotation syntax somewhat ->
    - `|` for single cursor is still fine, but subsequent cursors are |1, |2, …|n, and selections now >,>1, >|2, …>n & <|…<n, instead of |>|
- Also introduces some tests for the textnotation stuff.
- The above changes required some extensions to ModelEditSelection and EditableModel.


<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2417
FIxes #2418
Addresses #610

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
        - [ ] ~If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] ~Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
