### PR TITLE
Paredit Multicursor - Implement movement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Implement experimental support for multicursor paredit movement commands. Enable `calva.paredit.multicursor` in your settings to try it out. Closes [#2420](https://github.com/BetterThanTomorrow/calva/issues/2420).
+
 ## [2.0.416] - 2024-03-08
 
 - Internal textNotation testing system supports multiple selections, addressing [#610](https://github.com/BetterThanTomorrow/calva/issues/610)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- Implement experimental support for multicursor paredit movement commands. Enable `calva.paredit.multicursor` in your settings to try it out. Closes [#2420](https://github.com/BetterThanTomorrow/calva/issues/2420).
+- [Implement experimental support for multicursor paredit movement commands](https://github.com/BetterThanTomorrow/calva/issues/2420). Enable `calva.paredit.multicursor` in your settings to try it out. Addressing [#610](https://github.com/BetterThanTomorrow/calva/issues/610)
 
 ## [2.0.416] - 2024-03-08
 

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -148,5 +148,11 @@ There are some context keys you can utilize to configure keyboard shortcuts with
 
 In some instances built-in command defaults are the same as Paredit's defaults, and Paredit's functionality in a particular case is less than what the default is. This is true of *Expand Selection* and *Shrink Selection* for Windows/Linux when multiple lines are selected. In this particular case adding `!editorHasMultipleSelections` to the `when` clause of the binding makes for a better workflow. The point is that when the bindings overlap and default functionality is desired peaceful integration can be achieved with the right `when` clause. This is left out of Paredit's defaults to respect user preference, and ease of maintenance.
 
-
 Happy Editing! ❤️
+
+## Experimental Feature: Multicursor support
+
+There is an ongoing effort to support simultaneous multicursor editing with Paredit. This is an experimental feature and is not enabled by default. To enable it, set `calva.paredit.multicursor` to `true`. This feature is still in development and may not work as expected in all cases. Currently, this supports the following categories:
+
+- Movement
+- Selection

--- a/package.json
+++ b/package.json
@@ -957,6 +957,12 @@
             "markdownDescription": "When enabled, replaces the clipboard content with the deleted code.",
             "default": false,
             "scope": "window"
+          },
+          "calva.paredit.multicursor": {
+            "type": "boolean",
+            "markdownDescription": "Experimental: Support for multiple cursors in paredit commands.\nCurrently supported commands:\n- Cursor movement",
+            "default": false,
+            "scope": "window"
           }
         }
       },

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -28,12 +28,12 @@ export async function killRange(
   });
 }
 
-export function moveToRangeLeft(doc: EditableDocument, range: [number, number]) {
-  doc.selections = [new ModelEditSelection(Math.min(range[0], range[1]))];
+export function moveToRangeLeft(doc: EditableDocument, ranges: ModelEditRange[]) {
+  doc.selections = ranges.map((range) => new ModelEditSelection(Math.min(range[0], range[1])));
 }
 
-export function moveToRangeRight(doc: EditableDocument, range: [number, number]) {
-  doc.selections = [new ModelEditSelection(Math.max(range[0], range[1]))];
+export function moveToRangeRight(doc: EditableDocument, ranges: ModelEditRange[]) {
+  doc.selections = ranges.map((range) => new ModelEditSelection(Math.max(range[0], range[1])));
 }
 
 export function selectRange(doc: EditableDocument, range: [number, number]) {

--- a/src/extension-test/unit/common/text-notation.ts
+++ b/src/extension-test/unit/common/text-notation.ts
@@ -155,17 +155,17 @@ export function getText(doc: model.EditableDocument, replaceNewLine = false): st
 
 /**
  * Utility function to create a comparable structure with the text and
- * selection from a document
- */
-export function textAndSelection(doc: model.EditableDocument): [string, [number, number]] {
-  return [getText(doc), [doc.selections[0].anchor, doc.selections[0].active]];
-}
-
-/**
- * Utility function to create a comparable structure with the text and
  * selection from a document. Supports multiple cursors
  */
 export function textAndSelections(doc: model.EditableDocument): [string, [number, number][]] {
   // return [text(doc), [doc.selection.anchor, doc.selection.active]];
-  return [getText(doc), doc.selections.map((s) => [s.anchor, s.active])];
+  return [getText(doc), doc.selections.map((s) => s.asDirectedRange)];
+}
+
+/**
+ * Convenience single (primary) cursor version of `textAndSelections`
+ */
+export function textAndSelection(doc: model.EditableDocument): [string, [number, number]] {
+  const [text, [selection]] = textAndSelections(doc);
+  return [text, selection];
 }

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1,7 +1,12 @@
 import * as expect from 'expect';
 import * as paredit from '../../../cursor-doc/paredit';
 import * as model from '../../../cursor-doc/model';
-import { docFromTextNotation, textAndSelection, getText } from '../common/text-notation';
+import {
+  docFromTextNotation,
+  textAndSelection,
+  getText,
+  textAndSelections,
+} from '../common/text-notation';
 import { ModelEditSelection } from '../../../cursor-doc/model';
 
 model.initScanner(20000);
@@ -405,7 +410,7 @@ describe('paredit', () => {
         const b = docFromTextNotation('(def foo [:foo :bar |:baz|])');
         expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
       });
-      it('Leaves an sexp if at the end', () => {
+      it('Leaves a sexp if at the end', () => {
         const a = docFromTextNotation('(def foo [:foo :bar :baz|])');
         const b = docFromTextNotation('(def foo [:foo :bar :baz|]|)');
         expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
@@ -465,20 +470,20 @@ describe('paredit', () => {
       it('Places cursor at the right end of the selection', () => {
         const a = docFromTextNotation('(def >0foo>0 [vec])');
         const b = docFromTextNotation('(def foo| [vec])');
-        paredit.moveToRangeRight(a, textAndSelection(a)[1]);
+        paredit.moveToRangeRight(a, textAndSelections(a)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Places cursor at the right end of the selection 2', () => {
         const a = docFromTextNotation('(>0def foo>0 [vec])');
         const b = docFromTextNotation('(def foo| [vec])');
-        paredit.moveToRangeRight(a, textAndSelection(a)[1]);
+        paredit.moveToRangeRight(a, textAndSelections(a)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Move to right of given range, regardless of previous selection', () => {
         const a = docFromTextNotation('(<0def<0 foo [vec])');
         const b = docFromTextNotation('(def foo >0[vec]>0)');
         const c = docFromTextNotation('(def foo [vec]|)');
-        paredit.moveToRangeRight(a, textAndSelection(b)[1]);
+        paredit.moveToRangeRight(a, textAndSelections(b)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(c));
       });
     });
@@ -487,20 +492,20 @@ describe('paredit', () => {
       it('Places cursor at the left end of the selection', () => {
         const a = docFromTextNotation('(def >0foo>0 [vec])');
         const b = docFromTextNotation('(def |foo [vec])');
-        paredit.moveToRangeLeft(a, textAndSelection(a)[1]);
+        paredit.moveToRangeLeft(a, textAndSelections(a)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Places cursor at the left end of the selection 2', () => {
         const a = docFromTextNotation('(>0def foo>0 [vec])');
         const b = docFromTextNotation('(|def foo [vec])');
-        paredit.moveToRangeLeft(a, textAndSelection(a)[1]);
+        paredit.moveToRangeLeft(a, textAndSelections(a)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
       it('Move to left of given range, regardless of previous selection', () => {
         const a = docFromTextNotation('(<0def<0 foo [vec])');
         const b = docFromTextNotation('(def foo >0[vec]>0)');
         const c = docFromTextNotation('(def foo |[vec])');
-        paredit.moveToRangeLeft(a, textAndSelection(b)[1]);
+        paredit.moveToRangeLeft(a, textAndSelections(b)[1]);
         expect(textAndSelection(a)).toEqual(textAndSelection(c));
       });
     });

--- a/src/extension-test/unit/paredit/commands-test.ts
+++ b/src/extension-test/unit/paredit/commands-test.ts
@@ -1,0 +1,328 @@
+import * as expect from 'expect';
+import _ = require('lodash');
+import * as model from '../../../cursor-doc/model';
+import * as paredit from '../../../cursor-doc/paredit';
+import * as handlers from '../../../paredit/commands';
+import { docFromTextNotation, textAndSelection, textAndSelections } from '../common/text-notation';
+
+model.initScanner(20000);
+
+describe('paredit commands', () => {
+  describe('movement', () => {
+    describe('forwardSexp', () => {
+      it('Single-cursor: find the list in front', () => {
+        const a = docFromTextNotation('|(a b [c])•|1(a b [c])');
+        const b = docFromTextNotation('(a b [c])|•(a b [c])');
+        handlers.forwardSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursors: find the list in front', () => {
+        const a = docFromTextNotation('|(a b [c])•|1(a b [c])');
+        const b = docFromTextNotation('(a b [c])|•(a b [c])|1');
+        handlers.forwardSexp(a, true);
+        expect(a).toEqual(b);
+      });
+      it('Single-cursor: find the list in front through metadata', () => {
+        const a = docFromTextNotation('|^:a (b c [d])•|1^:a (b c [d])');
+        const b = docFromTextNotation('^:a (b c [d])|•^:a (b c [d])');
+        handlers.forwardSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursors: find the list in front through metadata', () => {
+        const a = docFromTextNotation('|^:a (b c [d])•|1^:a (b c [d])');
+        const b = docFromTextNotation('^:a (b c [d])|•^:a (b c [d])|1');
+        handlers.forwardSexp(a, true);
+        expect(a).toEqual(b);
+      });
+      it('Single-cursor: find the list in front through metadata and readers', () => {
+        const a = docFromTextNotation('|^:f #a #b (c d [e])•|1^:f #a #b (c d [e])');
+        const b = docFromTextNotation('^:f #a #b (c d [e])|•^:f #a #b (c d [e])');
+        handlers.forwardSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursors: find the list in front through metadata and readers', () => {
+        const a = docFromTextNotation('|^:f #a #b (c d [e])•|1^:f #a #b (c d [e])');
+        const b = docFromTextNotation('^:f #a #b (c d [e])|•^:f #a #b (c d [e])|1');
+        handlers.forwardSexp(a, true);
+        expect(a).toEqual(b);
+      });
+      it('Single-cursor: find the list in front through metadata and readers', () => {
+        const a = docFromTextNotation('|^:f #a #b (c d [e])•|1^:f #a #b (c d [e])');
+        const b = docFromTextNotation('^:f #a #b (c d [e])|•^:f #a #b (c d [e])');
+        handlers.forwardSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursors: find the list in front through metadata and readers', () => {
+        const a = docFromTextNotation('|^:f #a #b (c d [e])•|1^:f #a #b (c d [e])');
+        const b = docFromTextNotation('^:f #a #b (c d [e])|•^:f #a #b (c d [e])|1');
+        handlers.forwardSexp(a, true);
+        expect(a).toEqual(b);
+      });
+      it('Single-cursor: do not find anything at end of list', () => {
+        const a = docFromTextNotation('(|)•(|1)');
+        const b = docFromTextNotation('(|)•()');
+        handlers.forwardSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursors: do not find anything at end of list', () => {
+        const a = docFromTextNotation('(|)•(|1)');
+        const b = docFromTextNotation('(|)•(|1)');
+        handlers.forwardSexp(a, true);
+        expect(a).toEqual(b);
+      });
+      it('Single-cursor: Cursor 1 finds fwd sexp, cursor 2 does not, cursor 3 does', () => {
+        const a = docFromTextNotation('(|a)•(|1)•|2(b)');
+        const b = docFromTextNotation('(a|)•()•(b)');
+        handlers.forwardSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursors: Cursor 1 finds fwd sexp, cursor 2 does not, cursor 3 does', () => {
+        const a = docFromTextNotation('(|a)•(|1)•|2(b)');
+        const b = docFromTextNotation('(a|)•(|1)•(b)|2');
+        handlers.forwardSexp(a, true);
+        expect(a).toEqual(b);
+      });
+    });
+
+    describe('backwardSexp', () => {
+      it('Single-cursor: find the list preceding', () => {
+        const a = docFromTextNotation('(def foo |1[vec])|');
+        const b = docFromTextNotation('|(def foo [vec])');
+        handlers.backwardSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursor: find the list preceding', () => {
+        const a = docFromTextNotation('(def foo |1[vec])|');
+        const b = docFromTextNotation('|(def |1foo [vec])');
+        handlers.backwardSexp(a, true);
+        expect(a).toEqual(b);
+      });
+
+      it('Single-cursor: find the list preceding through metadata', () => {
+        const a = docFromTextNotation('^:foo (def |1foo [vec])|');
+        const b = docFromTextNotation('|^:foo (def foo [vec])');
+        handlers.backwardSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursor: find the list preceding through metadata', () => {
+        const a = docFromTextNotation('^:foo (def |1foo [vec])|');
+        const b = docFromTextNotation('|^:foo (|1def foo [vec])');
+        handlers.backwardSexp(a, true);
+        expect(a).toEqual(b);
+      });
+
+      it('Single-cursor: find the list preceding through metadata and readers', () => {
+        const a = docFromTextNotation('^:f #a #b (def |1foo [vec])|');
+        const b = docFromTextNotation('|^:f #a #b (def foo [vec])');
+        handlers.backwardSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursor: find the list preceding through metadata and readers', () => {
+        const a = docFromTextNotation('^:f #a #b (def |1foo [vec])|');
+        const b = docFromTextNotation('|^:f #a #b (|1def foo [vec])');
+        handlers.backwardSexp(a, true);
+        expect(a).toEqual(b);
+      });
+
+      it('Single-cursor: find the list preceding through metadata and readers', () => {
+        const a = docFromTextNotation('#c ^:f #a #b (def |1foo [vec])|');
+        const b = docFromTextNotation('|#c ^:f #a #b (def foo [vec])');
+        handlers.backwardSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursor: find the list preceding through metadata and readers', () => {
+        const a = docFromTextNotation('#c ^:f #a #b (def |1foo [vec])|');
+        const b = docFromTextNotation('|#c ^:f #a #b (|1def foo [vec])');
+        handlers.backwardSexp(a, true);
+        expect(a).toEqual(b);
+      });
+
+      it('Single-cursor: do not find anything at start of list', () => {
+        const a = docFromTextNotation('(|)•(|1)');
+        const b = docFromTextNotation('(|)•()');
+        handlers.backwardSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursor: do not find anything at start of list', () => {
+        const a = docFromTextNotation('(|)•(|1)');
+        const b = docFromTextNotation('(|)•(|1)');
+        handlers.backwardSexp(a, true);
+        expect(a).toEqual(b);
+      });
+
+      it('Single-cursor: Finds previous form, including space, and reverses direction', () => {
+        const a = docFromTextNotation('(def <foo [vec]<)|1');
+        const b = docFromTextNotation('(|def foo [vec])');
+        handlers.backwardSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursor: Finds previous form, including space, and reverses direction', () => {
+        const a = docFromTextNotation('(def <foo [vec]<)|1');
+        const b = docFromTextNotation('|1(|def foo [vec])');
+        handlers.backwardSexp(a, true);
+        expect(a).toEqual(b);
+      });
+
+      it('Single-cursor: Cursor 1 finds bwd sexp, cursor 2 does not, cursor 3 does', () => {
+        const a = docFromTextNotation('(a|)•(|1)•|2(b)');
+        const b = docFromTextNotation('(|a)•()•(b)');
+        handlers.backwardSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursor: Cursor 1 finds bwd sexp, cursor 2 does not, cursor 3 does', () => {
+        const a = docFromTextNotation('(a|)•(|1)•|2(b)');
+        const b = docFromTextNotation('(|a)•|2(|1)•(b)');
+        handlers.backwardSexp(a, true);
+        expect(a).toEqual(b);
+      });
+    });
+
+    describe('forwardDownSexp', () => {
+      it('Single-cursor: ', () => {
+        const a = docFromTextNotation('(|c•(|1#b •[:f :b :z])•#z•1)');
+        const b = docFromTextNotation('(c•(|#b •[:f :b :z])•#z•1)');
+        handlers.forwardDownSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursor: ', () => {
+        const a = docFromTextNotation('(|c•(|1#b •[:f :b :z])•#z•1)');
+        const b = docFromTextNotation('(c•(|#b •[|1:f :b :z])•#z•1)');
+        handlers.forwardDownSexp(a, true);
+        expect(a).toEqual(b);
+      });
+    });
+
+    describe('backwardDownSexp', () => {
+      it('Single-cursor: ', () => {
+        const a = docFromTextNotation('(c•(#b •[:f :b :z])|1•#z•1)|');
+        const b = docFromTextNotation('(c•(#b •[:f :b :z])•#z•1|)');
+        handlers.backwardDownSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursor: ', () => {
+        const a = docFromTextNotation('(c•(#b •[:f :b :z])|1•#z•1)|');
+        const b = docFromTextNotation('(c•(#b •[:f :b :z]|1)•#z•1|)');
+        handlers.backwardDownSexp(a, true);
+        expect(a).toEqual(b);
+      });
+    });
+
+    describe('forwardUpSexp', () => {
+      it('Single-cursor: ', () => {
+        const a = docFromTextNotation('|2(c•(#b •[:f |1:b :z|])•#z•1|3)');
+        const b = docFromTextNotation('(c•(#b •[:f :b :z]|)•#z•1)');
+        handlers.forwardUpSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursor: ', () => {
+        const a = docFromTextNotation('|2(c•(#b •[:f |1:b :z|])•#z•1|3)');
+        const b = docFromTextNotation('|1(c•(#b •[:f :b :z]|)•#z•1)|2');
+        handlers.forwardUpSexp(a, true);
+        // docFromTextNotation creates a mock doc that won't dedupe selections
+        // expect(_.uniqWith(a.selections, _.isEqual)).toEqual(b.selections);
+        expect(a.selections).toEqual(b.selections);
+      });
+    });
+
+    describe('backwardUpSexp', () => {
+      it('Single-cursor: ', () => {
+        const a = docFromTextNotation('(c•(|#b •[|1:f|2 :b :z])•#z•1)|3');
+        const b = docFromTextNotation('(c•|(#b •[:f :b :z])•#z•1)');
+        handlers.backwardUpSexp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursor: ', () => {
+        const a = docFromTextNotation('(c•(|#b •[|1:f|2 :b :z])•#z•1)|3');
+        const b = docFromTextNotation('(c•|(|1#b •[:f :b :z])•#z•1)|2');
+        handlers.backwardUpSexp(a, true);
+        // expect(_.uniqWith(a.selections, _.isEqual)).toEqual(b.selections);
+        expect(a.selections).toEqual(b.selections);
+      });
+    });
+
+    describe('forwardSexpOrUp', () => {
+      it('Single-cursor: leave sexp if at the end', () => {
+        const a = docFromTextNotation('(a|)•(b|1)');
+        const b = docFromTextNotation('(a)|•(b)');
+        handlers.forwardSexpOrUp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursors: leave sexp if at the end', () => {
+        const a = docFromTextNotation('(a|)•(b|1)');
+        const b = docFromTextNotation('(a)|•(b)|1');
+        handlers.forwardSexpOrUp(a, true);
+        expect(a).toEqual(b);
+      });
+      it('Single-cursor: one goes fwd a sexp, one leaves sexp b/c at the end', () => {
+        const a = docFromTextNotation('(|a)•(b|1)');
+        const b = docFromTextNotation('(a|)•(b)');
+        handlers.forwardSexpOrUp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursors: one goes fwd a sexp, one leaves sexp b/c at the end', () => {
+        const a = docFromTextNotation('(|a)•(b|1)');
+        const b = docFromTextNotation('(a|)•(b)|1');
+        handlers.forwardSexpOrUp(a, true);
+        expect(a).toEqual(b);
+      });
+    });
+
+    describe('backwardSexpOrUp', () => {
+      it('Single-cursor: go up when at front bounds', () => {
+        const a = docFromTextNotation('(|1a (|b 1))');
+        const b = docFromTextNotation('(a |(b 1))');
+        handlers.backwardSexpOrUp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursors: go up when at front bounds', () => {
+        const a = docFromTextNotation('(|1a (|b 1))');
+        const b = docFromTextNotation('|1(a |(b 1))');
+        handlers.backwardSexpOrUp(a, true);
+        expect(a).toEqual(b);
+      });
+      it('Single-cursor: one go up when at front bounds, the other back sexp', () => {
+        const a = docFromTextNotation('(|1a (b c|))');
+        const b = docFromTextNotation('(a (b |c))');
+        handlers.backwardSexpOrUp(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursors: one go up when at front bounds, the other back sexp', () => {
+        const a = docFromTextNotation('(|1a (b c|))');
+        const b = docFromTextNotation('|1(a (b |c))');
+        handlers.backwardSexpOrUp(a, true);
+        expect(a).toEqual(b);
+      });
+    });
+
+    describe('closeList', () => {
+      it('Single-cursor: ', () => {
+        const a = docFromTextNotation('|(c•(|1#b •[:f :b :z])•#z•1)');
+        const b = docFromTextNotation('|(c•(#b •[:f :b :z])•#z•1)');
+        handlers.closeList(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursor: ', () => {
+        const a = docFromTextNotation('|(c•(|1#b •[:f :b :z])•#z•1)');
+        const b = docFromTextNotation('|(c•(#b •[:f :b :z]|1)•#z•1)');
+        handlers.closeList(a, true);
+        expect(a).toEqual(b);
+      });
+    });
+
+    describe('openList', () => {
+      it('Single-cursor: ', () => {
+        const a = docFromTextNotation('(c•|(|1#b •[:f :b :z])|2•#z•1)');
+        const b = docFromTextNotation('(|c•(#b •[:f :b :z])•#z•1)');
+        handlers.openList(a, false);
+        expect(a).toEqual(b);
+      });
+      it('Multi-cursor: ', () => {
+        const a = docFromTextNotation('(c•|(|1#b •[:f :b :z])|2•#z•1)');
+        const b = docFromTextNotation('(|c•(|1#b •[:f :b :z])•#z•1)');
+        handlers.openList(a, true);
+        // expect(_.uniqWith(a.selections, _.isEqual)).toEqual(b.selections);
+        expect(a.selections).toEqual(b.selections);
+      });
+    });
+  });
+});

--- a/src/paredit/commands.ts
+++ b/src/paredit/commands.ts
@@ -1,0 +1,53 @@
+import { EditableDocument } from '../cursor-doc/model';
+import * as paredit from '../cursor-doc/paredit';
+
+export function forwardSexp(doc: EditableDocument, isMulti: boolean = false) {
+  const selections = isMulti ? doc.selections : [doc.selections[0]];
+  const ranges = selections.map((s) => paredit.forwardSexpRange(doc, s.end));
+  paredit.moveToRangeRight(doc, ranges);
+}
+export function backwardSexp(doc: EditableDocument, isMulti: boolean = false) {
+  const selections = isMulti ? doc.selections : [doc.selections[0]];
+  const ranges = selections.map((s) => paredit.backwardSexpRange(doc, s.start));
+  paredit.moveToRangeLeft(doc, ranges);
+}
+export function forwardDownSexp(doc: EditableDocument, isMulti: boolean = false) {
+  const selections = isMulti ? doc.selections : [doc.selections[0]];
+  const ranges = selections.map((s) => paredit.rangeToForwardDownList(doc, s.end));
+  paredit.moveToRangeRight(doc, ranges);
+}
+export function backwardDownSexp(doc: EditableDocument, isMulti: boolean = false) {
+  const selections = isMulti ? doc.selections : [doc.selections[0]];
+  const ranges = selections.map((s) => paredit.rangeToBackwardDownList(doc, s.start));
+  paredit.moveToRangeLeft(doc, ranges);
+}
+export function forwardUpSexp(doc: EditableDocument, isMulti: boolean = false) {
+  const selections = isMulti ? doc.selections : [doc.selections[0]];
+  const ranges = selections.map((s) => paredit.rangeToForwardUpList(doc, s.end));
+  paredit.moveToRangeRight(doc, ranges);
+}
+export function backwardUpSexp(doc: EditableDocument, isMulti: boolean = false) {
+  const selections = isMulti ? doc.selections : [doc.selections[0]];
+  const ranges = selections.map((s) => paredit.rangeToBackwardUpList(doc, s.start));
+  paredit.moveToRangeLeft(doc, ranges);
+}
+export function forwardSexpOrUp(doc: EditableDocument, isMulti: boolean = false) {
+  const selections = isMulti ? doc.selections : [doc.selections[0]];
+  const ranges = selections.map((s) => paredit.forwardSexpOrUpRange(doc, s.end));
+  paredit.moveToRangeRight(doc, ranges);
+}
+export function backwardSexpOrUp(doc: EditableDocument, isMulti: boolean = false) {
+  const selections = isMulti ? doc.selections : [doc.selections[0]];
+  const ranges = selections.map((s) => paredit.backwardSexpOrUpRange(doc, s.end));
+  paredit.moveToRangeLeft(doc, ranges);
+}
+export function closeList(doc: EditableDocument, isMulti: boolean = false) {
+  const selections = isMulti ? doc.selections : [doc.selections[0]];
+  const ranges = selections.map((s) => paredit.rangeToForwardList(doc, s.end));
+  paredit.moveToRangeRight(doc, ranges);
+}
+export function openList(doc: EditableDocument, isMulti: boolean = false) {
+  const selections = isMulti ? doc.selections : [doc.selections[0]];
+  const ranges = selections.map((s) => paredit.rangeToBackwardList(doc, s.start));
+  paredit.moveToRangeLeft(doc, ranges);
+}

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -11,6 +11,7 @@ import {
   ConfigurationChangeEvent,
 } from 'vscode';
 import * as paredit from '../cursor-doc/paredit';
+import * as handlers from './commands';
 import * as docMirror from '../doc-mirror/index';
 import { EditableDocument } from '../cursor-doc/model';
 import { assertIsDefined } from '../utilities';
@@ -41,6 +42,10 @@ function shouldKillAlsoCutToClipboard() {
   return workspace.getConfiguration().get('calva.paredit.killAlsoCutsToClipboard');
 }
 
+function multiCursorEnabled() {
+  return workspace.getConfiguration().get<boolean>('calva.paredit.multicursor');
+}
+
 type PareditCommand = {
   command: string;
   handler: (doc: EditableDocument) => void | Promise<any>;
@@ -50,61 +55,61 @@ const pareditCommands: PareditCommand[] = [
   {
     command: 'paredit.forwardSexp',
     handler: (doc: EditableDocument) => {
-      paredit.moveToRangeRight(doc, paredit.forwardSexpRange(doc));
+      handlers.forwardSexp(doc, multiCursorEnabled());
     },
   },
   {
     command: 'paredit.backwardSexp',
     handler: (doc: EditableDocument) => {
-      paredit.moveToRangeLeft(doc, paredit.backwardSexpRange(doc));
+      handlers.backwardSexp(doc, multiCursorEnabled());
     },
   },
   {
     command: 'paredit.forwardDownSexp',
     handler: (doc: EditableDocument) => {
-      paredit.moveToRangeRight(doc, paredit.rangeToForwardDownList(doc));
+      handlers.forwardDownSexp(doc, multiCursorEnabled());
     },
   },
   {
     command: 'paredit.backwardDownSexp',
     handler: (doc: EditableDocument) => {
-      paredit.moveToRangeLeft(doc, paredit.rangeToBackwardDownList(doc));
+      handlers.backwardDownSexp(doc, multiCursorEnabled());
     },
   },
   {
     command: 'paredit.forwardUpSexp',
     handler: (doc: EditableDocument) => {
-      paredit.moveToRangeRight(doc, paredit.rangeToForwardUpList(doc));
+      handlers.forwardUpSexp(doc, multiCursorEnabled());
     },
   },
   {
     command: 'paredit.backwardUpSexp',
     handler: (doc: EditableDocument) => {
-      paredit.moveToRangeLeft(doc, paredit.rangeToBackwardUpList(doc));
+      handlers.backwardUpSexp(doc, multiCursorEnabled());
     },
   },
   {
     command: 'paredit.forwardSexpOrUp',
     handler: (doc: EditableDocument) => {
-      paredit.moveToRangeRight(doc, paredit.forwardSexpOrUpRange(doc));
+      handlers.forwardSexpOrUp(doc, multiCursorEnabled());
     },
   },
   {
     command: 'paredit.backwardSexpOrUp',
     handler: (doc: EditableDocument) => {
-      paredit.moveToRangeLeft(doc, paredit.backwardSexpOrUpRange(doc));
+      handlers.backwardSexpOrUp(doc, multiCursorEnabled());
     },
   },
   {
     command: 'paredit.closeList',
     handler: (doc: EditableDocument) => {
-      paredit.moveToRangeRight(doc, paredit.rangeToForwardList(doc));
+      handlers.closeList(doc, multiCursorEnabled());
     },
   },
   {
     command: 'paredit.openList',
     handler: (doc: EditableDocument) => {
-      paredit.moveToRangeLeft(doc, paredit.rangeToBackwardList(doc));
+      handlers.openList(doc, multiCursorEnabled());
     },
   },
 


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

Depends on (is branched off of) #2419.

- Implement support for multicursor paredit movement commands, gated behind an experimental config.
- Along the way, introduces new indirection between `src/paredit/extension.ts` and `src/cursor-doc/paredit.ts` -> `src/paredit/commands.ts`, where the multicursor config setting is read.

Other smaller changes:
- **Clean up code/types, make StringDocument dedupe selections**
- **Add multicursor setting to manifest**
- **Add changelog entry**

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2420

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
        - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
