### PR TITLE
Paredit Multicursor - Implement selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Add selection to experimentally supported multicursor paredit commands](https://github.com/BetterThanTomorrow/calva/issues/2421). Enable `calva.paredit.multicursor` in your settings to try it out. Addressing [#610](https://github.com/BetterThanTomorrow/calva/issues/610)
+
 ## [2.0.417] - 2024-03-08
 
 - [Implement experimental support for multicursor paredit movement commands](https://github.com/BetterThanTomorrow/calva/issues/2420). Enable `calva.paredit.multicursor` in your settings to try it out. Addressing [#610](https://github.com/BetterThanTomorrow/calva/issues/610)

--- a/package.json
+++ b/package.json
@@ -960,7 +960,7 @@
           },
           "calva.paredit.multicursor": {
             "type": "boolean",
-            "markdownDescription": "Experimental: Support for multiple cursors in paredit commands.\nCurrently supported commands:\n- Cursor movement",
+            "markdownDescription": "Experimental: Support for multiple cursors in paredit commands.\nCurrently supported commands:\n- Cursor movement\n- Cursor selection",
             "default": false,
             "scope": "window"
           }

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -704,7 +704,7 @@ export class StringDocument implements EditableDocument {
    * - Remove selections contained in another, ie, prefer larger selections
    */
   set selections(newSelections: ModelEditSelection[]) {
-    let uniqueSelections = _(newSelections)
+    const uniqueSelections = _(newSelections)
       // drop nils
       .compact()
       // simple deduping of duplicate ranges

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -255,7 +255,12 @@ export interface EditableModel {
 export interface EditableDocument {
   selections: ModelEditSelection[];
   model: EditableModel;
-  selectionStack: ModelEditSelection[];
+  /**
+   * Selection history stack for grow/shrink selection operations.
+   * Is a 2d array to represent multiple cursors/selections at each grow/shrink step,
+   * with the first Selection of each inner array being the primar and possibly only cursor.
+   */
+  selectionsStack: ModelEditSelection[][];
   getTokenCursor: (offset?: number, previous?: boolean) => LispTokenCursor;
   insertString: (text: string) => void;
   getSelectionText: () => string;
@@ -723,7 +728,7 @@ export class StringDocument implements EditableDocument {
 
   model: LineInputModel;
 
-  selectionStack: ModelEditSelection[] = [];
+  selectionsStack: ModelEditSelection[][] = [];
 
   getTokenCursor(offset?: number, previous?: boolean): LispTokenCursor {
     if (isUndefined(offset)) {

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -210,6 +210,22 @@ export class ModelEditSelection {
 
     return this;
   }
+
+  static isSameRange(a: ModelEditSelection, b: ModelEditSelection) {
+    return _.isEqual(a?.asRange, b?.asRange);
+  }
+
+  static isSameSelection(a: ModelEditSelection, b: ModelEditSelection) {
+    return _.isEqual(a?.asDirectedRange, b?.asDirectedRange);
+  }
+
+  static containsRange(container: ModelEditSelection, containee: ModelEditSelection) {
+    if (containee && container) {
+      const containsStart = containee.start >= container.start && containee.start <= container.end;
+      const containsEnd = containee.end >= container.start && containee.end <= container.end;
+      return containsStart && containsEnd;
+    }
+  }
 }
 
 export type ModelEditOptions = {

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -129,7 +129,7 @@ export class MirroredDocument implements EditableDocument {
 
   model = new DocumentModel(this);
 
-  selectionStack: ModelEditSelection[] = [];
+  selectionsStack: ModelEditSelection[][] = [];
 
   public getTokenCursor(
     offset: number = this.selections[0].active,

--- a/src/paredit/commands.ts
+++ b/src/paredit/commands.ts
@@ -1,6 +1,8 @@
 import { EditableDocument } from '../cursor-doc/model';
 import * as paredit from '../cursor-doc/paredit';
 
+// MOVEMENT
+
 export function forwardSexp(doc: EditableDocument, isMulti: boolean = false) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.forwardSexpRange(doc, s.end));
@@ -50,4 +52,54 @@ export function openList(doc: EditableDocument, isMulti: boolean = false) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.rangeToBackwardList(doc, s.start));
   paredit.moveToRangeLeft(doc, ranges);
+}
+
+// SELECTION
+
+export function rangeForDefun(doc: EditableDocument, isMulti: boolean) {
+  const selections = isMulti ? doc.selections : [doc.selections[0]];
+  const ranges = selections.map((s) => paredit.rangeForDefun(doc, s.active));
+  paredit.selectRange(doc, ranges);
+}
+export function sexpRangeExpansion(doc: EditableDocument, isMulti: boolean) {
+  paredit.growSelection(doc, isMulti ? doc.selections : [doc.selections[0]]);
+}
+export function sexpRangeContraction(doc: EditableDocument, isMulti: boolean) {
+  paredit.shrinkSelection(doc, isMulti ? doc.selections : [doc.selections[0]]);
+}
+export function selectForwardSexp(doc: EditableDocument, isMulti: boolean) {
+  paredit.selectForwardSexp(doc, isMulti ? doc.selections : [doc.selections[0]]);
+}
+export function selectRight(doc: EditableDocument, isMulti: boolean) {
+  paredit.selectRight(doc, isMulti ? doc.selections : [doc.selections[0]]);
+}
+/* export function selectLeft(doc: EditableDocument, isMulti: boolean) {
+  paredit.selectLeft(doc, isMulti ? doc.selections : [doc.selections[0]]);
+} */
+export function selectBackwardSexp(doc: EditableDocument, isMulti: boolean) {
+  paredit.selectBackwardSexp(doc, isMulti ? doc.selections : [doc.selections[0]]);
+}
+export function selectForwardDownSexp(doc: EditableDocument, isMulti: boolean) {
+  paredit.selectForwardDownSexp(doc, isMulti ? doc.selections : [doc.selections[0]]);
+}
+export function selectBackwardDownSexp(doc: EditableDocument, isMulti: boolean) {
+  paredit.selectBackwardDownSexp(doc, isMulti ? doc.selections : [doc.selections[0]]);
+}
+export function selectForwardUpSexp(doc: EditableDocument, isMulti: boolean) {
+  paredit.selectForwardUpSexp(doc, isMulti ? doc.selections : [doc.selections[0]]);
+}
+export function selectForwardSexpOrUp(doc: EditableDocument, isMulti: boolean) {
+  paredit.selectForwardSexpOrUp(doc, isMulti ? doc.selections : [doc.selections[0]]);
+}
+export function selectBackwardSexpOrUp(doc: EditableDocument, isMulti: boolean) {
+  paredit.selectBackwardSexpOrUp(doc, isMulti ? doc.selections : [doc.selections[0]]);
+}
+export function selectBackwardUpSexp(doc: EditableDocument, isMulti: boolean) {
+  paredit.selectBackwardUpSexp(doc, isMulti ? doc.selections : [doc.selections[0]]);
+}
+export function selectCloseList(doc: EditableDocument, isMulti: boolean) {
+  paredit.selectCloseList(doc, isMulti ? doc.selections : [doc.selections[0]]);
+}
+export function selectOpenList(doc: EditableDocument, isMulti: boolean) {
+  paredit.selectOpenList(doc, isMulti ? doc.selections : [doc.selections[0]]);
 }

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -117,61 +117,101 @@ const pareditCommands: PareditCommand[] = [
   {
     command: 'paredit.rangeForDefun',
     handler: (doc: EditableDocument) => {
-      paredit.selectRange(doc, paredit.rangeForDefun(doc));
+      const isMulti = multiCursorEnabled();
+      handlers.rangeForDefun(doc, isMulti);
     },
   },
   {
     command: 'paredit.sexpRangeExpansion',
-    handler: paredit.growSelection,
-  }, // TODO: Inside string should first select contents
+    handler: (doc: EditableDocument) => {
+      const isMulti = multiCursorEnabled();
+      handlers.sexpRangeExpansion(doc, isMulti);
+    },
+  },
   {
     command: 'paredit.sexpRangeContraction',
-    handler: paredit.shrinkSelection,
+    handler: (doc: EditableDocument) => {
+      const isMulti = multiCursorEnabled();
+      handlers.sexpRangeContraction(doc, isMulti);
+    },
   },
 
   {
     command: 'paredit.selectForwardSexp',
-    handler: paredit.selectForwardSexp,
+    handler: (doc: EditableDocument) => {
+      const isMulti = multiCursorEnabled();
+      handlers.selectForwardSexp(doc, isMulti);
+    },
   },
   {
     command: 'paredit.selectRight',
-    handler: paredit.selectRight,
+    handler: (doc: EditableDocument) => {
+      const isMulti = multiCursorEnabled();
+      handlers.selectRight(doc, isMulti);
+    },
   },
   {
     command: 'paredit.selectBackwardSexp',
-    handler: paredit.selectBackwardSexp,
+    handler: (doc: EditableDocument) => {
+      const isMulti = multiCursorEnabled();
+      handlers.selectBackwardSexp(doc, isMulti);
+    },
   },
   {
     command: 'paredit.selectForwardDownSexp',
-    handler: paredit.selectForwardDownSexp,
+    handler: (doc: EditableDocument) => {
+      const isMulti = multiCursorEnabled();
+      handlers.selectForwardDownSexp(doc, isMulti);
+    },
   },
   {
     command: 'paredit.selectBackwardDownSexp',
-    handler: paredit.selectBackwardDownSexp,
+    handler: (doc: EditableDocument) => {
+      const isMulti = multiCursorEnabled();
+      handlers.selectBackwardDownSexp(doc, isMulti);
+    },
   },
   {
     command: 'paredit.selectForwardUpSexp',
-    handler: paredit.selectForwardUpSexp,
+    handler: (doc: EditableDocument) => {
+      const isMulti = multiCursorEnabled();
+      handlers.selectForwardUpSexp(doc, isMulti);
+    },
   },
   {
     command: 'paredit.selectForwardSexpOrUp',
-    handler: paredit.selectForwardSexpOrUp,
+    handler: (doc: EditableDocument) => {
+      const isMulti = multiCursorEnabled();
+      handlers.selectForwardSexpOrUp(doc, isMulti);
+    },
   },
   {
     command: 'paredit.selectBackwardSexpOrUp',
-    handler: paredit.selectBackwardSexpOrUp,
+    handler: (doc: EditableDocument) => {
+      const isMulti = multiCursorEnabled();
+      handlers.selectBackwardSexpOrUp(doc, isMulti);
+    },
   },
   {
     command: 'paredit.selectBackwardUpSexp',
-    handler: paredit.selectBackwardUpSexp,
+    handler: (doc: EditableDocument) => {
+      const isMulti = multiCursorEnabled();
+      handlers.selectBackwardUpSexp(doc, isMulti);
+    },
   },
   {
     command: 'paredit.selectCloseList',
-    handler: paredit.selectCloseList,
+    handler: (doc: EditableDocument) => {
+      const isMulti = multiCursorEnabled();
+      handlers.selectCloseList(doc, isMulti);
+    },
   },
   {
     command: 'paredit.selectOpenList',
-    handler: paredit.selectOpenList,
+    handler: (doc: EditableDocument) => {
+      const isMulti = multiCursorEnabled();
+      handlers.selectOpenList(doc, isMulti);
+    },
   },
 
   // EDITING


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

Depends on (ie branches off of) #2424 

Add multicursor support for paredit selection commands, including the usual movement-command-equivalents and grow/shrink selection.

Other changes:
- **Add util methods to ModelEditSelections**
- **make StringDocument selections dedupe like real vscode document selections** - ie, overlapping selections prefer the larger one.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2421

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
        - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
