### PR TITLE
Don't print prompt from catch-all out handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Slowness printing compiler errors and warnings to Output Window](https://github.com/BetterThanTomorrow/calva/issues/2291)
+
 ## [2.0.420] - 2024-03-10
 
 - [Allow to use an array of strings for `afterCLJReplJackInCode` in a connect sequence](https://github.com/BetterThanTomorrow/calva/issues/2423)

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -292,9 +292,7 @@ export class NReplSession {
         outputWindow.append(msgData.out);
       } else if (msgData.err) {
         const err = formatAsLineComments(msgData.err);
-        outputWindow.appendLine(err, (_) => {
-          outputWindow.appendPrompt();
-        });
+        outputWindow.appendLine(err);
       }
     }
   }


### PR DESCRIPTION
## What has changed?

In our catch-all nrepl message output handler we were using the callback to print a prompt after the message.
1. This doesn't make sense, we should just let the messages print and not assume a prompt should be printed too
2. This slows the printing down something awful
3. The prompts where all printed after a batch of messages

I haven't fixed 2 or 3, just removed the callback argument. Which speeds the printing up and doesn't hit the bug with the prompt written later (since no prompt is written).

* Addresses #2291
  * There's more to that issue, so we should leave it open

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
