### PR TITLE
1104 output dispatch interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Add Output Destinations configuration](https://github.com/BetterThanTomorrow/calva/issues/1104)
+
 ## [2.0.422] - 2024-03-11
 
 - Bump deps.clj to `v1.11.2.1446`

--- a/docs/site/output.md
+++ b/docs/site/output.md
@@ -1,6 +1,6 @@
 ---
 title: Evaluation results and outher output
-description: Calva displays the first line of the evaluation results inline, and also prints results, other REPL output, and other output to the configured Output Destination.
+description: Calva displays the first line of the evaluation results inline, and also prints results, other REPL output and more to the configured Output Destination.
 ---
 
 # Output Destinations

--- a/docs/site/output.md
+++ b/docs/site/output.md
@@ -1,140 +1,20 @@
 ---
-title: The Output/REPL Window
-description: When Calva evaluates Clojure/ClojureScript code, the results are displayed inline as well as printed to the results output window.
+title: Evaluation results and outher output
+description: Calva displays the first line of the evaluation results inline, and also prints results, other REPL output, and other output to the configured Output Destination.
 ---
 
-# The Output/REPL Window/File
+# Output Destinations
 
-When Calva evaluates Clojure/ClojureScript code, the results are displayed inline as well as printed to the results output window/file. This file is created and opened when Calva is connected to a REPL.
+Calva categorizes output into three types:
 
-In ClojureScript projects the window will be associated with the `cljs` REPL once this one is connected. It will then look something like so:
+* **evaluation results**: Clojure data returned from an evaluation.
+* **evaluation output**: stdout/stderr from an evaluation
+* **other output**: Other messages, logs, etc
 
-![Output Window Connected](images/howto/output/output-window-connected.png)
+With the setting `calva.outputDestinations`, you can configure where each category of output should go to:
 
-The first prompt is from when the `clj` REPL is connected, the second when Calva has a `cljs` REPL connection. The first part of the prompt tells you which REPL type the window is currently connected to. This gets important when the file/window is used as an interactive REPL.
-
-## Find the Output/REPL Window
-
-If you quickly want to open and switch to the output window there is the command **Calva: Show Output Window**, `ctrl+alt+o o`.
-
-To sync the Output/REPL window namespace with the current file before switching, use the **Switch Namespace of the Output/REPL Window to Current Namespace** command, `ctrl+alt+c alt+n`.
-
-## Find the File for the Current REPL Window Namespace
-
-When you are working from the Output/REPL window, and want to open the file that defines its current namespace, use the **Show File for the Current Output/REPL Window Namespace** command, `ctrl+alt+o o`.
-
-!!! Note
-    This also works for Clojure core and library namespaces.
-
-## Evaluating Code
-
-The window will be automatically associated with the REPL and the namespace of any project Clojure/ClojureScript file you evaluate code in. So for instance if you evaluate this code in a `clj` file with the namespace `fresh-reagent.handler`:
-
-```clojure
-(def mount-target
-  [:div#app
-   [:h2 "Welcome to fresh-reagent"]
-   [:p "please wait while Figwheel is waking up ..."]
-   [:p "(Check the js console for hints if nothing exciting happens.)"]])
-```
-
-The output window will print the defined var and then a new prompt reflecting the current REPL connection and namespace:
-
-![eval-results-1](images/howto/output/eval-results-1.png)
-
-If you then switch to the output window (`ctrl+alt+o o`), and enter this at the prompt:
-
-```clojure
-mount-target
-```
-
-then evaluate it using `alt+enter`, you'll get:
-
-![eval-results-2](images/howto/output/eval-results-2.png)
-
-This, since the namespace ”followed” the first evaluation over to the output window.
-
-## REPL History
-
-Recently evaluated forms in the REPL file are persisted and can easily be shown again for modifying and re-evaluating.
-
-### Navigate REPL History
-
-You can navigate up and down the last forms evaluated in the REPL file by using `alt+up` and `alt+down`, provided your cursor is at the end of the last form after the prompt. If the cursor is not at the end of the last form, then `alt+up` and `alt+down` will do what they are mapped to, which is by default "Move Line Up" and "Move Line Down," respectively.
-
-If you have typed some text after the prompt before you start traversing up the history, this text will be preserved and will display when you traverse back down the history. If you modify some text in the history while traversing, the modification will be saved at that location in history.
-
-### Clear REPL History
-
-You can clear the repl history by running the command "Clear REPL History" from the command palette.
-
-## Stack Traces
-
-When an evaluation produces an error, the output window will automatically print the the error message. If there is a stack trace associated with the error, this can now be printed on demand using the **Calva: Print Last Stacktrace to the Output Window** command. The output window will also have a Codelense button below the error message that will print the stack trace..
-
-![Print Stacktrace Codelense button](images/howto/output/print-stacktrace-codelense.png "Print Stacktrace Codelense button")
-
-For printed stacktraces, when source locations are available (Clojure files) you will be able to navigate to them by pressing `ctrl+click` (`cmd+click` on Mac) on the file name. You can also hover over symbols in the stack trace to see the symbol's documentation, and `ctrl+click` (`cmd+click` on Mac) the symbol to Peek Definition.
-
-![Stack trace clicking and peeking definition](images/howto/output/stack-traces.gif "Stack trace clicking and peeking definition")
-
-## Load Current Namespace
-
-When navigating namespaces it is easy to [forget to first require them](https://clojure.org/guides/repl/navigating_namespaces#_how_things_can_go_wrong) and that can be a bit tricky to fix. To help with this Calva's command **Load/Evaluate Current File and its Requires/Dependencies** also works in the output window, but then acts like **Load Current Namespace**.
-
-Consider you have two files, `pez/xxx.clj` and `pez/yyy.clj`, where `pez.yyy` requires `pez.xxx`.
-
-```clojure
-(ns pez.xxx)
-
-(def a :xxx-a)
-
-(def b :xxx-b)
-```
-
-```clojure
-(ns pez.yyy
-  (:require [pez.xxx]))
-
-(def a :yyy-a)
-
-(println "Hello" pez.xxx/a)
-```
-
-Then with a freshly jacked-in REPL you do `(ns pez.yyy)` and want to work with the vars defined there. Clojure will complain. But if you **Load/Evaluate Current File and its Requires/Dependencies**, it will start working. Something like so:
-
-![Load Current Namespace in the Calva Output Window](images/howto/output/load-current-namespace.png)
-
-!!! Note
-    This currently suffers from a limitation in Calva where it won't reload dependencies, so you will sometimes have to do this ”manually” anyway (by opening the files and loading them). See [Calva issue #907](https://github.com/BetterThanTomorrow/calva/issues/907)
-
-### Peek Current Namespace
-
-A somewhat hidden feature: You can see documentation for, peek and navigate to a namespace by hovering on the namespace symbol in one of the repl window prompts (just like you would if it was not in the prompt 😄).
-
-## Paredit Enabled
-
-The output window is mostly a regular Calva Clojure/ClojureScript file, which make everything that works in a regular file work in this file, including [Paredit](paredit.md). This makes it easy to navigate the input and output. For instance, to select the last evaluation results you can press `ctrl+w` (`shift+alt+right` on Windows and Linux):
-
-![Paredit select current form](images/howto/output/select-last-result.png)
-
-## Debugger Enabled
-
-The output window is mostly a regular... (you get it), which means you also have the [Calva debugger](debugger.md) at your command at the REPL prompt (only for `clj` sessions, so far). So instead of evaluating a function definition using `alt+enter` you can evaluate it and instrument it for debugging using `ctrl+alt+c i`. Then call the function.
-
-![repl-file debugger](images/howto/output/repl-file-debugger.png)
-
-## It is Ephemeral
-
-The contents of the output/REPL window is written to a file named `output.repl` in the `.calva/output-window` directory of your project. The file is recreated at every new session. And you should copy anything you want to keep from this file to wherever you want to keep it.
-
-You probably want to add `.calva/output-window/` to your `.<something>ignore` files. (There are some more files in that directory that you shouldn't keep under source control.)
-
-## Choose CLJ or CLJS REPL Connection
-
-In full stack projects, you will probably use the window as a REPL for both `clj` and `cljs`. You can toggle which REPL the window is connected to using the command **Calva: Toggle REPL Connection for CLJC files**. There is a button for this in the status bar:
-
-![Toggle CLJC](images/howto/cljc-toggle-button.png)
+* the [REPL Window](repl-window.md)
+* the _Calva Says_ Output Channel.
 
 ## REPL process output (stdout and stderr)
 
@@ -145,11 +25,3 @@ When Calva is connected to the REPL, the Output window will by default print not
 3. Anything printed to `stdout` and `stderr` by the REPL process
 
 You can control the default via the `calva.redirectServerOutputToRepl` setting. It defaults to `true`. Setting it to `false` before connecting the REPL will result in that **2.** and **3.** will not get printed in the Output window. It will then instead be printed wherever the REPL process is printing its messages, usually the terminal from where it was started (the **Jack-in terminal** if Calva started the REPL).
-
-The main reason for keeping the default is that all output from an evaluation is kept together, instead of some of it in the Output window and some of it in the REPL process terminal. It comes with the side effect that all REPL process output will also be printed in the Output window. There is currently no way to separate these. If you are working mostly in ClojureScript, you might want to disable `calva.redirectServerOutputToRepl`, since there are no child threads there anyway.
-
-## Known Quirks
-
-Due to limitations in the VS Code API it is hard for Calva to know if the output file is opened, and also if it is opened more than once. Make it a habit to leave this window opened. And if it is opened in several tabs, expect evaluation printouts to be a bit unpredictable.
-
-If you save the output/REPL file (which most often does not make much sense, but anyway) you will sometimes be presented with a message about VS Code being confused about the file contents being out of sync. Just choose to *Overwrite* the currently saved version and you should be fine.

--- a/docs/site/repl-window.md
+++ b/docs/site/repl-window.md
@@ -1,25 +1,25 @@
 ---
 title: The REPL Window
-description: The REPL window can be used for experimental code and can also double as an output window, displaying the results of evaluations and other output.
+description: The REPL window can be used as a live coding environment, and can also double as an output window, displaying the results of evaluations from any buffer and other output.
 ---
 
 # The REPL Window/File
 
-When Calva REPL Window is actually a regular file with some extra treament from Calva like displaying a prompt and generally “following” the current namespace. This file is created and opened when Calva is connected to a REPL. You can use it for experimental code (though there are also [Rich Comments](rich-comments.md) and [Fiddle Files](fiddle-files.md) for this). 
+The Calva REPL Window is actually a regular file with some extra treatment from Calva, like displaying a prompt, offering evaluation history recall and generally “following” the current namespace. This file is created and opened when Calva is connected to a REPL. You can use it for experimental code (though there are also [Rich Comments](rich-comments.md) and [Fiddle Files](fiddle-files.md) for this). 
 
-In ClojureScript projects the window will be associated with the `cljs` REPL once this one is connected. It will then look something like so:
+In ClojureScript projects, the window will be associated with the `cljs` REPL once it is connected. It will then look something like this:
 
 ![REPL Window Connected](images/howto/output/output-window-connected.png)
 
-The first prompt is from when the `clj` REPL is connected, the second when Calva has a `cljs` REPL connection. The first part of the prompt tells you which REPL type the window is currently connected to. This gets important when the file/window is used as an interactive REPL.
+The first prompt is from when the `clj` REPL is connected, and the second from `cljs`. The first _part_ of the prompt tells you which REPL type the window is currently connected to.
 
 ## Using the REPL Window for output
 
-By default the REPL Window doubles as the place where Calva sends output, like stdout/stderr and other messages. See [Calva Output](output.md) for more about this and how to change this behaviour.
+By default the REPL Window doubles as the place where Calva sends output like stdout/stderr and other messages. See [Calva Output](output.md) for more about this and how to change this behaviour.
 
 ## Finding the REPL Window
 
-If you quickly want to open and switch to the output window there is the command **Calva: Show/Open REPL Window**, `ctrl+alt+o r`.
+If you quickly want to open and/or switch to the REPL Window there is the command **Calva: Show/Open REPL Window**, `ctrl+alt+o r`.
 
 To sync the REPL window namespace with the current file before switching, use the **Switch Namespace of the REPL Window to Current Namespace** command, `ctrl+alt+c alt+n`.
 
@@ -42,7 +42,7 @@ The window will be automatically associated with the REPL and the namespace of a
    [:p "(Check the js console for hints if nothing exciting happens.)"]])
 ```
 
-If the REPL Window is set to be the output destination for evaluation results, the REPL window will print the defined var (otherwixe it will be printed to the destination configured). The REPL window will regardless print a new prompt reflecting the current REPL connection and namespace:
+If the REPL Window is the configured destination for evaluation results, the defined var will be printed there. Otherwise, it will be printed to the destination you've configured. In either case, the REPL window will print a new prompt reflecting the current REPL connection and namespace:
 
 ![eval-results-1](images/howto/output/eval-results-1.png)
 
@@ -52,11 +52,11 @@ If you then switch to the output window (`ctrl+alt+o r`), and enter this at the 
 mount-target
 ```
 
-then evaluate it using `alt+enter`, you'll get:
+then evaluate it using `alt+enter`, you'll get this:
 
 ![eval-results-2](images/howto/output/eval-results-2.png)
 
-This, since the namespace ”followed” the first evaluation over to the output window.
+... because the namespace ”followed” the first evaluation in the REPL window.
 
 ## REPL History
 
@@ -64,7 +64,7 @@ Recently evaluated forms in the REPL file are persisted and can easily be shown 
 
 ### Navigate REPL History
 
-You can navigate up and down the last forms evaluated in the REPL file by using `alt+up` and `alt+down`, provided your cursor is at the end of the last form after the prompt. If the cursor is not at the end of the last form, then `alt+up` and `alt+down` will do what they are mapped to, which is by default "Move Line Up" and "Move Line Down," respectively.
+You can navigate up and down the history of evaluated forms in the REPL file by pressing `alt+up` and `alt+down`, provided your cursor is at the end of the last form after the prompt. If the cursor is not at the end of the last form, then `alt+up` and `alt+down` will do whatever they are mapped to, which is by default "Move Line Up" and "Move Line Down," respectively.
 
 If you have typed some text after the prompt before you start traversing up the history, this text will be preserved and will display when you traverse back down the history. If you modify some text in the history while traversing, the modification will be saved at that location in history.
 
@@ -74,11 +74,11 @@ You can clear the repl history by running the command "Clear REPL History" from 
 
 ## Stack Traces
 
-When an evaluation produces an error, the output window will automatically print the the error message. If there is a stack trace associated with the error, this can now be printed on demand using the **Calva: Print Last Stacktrace to the Output Window** command. The output window will also have a Codelense button below the error message that will print the stack trace..
+When an evaluation produces an error, it will automatically be printed in the REPL Window. If there is a stack trace associated with the error, it can now be printed on demand using the **Calva: Print Last Stacktrace to the Output Window** command. You can also print the stack trace for any error message printed to the REPL Window via the Codelens button below it.
 
 ![Print Stacktrace Codelense button](images/howto/output/print-stacktrace-codelense.png "Print Stacktrace Codelense button")
 
-For printed stacktraces, when source locations are available (Clojure files) you will be able to navigate to them by pressing `ctrl+click` (`cmd+click` on Mac) on the file name. You can also hover over symbols in the stack trace to see the symbol's documentation, and `ctrl+click` (`cmd+click` on Mac) the symbol to Peek Definition.
+For printed stacktraces, when source locations are available (Clojure files), you will be able to navigate to them by pressing `ctrl+click` (`cmd+click` on Mac) on the file name. You can also hover over symbols in the stack trace to see the symbol's documentation, and `ctrl+click` (`cmd+click` on Mac) the symbol to Peek Definition.
 
 ![Stack trace clicking and peeking definition](images/howto/output/stack-traces.gif "Stack trace clicking and peeking definition")
 
@@ -87,9 +87,9 @@ For printed stacktraces, when source locations are available (Clojure files) you
 
 ## Load Current Namespace
 
-When navigating namespaces it is easy to [forget to first require them](https://clojure.org/guides/repl/navigating_namespaces#_how_things_can_go_wrong) and that can be a bit tricky to fix. To help with this Calva's command **Load/Evaluate Current File and its Requires/Dependencies** also works in the output window, but then acts like **Load Current Namespace**.
+When navigating namespaces it is easy to [forget to first require them](https://clojure.org/guides/repl/navigating_namespaces#_how_things_can_go_wrong) and that can be tricky to debug. To help with this, Calva's command **Load/Evaluate Current File and its Requires/Dependencies** also works in the REPL Window, but there, it acts like **Load Current Namespace**.
 
-Consider you have two files, `pez/xxx.clj` and `pez/yyy.clj`, where `pez.yyy` requires `pez.xxx`.
+Suppose you have two files, `pez/xxx.clj` and `pez/yyy.clj`, where `pez.yyy` requires `pez.xxx`.
 
 ```clojure
 (ns pez.xxx)
@@ -108,44 +108,44 @@ Consider you have two files, `pez/xxx.clj` and `pez/yyy.clj`, where `pez.yyy` re
 (println "Hello" pez.xxx/a)
 ```
 
-Then with a freshly jacked-in REPL you do `(ns pez.yyy)` and want to work with the vars defined there. Clojure will complain. But if you **Load/Evaluate Current File and its Requires/Dependencies**, it will start working. Something like so:
+Then, with a freshly jacked-in REPL, you evaluate `(ns pez.yyy)` and want to work with the vars defined there, Clojure will complain. But if you **Load/Evaluate Current File and its Requires/Dependencies**, it will start working. Something like so:
 
 ![Load Current Namespace in the Calva Output Window](images/howto/output/load-current-namespace.png)
 
 !!! Note
-    This currently suffers from a limitation in Calva where it won't reload dependencies, so you will sometimes have to do this ”manually” anyway (by opening the files and loading them). See [Calva issue #907](https://github.com/BetterThanTomorrow/calva/issues/907)
+    This currently suffers from a limitation in Calva where it won't reload dependencies, so you will sometimes have to do this ”manually” anyways (by opening the files and loading them yourself). See [Calva issue #907](https://github.com/BetterThanTomorrow/calva/issues/907)
 
 ### Peek Current Namespace
 
-A somewhat hidden feature: You can see documentation for, peek and navigate to a namespace by hovering on the namespace symbol in one of the repl window prompts (just like you would if it was not in the prompt 😄).
+A somewhat hidden feature: You can peek, see documentation for, and navigate to a namespace by hovering on the namespace symbol in one of the REPL Window prompts (just like you would if it was not in the prompt 😄).
 
 ## Paredit Enabled
 
-The output window is mostly a regular Calva Clojure/ClojureScript file, which make everything that works in a regular file work in this file, including [Paredit](paredit.md). This makes it easy to navigate the input and output. For instance, to select the last evaluation results you can press `ctrl+w` (`shift+alt+right` on Windows and Linux):
+The REPL Window is mostly a regular Calva Clojure/ClojureScript file, which makes everything that works in a regular file work in this file, including [Paredit](paredit.md). This makes it easy to navigate the input and output there. For instance, to select the last evaluation results, you can press `ctrl+w` (`shift+alt+right` on Windows and Linux):
 
 ![Paredit select current form](images/howto/output/select-last-result.png)
 
 ## Debugger Enabled
 
-The output window is mostly a regular... (you get it), which means you also have the [Calva debugger](debugger.md) at your command at the REPL prompt (only for `clj` sessions, so far). So instead of evaluating a function definition using `alt+enter` you can evaluate it and instrument it for debugging using `ctrl+alt+c i`. Then call the function.
+The output window is mostly a regular... (you get it), which means you also have the [Calva debugger](debugger.md) at your command at the REPL prompt (only for `clj` sessions, for now). So instead of evaluating a function definition using `alt+enter`, you can evaluate it and instrument it for debugging using `ctrl+alt+c i`, and then call the function.
 
 ![repl-file debugger](images/howto/output/repl-file-debugger.png)
 
 ## It is Ephemeral
 
-The contents of the output/REPL window is written to a file named `output.repl` in the `.calva/output-window` directory of your project. The file is recreated at every new session. And you should copy anything you want to keep from this file to wherever you want to keep it.
+The contents of the output/REPL window is written to a file named `output.repl` in the `.calva/output-window` directory of your project. The file is recreated every new session, so you should copy or save anything you want to preserve between sessions.
 
 You probably want to add `.calva/output-window/` to your `.<something>ignore` files. (There are some more files in that directory that you shouldn't keep under source control.)
 
 ## Choose CLJ or CLJS REPL Connection
 
-In full stack projects, you will probably use the window as a REPL for both `clj` and `cljs`. You can toggle which REPL the window is connected to using the command **Calva: Toggle REPL Connection for CLJC files**. There is a button for this in the status bar:
+In full-stack projects, you will probably use the window as a REPL for both `clj` and `cljs`. You can toggle which REPL the window is connected to by using the command **Calva: Toggle REPL Connection for CLJC files**. There is also a button for this in the status bar:
 
 ![Toggle CLJC](images/howto/cljc-toggle-button.png)
 
 
-## Known Quirks
+## Known Quirks and Caveats
 
-Due to limitations in the VS Code API it is hard for Calva to know if the REPL file is opened, and also if it is opened more than once. Make it a habit to leave this window opened. And if it is opened in several tabs, expect evaluation printouts to be a bit unpredictable.
+Due to limitations in the VS Code API it is hard for Calva to know if the REPL file is open, and if it was opened more than once. Therefore, we suggest you make it a habit to leave this window open, or even pinned. And if it is open in several tabs, expect evaluation printouts to be a bit unpredictable.
 
 If you save the REPL file (which most often does not make much sense, but anyway) you will sometimes be presented with a message about VS Code being confused about the file contents being out of sync. Just choose to *Overwrite* the currently saved version and you should be fine.

--- a/docs/site/repl-window.md
+++ b/docs/site/repl-window.md
@@ -1,0 +1,151 @@
+---
+title: The REPL Window
+description: The REPL window can be used for experimental code and can also double as an output window, displaying the results of evaluations and other output.
+---
+
+# The REPL Window/File
+
+When Calva REPL Window is actually a regular file with some extra treament from Calva like displaying a prompt and generally “following” the current namespace. This file is created and opened when Calva is connected to a REPL. You can use it for experimental code (though there are also [Rich Comments](rich-comments.md) and [Fiddle Files](fiddle-files.md) for this). 
+
+In ClojureScript projects the window will be associated with the `cljs` REPL once this one is connected. It will then look something like so:
+
+![REPL Window Connected](images/howto/output/output-window-connected.png)
+
+The first prompt is from when the `clj` REPL is connected, the second when Calva has a `cljs` REPL connection. The first part of the prompt tells you which REPL type the window is currently connected to. This gets important when the file/window is used as an interactive REPL.
+
+## Using the REPL Window for output
+
+By default the REPL Window doubles as the place where Calva sends output, like stdout/stderr and other messages. See [Calva Output](output.md) for more about this and how to change this behaviour.
+
+## Finding the REPL Window
+
+If you quickly want to open and switch to the output window there is the command **Calva: Show/Open REPL Window**, `ctrl+alt+o r`.
+
+To sync the REPL window namespace with the current file before switching, use the **Switch Namespace of the REPL Window to Current Namespace** command, `ctrl+alt+c alt+n`.
+
+## Find the File for the Current REPL Window Namespace
+
+When you are editing things in the REPL window, and want to open the file that defines its current namespace, use the **Show File for the Current REPL Window Namespace** command, `ctrl+alt+o r`.
+
+!!! Note
+    This also works for Clojure core and library namespaces.
+
+## Evaluating Code
+
+The window will be automatically associated with the REPL and the namespace of any project Clojure/ClojureScript file you evaluate code in. So for instance if you evaluate this code in a `clj` file with the namespace `fresh-reagent.handler`:
+
+```clojure
+(def mount-target
+  [:div#app
+   [:h2 "Welcome to fresh-reagent"]
+   [:p "please wait while Figwheel is waking up ..."]
+   [:p "(Check the js console for hints if nothing exciting happens.)"]])
+```
+
+If the REPL Window is set to be the output destination for evaluation results, the REPL window will print the defined var (otherwixe it will be printed to the destination configured). The REPL window will regardless print a new prompt reflecting the current REPL connection and namespace:
+
+![eval-results-1](images/howto/output/eval-results-1.png)
+
+If you then switch to the output window (`ctrl+alt+o r`), and enter this at the prompt:
+
+```clojure
+mount-target
+```
+
+then evaluate it using `alt+enter`, you'll get:
+
+![eval-results-2](images/howto/output/eval-results-2.png)
+
+This, since the namespace ”followed” the first evaluation over to the output window.
+
+## REPL History
+
+Recently evaluated forms in the REPL file are persisted and can easily be shown again for modifying and re-evaluating.
+
+### Navigate REPL History
+
+You can navigate up and down the last forms evaluated in the REPL file by using `alt+up` and `alt+down`, provided your cursor is at the end of the last form after the prompt. If the cursor is not at the end of the last form, then `alt+up` and `alt+down` will do what they are mapped to, which is by default "Move Line Up" and "Move Line Down," respectively.
+
+If you have typed some text after the prompt before you start traversing up the history, this text will be preserved and will display when you traverse back down the history. If you modify some text in the history while traversing, the modification will be saved at that location in history.
+
+### Clear REPL History
+
+You can clear the repl history by running the command "Clear REPL History" from the command palette.
+
+## Stack Traces
+
+When an evaluation produces an error, the output window will automatically print the the error message. If there is a stack trace associated with the error, this can now be printed on demand using the **Calva: Print Last Stacktrace to the Output Window** command. The output window will also have a Codelense button below the error message that will print the stack trace..
+
+![Print Stacktrace Codelense button](images/howto/output/print-stacktrace-codelense.png "Print Stacktrace Codelense button")
+
+For printed stacktraces, when source locations are available (Clojure files) you will be able to navigate to them by pressing `ctrl+click` (`cmd+click` on Mac) on the file name. You can also hover over symbols in the stack trace to see the symbol's documentation, and `ctrl+click` (`cmd+click` on Mac) the symbol to Peek Definition.
+
+![Stack trace clicking and peeking definition](images/howto/output/stack-traces.gif "Stack trace clicking and peeking definition")
+
+!!! Note "Output destinations"
+    If you have configured some other destination for stderr output, the error message will be printed there as well. But it will _also_ be printed to the REPL Window, because the augmented stack traces need this (because reasons). 
+
+## Load Current Namespace
+
+When navigating namespaces it is easy to [forget to first require them](https://clojure.org/guides/repl/navigating_namespaces#_how_things_can_go_wrong) and that can be a bit tricky to fix. To help with this Calva's command **Load/Evaluate Current File and its Requires/Dependencies** also works in the output window, but then acts like **Load Current Namespace**.
+
+Consider you have two files, `pez/xxx.clj` and `pez/yyy.clj`, where `pez.yyy` requires `pez.xxx`.
+
+```clojure
+(ns pez.xxx)
+
+(def a :xxx-a)
+
+(def b :xxx-b)
+```
+
+```clojure
+(ns pez.yyy
+  (:require [pez.xxx]))
+
+(def a :yyy-a)
+
+(println "Hello" pez.xxx/a)
+```
+
+Then with a freshly jacked-in REPL you do `(ns pez.yyy)` and want to work with the vars defined there. Clojure will complain. But if you **Load/Evaluate Current File and its Requires/Dependencies**, it will start working. Something like so:
+
+![Load Current Namespace in the Calva Output Window](images/howto/output/load-current-namespace.png)
+
+!!! Note
+    This currently suffers from a limitation in Calva where it won't reload dependencies, so you will sometimes have to do this ”manually” anyway (by opening the files and loading them). See [Calva issue #907](https://github.com/BetterThanTomorrow/calva/issues/907)
+
+### Peek Current Namespace
+
+A somewhat hidden feature: You can see documentation for, peek and navigate to a namespace by hovering on the namespace symbol in one of the repl window prompts (just like you would if it was not in the prompt 😄).
+
+## Paredit Enabled
+
+The output window is mostly a regular Calva Clojure/ClojureScript file, which make everything that works in a regular file work in this file, including [Paredit](paredit.md). This makes it easy to navigate the input and output. For instance, to select the last evaluation results you can press `ctrl+w` (`shift+alt+right` on Windows and Linux):
+
+![Paredit select current form](images/howto/output/select-last-result.png)
+
+## Debugger Enabled
+
+The output window is mostly a regular... (you get it), which means you also have the [Calva debugger](debugger.md) at your command at the REPL prompt (only for `clj` sessions, so far). So instead of evaluating a function definition using `alt+enter` you can evaluate it and instrument it for debugging using `ctrl+alt+c i`. Then call the function.
+
+![repl-file debugger](images/howto/output/repl-file-debugger.png)
+
+## It is Ephemeral
+
+The contents of the output/REPL window is written to a file named `output.repl` in the `.calva/output-window` directory of your project. The file is recreated at every new session. And you should copy anything you want to keep from this file to wherever you want to keep it.
+
+You probably want to add `.calva/output-window/` to your `.<something>ignore` files. (There are some more files in that directory that you shouldn't keep under source control.)
+
+## Choose CLJ or CLJS REPL Connection
+
+In full stack projects, you will probably use the window as a REPL for both `clj` and `cljs`. You can toggle which REPL the window is connected to using the command **Calva: Toggle REPL Connection for CLJC files**. There is a button for this in the status bar:
+
+![Toggle CLJC](images/howto/cljc-toggle-button.png)
+
+
+## Known Quirks
+
+Due to limitations in the VS Code API it is hard for Calva to know if the REPL file is opened, and also if it is opened more than once. Make it a habit to leave this window opened. And if it is opened in several tabs, expect evaluation printouts to be a bit unpredictable.
+
+If you save the REPL file (which most often does not make much sense, but anyway) you will sometimes be presented with a message about VS Code being confused about the file contents being out of sync. Just choose to *Overwrite* the currently saved version and you should be fine.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
     - connect-sequences.md
     - notebooks.md
     - clojuredocs.md
+    - repl-window.md
     - output.md
     - debugger.md
     - pprint.md

--- a/package.json
+++ b/package.json
@@ -165,6 +165,46 @@
         "type": "object",
         "title": "Calva",
         "properties": {
+          "calva.outputDestinations": {
+            "type": "object",
+            "markdownDescription": [
+              "Calva categorizes output into three types:\n- **evaluation results**: Clojure data returned from an evaluation.\n- **evaluation output**: stdout/stderr from an evaluation\n- **other output**: Other messages, logs, etc\n\nYou can select where each category of output should go to: the REPL Window or to the _Calva Says_ Output Channel."
+            ],
+            "properties": {
+              "evalResults": {
+                "type": "string",
+                "enum": [
+                  "repl-window",
+                  "output-channel"
+                ],
+                "default": "repl-window",
+                "markdownDescription": "Destination for evaluation results. (Clojure data returned from an evaluation)."
+              },
+              "evalOutput": {
+                "type": "string",
+                "enum": [
+                  "repl-window",
+                  "output-channel"
+                ],
+                "default": "repl-window",
+                "markdownDescription": "Destination for evaluation output (stdout/stderr from an evaluation)."
+              },
+              "otherOutput": {
+                "type": "string",
+                "enum": [
+                  "repl-window",
+                  "output-channel"
+                ],
+                "default": "repl-window",
+                "markdownDescription": "Destination for other output (Calva messages, out-of-band stdout/stderr, etcetera)."
+              }
+            },
+            "default": {
+              "evalResults": "repl-window",
+              "evalOutput": "repl-window",
+              "otherOutput": "repl-window"
+            }
+          },
           "calva.fiddleFilePaths": {
             "type": "array",
             "markdownDescription": "An array of `source` and `fiddle` root paths, relative to the project root. This is used by the commands **Calva: Open Fiddle File for Current File**, and **Calva: Evaluate Fiddle File for Current File**. Example:\n\n```json\n\"calva.fiddleFilePaths\": [\n  {\n    \"source\": [\"src\"],\n    \"fiddle\": [\"env\", \"dev\", \"fiddles\"]\n  }\n]\n```\n\nThe default is `null`, which will make Calva associate files with a `.fiddle` file extension as the fiddle file for a Clojure file. E.g. a file `src/foo/bar/baz_main.cljc`, will have an associated fiddle file named `src/foo/bar/baz_main.fiddle`. See [calva.io/fiddle](https://calva.io/fiddle-files/) for more info.",

--- a/package.json
+++ b/package.json
@@ -537,7 +537,7 @@
                 },
                 "evaluationSendCodeToOutputWindow": {
                   "type": "boolean",
-                  "markDownDescription": "Should the code snippet evaluated be echoed to the Output/REPL Window?"
+                  "markDownDescription": "Should the code snippet evaluated be echoed to the REPL Window?"
                 }
               },
               "required": [
@@ -785,7 +785,7 @@
                         },
                         "printThisLineRegExp": {
                           "type": "string",
-                          "description": "A regular expression which, when matched in the stdout from any code evaluations in the cljsType, will make the matched text be printed to the Output/REPL window."
+                          "description": "A regular expression which, when matched in the stdout from any code evaluations in the cljsType, will make the matched text be printed to the wherever Calva prints output."
                         }
                       }
                     }
@@ -1911,30 +1911,30 @@
       {
         "category": "Calva",
         "command": "calva.showOutputWindow",
-        "title": "Show Output/REPL Window",
+        "title": "Show/Open REPL Window",
         "enablement": "calva:connected"
       },
       {
         "category": "Calva",
         "command": "calva.showFileForOutputWindowNS",
-        "title": "Show File for the Current Output/REPL Window Namespace",
+        "title": "Show File for the Current REPL Window Namespace",
         "enablement": "calva:connected"
       },
       {
         "command": "calva.setOutputWindowNamespace",
-        "title": "Switch Namespace in Output/REPL Window to Current Namespace",
+        "title": "Switch Namespace in REPL Window to Current Namespace",
         "enablement": "calva:connected",
         "category": "Calva"
       },
       {
         "command": "calva.sendCurrentFormToOutputWindow",
-        "title": "Send Current Form to Output/REPL Window",
+        "title": "Send Current Form to REPL Window",
         "enablement": "calva:connected",
         "category": "Calva"
       },
       {
         "command": "calva.sendCurrentTopLevelFormToOutputWindow",
-        "title": "Send Current Top Level Form to Output/REPL Window",
+        "title": "Send Current Top Level Form to REPL Window",
         "enablement": "calva:connected",
         "category": "Calva"
       },
@@ -2615,12 +2615,12 @@
       },
       {
         "command": "calva.showOutputWindow",
-        "key": "ctrl+alt+o o",
+        "key": "ctrl+alt+o r",
         "when": "calva:keybindingsEnabled && calva:connected && !calva:outputWindowActive"
       },
       {
         "command": "calva.showFileForOutputWindowNS",
-        "key": "ctrl+alt+o o",
+        "key": "ctrl+alt+o r",
         "when": "calva:keybindingsEnabled && calva:connected && calva:outputWindowActive"
       },
       {

--- a/package.json
+++ b/package.json
@@ -785,7 +785,7 @@
                         },
                         "printThisLineRegExp": {
                           "type": "string",
-                          "description": "A regular expression which, when matched in the stdout from any code evaluations in the cljsType, will make the matched text be printed to the wherever Calva prints output."
+                          "description": "A regular expression which, when matched in the stdout from any code evaluations in the cljsType, will make the matched text be printed to wherever Calva prints output."
                         }
                       }
                     }

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
           "calva.outputDestinations": {
             "type": "object",
             "markdownDescription": [
-              "Calva categorizes output into three types:\n- **evaluation results**: Clojure data returned from an evaluation.\n- **evaluation output**: stdout/stderr from an evaluation\n- **other output**: Other messages, logs, etc\n\nYou can select where each category of output should go to: the REPL Window or to the _Calva Says_ Output Channel."
+              "Where different types of Calva output should be printed.\nCalva categorizes output into three types:\n- **evaluation results**: Clojure data returned from an evaluation.\n- **evaluation output**: stdout/stderr from an evaluation\n- **other output**: Other messages, logs, etc\n\nYou can select where each category of output should go to: the REPL Window or to the _Calva Says_ Output Channel."
             ],
             "properties": {
               "evalResults": {

--- a/src/clojuredocs.ts
+++ b/src/clojuredocs.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import * as util from './utilities';
 import * as nrepl from './nrepl';
 import * as lsp from './lsp';
-import * as outputWindow from './results-output/results-doc';
 import * as namespace from './namespace';
 import * as replSession from './nrepl/repl-session';
 import * as docMirror from './doc-mirror/index';
@@ -31,21 +30,20 @@ export function init(cljSession: nrepl.NReplSession) {
   });
 }
 
-export async function printClojureDocsToOutputWindow(clientProvider: lsp.ClientProvider) {
+export async function printClojureDocsToOutput(clientProvider: lsp.ClientProvider) {
   const docs = await clojureDocsLookup(clientProvider);
   if (!docs) {
     return;
   }
-  printTextToOutputWindow(docsEntry2ClojureCode(docs));
+  printTextToOutput(docsEntry2ClojureCode(docs));
 }
 
-export function printTextToOutputWindowCommand(args: { [x: string]: string }) {
-  printTextToOutputWindow(args['text']);
+export function printTextToOutputCommand(args: { [x: string]: string }) {
+  printTextToOutput(args['text']);
 }
 
-function printTextToOutputWindow(text: string) {
-  output.appendClojure(text);
-  outputWindow.appendPrompt();
+function printTextToOutput(text: string) {
+  output.appendClojureOther(text);
 }
 
 export async function printClojureDocsToRichComment(clientProvider: lsp.ClientProvider) {
@@ -135,16 +133,16 @@ function getHoverForExample(
   const printToRCFCommandUri = `command:calva.printTextToRichCommentCommand?${encodeURIComponent(
     JSON.stringify([{ text: exampleAndSeeAlsos, position: position }])
   )}`;
-  const printToOutputWindowCommandUri = `command:calva.printTextToOutputWindowCommand?${encodeURIComponent(
+  const printToOutputCommandUri = `command:calva.printTextToOutputCommand?${encodeURIComponent(
     JSON.stringify([{ text: exampleAndSeeAlsos, position: position }])
   )}`;
   const rcfCommandMd = `[To Rich Comment](${printToRCFCommandUri} "Print the example to a \`(comment ...)\` block")`;
-  const outputWindowCommandMd = `[To Output Window](${printToOutputWindowCommandUri} "Print the example to the Output/REPL Window")`;
+  const outputCommandMd = `[To Output](${printToOutputCommandUri} "Print the example to the Output")`;
   const hover = new vscode.MarkdownString();
   hover.isTrusted = true;
   hover.appendMarkdown(`### ${header}\n\n`);
   if (isWritableDocument) {
-    hover.appendMarkdown(`${rcfCommandMd} | ${outputWindowCommandMd}\n`);
+    hover.appendMarkdown(`${rcfCommandMd} | ${outputCommandMd}\n`);
   }
   hover.appendCodeblock(example, 'clojure');
   return hover;

--- a/src/clojuredocs.ts
+++ b/src/clojuredocs.ts
@@ -7,6 +7,7 @@ import * as namespace from './namespace';
 import * as replSession from './nrepl/repl-session';
 import * as docMirror from './doc-mirror/index';
 import * as paredit from './cursor-doc/paredit';
+import * as output from './results-output/output';
 
 export type DocsEntry = {
   name: string;
@@ -43,7 +44,7 @@ export function printTextToOutputWindowCommand(args: { [x: string]: string }) {
 }
 
 function printTextToOutputWindow(text: string) {
-  outputWindow.appendLine(text);
+  output.appendClojure(text);
   outputWindow.appendPrompt();
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ import _ = require('lodash');
 import { isDefined } from './utilities';
 import * as converters from './converters';
 import * as nreplUtil from './nrepl/util';
+import * as output from './results-output/output';
 
 const REPL_FILE_EXT = 'calva-repl';
 const FIDDLE_FILE_EXT = 'fiddle';
@@ -256,6 +257,8 @@ function getConfig() {
     ),
     redirectServerOutputToRepl: configOptions.get<boolean>('redirectServerOutputToRepl'),
     fiddleFilePaths: configOptions.get<fiddleFilesUtil.FiddleFilePaths>('fiddleFilePaths'),
+    outputDestinations:
+      configOptions.get<output.OutputDestinationConfiguration>('outputDestinations'),
   };
 }
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -348,7 +348,7 @@ function createCLJSReplType(
   const printThisPrinter: processOutputFn = (x) => {
       if (cljsType.printThisLineRegExp) {
         if (x.search(cljsType.printThisLineRegExp) >= 0) {
-          outputWindow.append('; ' + x.replace(/\s*$/, ''));
+          output.appendLineEvalOut(x.trimEnd());
         }
       }
     },

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -29,6 +29,7 @@ import * as jszip from 'jszip';
 import { addEdnConfig, getConfig } from './config';
 import { getJarContents } from './utilities';
 import { ConnectType } from './nrepl/connect-types';
+import * as output from './results-output/output';
 
 async function readJarContent(uri: string) {
   try {

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -112,7 +112,7 @@ async function connectToHost(hostname: string, port: number, connectSequence: Re
     setStateValue('clj', cljSession);
     setStateValue('cljc', cljSession);
     status.update();
-    output.appendLineOtherOut(
+    outputWindow.appendLine(
       `Connected session: clj\n${formatAsLineComments(outputWindow.CLJ_CONNECT_GREETINGS)}`
     );
     replSession.updateReplSessionType();

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -112,9 +112,7 @@ async function connectToHost(hostname: string, port: number, connectSequence: Re
     setStateValue('clj', cljSession);
     setStateValue('cljc', cljSession);
     status.update();
-    outputWindow.appendLine(
-      `Connected session: clj\n${formatAsLineComments(outputWindow.CLJ_CONNECT_GREETINGS)}`
-    );
+    output.appendLineOtherOut(`Connected session: clj`);
     replSession.updateReplSessionType();
 
     outputWindow.setSession(cljSession, nClient.ns);
@@ -197,11 +195,8 @@ async function setUpCljsRepl(session: NReplSession, build) {
   setStateValue('cljs', session);
   setStateValue('cljc', session);
   status.update();
-  output.appendLineOtherOut(
-    `Connected session: cljs${build ? ', repl: ' + build : ''}\n${
-      outputWindow.CLJS_CONNECT_GREETINGS
-    }`
-  );
+  output.appendLineOtherOut(`Connected session: cljs${build ? ', repl: ' + build : ''}`);
+  outputWindow.appendLine(formatAsLineComments(outputWindow.CLJS_CONNECT_GREETINGS));
   const description = await session.describe(true);
   const ns = description.aux?.['current-ns'] || 'user';
   await session.eval(`(in-ns '${ns})`, 'user').value;

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -198,9 +198,9 @@ async function setUpCljsRepl(session: NReplSession, build) {
   setStateValue('cljc', session);
   status.update();
   output.appendLineOtherOut(
-    `Connected session: cljs${build ? ', repl: ' + build : ''}\n${formatAsLineComments(
+    `Connected session: cljs${build ? ', repl: ' + build : ''}\n${
       outputWindow.CLJS_CONNECT_GREETINGS
-    )}`
+    }`
   );
   const description = await session.describe(true);
   const ns = description.aux?.['current-ns'] || 'user';

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -130,7 +130,7 @@ async function connectToHost(hostname: string, port: number, connectSequence: Re
         {}
       );
     }
-    outputWindow.appendPrompt();
+    output.replWindowAppendPrompt();
 
     if (connectSequence.afterCLJReplJackInCode) {
       output.appendLineOtherOut(`Evaluating 'afterCLJReplJackInCode'`);
@@ -141,7 +141,7 @@ async function connectToHost(hostname: string, port: number, connectSequence: Re
         {}
       );
     }
-    outputWindow.appendPrompt();
+    output.replWindowAppendPrompt();
 
     clojureDocs.init(cljSession);
 
@@ -216,7 +216,7 @@ async function setUpCljsRepl(session: NReplSession, build) {
       ns,
       {}
     );
-    outputWindow.appendPrompt();
+    output.replWindowAppendPrompt();
   }
   replSession.updateReplSessionType();
 }
@@ -879,7 +879,7 @@ export default {
       if (outputWindow.isResultsDoc(util.getActiveTextEditor().document)) {
         outputWindow.setSession(newSession, undefined);
         replSession.updateReplSessionType();
-        outputWindow.appendPrompt();
+        output.replWindowAppendPrompt();
       }
       status.update();
     }

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -9,6 +9,7 @@ import * as replSession from './nrepl/repl-session';
 import evaluate from './evaluate';
 import * as state from './state';
 import { getStateValue } from '../out/cljs-lib/cljs-lib';
+import * as output from './results-output/output';
 
 export type CustomREPLCommandSnippet = {
   name: string;
@@ -76,7 +77,7 @@ async function evaluateCodeInContext(
   options: any
 ) {
   const result = await evaluateSnippet(editor, code, context, options);
-  outputWindow.appendPrompt();
+  output.replWindowAppendPrompt();
   return result;
 }
 

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -141,8 +141,8 @@ async function getSnippetDefinition(codeOrKey: string, editorNS: string, editorR
       }
     }
     if (pick === undefined) {
-      outputWindow.appendLine(
-        '; No snippets configured. Configure snippets in `calva.customREPLCommandSnippets`.'
+      output.appendLineOtherOut(
+        'No snippets configured. Configure snippets in `calva.customREPLCommandSnippets`.'
       );
       return;
     }

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -16,6 +16,7 @@ import { getConfig } from './config';
 import * as replSession from './nrepl/repl-session';
 import * as getText from './util/get-text';
 import * as customSnippets from './custom-snippets';
+import * as output from './results-output/output';
 
 function interruptAllEvaluations() {
   if (util.getConnectedState()) {
@@ -113,7 +114,7 @@ async function evaluateCodeUpdatingUI(
       line: line + 1,
       column: column + 1,
       stdout: (m) => {
-        outputWindow.append(m);
+        output.appendEvalOut(m);
       },
       stderr: (m) => err.push(m),
       pprintOptions: pprintOptions,
@@ -526,9 +527,9 @@ async function loadFile(
   const res = session.loadFile(fileContents, {
     fileName,
     filePath,
-    stdout: (m) => outputWindow.append(m),
+    stdout: (m) => output.appendEvalOut(m),
     stderr: (m) => {
-      outputWindow.appendLine(formatAsLineComments(m));
+      output.appendLineEvalErr(m);
       errorMessages.push(m);
     },
     pprintOptions: pprintOptions,

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -272,7 +272,7 @@ async function evaluateSelection(document = {}, options) {
         { ...options, ns, nsForm, line, column, filePath, session },
         codeSelection
       );
-      outputWindow.appendPrompt();
+      output.replWindowAppendPrompt();
     }
   } else {
     void vscode.window.showErrorMessage('Not connected to a REPL');
@@ -504,7 +504,7 @@ async function loadFileCommand() {
   if (util.getConnectedState()) {
     await loadDocument({}, getConfig().prettyPrintingOptions, true);
     return new Promise((resolve) => {
-      outputWindow.appendPrompt(resolve);
+      output.replWindowAppendPrompt(resolve);
     });
   } else {
     offerToConnect();
@@ -678,7 +678,7 @@ async function evaluateInOutputWindow(code: string, sessionType: string, ns: str
     if (outputWindow.getNs() !== ns) {
       outputWindow.setSession(session, ns);
       if (options.evaluationSendCodeToOutputWindow !== false) {
-        outputWindow.appendPrompt();
+        output.replWindowAppendPrompt();
       }
     }
 

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -123,7 +123,7 @@ async function evaluateCodeUpdatingUI(
     try {
       if (evaluationSendCodeToOutputWindow) {
         outputWindow.appendLine(code);
-        if (output.getDestinationConfiguration().evalOutput !== 'output-window') {
+        if (output.getDestinationConfiguration().evalOutput !== 'repl-window') {
           output.appendClojureEval(code);
         }
       }
@@ -170,7 +170,7 @@ async function evaluateCodeUpdatingUI(
             outputWindow.appendLine(formatAsLineComments(errMsg), (_, afterResultLocation) => {
               outputWindow.markLastStacktraceRange(afterResultLocation);
             });
-            if (output.getDestinationConfiguration().evalOutput !== 'output-window') {
+            if (output.getDestinationConfiguration().evalOutput !== 'repl-window') {
               output.appendClojureOther(errMsg);
             }
           } else {
@@ -221,7 +221,7 @@ async function evaluateCodeUpdatingUI(
               console.error(`Failed fetching stacktrace: ${e.message}`);
             });
         });
-        if (output.getDestinationConfiguration().evalOutput !== 'output-window') {
+        if (output.getDestinationConfiguration().evalOutput !== 'repl-window') {
           output.appendLineEvalErr(err.length ? err.join('\n') : e);
         }
       }
@@ -557,7 +557,7 @@ async function loadFile(
         }
       }
     );
-    if (output.getDestinationConfiguration().evalOutput !== 'output-window') {
+    if (output.getDestinationConfiguration().evalOutput !== 'repl-window') {
       output.appendLineEvalErr(`Evaluation of file ${fileName} failed: ${e}`);
     }
     if (

--- a/src/extension-test/integration/suite/jack-in-test.ts
+++ b/src/extension-test/integration/suite/jack-in-test.ts
@@ -49,6 +49,9 @@ suite('Jack-in suite', () => {
   test('start repl and connect (jack-in)', async function () {
     testUtil.log(suite, 'start repl and connect (jack-in)');
 
+    const settings = {};
+    await writeSettings(settings);
+
     const testFilePath = await startJackInProcedure(suite, 'calva.jackIn', 'deps.edn');
 
     await loadAndAssert(suite, testFilePath, ['; bar', 'nil', 'clj꞉test꞉> ']);

--- a/src/extension-test/integration/suite/jack-in-test.ts
+++ b/src/extension-test/integration/suite/jack-in-test.ts
@@ -51,7 +51,7 @@ suite('Jack-in suite', () => {
 
     const testFilePath = await startJackInProcedure(suite, 'calva.jackIn', 'deps.edn');
 
-    await loadAndAssert(suite, testFilePath, ['bar', 'nil', 'clj꞉test꞉> ']);
+    await loadAndAssert(suite, testFilePath, ['; bar', 'nil', 'clj꞉test꞉> ']);
 
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     testUtil.log(suite, 'test.clj closed');
@@ -72,7 +72,7 @@ suite('Jack-in suite', () => {
     };
     await writeSettings(settings);
     const testFilePath = await startJackInProcedure(suite, 'calva.jackIn', 'deps.edn');
-    await loadAndAssert(suite, testFilePath, [':hello :world!', 'bar', 'nil', 'clj꞉test꞉> ']);
+    await loadAndAssert(suite, testFilePath, ['; :hello :world!', '; bar', 'nil', 'clj꞉test꞉> ']);
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     testUtil.log(suite, 'test.clj closed');
   });
@@ -92,7 +92,7 @@ suite('Jack-in suite', () => {
     };
     await writeSettings(settings);
     const testFilePath = await startJackInProcedure(suite, 'calva.jackIn', 'deps.edn');
-    await loadAndAssert(suite, testFilePath, [':hello', ':world!', 'bar', 'nil', 'clj꞉test꞉> ']);
+    await loadAndAssert(suite, testFilePath, ['; :hello', '; :world!', '; bar', 'nil', 'clj꞉test꞉> ']);
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     testUtil.log(suite, 'test.clj closed');
   });
@@ -112,7 +112,7 @@ suite('Jack-in suite', () => {
     };
     await writeSettings(settings);
     const testFilePath = await startJackInProcedure(suite, 'calva.jackIn', undefined, true);
-    await loadAndAssert(suite, testFilePath, ['bar', 'nil', 'clj꞉test꞉> ']);
+    await loadAndAssert(suite, testFilePath, ['; bar', 'nil', 'clj꞉test꞉> ']);
 
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     testUtil.log(suite, 'test.clj closed');

--- a/src/extension-test/integration/suite/jack-in-test.ts
+++ b/src/extension-test/integration/suite/jack-in-test.ts
@@ -148,15 +148,15 @@ async function loadAndAssert(suite: string, testFilePath: string, needleOutputLi
       preserveFocus: false,
     })
   );
-  testUtil.log(suite, 'opened document again');
+  testUtil.log(suite, 'opened test.clj document again');
 
   await commands.executeCommand('calva.loadFile');
   const haystackOutputLines = resultsDoc.model.lineInputModel.lines.map((v) => v.text);
   assert.ok(
     needleOutputLines.every((needle) => haystackOutputLines.includes(needle)),
-    `Expected output to contain all of ${needleOutputLines.join(
+    `Expected output to contain all these lines: [\n${needleOutputLines.join(
       '\n'
-    )}, but got ${haystackOutputLines.join('\n')}`
+    )}\n]\n, but got: [\n${haystackOutputLines.join('\n')}\n]\n`
   );
 }
 
@@ -205,7 +205,7 @@ async function startJackInProcedure(
       // Project root quick pick
       await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
     }
-    await testUtil.sleep(50);
+    await testUtil.sleep(100);
   }
 
   return testFilePath;

--- a/src/extension-test/integration/suite/jack-in-test.ts
+++ b/src/extension-test/integration/suite/jack-in-test.ts
@@ -92,7 +92,13 @@ suite('Jack-in suite', () => {
     };
     await writeSettings(settings);
     const testFilePath = await startJackInProcedure(suite, 'calva.jackIn', 'deps.edn');
-    await loadAndAssert(suite, testFilePath, ['; :hello', '; :world!', '; bar', 'nil', 'clj꞉test꞉> ']);
+    await loadAndAssert(suite, testFilePath, [
+      '; :hello',
+      '; :world!',
+      '; bar',
+      'nil',
+      'clj꞉test꞉> ',
+    ]);
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     testUtil.log(suite, 'test.clj closed');
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -238,13 +238,13 @@ async function activate(context: vscode.ExtensionContext) {
     },
     openUserConfigEdn: config.openCalvaConfigEdn,
     prettyPrintReplaceCurrentForm: edit.prettyPrintReplaceCurrentForm,
-    printClojureDocsToOutputWindow: clojureDocs.printClojureDocsToOutputWindow,
+    printClojureDocsToOutputWindow: clojureDocs.printClojureDocsToOutput,
     printClojureDocsToRichComment: clojureDocs.printClojureDocsToRichComment,
     printLastStacktrace: () => {
       outputWindow.printLastStacktrace();
       outputWindow.appendPrompt();
     },
-    printTextToOutputWindowCommand: clojureDocs.printTextToOutputWindowCommand,
+    printTextToOutputCommand: clojureDocs.printTextToOutputCommand,
     printTextToRichCommentCommand: clojureDocs.printTextToRichCommentCommand,
     refresh: refresh.refresh,
     refreshAll: refresh.refreshAll,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,7 +64,9 @@ function setKeybindingsEnabledContext() {
 function initializeState() {
   setStateValue('connected', false);
   setStateValue('connecting', false);
-  setStateValue('outputChannel', vscode.window.createOutputChannel('Calva says'));
+  const outputChannel = vscode.window.createOutputChannel('Calva says', 'markdown');
+  setStateValue('outputChannel', outputChannel);
+  output.initOutputChannel(outputChannel);
   setStateValue('connectionLogChannel', vscode.window.createOutputChannel('Calva Connection Log'));
   setStateValue(
     'diagnosticCollection',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,7 @@ import { capitalize } from './utilities';
 import * as overrides from './overrides';
 import * as lsp from './lsp';
 import * as fiddleFiles from './fiddle-files';
+import * as output from './results-output/output';
 
 function onDidChangeEditorOrSelection(editor: vscode.TextEditor) {
   replHistory.setReplHistoryCommandsActiveContext(editor);
@@ -242,7 +243,7 @@ async function activate(context: vscode.ExtensionContext) {
     printClojureDocsToRichComment: clojureDocs.printClojureDocsToRichComment,
     printLastStacktrace: () => {
       outputWindow.printLastStacktrace();
-      outputWindow.appendPrompt();
+      output.replWindowAppendPrompt();
     },
     printTextToOutputCommand: clojureDocs.printTextToOutputCommand,
     printTextToRichCommentCommand: clojureDocs.printTextToRichCommentCommand,
@@ -378,7 +379,7 @@ async function activate(context: vscode.ExtensionContext) {
         if (evalOnSave) {
           if (!outputWindow.isResultsDoc(document)) {
             await eval.loadDocument(document, config.getConfig().prettyPrintingOptions, false);
-            outputWindow.appendPrompt();
+            output.replWindowAppendPrompt();
           }
         }
 

--- a/src/fiddle-files.ts
+++ b/src/fiddle-files.ts
@@ -7,7 +7,7 @@ import eval from './evaluate';
 import * as path from 'path';
 import * as namespace from './namespace';
 import * as outputWindow from './results-output/results-doc';
-import * as docMirror from './doc-mirror/index';
+import * as output from './results-output/output';
 
 // TODO: This viewColumn memory could probably be a shared thing for all of Calva.
 //       At least the REPL window has similar functionality an could benefit from this more general approach.
@@ -148,7 +148,7 @@ export async function evaluateFiddleForSourceFile() {
       nsForm,
     });
     return new Promise((resolve) => {
-      outputWindow.appendPrompt(resolve);
+      output.replWindowAppendPrompt(resolve);
     });
   } catch (e) {
     openFiddleForSourceFile();

--- a/src/fiddle-files.ts
+++ b/src/fiddle-files.ts
@@ -143,7 +143,7 @@ export async function evaluateFiddleForSourceFile() {
     const fiddleSelection = filePathToSelection.get(fiddleFilePath);
     const p = fiddleSelection ? doc.offsetAt(fiddleSelection.active) : 0;
     const [ns, nsForm] = nsUtil.nsFromText(code, p) || namespace.getDocumentNamespace();
-    outputWindow.appendLine(`; Evaluating fiddle: ${relativeFiddleFilePath}`);
+    output.appendLineOtherOut(`Evaluating fiddle: ${relativeFiddleFilePath}`);
     await eval.evaluateInOutputWindow(code, path.extname(fiddleFilePath).replace(/^\./, ''), ns, {
       nsForm,
     });

--- a/src/joyride.ts
+++ b/src/joyride.ts
@@ -64,7 +64,7 @@ export async function joyrideJackIn(projectDir: string) {
       .then(async (port) => {
         utilities.setLaunchingState(null);
         await connector.connect(connectSequences.joyrideDefaults[0], true, 'localhost', `${port}`);
-        outputWindow.appendLine('; Jack-in done.');
+        output.appendLineOtherOut('Jack-in done.');
         output.replWindowAppendPrompt();
       })
       .catch((e: Error) => {

--- a/src/joyride.ts
+++ b/src/joyride.ts
@@ -1,4 +1,3 @@
-import status from './status';
 import * as semver from 'semver';
 import * as connector from './connector';
 import * as state from './state';
@@ -8,6 +7,7 @@ import * as open from 'open';
 import * as outputWindow from './results-output/results-doc';
 import * as utilities from './utilities';
 import { ConnectType } from './nrepl/connect-types';
+import * as output from './results-output/output';
 
 const JOYRIDE_NREPL_START_API_VERSION = '0.0.5';
 
@@ -65,7 +65,7 @@ export async function joyrideJackIn(projectDir: string) {
         utilities.setLaunchingState(null);
         await connector.connect(connectSequences.joyrideDefaults[0], true, 'localhost', `${port}`);
         outputWindow.appendLine('; Jack-in done.');
-        outputWindow.appendPrompt();
+        output.replWindowAppendPrompt();
       })
       .catch((e: Error) => {
         console.error('Joyride REPL start failed: ', e);

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -6,6 +6,7 @@ import { Config, getConfig } from '../config';
 import * as outputWindow from '../results-output/results-doc';
 import { formatAsLineComments } from '../results-output/util';
 import { ConnectType } from './connect-types';
+import * as output from '../results-output/output';
 
 enum ProjectTypes {
   'Leiningen' = 'Leiningen',
@@ -305,14 +306,12 @@ const defaultCljsTypes: { [id: string]: CljsTypeConfig } = {
 const connectSequencesDocLink = `  - See https://calva.io/connect-sequences/`;
 
 const defaultProjectSettingMsg = (project: string) =>
-  formatAsLineComments(
-    [
-      `Connecting using "${project}" project type.`,
-      `You can make Calva auto-select this.`,
-      connectSequencesDocLink,
-      '\n',
-    ].join('\n')
-  );
+  [
+    `Connecting using "${project}" project type.`,
+    `You can make Calva auto-select this.`,
+    connectSequencesDocLink,
+    '\n',
+  ].join('\n');
 
 /** Retrieve the replConnectSequences from the config */
 function getCustomConnectSequences(): ReplConnectSequence[] {
@@ -353,7 +352,7 @@ function getConnectSequences(projectTypes: string[]): ReplConnectSequence[] {
 }
 
 function informAboutDefaultProjectForJackIn(project: string) {
-  outputWindow.appendLine(defaultProjectSettingMsg(project));
+  output.appendLineOtherOut(defaultProjectSettingMsg(project));
 }
 
 /**
@@ -384,28 +383,20 @@ function getUserSpecifiedSequence(
     );
 
     if (defaultSequence) {
-      outputWindow.appendLine(
-        formatAsLineComments(
-          [
-            `Auto-selecting project type "${defaultSequence.name}".`,
-            `You can change this from settings:`,
-            connectSequencesDocLink,
-            '\n',
-          ].join('\n')
-        )
+      output.appendLineOtherOut(
+        [
+          `Auto-selecting project type "${defaultSequence.name}".`,
+          `You can change this from settings:`,
+          connectSequencesDocLink,
+          '\n',
+        ].join('\n')
       );
 
       return defaultSequence;
     } else {
-      outputWindow.appendLine(
-        formatAsLineComments(
-          [
-            `Project type "${userSpecifiedProjectType}" not found.`,
-            `You need to update the auto-select setting.`,
-            connectSequencesDocLink,
-            '\n',
-          ].join('\n')
-        )
+      output.appendLineOtherErr(`Project type "${userSpecifiedProjectType}" not found.`);
+      output.appendLineOtherOut(
+        [`You need to update the auto-select setting.`, connectSequencesDocLink, '\n'].join('\n')
       );
     }
   }

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -14,6 +14,7 @@ import { getStateValue, prettyPrint } from '../../out/cljs-lib/cljs-lib';
 import { getConfig } from '../config';
 import { log, Direction } from './logging';
 import * as string from '../util/string';
+import * as output from '../results-output/output';
 
 function hasStatus(res: any, status: string): boolean {
   return res.status && res.status.indexOf(status) > -1;
@@ -289,10 +290,9 @@ export class NReplSession {
 
     if ((msgData.out || msgData.err) && this.replType) {
       if (msgData.out) {
-        outputWindow.append(msgData.out);
+        output.appendEvalOut(msgData.out);
       } else if (msgData.err) {
-        const err = formatAsLineComments(msgData.err);
-        outputWindow.appendLine(err);
+        output.appendLineEvalErr(msgData.err);
       }
     }
   }

--- a/src/nrepl/jack-in-terminal.ts
+++ b/src/nrepl/jack-in-terminal.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as child from 'child_process';
 import * as kill from 'tree-kill';
-import * as outputWindow from '../results-output/results-doc';
+import * as output from '../results-output/output';
 
 export interface JackInTerminalOptions extends vscode.TerminalOptions {
   name: string;
@@ -35,7 +35,7 @@ export class JackInTerminal implements vscode.Pseudoterminal {
   ) {}
 
   open(initialDimensions: vscode.TerminalDimensions | undefined): void {
-    outputWindow.appendLine(`; Starting Jack-in Terminal: ${createCommandLine(this.options)}`);
+    output.appendLineOtherOut(`Starting Jack-in Terminal: ${createCommandLine(this.options)}`);
     this.writeEmitter.fire(
       'This is a pseudo terminal, only used for hosting the Jack-in REPL process. It takes no input.\r\nPressing ctrl+c with this terminal focused, killing this terminal, or closing/reloading the VS Code window will all stop/kill the Jack-in REPL process.\r\n\r\n'
     );

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -19,6 +19,7 @@ import * as liveShareSupport from '../live-share';
 import { getConfig } from '../config';
 import * as joyride from '../joyride';
 import { ConnectType } from './connect-types';
+import * as output from '../results-output/output';
 
 let jackInPTY: JackInTerminal = undefined;
 let jackInTerminal: vscode.Terminal = undefined;
@@ -74,7 +75,7 @@ function executeJackInTask(
           utilities.setJackedInState(true);
           statusbar.update();
           outputWindow.appendLine('; Jack-in done.');
-          outputWindow.appendPrompt();
+          output.replWindowAppendPrompt();
           if (cb) {
             cb();
           }

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -74,7 +74,7 @@ function executeJackInTask(
         void connector.connect(connectSequence, true, hostname, port).then(() => {
           utilities.setJackedInState(true);
           statusbar.update();
-          outputWindow.appendLine('; Jack-in done.');
+          output.appendLineOtherOut('Jack-in done.');
           output.replWindowAppendPrompt();
           if (cb) {
             cb();
@@ -82,10 +82,10 @@ function executeJackInTask(
         });
       },
       (errorMessage) => {
-        outputWindow.appendLine('; Error in Jack-in: unable to read port file');
-        outputWindow.appendLine(`; ${errorMessage}`);
-        outputWindow.appendLine(
-          '; You may have chosen the wrong jack-in configuration for your project.'
+        output.appendLineOtherErr('Error in Jack-in: unable to read port file');
+        output.appendLineOtherErr(`${errorMessage}`);
+        output.appendLineOtherErr(
+          'You may have chosen the wrong jack-in configuration for your project.'
         );
         void vscode.window.showErrorMessage(
           'Error in Jack-in: unable to read port file. See output window for more information.'
@@ -300,14 +300,14 @@ export async function jackIn(
     console.error('An error occurred while setting up Live Share listener.', e);
   }
   if (state.getProjectRootUri().scheme === 'vsls') {
-    outputWindow.appendLine("; Aborting Jack-in, since you're the guest of a live share session.");
-    outputWindow.appendLine(
-      '; Please use this command instead: Connect to a running REPL server in the project.'
+    output.appendLineOtherErr("Aborting Jack-in, since you're the guest of a live share session.");
+    output.appendLineOtherOut(
+      'Please use this command instead: Connect to a running REPL server in the project.'
     );
     return;
   }
   await outputWindow.initResultsDoc();
-  outputWindow.appendLine('; Jacking in...');
+  output.appendLineOtherOut('Jacking in...');
   await outputWindow.openResultsDoc();
 
   let projectConnectSequence: ReplConnectSequence = connectSequence;
@@ -315,13 +315,13 @@ export async function jackIn(
     try {
       projectConnectSequence = await getProjectConnectSequence(disableAutoSelect);
     } catch (e) {
-      outputWindow.appendLine(`; ${e}\n; Aborting jack-in.`);
+      output.appendLineOtherErr(`${e}\nAborting jack-in.`);
       // TODO: Figure out why this is not shown to the user.
       void vscode.window.showErrorMessage(e, 'OK');
       return;
     }
     if (!projectConnectSequence) {
-      outputWindow.appendLine('; Aborting jack-in. No project type selected.');
+      output.appendLineOtherErr('Aborting jack-in. No project type selected.');
       return;
     }
   }
@@ -392,7 +392,7 @@ export function calvaDisconnect() {
           utilities.setLaunchingState(null);
           utilities.setConnectingState(false);
           statusbar.update();
-          outputWindow.appendLine('; Interrupting Jack-in process.');
+          output.appendLineOtherOut('Interrupting Jack-in process.');
         }
       });
     return;

--- a/src/nrepl/repl-start.ts
+++ b/src/nrepl/repl-start.ts
@@ -11,6 +11,7 @@ import * as replSession from './repl-session';
 import * as cljsLib from '../../out/cljs-lib/cljs-lib';
 import { ReplConnectSequence } from './connectSequence';
 import * as fiddleFiles from '../fiddle-files';
+import * as output from '../results-output/output';
 
 const TEMPLATES_SUB_DIR = 'bundled';
 const DRAM_BASE_URL = 'https://raw.githubusercontent.com/BetterThanTomorrow/dram';
@@ -265,7 +266,7 @@ export async function startStandaloneRepl(
       preserveFocus: false,
     });
     await eval.loadDocument({}, getConfig().prettyPrintingOptions);
-    outputWindow.appendPrompt();
+    output.replWindowAppendPrompt();
   });
 }
 

--- a/src/providers/annotations.ts
+++ b/src/providers/annotations.ts
@@ -27,24 +27,6 @@ const evalResultsDecorationType = vscode.window.createTextEditorDecorationType({
   rangeBehavior: vscode.DecorationRangeBehavior.ClosedOpen,
 });
 
-let resultsLocations: [vscode.Range, vscode.Position, vscode.Location][] = [];
-
-function getResultsLocation(pos: vscode.Position): vscode.Location | undefined {
-  for (const [range, _evaluatePosition, location] of resultsLocations) {
-    if (range.contains(pos)) {
-      return location;
-    }
-  }
-}
-
-function getEvaluationPosition(pos: vscode.Position): vscode.Position | undefined {
-  for (const [range, evaluatePosition, _location] of resultsLocations) {
-    if (range.contains(pos)) {
-      return evaluatePosition;
-    }
-  }
-}
-
 function evaluated(contentText, hoverText, hasError) {
   return {
     renderOptions: {
@@ -102,7 +84,6 @@ function clearEvaluationDecorations(editor?: vscode.TextEditor) {
       setSelectionDecorations(editor, [], status);
     }
   }
-  resultsLocations = [];
 }
 
 function clearAllEvaluationDecorations() {
@@ -137,7 +118,6 @@ function decorateSelection(
   codeSelection: vscode.Selection,
   editor: vscode.TextEditor,
   evaluatePosition: vscode.Position,
-  resultsLocation,
   status: AnnotationStatus
 ) {
   const uri = editor.document.uri;
@@ -167,9 +147,6 @@ function decorateSelection(
   setSelectionDecorations(editor, [], status);
   decorationRanges.push(decoration);
   setSelectionDecorations(editor, decorationRanges, status);
-  if (status == AnnotationStatus.SUCCESS || status == AnnotationStatus.ERROR) {
-    resultsLocations.push([codeSelection, evaluatePosition, resultsLocation]);
-  }
 }
 
 function onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent) {
@@ -196,6 +173,4 @@ export default {
   decorateResults,
   decorateSelection,
   onDidChangeTextDocument,
-  getResultsLocation,
-  getEvaluationPosition,
 };

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -20,9 +20,7 @@ async function provideClojureDefinition(
   position: vscode.Position,
   _token
 ) {
-  const evalPos = annotations.getEvaluationPosition(position);
-  const posIsEvalPos = evalPos && position.isEqual(evalPos);
-  if (util.getConnectedState() && !posIsEvalPos) {
+  if (util.getConnectedState()) {
     const client = replSession.getSession(util.getFileType(document));
     if (client?.supports('info')) {
       const text = util.getWordAtPosition(document, position);

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -8,10 +8,8 @@ export interface AfterAppendCallback {
 }
 
 let outputChannel: vscode.OutputChannel;
-function initOutputChannel() {
-  if (!outputChannel) {
-    outputChannel = vscode.window.createOutputChannel('Calva Results', 'markdown');
-  }
+export function initOutputChannel(channel: vscode.OutputChannel) {
+  outputChannel = channel;
 }
 
 export type OutputDestination = 'repl-window' | 'output-channel';
@@ -55,7 +53,6 @@ function appendClojure(
     return;
   }
   if (destination === 'output-channel') {
-    initOutputChannel();
     outputChannel.appendLine(
       (didLastTerminateLine ? '' : '\n') + '```clojure\n' + message + '\n```'
     );
@@ -99,7 +96,6 @@ function append(destination: OutputDestination, message: string, after?: AfterAp
     return;
   }
   if (destination === 'output-channel') {
-    initOutputChannel();
     outputChannel.append(util.stripAnsi(message));
     // TODO: Deal with `after`
     return;
@@ -163,7 +159,6 @@ function appendLine(destination: OutputDestination, message: string, after?: Aft
     return;
   }
   if (destination === 'output-channel') {
-    initOutputChannel();
     outputChannel.appendLine(message);
     return;
   }

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -1,6 +1,7 @@
 import * as outputWindow from './results-doc';
 import * as config from '../config';
 import * as vscode from 'vscode';
+import * as util from '../utilities';
 
 export interface AfterAppendCallback {
   (insertLocation: vscode.Location, newPosition?: vscode.Location): any;
@@ -92,14 +93,14 @@ function append(destination: OutputDestination, message: string, after?: AfterAp
   didLastOutputTerminateLine[destination] = message.endsWith('\n');
   if (destination === 'output-window') {
     outputWindow.append(
-      `${didLastTerminateLine ? '; ' : ''}${asClojureLineComments(message)}`,
+      `${didLastTerminateLine ? '; ' : ''}${asClojureLineComments(util.stripAnsi(message))}`,
       after
     );
     return;
   }
   if (destination === 'output-channel') {
     initOutputChannel();
-    outputChannel.append(message);
+    outputChannel.append(util.stripAnsi(message));
     return;
   }
 }
@@ -155,7 +156,7 @@ function appendLine(destination: OutputDestination, message: string, after?: Aft
   didLastOutputTerminateLine[destination] = true;
   if (destination === 'output-window') {
     outputWindow.appendLine(
-      `${didLastTerminateLine ? '; ' : ''}${asClojureLineComments(message)}`,
+      `${didLastTerminateLine ? '; ' : ''}${asClojureLineComments(util.stripAnsi(message))}`,
       after
     );
     return;

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -1,0 +1,83 @@
+import * as outputWindow from './results-doc';
+import * as config from '../config';
+import * as vscode from 'vscode';
+
+export interface AfterAppendCallback {
+  (insertLocation: vscode.Location, newPosition?: vscode.Location): any;
+}
+
+let outputChannel: vscode.OutputChannel;
+function initOutputChannel() {
+  if (!outputChannel) {
+    outputChannel = vscode.window.createOutputChannel('Calva Results', 'markdown');
+  }
+}
+
+type OutputDestinations = 'output-window' | 'output-channel';
+
+export type OutputDestinationConfiguration = {
+  results: OutputDestinations;
+  out: OutputDestinations;
+};
+
+export const defaultDestinationConfiguration: OutputDestinationConfiguration = {
+  results: 'output-channel',
+  out: 'output-channel',
+};
+
+function getDestinationConfiguration(): OutputDestinationConfiguration {
+  return config.getConfig().outputDestinations || defaultDestinationConfiguration;
+}
+
+export function appendClojure(message: string, after?: AfterAppendCallback) {
+  const destination = getDestinationConfiguration().results;
+  if (destination === 'output-window') {
+    outputWindow.append(`${message}\n`, after);
+    return;
+  }
+  if (destination === 'output-channel') {
+    initOutputChannel();
+    outputChannel.append('```clojure\n' + message + '\n```\n');
+    return;
+  }
+}
+
+let didLastOutputTerminateLine = true;
+
+export function appendOut(message: string, after?: AfterAppendCallback) {
+  const destination = getDestinationConfiguration().out;
+  if (destination === 'output-window') {
+    if (!didLastOutputTerminateLine) {
+      outputWindow.append('\n');
+    }
+    outputWindow.append(`${(didLastOutputTerminateLine ? '; ' : '') + message}`, after);
+    didLastOutputTerminateLine = message.endsWith('\n');
+    return;
+  }
+  if (destination === 'output-channel') {
+    initOutputChannel();
+    outputChannel.append(message);
+    return;
+  }
+}
+
+function asClojureLineComments(message: string) {
+  return message
+    .split('\n')
+    .map((line) => `; ${line}`)
+    .join('\n');
+}
+
+export function appendLineOut(message: string, after?: AfterAppendCallback) {
+  const destination = getDestinationConfiguration().out;
+  if (destination === 'output-window') {
+    didLastOutputTerminateLine = true;
+    outputWindow.appendLine(asClojureLineComments(message), after);
+    return;
+  }
+  if (destination === 'output-channel') {
+    initOutputChannel();
+    outputChannel.appendLine(message);
+    return;
+  }
+}

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -23,9 +23,9 @@ export type OutputDestinationConfiguration = {
 };
 
 export const defaultDestinationConfiguration: OutputDestinationConfiguration = {
-  evalResults: 'output-channel',
-  evalOutput: 'output-channel',
-  otherOutput: 'output-channel',
+  evalResults: 'output-window',
+  evalOutput: 'output-window',
+  otherOutput: 'output-window',
 };
 
 function getDestinationConfiguration(): OutputDestinationConfiguration {
@@ -33,10 +33,7 @@ function getDestinationConfiguration(): OutputDestinationConfiguration {
 }
 
 function asClojureLineComments(message: string) {
-  return message
-    .split('\n')
-    .map((line) => `; ${line}`)
-    .join('\n');
+  return message.replace(/\n(?!$)/g, '\n; ');
 }
 
 // Used to decide if new output result output should be prepended with a newline or not.

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -216,3 +216,13 @@ export function appendLineOtherErr(message: string, after?: AfterAppendCallback)
   const destination = getDestinationConfiguration().otherOutput;
   appendLine(destination, message, after);
 }
+
+/**
+ * Appends a prompt to the output window.
+ * Needs to be called via here, because we keep track of wether the last output ended with a newline or not.
+ * @param onAppended Optional callback to run after the append
+ */
+export function replWindowAppendPrompt(onAppended?: outputWindow.OnAppendedCallback) {
+  didLastOutputTerminateLine['output-window'] = true;
+  outputWindow.appendPrompt(onAppended);
+}

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -13,52 +13,22 @@ function initOutputChannel() {
   }
 }
 
-type OutputDestinations = 'output-window' | 'output-channel';
+export type OutputDestination = 'output-window' | 'output-channel';
 
 export type OutputDestinationConfiguration = {
-  results: OutputDestinations;
-  out: OutputDestinations;
+  evalResults: OutputDestination;
+  evalOutput: OutputDestination;
+  otherOutput: OutputDestination;
 };
 
 export const defaultDestinationConfiguration: OutputDestinationConfiguration = {
-  results: 'output-channel',
-  out: 'output-channel',
+  evalResults: 'output-channel',
+  evalOutput: 'output-channel',
+  otherOutput: 'output-channel',
 };
 
 function getDestinationConfiguration(): OutputDestinationConfiguration {
   return config.getConfig().outputDestinations || defaultDestinationConfiguration;
-}
-
-export function appendClojure(message: string, after?: AfterAppendCallback) {
-  const destination = getDestinationConfiguration().results;
-  if (destination === 'output-window') {
-    outputWindow.append(`${message}\n`, after);
-    return;
-  }
-  if (destination === 'output-channel') {
-    initOutputChannel();
-    outputChannel.append('```clojure\n' + message + '\n```\n');
-    return;
-  }
-}
-
-let didLastOutputTerminateLine = true;
-
-export function appendOut(message: string, after?: AfterAppendCallback) {
-  const destination = getDestinationConfiguration().out;
-  if (destination === 'output-window') {
-    if (!didLastOutputTerminateLine) {
-      outputWindow.append('\n');
-    }
-    outputWindow.append(`${(didLastOutputTerminateLine ? '; ' : '') + message}`, after);
-    didLastOutputTerminateLine = message.endsWith('\n');
-    return;
-  }
-  if (destination === 'output-channel') {
-    initOutputChannel();
-    outputChannel.append(message);
-    return;
-  }
 }
 
 function asClojureLineComments(message: string) {
@@ -68,11 +38,126 @@ function asClojureLineComments(message: string) {
     .join('\n');
 }
 
-export function appendLineOut(message: string, after?: AfterAppendCallback) {
-  const destination = getDestinationConfiguration().out;
+// Used to decide if new output result output should be prepended with a newline or not.
+// Also: For non-result output, the repl window output should be be printed as line comments.
+const didLastOutputTerminateLine = {
+  'output-window': true,
+  'output-channel': true,
+};
+
+function appendClojure(
+  destination: OutputDestination,
+  message: string,
+  after?: AfterAppendCallback
+) {
+  const didLastTerminateLine = didLastOutputTerminateLine[destination];
+  didLastOutputTerminateLine[destination] = true;
   if (destination === 'output-window') {
-    didLastOutputTerminateLine = true;
-    outputWindow.appendLine(asClojureLineComments(message), after);
+    outputWindow.append(`${didLastTerminateLine ? '' : '\n'}${message}\n`, after);
+    return;
+  }
+  if (destination === 'output-channel') {
+    initOutputChannel();
+    outputChannel.append((didLastTerminateLine ? '' : '\n') + '```clojure\n' + message + '\n```\n');
+    return;
+  }
+}
+
+/**
+ * Appends evaluation related Clojure code.
+ * Prepending with newline if last output did not end with a newline.
+ * Fencing in a `clojure` markdown block if destination is `output-channel`.
+ * @param code The code to append
+ * @param after Optional callback to run after the append
+ */
+export function appendClojureEval(code: string, after?: AfterAppendCallback) {
+  const destination = getDestinationConfiguration().evalResults;
+  appendClojure(destination, code, after);
+}
+
+/**
+ * Appends evaluation related Clojure code.
+ * Prepending with newline if last output did not end with a newline.
+ * Fencing in a `clojure` markdown block if destination is `output-channel`.
+ * @param code The code to append
+ * @param after Optional callback to run after the append
+ */
+export function appendClojureOther(message: string, after?: AfterAppendCallback) {
+  const destination = getDestinationConfiguration().otherOutput;
+  appendClojure(destination, message, after);
+}
+
+function append(destination: OutputDestination, message: string, after?: AfterAppendCallback) {
+  const didLastTerminateLine = didLastOutputTerminateLine[destination];
+  didLastOutputTerminateLine[destination] = message.endsWith('\n');
+  if (destination === 'output-window') {
+    outputWindow.append(
+      `${didLastTerminateLine ? '; ' : ''}${asClojureLineComments(message)}`,
+      after
+    );
+    return;
+  }
+  if (destination === 'output-channel') {
+    initOutputChannel();
+    outputChannel.append(message);
+    return;
+  }
+}
+
+/**
+ * Appends output without adding a newline at the end.
+ * Use for stdout messages related to an evaluation
+ * @param message The message to append
+ * @param after Optional callback to run after the append
+ */
+export function appendEvalOut(message: string, after?: AfterAppendCallback) {
+  const destination = getDestinationConfiguration().evalOutput;
+  append(destination, message, after);
+}
+
+/**
+ * Appends output without adding a newline at the end.
+ * Use for stderr messages related to an evaluation
+ * @param message The message to append
+ * @param after Optional callback to run after the append
+ */
+export function appendEvalErr(message: string, after?: AfterAppendCallback) {
+  const destination = getDestinationConfiguration().evalOutput;
+  append(destination, message, after);
+}
+
+/**
+ * Appends output without adding a newline at the end.
+ * Use for stdout and other messages not related to an evaluation
+ * (e.g. out of band messages)
+ * @param message The message to append
+ * @param after Optional callback to run after the append
+ */
+export function appendOtherOut(message: string, after?: AfterAppendCallback) {
+  const destination = getDestinationConfiguration().otherOutput;
+  append(destination, message, after);
+}
+
+/**
+ * Appends output without adding a newline at the end.
+ * Use for stderr and other error messages not related to an evaluation
+ * (e.g. out of band messages)
+ * @param message The message to append
+ * @param after Optional callback to run after the append
+ */
+export function appendOtherErr(message: string, after?: AfterAppendCallback) {
+  const destination = getDestinationConfiguration().otherOutput;
+  append(destination, message, after);
+}
+
+function appendLine(destination: OutputDestination, message: string, after?: AfterAppendCallback) {
+  const didLastTerminateLine = didLastOutputTerminateLine[destination];
+  didLastOutputTerminateLine[destination] = true;
+  if (destination === 'output-window') {
+    outputWindow.appendLine(
+      `${didLastTerminateLine ? '; ' : ''}${asClojureLineComments(message)}`,
+      after
+    );
     return;
   }
   if (destination === 'output-channel') {
@@ -80,4 +165,52 @@ export function appendLineOut(message: string, after?: AfterAppendCallback) {
     outputChannel.appendLine(message);
     return;
   }
+}
+
+/**
+ * Appends output adding a newline at the end.
+ * Use for stdout messages related to an evaluation
+ * (Maybe there is no use case for this even, as all eval output already should have any newlines needed)
+ * @param message The message to append
+ * @param after Optional callback to run after the append
+ */
+export function appendLineEvalOut(message: string, after?: AfterAppendCallback) {
+  const destination = getDestinationConfiguration().evalOutput;
+  appendLine(destination, message, after);
+}
+
+/**
+ * Appends output adding a newline at the end.
+ * Use for stderr messages related to an evaluation
+ * (Maybe there is no use case for this even, as all eval output already should have any newlines needed)
+ * @param message The message to append
+ * @param after Optional callback to run after the append
+ */
+export function appendLineEvalErr(message: string, after?: AfterAppendCallback) {
+  const destination = getDestinationConfiguration().evalOutput;
+  appendLine(destination, message, after);
+}
+
+/**
+ * Appends output adding a newline at the end.
+ * Use for stdout and other messages not related to an evaluation
+ * (e.g. out of band messages)
+ * @param message The message to append
+ * @param after Optional callback to run after the append
+ */
+export function appendLineOtherOut(message: string, after?: AfterAppendCallback) {
+  const destination = getDestinationConfiguration().otherOutput;
+  appendLine(destination, message, after);
+}
+
+/**
+ * Appends output adding a newline at the end.
+ * Use for stderr and other error messages not related to an evaluation
+ * (e.g. out of band messages)
+ * @param message The message to append
+ * @param after Optional callback to run after the append
+ */
+export function appendLineOtherErr(message: string, after?: AfterAppendCallback) {
+  const destination = getDestinationConfiguration().otherOutput;
+  appendLine(destination, message, after);
 }

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -34,10 +34,10 @@ function asClojureLineComments(message: string) {
   return message.replace(/\n(?!$)/g, '\n; ');
 }
 
-// Used to decide if new output result output should be prepended with a newline or not.
-// Also: For non-result output, the repl window output should be be printed as line comments.
-const didLastOutputTerminateLine = {
-  'output-window': true,
+// Used to decide if new result output should be prepended with a newline or not.
+// Also: For non-result output, whether the repl window output should be be printed as line comments.
+const didLastOutputTerminateLine: Record<OutputDestination, boolean> = {
+  'repl-window': true,
   'output-channel': true,
 };
 

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -23,9 +23,9 @@ export type OutputDestinationConfiguration = {
 };
 
 export const defaultDestinationConfiguration: OutputDestinationConfiguration = {
-  evalResults: 'output-window',
-  evalOutput: 'output-window',
-  otherOutput: 'output-window',
+  evalResults: 'output-channel',
+  evalOutput: 'output-channel',
+  otherOutput: 'output-channel',
 };
 
 export function getDestinationConfiguration(): OutputDestinationConfiguration {

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -51,12 +51,15 @@ function appendClojure(
   const didLastTerminateLine = didLastOutputTerminateLine[destination];
   didLastOutputTerminateLine[destination] = true;
   if (destination === 'output-window') {
-    outputWindow.append(`${didLastTerminateLine ? '' : '\n'}${message}\n`, after);
+    outputWindow.appendLine(`${didLastTerminateLine ? '' : '\n'}${message}`, after);
     return;
   }
   if (destination === 'output-channel') {
     initOutputChannel();
-    outputChannel.append((didLastTerminateLine ? '' : '\n') + '```clojure\n' + message + '\n```\n');
+    outputChannel.appendLine(
+      (didLastTerminateLine ? '' : '\n') + '```clojure\n' + message + '\n```'
+    );
+    // TODO: Deal with `after`
     return;
   }
 }
@@ -98,6 +101,7 @@ function append(destination: OutputDestination, message: string, after?: AfterAp
   if (destination === 'output-channel') {
     initOutputChannel();
     outputChannel.append(util.stripAnsi(message));
+    // TODO: Deal with `after`
     return;
   }
 }

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -28,7 +28,7 @@ export const defaultDestinationConfiguration: OutputDestinationConfiguration = {
   otherOutput: 'output-window',
 };
 
-function getDestinationConfiguration(): OutputDestinationConfiguration {
+export function getDestinationConfiguration(): OutputDestinationConfiguration {
   return config.getConfig().outputDestinations || defaultDestinationConfiguration;
 }
 

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -14,7 +14,7 @@ function initOutputChannel() {
   }
 }
 
-export type OutputDestination = 'output-window' | 'output-channel';
+export type OutputDestination = 'repl-window' | 'output-channel';
 
 export type OutputDestinationConfiguration = {
   evalResults: OutputDestination;
@@ -50,7 +50,7 @@ function appendClojure(
 ) {
   const didLastTerminateLine = didLastOutputTerminateLine[destination];
   didLastOutputTerminateLine[destination] = true;
-  if (destination === 'output-window') {
+  if (destination === 'repl-window') {
     outputWindow.appendLine(`${didLastTerminateLine ? '' : '\n'}${message}`, after);
     return;
   }
@@ -91,7 +91,7 @@ export function appendClojureOther(message: string, after?: AfterAppendCallback)
 function append(destination: OutputDestination, message: string, after?: AfterAppendCallback) {
   const didLastTerminateLine = didLastOutputTerminateLine[destination];
   didLastOutputTerminateLine[destination] = message.endsWith('\n');
-  if (destination === 'output-window') {
+  if (destination === 'repl-window') {
     outputWindow.append(
       `${didLastTerminateLine ? '; ' : ''}${asClojureLineComments(util.stripAnsi(message))}`,
       after
@@ -155,7 +155,7 @@ export function appendOtherErr(message: string, after?: AfterAppendCallback) {
 function appendLine(destination: OutputDestination, message: string, after?: AfterAppendCallback) {
   const didLastTerminateLine = didLastOutputTerminateLine[destination];
   didLastOutputTerminateLine[destination] = true;
-  if (destination === 'output-window') {
+  if (destination === 'repl-window') {
     outputWindow.appendLine(
       `${didLastTerminateLine ? '; ' : ''}${asClojureLineComments(util.stripAnsi(message))}`,
       after

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -200,7 +200,9 @@ export async function initResultsDoc(): Promise<vscode.TextDocument> {
     return resultsDoc;
   }
 
-  const greetings = `${formatAsLineComments(START_GREETINGS)}\n\n`;
+  const greetings = `${formatAsLineComments(START_GREETINGS)}\n\n${formatAsLineComments(
+    CLJ_CONNECT_GREETINGS
+  )}\n\n`;
   const edit = new vscode.WorkspaceEdit();
   const fullRange = new vscode.Range(resultsDoc.positionAt(0), resultsDoc.positionAt(Infinity));
   edit.replace(docUri, fullRange, greetings);

--- a/src/results-output/results-doc.ts
+++ b/src/results-output/results-doc.ts
@@ -14,6 +14,7 @@ import * as docMirror from '../doc-mirror/index';
 import { PrintStackTraceCodelensProvider } from '../providers/codelense';
 import * as replSession from '../nrepl/repl-session';
 import { formatAsLineComments, splitEditQueueForTextBatching } from './util';
+import * as output from './output';
 
 const RESULTS_DOC_NAME = `output.${config.REPL_FILE_EXT}`;
 
@@ -246,7 +247,7 @@ export function setNamespaceFromCurrentFile() {
   );
   setSession(session, ns);
   replSession.updateReplSessionType();
-  appendPrompt();
+  output.replWindowAppendPrompt();
 }
 
 async function appendFormGrabbingSessionAndNS(topLevel: boolean) {
@@ -386,7 +387,7 @@ export function appendLine(text = '', onAppended?: OnAppendedCallback): void {
 
 export function discardPendingPrints(): void {
   resultsBuffer = [];
-  appendPrompt();
+  output.replWindowAppendPrompt();
 }
 
 export type OutputStacktraceEntry = { uri: vscode.Uri; line: number };

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -8,6 +8,7 @@ import * as lsp from './lsp/definitions';
 import * as namespace from './namespace';
 import { getSession, updateReplSessionType } from './nrepl/repl-session';
 import * as getText from './util/get-text';
+import * as output from './results-output/output';
 
 const diagnosticCollection = vscode.languages.createDiagnosticCollection('calva');
 
@@ -249,7 +250,7 @@ async function runAllTests(controller: vscode.TestController, document = {}) {
     outputWindow.appendLine('; ' + e);
   }
   updateReplSessionType();
-  outputWindow.appendPrompt();
+  output.replWindowAppendPrompt();
 }
 
 function runAllTestsCommand(controller: vscode.TestController) {
@@ -311,7 +312,7 @@ async function runNamespaceTestsImpl(
 
   outputWindow.setSession(session, nss[0]);
   updateReplSessionType();
-  outputWindow.appendPrompt();
+  output.replWindowAppendPrompt();
 }
 
 async function runNamespaceTests(controller: vscode.TestController, document: vscode.TextDocument) {
@@ -358,7 +359,7 @@ async function runTestUnderCursor(controller: vscode.TestController) {
   } else {
     outputWindow.appendLine('; No test found at cursor');
   }
-  outputWindow.appendPrompt();
+  output.replWindowAppendPrompt();
 }
 
 function runTestUnderCursorCommand(controller: vscode.TestController) {
@@ -394,7 +395,7 @@ async function rerunTests(controller: vscode.TestController, document = {}) {
     outputWindow.appendLine('; ' + e);
   }
 
-  outputWindow.appendPrompt();
+  output.replWindowAppendPrompt();
 }
 
 function rerunTestsCommand(controller: vscode.TestController) {

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -216,7 +216,7 @@ async function reportTests(
             outputWindow.appendLine(messages, (_, afterResultLocation) => {
               outputWindow.markLastStacktraceRange(afterResultLocation);
             });
-            if (output.getDestinationConfiguration().otherOutput !== 'output-window') {
+            if (output.getDestinationConfiguration().otherOutput !== 'repl-window') {
               output.appendLineOtherOut(messages);
             }
           } else if (messages) {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -11,6 +11,7 @@ import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as url from 'url';
 import { isUndefined } from 'lodash';
 import * as fiddleFiles from './fiddle-files';
+import * as output from './results-output/output';
 
 const specialWords = ['-', '+', '/', '*']; //TODO: Add more here
 const syntaxQuoteSymbol = '`';
@@ -281,14 +282,14 @@ function logSuccess(results) {
 }
 
 function logError(error) {
-  outputWindow.appendLine('; ' + error.reason);
+  output.appendLineOtherErr(error.reason);
   if (
     error.line !== undefined &&
     error.line !== null &&
     error.column !== undefined &&
     error.column !== null
   ) {
-    outputWindow.appendLine(';   at line: ' + error.line + ' and column: ' + error.column);
+    output.appendLineOtherOut('  at line: ' + error.line + ' and column: ' + error.column);
   }
 }
 
@@ -321,12 +322,12 @@ function markError(error) {
 }
 
 function logWarning(warning) {
-  outputWindow.appendLine('; ' + warning.reason);
+  output.appendLineOtherOut(warning.reason);
   if (warning.line !== null) {
     if (warning.column !== null) {
-      outputWindow.appendLine(';   at line: ' + warning.line + ' and column: ' + warning.column);
+      output.appendLineOtherOut('  at line: ' + warning.line + ' and column: ' + warning.column);
     } else {
-      outputWindow.appendLine(';   at line: ' + warning.line);
+      output.appendLineOtherOut('  at line: ' + warning.line);
     }
   }
 }

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -132,5 +132,10 @@
       "customJackInCommandLine": "echo PROJECT-ROOT-PATH: 'JACK-IN-PROJECT-ROOT-PATH', NREPL-PORT-FILE: 'JACK-IN-NREPL-PORT-FILE', NREPL-PORT: 'JACK-IN-NREPL-PORT', LEIN-PROFILES: 'JACK-IN-LEIN-PROFILES', LEIN-LAUNCH-ALIAS 'JACK-IN-LEIN-LAUNCH-ALIAS', CLJ-MIDDLEWARE: 'JACK-IN-CLJ-MIDDLEWARE', CLJS-MIDDLEWARE: 'JACK-IN-CLJS-MIDDLEWARE' ; ../../custom-jack-in.bb --aliases JACK-IN-CLJS-LAUNCH-BUILDS --cider-nrepl-version JACK-IN-CIDER-NREPL-VERSION",
       "cljsType": "shadow-cljs"
     }
-  ]
+  ],
+  "calva.outputDestinations": {
+    "evalResults": "output-channel",
+    "evalOutput": "output-channel",
+    "otherOutput": "output-channel"
+  }
 }

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -132,10 +132,5 @@
       "customJackInCommandLine": "echo PROJECT-ROOT-PATH: 'JACK-IN-PROJECT-ROOT-PATH', NREPL-PORT-FILE: 'JACK-IN-NREPL-PORT-FILE', NREPL-PORT: 'JACK-IN-NREPL-PORT', LEIN-PROFILES: 'JACK-IN-LEIN-PROFILES', LEIN-LAUNCH-ALIAS 'JACK-IN-LEIN-LAUNCH-ALIAS', CLJ-MIDDLEWARE: 'JACK-IN-CLJ-MIDDLEWARE', CLJS-MIDDLEWARE: 'JACK-IN-CLJS-MIDDLEWARE' ; ../../custom-jack-in.bb --aliases JACK-IN-CLJS-LAUNCH-BUILDS --cider-nrepl-version JACK-IN-CIDER-NREPL-VERSION",
       "cljsType": "shadow-cljs"
     }
-  ],
-  "calva.outputDestinations": {
-    "evalResults": "output-channel",
-    "evalOutput": "output-channel",
-    "otherOutput": "output-channel"
-  }
+  ]
 }


### PR DESCRIPTION
## What has changed?

As you and I discussed in that huddle, @bpringe: Introducing an output ”dispatch” module. (Almost) all output goes via this module, as an indirection before it is then printed to the REPL window. This as a preparation for introducing a new REPL window implementation (very probably a Web View).

I've also added a configuration for directing output to an output channel (Calva says) instead. Mostly as a a proof of concept and to shake out some edge cases which I don't think I would have understood if the indirection was _only_ to one final destination.

The destinations are separated in three categories of output:

- `evalResults`: Destination for evaluation results. (Clojure data returned from an evaluation).
- `evalOutput`: Destination for evaluation output (stdout/stderr from an evaluation).
- `otherOutput`: Destination for other output (Calva messages, out-of-band stdout/stderr, etcetera).

For each of these output categories the user can configure if the output should go to the REPL Window or to the _Calva says_ output channel.

The default is to have all output categories go to the REPL Window. So the users should not notice this change. Or, they will, because:

## Caveats
> Now all stdout and stderr is printed as line comments to the REPL window.

This is because I couldn't bother with making up some API for how to control this. And also, now output that isn't Clojure data can't mess up the structure of the REPL window text.

Also:

> Evaluation error output, and some output from the test runner, as always printed to the REPL Window (and to the output channel as well, if that is configured as the destination).

This is because the stack trace mechanism and something something with the test runner relies on the ranges of the output in the REPL Window, and this PR would grow too big if I started to try decouple that as well.

## Note about the dispatcher (internal) API

When printing output, besides from determining which of the three output categories the output belongs to, we also need to consider if it is an error or not. I made it like this so that if we add an output destination that can highlight errors, we get the error ouput via separate functions in the dispatcher.

I'm half planning to add a simple pseudo terminal as a third output option. Then we can use ANSI escape codes for marking things as errors.

* Fixes #1104

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
