### PR TITLE
paredit.md Grow Selection -> Expand Selection Fixes #2441

### DIFF
--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -48,7 +48,7 @@ To make the command descriptions a bit clearer, each entry is animated. When you
 
 ### Strings are not Lists, but Anyway...
 
-In Calva Paredit, strings are treated in much the same way as lists are. Here's an example showing **Slurp** and **Barf**, **Forward/Backward List**, and **Grow Selection**.
+In Calva Paredit, strings are treated in much the same way as lists are. Here's an example showing **Slurp** and **Barf**, **Forward/Backward List**, and **Expand Selection**.
 
 ![](images/paredit/string-as-list.gif)
 
@@ -76,7 +76,7 @@ Most of these commands are selecting ”versions” of the navigation commands a
 Default keybinding    | Action | Description
 ------------------    | ------ | -----------
  `shift+alt+right` (win/linux)<br>`ctrl+w` (mac)                | **Expand Selection** | Starts from the cursor and selects the current form. Then will keep expanding to enclosing forms.<br> ![](images/paredit/grow-selection.gif)
- `shift+alt+left` (win/linux)<br>`ctrl+shift+w` (mac)         | **Shrink Selection** | Contracts back from an expanded selection performed by any Paredit selection command.<br> ![](images/paredit/shrink-selection.gif)<br>(In the animation the selection is first grown using a combination of **Grow Selection** and some lateral selection commands, then shrunk all the way back down to no selection.)
+ `shift+alt+left` (win/linux)<br>`ctrl+shift+w` (mac)         | **Shrink Selection** | Contracts back from an expanded selection performed by any Paredit selection command.<br> ![](images/paredit/shrink-selection.gif)<br>(In the animation the selection is first grown using a combination of **Expand Selection** and some lateral selection commands, then shrunk all the way back down to no selection.)
  `ctrl+alt+w space`      | **Select Top Level Form** | Top level in a structural sense. Typically where your`(def ...)`/`(defn ...)` type forms. Please note that`(comment ...)` forms create a new top level. <br> ![](images/paredit/select-top-level-form.gif)
  `shift+ctrl+right` (win/linux)<br>`shift+alt+right` (mac)  | **Select Forward Sexp** | ![](images/paredit/select-forward-sexp.gif)
   `ctrl+shift+k`         | **Select Right**          | Select forward to the end of the current form or the first newline. See **Kill right** below. (The animation also shows **Shrink Selection**).<br> ![](images/paredit/select-right.gif)


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

If you have updated only the documentation, including README and GitHub templates, then we most often want those changes directed to the `published` branch (which is the default, so you probably don't have to do anything.
-->

## What has Changed?
<!-- Please tell us what the change is about and why and such. For simple typos, just say that. 😄 -->

- Renamed _"Grow Selection"_ -> _"Expand Selection"_

<!-- Please consider creating an issue for your documentation update, if there isn't one already. Tell us which issue you are fixing. -->

Fixes #2441

<!-- Also include `Fixes #12345` in the commit message. -->

## My Calva Documentation Only PR Checklist

<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [Editing Documentation](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Hack-on-Calva#editing-documentation)
- [x] Directed this pull request at the `published` branch.
- [ ] ~Built the site locally (if the changes were more involved than simple typo fixes), and verified that the site is presented as expected.~
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_ (if there was is an issue for the documentation change)
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [ ] ~If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik

