### PR TITLE
Avoid fencing ”simple” clojure data printed to output channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Printing non-list Clojure results with code fencing gets verbose](https://github.com/BetterThanTomorrow/calva/issues/2450)
 - Fix: [Changing outputDestinations to output-channel breaks **Load/Evaluate Current File and its Requires...**](https://github.com/BetterThanTomorrow/calva/issues/2444)
 
 ## [2.0.426] - 2024-03-22

--- a/src/cursor-doc/utilities.ts
+++ b/src/cursor-doc/utilities.ts
@@ -1,4 +1,5 @@
 import * as model from './model';
+import { LispTokenCursor } from './token-cursor';
 
 export type MissingTexts = {
   append: string;
@@ -32,4 +33,27 @@ export function getMissingBrackets(text: string): MissingTexts {
     });
     return { prepend: missingOpens.join(''), append: missingCloses.join('') };
   }
+}
+
+export function isRightSexpStructural(cursor: LispTokenCursor): boolean {
+  cursor.forwardWhitespace();
+  if (cursor.getToken().type === 'comment') {
+    return false;
+  }
+  cursor.forwardSexp(true, true, false);
+  cursor.backwardSexp(false, false, false, false);
+
+  const token = cursor.getToken();
+  if (token.type === 'open') {
+    return !!token.raw.match(/[([{]$/);
+  }
+  return false;
+}
+
+export function hasMoreThanSingleSexp(doc: model.EditableDocument): boolean {
+  const cursor = doc.getTokenCursor(0);
+  cursor.forwardWhitespace(true);
+  cursor.forwardSexp(false, false, false);
+  cursor.forwardWhitespace(false);
+  return !cursor.atEnd();
 }

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -2,6 +2,8 @@ import * as outputWindow from './results-doc';
 import * as config from '../config';
 import * as vscode from 'vscode';
 import * as util from '../utilities';
+import * as model from '../cursor-doc/model';
+import * as cursorUtil from '../cursor-doc/utilities';
 
 export interface AfterAppendCallback {
   (insertLocation: vscode.Location, newPosition?: vscode.Location): any;
@@ -65,9 +67,12 @@ function appendClojure(
     return;
   }
   if (destination === 'output-channel') {
-    outputChannel.appendLine(
-      (didLastTerminateLine ? '' : '\n') + '```clojure\n' + message + '\n```'
-    );
+    const doc = new model.StringDocument(message);
+    const cursor = doc.getTokenCursor(0);
+    const shouldFence =
+      cursorUtil.hasMoreThanSingleSexp(doc) || cursorUtil.isRightSexpStructural(cursor);
+    const outputMessage = shouldFence ? '```clojure\n' + message + '\n```' : message;
+    outputChannel.appendLine((didLastTerminateLine ? '' : '\n') + outputMessage);
     if (after) {
       after(undefined, undefined);
     }


### PR DESCRIPTION
## What has changed?

When printing Clojure code to the output channel we now check if the code really needs syntax highlighting and only fence if it's some kind of list or if there are more than one sexpression in the output cod.

* Fixes #2450 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
        - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
