### PR TITLE
Add command for opening the terminal ouput destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Add command for opening the Terminal output destination](https://github.com/BetterThanTomorrow/calva/issues/2455)
+
 ## [2.0.428] - 2024-03-23
 
 - [Add a Terminal output destination option](https://github.com/BetterThanTomorrow/calva/issues/2452)

--- a/docs/site/output.md
+++ b/docs/site/output.md
@@ -19,6 +19,15 @@ With the setting `calva.outputDestinations`, you can configure where each catego
 
 The reason there are several options for this is partly legacy and partly because VS Code restricts the placement of different views in different ways. We hope you will find a combination of output destinations that suits you.
 
+## Commands for showing output destinations
+
+These are the commands and their default keyboard shortcuts for revealing output destinations
+
+* **Calva: Show/Open the result output destination** - `ctrl+alt+o o`
+* **Calva: Show/Open the Calva says Output Channel** - `ctrl+alt+o c`
+* **Calva: Show/Open the Calva Output Terminal** - `ctrl+alt+o t`
+* **Calva: Show/Open REPL Window** - `ctrl+alt+o r`
+
 ## REPL process output (stdout and stderr)
 
 When Calva is connected to the REPL, the Output window will by default print not only results of evaluations, but also:
@@ -29,9 +38,3 @@ When Calva is connected to the REPL, the Output window will by default print not
 
 You can control the default via the `calva.redirectServerOutputToRepl` setting. It defaults to `true`. Setting it to `false` before connecting the REPL will result in that **2.** and **3.** will not get printed in the Output window. It will then instead be printed wherever the REPL process is printing its messages, usually the terminal from where it was started (the **Jack-in terminal** if Calva started the REPL).
 
-## Commands for showing output destinations
-
-These are the commands and their default keyboard shortcuts for revealing output destinations
-
-* **Calva: Show/Open the result output destination** - `ctrl+alt+o ctrl+o`
-* **Calva: Show/Open the Calva says Output Channel** - `ctrl+alt+o o`

--- a/package.json
+++ b/package.json
@@ -1924,6 +1924,11 @@
       },
       {
         "category": "Calva",
+        "command": "calva.showOutputTerminal",
+        "title": "Show/Open the Calva Output Terminal"
+      },
+      {
+        "category": "Calva",
         "command": "calva.showResultOutputDestination",
         "title": "Show/Open the result output destination"
       },
@@ -2641,12 +2646,17 @@
       },
       {
         "command": "calva.showResultOutputDestination",
-        "key": "ctrl+alt+o ctrl+o",
+        "key": "ctrl+alt+o o",
         "when": "calva:keybindingsEnabled"
       },
       {
         "command": "calva.showOutputChannel",
-        "key": "ctrl+alt+o o",
+        "key": "ctrl+alt+o c",
+        "when": "calva:keybindingsEnabled"
+      },
+      {
+        "command": "calva.showOutputTerminal",
+        "key": "ctrl+alt+o t",
         "when": "calva:keybindingsEnabled"
       },
       {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -271,6 +271,7 @@ async function activate(context: vscode.ExtensionContext) {
     showNextReplHistoryEntry: replHistory.showNextReplHistoryEntry,
     showOutputWindow: () => outputWindow.revealResultsDoc(false),
     showOutputChannel: output.showOutputChannel,
+    showOutputTerminal: output.showOutputTerminal,
     showResultOutputDestination: output.showResultOutputDestination,
     showPreviousReplHistoryEntry: replHistory.showPreviousReplHistoryEntry,
     startJoyrideReplAndConnect: async () => {

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -42,12 +42,8 @@ export function showOutputChannel() {
   outputChannel.show(true);
 }
 
-export function showResultOutputDestination() {
-  if (getDestinationConfiguration().evalResults === 'output-channel') {
-    return showOutputChannel();
-  } else {
-    return outputWindow.revealResultsDoc(true);
-  }
+export function showOutputTerminal() {
+  outputTerminal.show(true);
 }
 
 export type OutputDestination = 'repl-window' | 'output-channel' | 'terminal';
@@ -97,6 +93,19 @@ function getTerminal() {
     outputTerminal = vscode.window.createTerminal({ name: 'Calva Output', pty: outputPTY });
   }
   return outputPTY;
+}
+
+export function showResultOutputDestination() {
+  if (getDestinationConfiguration().evalResults === 'output-channel') {
+    return showOutputChannel();
+  }
+  if (getDestinationConfiguration().evalResults === 'terminal') {
+    if (!outputTerminal) {
+      getTerminal();
+    }
+    return showOutputTerminal();
+  }
+  return outputWindow.revealResultsDoc(true);
 }
 
 export function getDestinationConfiguration(): OutputDestinationConfiguration {


### PR DESCRIPTION
Also change the default keybindings for these commands a bit.

## What has changed?

Added the missing command, and also made the command for showing the current evaluation results destination aware of the terminal option.

And tweaked the default keybindings for these commands. See updated docs.

* Fixes #2455

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
    - [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
        - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
