### PR TITLE
Skip chalking output messages if they already have ANSI escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- [Add setting for migrating the REPL Window file to the new project subpath](https://github.com/BetterThanTomorrow/calva/issues/2458)
+- [Add opt-in setting for migrating the REPL Window file to the new project subpath](https://github.com/BetterThanTomorrow/calva/issues/2458)
+- [Honor existing ANSI escape sequences in messages for terminal output destination](https://github.com/BetterThanTomorrow/calva/issues/2459)
 
 ## [2.0.429] - 2024-03-23
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@vscode/debugadapter": "^1.64.0",
+        "ansi-regex": "^5.0.1",
         "axios": "^1.4.0",
         "chalk": "^4.1.2",
         "extract-zip": "^2.0.1",
@@ -2412,6 +2413,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -5056,15 +5065,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16"
-      }
-    },
-    "node_modules/gauge/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/gensync": {
@@ -8617,15 +8617,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/pretty-format/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -9535,15 +9526,6 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -12835,6 +12817,11 @@
         }
       }
     },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -14911,14 +14898,6 @@
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        }
       }
     },
     "gensync": {
@@ -17652,12 +17631,6 @@
         "react-is": "^17.0.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -18371,14 +18344,6 @@
       "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        }
       }
     },
     "strip-bom": {

--- a/package.json
+++ b/package.json
@@ -3233,6 +3233,7 @@
   },
   "dependencies": {
     "@vscode/debugadapter": "^1.64.0",
+    "ansi-regex": "^5.0.1",
     "axios": "^1.4.0",
     "chalk": "^4.1.2",
     "extract-zip": "^2.0.1",

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -5,6 +5,7 @@ import * as util from '../utilities';
 import * as model from '../cursor-doc/model';
 import * as cursorUtil from '../cursor-doc/utilities';
 import * as chalk from 'chalk';
+import * as ansiRegex from 'ansi-regex';
 import * as printer from '../printer';
 
 const customChalk = new chalk.Instance({ level: 3 });
@@ -125,6 +126,10 @@ function destinationSupportsAnsi(destination: OutputDestination) {
   return destination === 'terminal';
 }
 
+function messageContainsAnsi(message: string) {
+  return ansiRegex().test(message);
+}
+
 // Used to decide if new result output should be prepended with a newline or not.
 // Also: For non-result output, whether the repl window output should be be printed as line comments.
 const didLastOutputTerminateLine: Record<OutputDestination, boolean> = {
@@ -225,9 +230,10 @@ function append(destination: OutputDestination, message: string, after?: AfterAp
  */
 export function appendEvalOut(message: string, after?: AfterAppendCallback) {
   const destination = getDestinationConfiguration().evalOutput;
-  const coloredMessage = destinationSupportsAnsi(destination)
-    ? themedChalk().evalOut(message)
-    : message;
+  const coloredMessage =
+    destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
+      ? themedChalk().evalOut(message)
+      : message;
   append(destination, coloredMessage, after);
 }
 
@@ -239,9 +245,10 @@ export function appendEvalOut(message: string, after?: AfterAppendCallback) {
  */
 export function appendEvalErr(message: string, after?: AfterAppendCallback) {
   const destination = getDestinationConfiguration().evalOutput;
-  const coloredMessage = destinationSupportsAnsi(destination)
-    ? themedChalk().evalErr(message)
-    : message;
+  const coloredMessage =
+    destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
+      ? themedChalk().evalErr(message)
+      : message;
   append(destination, coloredMessage, after);
 }
 
@@ -254,9 +261,10 @@ export function appendEvalErr(message: string, after?: AfterAppendCallback) {
  */
 export function appendOtherOut(message: string, after?: AfterAppendCallback) {
   const destination = getDestinationConfiguration().otherOutput;
-  const coloredMessage = destinationSupportsAnsi(destination)
-    ? themedChalk().otherOut(message)
-    : message;
+  const coloredMessage =
+    destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
+      ? themedChalk().otherOut(message)
+      : message;
   append(destination, coloredMessage, after);
 }
 
@@ -269,9 +277,10 @@ export function appendOtherOut(message: string, after?: AfterAppendCallback) {
  */
 export function appendOtherErr(message: string, after?: AfterAppendCallback) {
   const destination = getDestinationConfiguration().otherOutput;
-  const coloredMessage = destinationSupportsAnsi(destination)
-    ? themedChalk().otherErr(message)
-    : message;
+  const coloredMessage =
+    destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
+      ? themedChalk().otherErr(message)
+      : message;
   append(destination, coloredMessage, after);
 }
 
@@ -303,9 +312,10 @@ function appendLine(destination: OutputDestination, message: string, after?: Aft
  */
 export function appendLineEvalOut(message: string, after?: AfterAppendCallback) {
   const destination = getDestinationConfiguration().evalOutput;
-  const coloredMessage = destinationSupportsAnsi(destination)
-    ? themedChalk().evalOut(message)
-    : message;
+  const coloredMessage =
+    destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
+      ? themedChalk().evalOut(message)
+      : message;
   appendLine(destination, coloredMessage, after);
 }
 
@@ -318,9 +328,10 @@ export function appendLineEvalOut(message: string, after?: AfterAppendCallback) 
  */
 export function appendLineEvalErr(message: string, after?: AfterAppendCallback) {
   const destination = getDestinationConfiguration().evalOutput;
-  const coloredMessage = destinationSupportsAnsi(destination)
-    ? themedChalk().evalErr(message)
-    : message;
+  const coloredMessage =
+    destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
+      ? themedChalk().evalErr(message)
+      : message;
   appendLine(destination, coloredMessage, after);
 }
 
@@ -333,9 +344,10 @@ export function appendLineEvalErr(message: string, after?: AfterAppendCallback) 
  */
 export function appendLineOtherOut(message: string, after?: AfterAppendCallback) {
   const destination = getDestinationConfiguration().otherOutput;
-  const coloredMessage = destinationSupportsAnsi(destination)
-    ? themedChalk().otherOut(message)
-    : message;
+  const coloredMessage =
+    destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
+      ? themedChalk().otherOut(message)
+      : message;
   appendLine(destination, coloredMessage, after);
 }
 
@@ -348,9 +360,10 @@ export function appendLineOtherOut(message: string, after?: AfterAppendCallback)
  */
 export function appendLineOtherErr(message: string, after?: AfterAppendCallback) {
   const destination = getDestinationConfiguration().otherOutput;
-  const coloredMessage = destinationSupportsAnsi(destination)
-    ? themedChalk().otherErr(message)
-    : message;
+  const coloredMessage =
+    destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
+      ? themedChalk().otherErr(message)
+      : message;
   appendLine(destination, coloredMessage, after);
 }
 


### PR DESCRIPTION
## What has changed?

When printing err and out messages to the terminal we first check if the message already have ANSI escape, before we use `chalk` to add our own. This should let people who have made their repls print pretty stdout or stderr messages use the terminal output destination and it should work much like a CLI repl would work.

* Fixes #2459

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~~[ ] Added to or updated docs in this branch, if appropriate~~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
