### PR TITLE
Opt in repl window bare output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Extraneous newlines printed to terminal for some output](https://github.com/BetterThanTomorrow/calva/issues/2468)
+- [Add legacy opt-in for printing bare `stdout` to the REPL Window](https://github.com/BetterThanTomorrow/calva/issues/2470)
 
 ## [2.0.431] - 2024-03-25
 

--- a/docs/site/output.md
+++ b/docs/site/output.md
@@ -28,6 +28,14 @@ These are the commands and their default keyboard shortcuts for revealing output
 * **Calva: Show/Open the Calva Output Terminal** - `ctrl+alt+o t`
 * **Calva: Show/Open REPL Window** - `ctrl+alt+o r`
 
+## About stdout in the REPL Window
+
+Since Calva v2.0.423 the REPL Window prints `stdout` prepended with `;` to make it into line comments. This is because stdout output easily breaks the Clojure structure of the REPL Window, making it misbehave in various ways. We made this change because as maintainers of Calva we have seen all too often how this hits users, and it is also taking too much of our Calva time to try mitigate the problem, which is fundamentally not fixable.
+
+There are now other output destinations that do not have this limitation.
+
+All that said. If you want to keep using the REPL Window for stdout output, and need the old behavior, you can enable the setting: `calva.legacyPrintBareReplWindowOutput`. Please note that at some point after we have created a dedicated Output Window, the REPL Window will be retired as a destination for output.
+
 ## REPL process output (stdout and stderr)
 
 When Calva is connected to the REPL, the Output window will by default print not only results of evaluations, but also:

--- a/package.json
+++ b/package.json
@@ -170,6 +170,11 @@
             "default": true,
             "markdownDescription": "For legacy reasons, the REPL window used to be located in`${projectRootPath}/.calva/output-window/output.calva-repl`. The default directory will change to `${projectRootPath}/.calva/repl.calva-repl`. Disable this setting to start using the new path. And then add `**/.calva/repl.calva-repl` to your `.gitignore`."
           },
+          "calva.legacyPrintBareReplWindowOutput": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Non-result output risks breaking the structure of the Clojure document. Therefore `stdout` from the REPL process is prepended with `;` to make the output into line comments, which is non-structural. Enable this setting to print bare output, without the line comment protection. **NB: The REPL window may stop working, or work very strangely or slowly.** Also note that the REPL Window is being deprecated as a destination for output, so you may anyway instead want to use the `calva.outputDestinations` settings to direct `stdout` and `stderr` to the _Calva Output_ `terminal` destination instead."
+          },
           "calva.outputDestinations": {
             "type": "object",
             "markdownDescription": [

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
           "calva.useLegacyReplWindowPath": {
             "type": "boolean",
             "default": true,
-            "markdownDescription": "For legacy reasons, the REPL window used to be located in`${projectRootPath}/.calva/output-window/output.calva-repl`. The default directory will change to `${projectRootPath}/.calva/repl.calva-repl`. Disable this setting to start using the new path. And then add `**/.calva/repl.calva-repl` to your `.gitignore`."
+            "markdownDescription": "For legacy reasons, the REPL window used to be located in `${projectRootPath}/.calva/output-window/output.calva-repl`. The default directory will change to `${projectRootPath}/.calva/repl.calva-repl`. Disable this setting to start using the new path. And then add `**/.calva/repl.calva-repl` to your `.gitignore`."
           },
           "calva.legacyPrintBareReplWindowOutput": {
             "type": "boolean",

--- a/src/config.ts
+++ b/src/config.ts
@@ -260,6 +260,7 @@ function getConfig() {
     outputDestinations:
       configOptions.get<output.OutputDestinationConfiguration>('outputDestinations'),
     useLegacyReplWindowPath: configOptions.get<boolean>('useLegacyReplWindowPath'),
+    legacyPrintBareReplWindowOutput: configOptions.get<boolean>('legacyPrintBareReplWindowOutput'),
   };
 }
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -139,6 +139,9 @@ async function connectToHost(hostname: string, port: number, connectSequence: Re
         {}
       );
     }
+    if (!connectSequence.cljsType || connectSequence.cljsType === 'none') {
+      output.maybePrintLegacyREPLWindowOutputMessage();
+    }
     output.replWindowAppendPrompt();
 
     clojureDocs.init(cljSession);
@@ -211,6 +214,7 @@ async function setUpCljsRepl(session: NReplSession, build) {
       ns,
       {}
     );
+    output.maybePrintLegacyREPLWindowOutputMessage();
     output.replWindowAppendPrompt();
   }
   replSession.updateReplSessionType();

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -10,6 +10,14 @@ import * as printer from '../printer';
 
 const customChalk = new chalk.Instance({ level: 3 });
 
+type OutputCategory = 'evalResults' | 'clojure' | 'evalOut' | 'evalErr' | 'otherOut' | 'otherErr';
+
+type AppendOptions = {
+  destination: OutputDestination;
+  outputCategory: OutputCategory;
+  after?: AfterAppendCallback;
+};
+
 const lightTheme = {
   evalOut: customChalk.gray,
   evalErr: customChalk.red,
@@ -142,11 +150,8 @@ const didLastOutputTerminateLine: Record<OutputDestination, boolean> = {
   terminal: true,
 };
 
-function appendClojure(
-  destination: OutputDestination,
-  message: string,
-  after?: AfterAppendCallback
-) {
+function appendClojure(options: AppendOptions, message: string, after?: AfterAppendCallback) {
+  const destination = options.destination;
   const didLastTerminateLine = didLastOutputTerminateLine[destination];
   didLastOutputTerminateLine[destination] = true;
   if (destination === 'repl-window') {
@@ -185,7 +190,7 @@ function appendClojure(
  */
 export function appendClojureEval(code: string, after?: AfterAppendCallback) {
   const destination = getDestinationConfiguration().evalResults;
-  appendClojure(destination, code, after);
+  appendClojure({ destination, outputCategory: 'evalResults' }, code, after);
 }
 
 /**
@@ -197,10 +202,11 @@ export function appendClojureEval(code: string, after?: AfterAppendCallback) {
  */
 export function appendClojureOther(message: string, after?: AfterAppendCallback) {
   const destination = getDestinationConfiguration().otherOutput;
-  appendClojure(destination, message, after);
+  appendClojure({ destination, outputCategory: 'clojure' }, message, after);
 }
 
-function append(destination: OutputDestination, message: string, after?: AfterAppendCallback) {
+function append(options: AppendOptions, message: string, after?: AfterAppendCallback) {
+  const destination = options.destination;
   const didLastTerminateLine = didLastOutputTerminateLine[destination];
   didLastOutputTerminateLine[destination] = message.endsWith('\n');
   if (destination === 'repl-window') {
@@ -238,7 +244,7 @@ export function appendEvalOut(message: string, after?: AfterAppendCallback) {
     destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
       ? themedChalk().evalOut(message)
       : message;
-  append(destination, coloredMessage, after);
+  append({ destination, outputCategory: 'evalOut' }, coloredMessage, after);
 }
 
 /**
@@ -253,7 +259,7 @@ export function appendEvalErr(message: string, after?: AfterAppendCallback) {
     destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
       ? themedChalk().evalErr(message)
       : message;
-  append(destination, coloredMessage, after);
+  append({ destination, outputCategory: 'evalErr' }, coloredMessage, after);
 }
 
 /**
@@ -269,7 +275,7 @@ export function appendOtherOut(message: string, after?: AfterAppendCallback) {
     destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
       ? themedChalk().otherOut(message)
       : message;
-  append(destination, coloredMessage, after);
+  append({ destination, outputCategory: 'otherOut' }, coloredMessage, after);
 }
 
 /**
@@ -285,10 +291,11 @@ export function appendOtherErr(message: string, after?: AfterAppendCallback) {
     destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
       ? themedChalk().otherErr(message)
       : message;
-  append(destination, coloredMessage, after);
+  append({ destination, outputCategory: 'otherErr' }, coloredMessage, after);
 }
 
-function appendLine(destination: OutputDestination, message: string, after?: AfterAppendCallback) {
+function appendLine(options: AppendOptions, message: string, after?: AfterAppendCallback) {
+  const destination = options.destination;
   const didLastTerminateLine = didLastOutputTerminateLine[destination];
   didLastOutputTerminateLine[destination] = true;
   if (destination === 'repl-window') {
@@ -303,7 +310,7 @@ function appendLine(destination: OutputDestination, message: string, after?: Aft
     return;
   }
   if (destination === 'terminal') {
-    append(destination, message + '\r\n', after);
+    append(options, message + '\r\n', after);
   }
 }
 
@@ -320,7 +327,7 @@ export function appendLineEvalOut(message: string, after?: AfterAppendCallback) 
     destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
       ? themedChalk().evalOut(message)
       : message;
-  appendLine(destination, coloredMessage, after);
+  appendLine({ destination, outputCategory: 'evalOut' }, coloredMessage, after);
 }
 
 /**
@@ -336,7 +343,7 @@ export function appendLineEvalErr(message: string, after?: AfterAppendCallback) 
     destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
       ? themedChalk().evalErr(message)
       : message;
-  appendLine(destination, coloredMessage, after);
+  appendLine({ destination, outputCategory: 'evalErr' }, coloredMessage, after);
 }
 
 /**
@@ -352,7 +359,7 @@ export function appendLineOtherOut(message: string, after?: AfterAppendCallback)
     destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
       ? themedChalk().otherOut(message)
       : message;
-  appendLine(destination, coloredMessage, after);
+  appendLine({ destination, outputCategory: 'otherOut' }, coloredMessage, after);
 }
 
 /**
@@ -368,7 +375,7 @@ export function appendLineOtherErr(message: string, after?: AfterAppendCallback)
     destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
       ? themedChalk().otherErr(message)
       : message;
-  appendLine(destination, coloredMessage, after);
+  appendLine({ destination, outputCategory: 'otherErr' }, coloredMessage, after);
 }
 
 /**

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -150,6 +150,21 @@ const didLastOutputTerminateLine: Record<OutputDestination, boolean> = {
   terminal: true,
 };
 
+let havePrintedLegacyReplWindowOutputMessage = false;
+
+export function maybePrintLegacyREPLWindowOutputMessage() {
+  if (
+    !havePrintedLegacyReplWindowOutputMessage &&
+    config.getConfig().outputDestinations.evalOutput === 'repl-window' &&
+    !config.getConfig().legacyPrintBareReplWindowOutput
+  ) {
+    const message =
+      '"Please see https://calva.io/output/#about-stdout-in-the-repl-window\nabout why stdout printed to this file is prepended with `;` to be line comments."';
+    outputWindow.appendLine(message);
+    havePrintedLegacyReplWindowOutputMessage = true;
+  }
+}
+
 function appendClojure(options: AppendOptions, message: string, after?: AfterAppendCallback) {
   const destination = options.destination;
   const didLastTerminateLine = didLastOutputTerminateLine[destination];

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -210,10 +210,11 @@ function append(options: AppendOptions, message: string, after?: AfterAppendCall
   const didLastTerminateLine = didLastOutputTerminateLine[destination];
   didLastOutputTerminateLine[destination] = message.endsWith('\n');
   if (destination === 'repl-window') {
-    outputWindow.append(
-      `${didLastTerminateLine ? '; ' : ''}${asClojureLineComments(util.stripAnsi(message))}`,
-      after
-    );
+    const decoratedMessage =
+      options.outputCategory === 'evalOut' && config.getConfig().legacyPrintBareReplWindowOutput
+        ? message
+        : `${didLastTerminateLine ? '; ' : ''}${asClojureLineComments(util.stripAnsi(message))}`;
+    outputWindow.append(decoratedMessage, after);
     return;
   }
   if (destination === 'output-channel') {
@@ -299,10 +300,11 @@ function appendLine(options: AppendOptions, message: string, after?: AfterAppend
   const didLastTerminateLine = didLastOutputTerminateLine[destination];
   didLastOutputTerminateLine[destination] = true;
   if (destination === 'repl-window') {
-    outputWindow.appendLine(
-      `${didLastTerminateLine ? '; ' : ''}${asClojureLineComments(util.stripAnsi(message))}`,
-      after
-    );
+    const decoratedMessage =
+      options.outputCategory === 'evalOut' && config.getConfig().legacyPrintBareReplWindowOutput
+        ? message
+        : `${didLastTerminateLine ? '; ' : ''}${asClojureLineComments(util.stripAnsi(message))}`;
+    outputWindow.appendLine(decoratedMessage, after);
     return;
   }
   if (destination === 'output-channel') {


### PR DESCRIPTION
## What has changed?

Adding a setting for enabling legacy stdout printing to the REPL Window. See #2470 and Slack for rationale.

* Fixes #2470 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
