### PR TITLE
Paredit Multicursor - Rewrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- Implement experimental support for multicursor rewrap commands. Enable `calva.paredit.multicursor` in your settings to try it out. Addressing [#2448](https://github.com/BetterThanTomorrow/calva/issues/2448) 
+- [Implement experimental support for multicursor rewrap commands](https://github.com/BetterThanTomorrow/calva/issues/2448). Enable `calva.paredit.multicursor` in your settings to try it out. Addressing [#2445](https://github.com/BetterThanTomorrow/calva/issues/2445) 
 
 ## [2.0.432] - 2024-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- [Implement experimental support for multicursor rewrap commands](https://github.com/BetterThanTomorrow/calva/issues/2448). Enable `calva.paredit.multicursor` in your settings to try it out. Addressing [#2445](https://github.com/BetterThanTomorrow/calva/issues/2445) 
+- [Implement experimental support for multicursor rewrap commands](https://github.com/BetterThanTomorrow/calva/issues/2448). Enable `calva.paredit.multicursor` in your settings to try it out. Closes [#2473](https://github.com/BetterThanTomorrow/calva/issues/2473) 
 
 ## [2.0.432] - 2024-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Implement experimental support for multicursor rewrap commands. Enable `calva.paredit.multicursor` in your settings to try it out. Addressing [#2448](https://github.com/BetterThanTomorrow/calva/issues/2448) 
+
 ## [2.0.432] - 2024-03-26
 
 - Fix: [Extraneous newlines printed to terminal for some output](https://github.com/BetterThanTomorrow/calva/issues/2468)

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -156,4 +156,5 @@ Happy Editing! ❤️
 There is an ongoing effort to support simultaneous multicursor editing with Paredit. This is an experimental feature and is not enabled by default. To enable it, set `calva.paredit.multicursor` to `true`. This feature is still in development and may not work as expected in all cases. Currently, this supports the following categories:
 
 - Movement
-- Selection
+- Selection (except for `Select Current Form` - coming soon!)
+- Rewrap

--- a/package.json
+++ b/package.json
@@ -1023,7 +1023,7 @@
           },
           "calva.paredit.multicursor": {
             "type": "boolean",
-            "markdownDescription": "Experimental: Support for multiple cursors in paredit commands.\nCurrently supported commands:\n- Cursor movement\n- Cursor selection",
+            "markdownDescription": "Experimental: Support for multiple cursors in paredit commands.\nCurrently supported commands:\n- Cursor movement\n- Cursor selection\n- Rewrap",
             "default": false,
             "scope": "window"
           }

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -700,14 +700,14 @@ export function rewrapSexpr(
   selections.forEach((sel, index) => {
     const { active } = sel;
     const cursor = doc.getTokenCursor(active);
-  if (cursor.backwardList()) {
-    cursor.backwardUpList();
-    const oldOpenStart = cursor.offsetStart;
-    const oldOpenLength = cursor.getToken().raw.length;
-    const oldOpenEnd = oldOpenStart + oldOpenLength;
-    if (cursor.forwardSexp()) {
-      const oldCloseStart = cursor.offsetStart - close.length;
-      const oldCloseEnd = cursor.offsetStart;
+    if (cursor.backwardList()) {
+      cursor.backwardUpList();
+      const oldOpenStart = cursor.offsetStart;
+      const oldOpenLength = cursor.getToken().raw.length;
+      const oldOpenEnd = oldOpenStart + oldOpenLength;
+      if (cursor.forwardSexp()) {
+        const oldCloseStart = cursor.offsetStart - close.length;
+        const oldCloseEnd = cursor.offsetStart;
         const openChange = open.length - oldOpenLength;
         edits.push(
           {
@@ -720,13 +720,13 @@ export function rewrapSexpr(
             change: openChange,
             type: 'open',
           }
-      );
+        );
         newSelections[index] = {
           selection: new ModelEditSelection(active),
           change: openChange,
         };
+      }
     }
-  }
   });
 
   // Due to the nature of dealing with list boundaries, multiple cursors could be targeting

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -670,14 +670,36 @@ export async function wrapSexpr(
   }
 }
 
-export async function rewrapSexpr(
+/**
+ * 'Rewraps' the lists containing each cursor/selection, as provided by `selections`, with
+ * the provided `open` and `close` strings.
+ *
+ * Single cursor is just the simpler special case when `selections.length` is 1
+ * High level overview:
+ * - For each cursor, find the offsets/ranges for its containing list's open/close tokens.
+ * - Make 2 ModelEdits for each token's replacement +  1 Selection; record the offset change.
+ * - Dedupe each edit (as multi cursors could be in the same list).
+ * - Then, reposition the edits and selections by the preceding edits' offset changes.
+ * - Finally, apply the edits and update the selections.
+ *
+ * @param doc
+ * @param open
+ * @param close
+ * @param selections
+ * @returns
+ */
+export function rewrapSexpr(
   doc: EditableDocument,
   open: string,
   close: string,
-  start: number = doc.selections[0].anchor,
-  end: number = doc.selections[0].active
-): Promise<Thenable<boolean>> {
-  const cursor = doc.getTokenCursor(end);
+  selections = [doc.selections[0]]
+) {
+  const edits: { type: 'open' | 'close'; change: number; edit: ModelEdit<'changeRange'> }[] = [],
+    newSelections = _.clone(selections).map((s) => ({ selection: s, change: 0 }));
+
+  selections.forEach((sel, index) => {
+    const { active } = sel;
+    const cursor = doc.getTokenCursor(active);
   if (cursor.backwardList()) {
     cursor.backwardUpList();
     const oldOpenStart = cursor.offsetStart;
@@ -686,16 +708,65 @@ export async function rewrapSexpr(
     if (cursor.forwardSexp()) {
       const oldCloseStart = cursor.offsetStart - close.length;
       const oldCloseEnd = cursor.offsetStart;
-      const d = open.length - oldOpenLength;
-      return doc.model.edit(
-        [
-          new ModelEdit('changeRange', [oldCloseStart, oldCloseEnd, close]),
-          new ModelEdit('changeRange', [oldOpenStart, oldOpenEnd, open]),
-        ],
-        { selections: [new ModelEditSelection(end + d)] }
+        const openChange = open.length - oldOpenLength;
+        edits.push(
+          {
+            edit: new ModelEdit('changeRange', [oldCloseStart, oldCloseEnd, close]),
+            change: 0,
+            type: 'close',
+          },
+          {
+            edit: new ModelEdit('changeRange', [oldOpenStart, oldOpenEnd, open]),
+            change: openChange,
+            type: 'open',
+          }
       );
+        newSelections[index] = {
+          selection: new ModelEditSelection(active),
+          change: openChange,
+        };
     }
   }
+  });
+
+  // Due to the nature of dealing with list boundaries, multiple cursors could be targeting
+  // the same lists, which will result in attempting to delete the same ranges twice. So we dedupe.
+  const uniqEdits = _.uniqWith(edits, _.isEqual);
+
+  // for both edits and new selections, get the offset by which to move each based on prior edits
+  function getOffset(cursorOffset: number) {
+    return _(uniqEdits)
+      .filter((x) => {
+        const [xStart] = x.edit.args;
+        return xStart < cursorOffset;
+      })
+      .map(({ change }) => change)
+      .sum();
+  }
+
+  const editsToApply = _(uniqEdits)
+    // First, importantly, sort by list open char offset
+    .sortBy((e) => e.edit.args[0])
+    // now, let's iterate thru each cursor and adjust their positions if earlier chars are delete/added
+    .map((e) => {
+      const [oldStart, oldEnd, text] = e.edit.args;
+      const offset = getOffset(oldStart);
+      const newStart = oldStart + offset;
+      const newEnd = oldEnd + offset;
+      return { ...e.edit, args: [newStart, newEnd, text] as const };
+    })
+    .value();
+  const selectionsToApply = newSelections.map(({ selection }) => {
+    const { active } = selection;
+    const newSel = selection.clone();
+    const offset = getOffset(active);
+    newSel.reposition(offset);
+    return newSel;
+  });
+
+  return doc.model.edit(editsToApply, {
+    selections: selectionsToApply,
+  });
 }
 
 export async function splitSexp(doc: EditableDocument, start: number = doc.selections[0].active) {

--- a/src/extension-test/unit/paredit/commands-test.ts
+++ b/src/extension-test/unit/paredit/commands-test.ts
@@ -1128,6 +1128,35 @@ describe('paredit commands', () => {
           expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
 
+        it('Multi-cursor: Handles rewrapping nested forms [] -> {}', async () => {
+          const a = docFromTextNotation('[:d :e [a|1 [b c|]]]');
+          const b = docFromTextNotation('[:d :e {a|1 {b c|}}]');
+          await handlers.rewrapCurly(a, true);
+          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
+          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        });
+        it('Multi-cursor: Handles rewrapping nested forms [] -> {} 2', async () => {
+          const a = docFromTextNotation('[|1:d :e [a|2 [b c|]]]');
+          const b = docFromTextNotation('{|1:d :e {a|2 {b c|}}}');
+          await handlers.rewrapCurly(a, true);
+          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
+          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        });
+        it('Multi-cursor: Handles rewrapping nested forms mixed -> {}', async () => {
+          const a = docFromTextNotation('[:d :e (a|1 {b c|})]');
+          const b = docFromTextNotation('[:d :e {a|1 {b c|}}]');
+          await handlers.rewrapCurly(a, true);
+          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
+          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        });
+        it('Multi-cursor: Handles rewrapping nested forms mixed -> {} 2', async () => {
+          const a = docFromTextNotation('[|1:d :e (a|2 {b c|})]');
+          const b = docFromTextNotation('{|1:d :e {a|2 {b c|}}}');
+          await handlers.rewrapCurly(a, true);
+          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
+          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        });
+
         it('Single-cursor: Rewraps #{} -> {}', async () => {
           const a = docFromTextNotation('#{a #{b c|} d}');
           const b = docFromTextNotation('#{a {b c|} d}');

--- a/src/paredit/commands.ts
+++ b/src/paredit/commands.ts
@@ -122,3 +122,25 @@ export async function killLeft(
     result.editOptions
   );
 }
+
+// REWRAP
+
+export function rewrapQuote(doc: EditableDocument, isMulti: boolean) {
+  return paredit.rewrapSexpr(doc, '"', '"', isMulti ? doc.selections : [doc.selections[0]]);
+}
+
+export function rewrapSet(doc: EditableDocument, isMulti: boolean) {
+  return paredit.rewrapSexpr(doc, '#{', '}', isMulti ? doc.selections : [doc.selections[0]]);
+}
+
+export function rewrapCurly(doc: EditableDocument, isMulti: boolean) {
+  return paredit.rewrapSexpr(doc, '{', '}', isMulti ? doc.selections : [doc.selections[0]]);
+}
+
+export function rewrapSquare(doc: EditableDocument, isMulti: boolean) {
+  return paredit.rewrapSexpr(doc, '[', ']', isMulti ? doc.selections : [doc.selections[0]]);
+}
+
+export function rewrapParens(doc: EditableDocument, isMulti: boolean) {
+  return paredit.rewrapSexpr(doc, '(', ')', isMulti ? doc.selections : [doc.selections[0]]);
+}

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -392,31 +392,36 @@ const pareditCommands: PareditCommand[] = [
   {
     command: 'paredit.rewrapParens',
     handler: (doc: EditableDocument) => {
-      return paredit.rewrapSexpr(doc, '(', ')');
+      const isMulti = multiCursorEnabled();
+      return handlers.rewrapParens(doc, isMulti);
     },
   },
   {
     command: 'paredit.rewrapSquare',
     handler: (doc: EditableDocument) => {
-      return paredit.rewrapSexpr(doc, '[', ']');
+      const isMulti = multiCursorEnabled();
+      return handlers.rewrapSquare(doc, isMulti);
     },
   },
   {
     command: 'paredit.rewrapCurly',
     handler: (doc: EditableDocument) => {
-      return paredit.rewrapSexpr(doc, '{', '}');
+      const isMulti = multiCursorEnabled();
+      return handlers.rewrapCurly(doc, isMulti);
     },
   },
   {
     command: 'paredit.rewrapSet',
     handler: (doc: EditableDocument) => {
-      return paredit.rewrapSexpr(doc, '#{', '}');
+      const isMulti = multiCursorEnabled();
+      return handlers.rewrapSet(doc, isMulti);
     },
   },
   {
     command: 'paredit.rewrapQuote',
     handler: (doc: EditableDocument) => {
-      return paredit.rewrapSexpr(doc, '"', '"');
+      const isMulti = multiCursorEnabled();
+      return handlers.rewrapQuote(doc, isMulti);
     },
   },
   {


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Implement multicursor for paredit rewrap
- Like my other multicursor work this time, extracted command logic into a commands.ts file, adding some indirection and opt-in multicursor based on user setting etc
- Add tests

Originally this was going to include multicursor wrap (now a WIP at #2472 ), but a couple of test cases keeping failing, so here's rewrap alone!

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2473 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
