### PR TITLE
Paredit Multicursor - SelectCurrentForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- [Implement experimental support for multicursor rewrap commands](https://github.com/BetterThanTomorrow/calva/issues/2448). Enable `calva.paredit.multicursor` in your settings to try it out. Closes [#2473](https://github.com/BetterThanTomorrow/calva/issues/2473) 
+- [Implement experimental support for multicursor selectCurrentForm command](https://github.com/BetterThanTomorrow/calva/issues/2476). Enable `calva.paredit.multicursor` in your settings to try it out. Closes [#2476](https://github.com/BetterThanTomorrow/calva/issues/2476) 
+- [Implement experimental support for multicursor rewrap commands](https://github.com/BetterThanTomorrow/calva/issues/2473). Enable `calva.paredit.multicursor` in your settings to try it out. Closes [#2473](https://github.com/BetterThanTomorrow/calva/issues/2473) 
 
 ## [2.0.432] - 2024-03-26
 

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -125,7 +125,7 @@ Default keybinding                | Action | Description
     You can have the *kill* commands always copy the deleted code to the clipboard by setting `calva.paredit.killAlsoCutsToClipboard` to `true`.  If you want to do this more on-demand, you can kill text by using the [selection commands](#selecting) and then *Cut* once you have the selection.
 
 !!! Note "clojure-lsp drag fwd/back overlap"
-    As an experimental feature, the two commands for dragging forms forward and backward have clojure-lsp alternativs. See the [clojure-lsp](clojure-lsp.md#clojure-lsp-drag-fwdback) page.
+    As an experimental feature, the two commands for dragging forms forward and backward have clojure-lsp alternatives. See the [clojure-lsp](clojure-lsp.md#clojure-lsp-drag-fwdback) page.
 
 ### Drag bindings forward/backward
 

--- a/package.json
+++ b/package.json
@@ -1562,8 +1562,8 @@
         "enablement": "editorLangId == clojure"
       },
       {
-        "category": "Calva",
-        "command": "paredit.selectCurrentForm",
+        "category": "Calva Paredit",
+        "command": "calva.selectCurrentForm", // legacy id for backward compat
         "title": "Select Current Form",
         "enablement": "editorLangId == clojure"
       },
@@ -2151,7 +2151,7 @@
         "when": "calva:keybindingsEnabled"
       },
       {
-        "command": "calva.selectCurrentForm",
+        "command": "calva.selectCurrentForm", // legacy id for backward compat
         "key": "ctrl+alt+c ctrl+s",
         "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
       },
@@ -3078,7 +3078,7 @@
         },
         {
           "when": "editorLangId == clojure",
-          "command": "calva.selectCurrentForm",
+          "command": "calva.selectCurrentForm", // legacy id for backward compat
           "group": "calva/a-structural-editing"
         },
         {

--- a/package.json
+++ b/package.json
@@ -1344,12 +1344,6 @@
         "category": "Calva"
       },
       {
-        "command": "calva.selectCurrentForm",
-        "title": "Select Current Form",
-        "category": "Calva",
-        "enablement": "editorLangId == clojure"
-      },
-      {
         "command": "calva.clearInlineResults",
         "title": "Clear Inline Evaluation Results",
         "category": "Calva",
@@ -1565,6 +1559,12 @@
         "category": "Calva Paredit",
         "command": "paredit.closeList",
         "title": "Move Cursor Forward to List End/Close",
+        "enablement": "editorLangId == clojure"
+      },
+      {
+        "category": "Calva",
+        "command": "paredit.selectCurrentForm",
+        "title": "Select Current Form",
         "enablement": "editorLangId == clojure"
       },
       {

--- a/package.json
+++ b/package.json
@@ -1563,7 +1563,7 @@
       },
       {
         "category": "Calva Paredit",
-        "command": "calva.selectCurrentForm", // legacy id for backward compat
+        "command": "calva.selectCurrentForm",
         "title": "Select Current Form",
         "enablement": "editorLangId == clojure"
       },
@@ -2151,7 +2151,7 @@
         "when": "calva:keybindingsEnabled"
       },
       {
-        "command": "calva.selectCurrentForm", // legacy id for backward compat
+        "command": "calva.selectCurrentForm",
         "key": "ctrl+alt+c ctrl+s",
         "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus"
       },
@@ -3078,7 +3078,7 @@
         },
         {
           "when": "editorLangId == clojure",
-          "command": "calva.selectCurrentForm", // legacy id for backward compat
+          "command": "calva.selectCurrentForm",
           "group": "calva/a-structural-editing"
         },
         {

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -49,37 +49,26 @@ export function selectRange(doc: EditableDocument, ranges: ModelEditRange[]) {
   growSelectionStack(doc, ranges);
 }
 
-function getFormSelection(
-  doc: EditableDocument,
-  offset: number,
-  topLevel: boolean
-): ModelEditSelection | undefined {
-  const idx = offset;
-  const cursor = doc.getTokenCursor(idx);
-  const range = topLevel ? cursor.rangeForDefun(idx) : cursor.rangeForCurrentForm(idx);
-  if (range) {
-    return new ModelEditSelection(range[0], range[1]);
-  } else {
-    return undefined;
-  }
-}
-
+// TODO: implement via growSelectionStack
 export function selectForm(
   // doc: MirroredDocument,
   doc: EditableDocument,
-  toplevel: boolean,
+  topLevel: boolean,
   selections = doc.selections
 ) {
-  // const editor = util.getActiveTextEditor(),
-  // doc = util.getDocument(document),
-  // selection = doc.selections[0];
-
   const newSels = selections.map((sel) => {
-    // const selection = sel.asSelection(vscDoc);
     const selection = sel;
     if (selection.isCursor) {
-      // const codeSelection = selectionFn(vscDoc, selection.active, toplevel);
-      const codeSelection = getFormSelection(doc, selection.active, toplevel);
+      let codeSelection;
+      const cursor = doc.getTokenCursor(selection.active);
+      const range = topLevel
+        ? cursor.rangeForDefun(selection.active)
+        : cursor.rangeForCurrentForm(selection.active);
+      if (range) {
+        codeSelection = new ModelEditSelection(range[0], range[1]);
+      } else {
+        codeSelection = undefined;
+      }
       if (codeSelection) {
         return codeSelection;
       }

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -49,13 +49,7 @@ export function selectRange(doc: EditableDocument, ranges: ModelEditRange[]) {
   growSelectionStack(doc, ranges);
 }
 
-// TODO: implement via growSelectionStack
-export function selectForm(
-  // doc: MirroredDocument,
-  doc: EditableDocument,
-  topLevel: boolean,
-  selections = doc.selections
-) {
+export function selectForm(doc: EditableDocument, topLevel: boolean, selections = doc.selections) {
   const newSels = selections.map((sel) => {
     const selection = sel;
     if (selection.isCursor) {
@@ -76,7 +70,7 @@ export function selectForm(
     return sel;
   });
 
-  doc.selections = newSels;
+  growSelectionStack(doc, newSels.map(_.property('asDirectedRange')));
 }
 
 export function selectRangeForward(

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -49,6 +49,47 @@ export function selectRange(doc: EditableDocument, ranges: ModelEditRange[]) {
   growSelectionStack(doc, ranges);
 }
 
+function getFormSelection(
+  doc: EditableDocument,
+  offset: number,
+  topLevel: boolean
+): ModelEditSelection | undefined {
+  const idx = offset;
+  const cursor = doc.getTokenCursor(idx);
+  const range = topLevel ? cursor.rangeForDefun(idx) : cursor.rangeForCurrentForm(idx);
+  if (range) {
+    return new ModelEditSelection(range[0], range[1]);
+  } else {
+    return undefined;
+  }
+}
+
+export function selectForm(
+  // doc: MirroredDocument,
+  doc: EditableDocument,
+  toplevel: boolean,
+  selections = doc.selections
+) {
+  // const editor = util.getActiveTextEditor(),
+  // doc = util.getDocument(document),
+  // selection = doc.selections[0];
+
+  const newSels = selections.map((sel) => {
+    // const selection = sel.asSelection(vscDoc);
+    const selection = sel;
+    if (selection.isCursor) {
+      // const codeSelection = selectionFn(vscDoc, selection.active, toplevel);
+      const codeSelection = getFormSelection(doc, selection.active, toplevel);
+      if (codeSelection) {
+        return codeSelection;
+      }
+    }
+    return sel;
+  });
+
+  doc.selections = newSels;
+}
+
 export function selectRangeForward(
   doc: EditableDocument,
   ranges: ModelEditRange[],

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -49,7 +49,11 @@ export function selectRange(doc: EditableDocument, ranges: ModelEditRange[]) {
   growSelectionStack(doc, ranges);
 }
 
-export function selectForm(doc: EditableDocument, topLevel: boolean, selections = doc.selections) {
+export function selectCurrentForm(
+  doc: EditableDocument,
+  topLevel: boolean,
+  selections = doc.selections
+) {
   const newSels = selections.map((sel) => {
     const selection = sel;
     if (selection.isCursor) {

--- a/src/extension-test/unit/paredit/commands-test.ts
+++ b/src/extension-test/unit/paredit/commands-test.ts
@@ -334,25 +334,92 @@ describe('paredit commands', () => {
 
   describe('selection', () => {
     describe('selectCurrentForm', () => {
-      it('Single-cursor:', () => {
+      it('Single-cursor: handles cases like reader tags/metadata + keeps other selections ', () => {
         const a = docFromTextNotation(
-          '(defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
+          '(defn|1 [a b]•(let [^js a|a #p (+ a)•b b]•{:a aa•:b b}))•(:a)'
         );
         const aSelections = a.selections;
         const b = docFromTextNotation(
-          '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(|:a|)'
+          '(defn [a b]•(let [|^js aa| #p (+ a)•b b]•{:a aa•:b b}))•(:a)'
         );
         handlers.selectCurrentForm(a, false);
         expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
         expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
-      it('Multi-cursor:', () => {
+      it('Multi-cursor: handles cases like reader tags/metadata + keeps other selections ', () => {
         const a = docFromTextNotation(
           '(defn|1 |2[a b]•(let [|3^js aa |4#p (+ a)•<5b b<5]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
         const b = docFromTextNotation(
           '(|1defn|1 |2[a b]|2•(let [|3^js aa|3 |4#p (+ a)|4•<5b b<5]•{:a aa•:b b}))•(|:a|)'
+        );
+        handlers.selectCurrentForm(a, true);
+        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
+        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+      });
+
+      it('Single-cursor: handles cursor at a distance from form', () => {
+        const a = docFromTextNotation('[|1    a b  |2c    d { e f}|3 g   |]');
+        const aSelections = a.selections;
+        const b = docFromTextNotation('[    a b  c    d { e f} |g|   ]');
+        handlers.selectCurrentForm(a, false);
+        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
+        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+      });
+      it('Multi-cursor: handles cursor at a distance from form', () => {
+        const a = docFromTextNotation('[|1    a b  |2c    d { e f}|3 g   |]');
+        const aSelections = a.selections;
+        const b = docFromTextNotation('[    |1a|1 b  |2c|2    d |3{ e f}|3 |g|   ]');
+        handlers.selectCurrentForm(a, true);
+        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
+        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+      });
+
+      it('Single-cursor: collapses overlapping selections', () => {
+        const a = docFromTextNotation(
+          '(de|1fn| [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:a)'
+        );
+        const aSelections = a.selections;
+        const b = docFromTextNotation(
+          '(|defn| [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:a)'
+        );
+        handlers.selectCurrentForm(a, false);
+        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
+        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+      });
+      it('Multi-cursor: collapses overlapping selections', () => {
+        const a = docFromTextNotation(
+          '(de|5fn|1 |2[a b]•(let [|3^js aa |4#p (+ a)•<5b b<5]•{:a aa•:b b}))•(:|a)'
+        );
+        const aSelections = a.selections;
+        const b = docFromTextNotation(
+          '(|1defn|1 |2[a b]|2•(let [|3^js aa|3 |4#p (+ a)|4•<5b b<5]•{:a aa•:b b}))•(|:a|)'
+        );
+        handlers.selectCurrentForm(a, true);
+        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
+        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+      });
+
+      it('Single-cursor: collapses overlapping selections preferring the larger one', () => {
+        const a = docFromTextNotation(
+          '(de|1fn| [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:a)'
+        );
+        const aSelections = a.selections;
+        const b = docFromTextNotation(
+          '(|defn| [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:a)'
+        );
+        handlers.selectCurrentForm(a, false);
+        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
+        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+      });
+      it('Multi-cursor: collapses overlapping selections preferring the larger one', () => {
+        const a = docFromTextNotation(
+          '(defn [a b]•(let [^js aa #p (+ a)•b |b]|1•|3{:a a|2a•:b b}))•(:a)'
+        );
+        const aSelections = a.selections;
+        const b = docFromTextNotation(
+          '(defn [a b]•(let |1[^js aa #p (+ a)•b b]|1•|3{:a aa•:b b}|3))•(:a)'
         );
         handlers.selectCurrentForm(a, true);
         expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));

--- a/src/extension-test/unit/paredit/commands-test.ts
+++ b/src/extension-test/unit/paredit/commands-test.ts
@@ -333,6 +333,32 @@ describe('paredit commands', () => {
   });
 
   describe('selection', () => {
+    describe('selectCurrentForm', () => {
+      it('Single-cursor:', () => {
+        const a = docFromTextNotation(
+          '(defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
+        );
+        const aSelections = a.selections;
+        const b = docFromTextNotation(
+          '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(|:a|)'
+        );
+        handlers.selectCurrentForm(a, false);
+        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
+        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+      });
+      it('Multi-cursor:', () => {
+        const a = docFromTextNotation(
+          '(defn|1 |2[a b]•(let [|3^js aa |4#p (+ a)•<5b b<5]•{:a aa•:b b}))•(:|a)'
+        );
+        const aSelections = a.selections;
+        const b = docFromTextNotation(
+          '(|1defn|1 |2[a b]|2•(let [|3^js aa|3 |4#p (+ a)|4•<5b b<5]•{:a aa•:b b}))•(|:a|)'
+        );
+        handlers.selectCurrentForm(a, true);
+        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
+        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+      });
+    });
     describe('rangeForDefun', () => {
       it('Single-cursor:', () => {
         const a = docFromTextNotation(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,6 @@ import * as definition from './providers/definition';
 import { CalvaSignatureHelpProvider } from './providers/signature';
 import testRunner from './testRunner';
 import annotations from './providers/annotations';
-import * as select from './select';
 import eval from './evaluate';
 import refresh from './refresh';
 import * as greetings from './greet';
@@ -258,7 +257,6 @@ async function activate(context: vscode.ExtensionContext) {
     runCustomREPLCommand: snippets.evaluateCustomCodeSnippetCommand,
     runNamespaceTests: () => testRunner.runNamespaceTestsCommand(testController),
     runTestUnderCursor: () => testRunner.runTestUnderCursorCommand(testController),
-    selectCurrentForm: select.selectCurrentForm,
     sendCurrentFormToOutputWindow: outputWindow.appendCurrentForm,
     openFiddleForSourceFile: fiddleFiles.openFiddleForSourceFile,
     evaluateFiddleForSourceFile: fiddleFiles.evaluateFiddleForSourceFile,

--- a/src/paredit/commands.ts
+++ b/src/paredit/commands.ts
@@ -56,6 +56,10 @@ export function openList(doc: EditableDocument, isMulti: boolean = false) {
 
 // SELECTION
 
+export function selectCurrentForm(doc: EditableDocument, isMulti: boolean = false) {
+  paredit.selectForm(doc, false, isMulti ? doc.selections : [doc.selections[0]]);
+}
+
 export function rangeForDefun(doc: EditableDocument, isMulti: boolean) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.rangeForDefun(doc, s.active));

--- a/src/paredit/commands.ts
+++ b/src/paredit/commands.ts
@@ -57,9 +57,8 @@ export function openList(doc: EditableDocument, isMulti: boolean = false) {
 // SELECTION
 
 export function selectCurrentForm(doc: EditableDocument, isMulti: boolean = false) {
-  paredit.selectForm(doc, false, isMulti ? doc.selections : [doc.selections[0]]);
+  paredit.selectCurrentForm(doc, false, isMulti ? doc.selections : [doc.selections[0]]);
 }
-
 export function rangeForDefun(doc: EditableDocument, isMulti: boolean) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.rangeForDefun(doc, s.active));

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -115,7 +115,7 @@ const pareditCommands: PareditCommand[] = [
 
   // SELECTING
   {
-    command: 'paredit.selectCurrentForm',
+    command: 'calva.selectCurrentForm', // legacy command id for backward compat
     handler: (doc: EditableDocument) => {
       const isMulti = multiCursorEnabled();
       handlers.selectCurrentForm(doc, isMulti);

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -115,6 +115,13 @@ const pareditCommands: PareditCommand[] = [
 
   // SELECTING
   {
+    command: 'paredit.selectCurrentForm',
+    handler: (doc: EditableDocument) => {
+      const isMulti = multiCursorEnabled();
+      handlers.selectCurrentForm(doc, isMulti);
+    },
+  },
+  {
     command: 'paredit.rangeForDefun',
     handler: (doc: EditableDocument) => {
       const isMulti = multiCursorEnabled();

--- a/src/select.ts
+++ b/src/select.ts
@@ -37,28 +37,3 @@ export function getEnclosingFormSelection(
     }
   }
 }
-
-function selectForm(
-  document = {},
-  selectionFn: (
-    doc: vscode.TextDocument,
-    pos: vscode.Position,
-    topLevel: boolean
-  ) => vscode.Selection | undefined,
-  toplevel: boolean
-) {
-  const editor = util.getActiveTextEditor(),
-    doc = util.getDocument(document),
-    selection = editor.selections[0];
-
-  if (selection.isEmpty) {
-    const codeSelection = selectionFn(doc, selection.active, toplevel);
-    if (codeSelection) {
-      editor.selections = [codeSelection];
-    }
-  }
-}
-
-export function selectCurrentForm(document = {}) {
-  selectForm(document, getFormSelection, false);
-}


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

~~This PR is targeting my other PR #2474 's branch, such that once that gets merged, this should automatically target `dev`, but I'll leave the 2nd branch target checkbox unmarked just in case for now~~

- Implement multicursor `selectCurrentForm`
- Removes its previous implementation in `src/select.ts` and exposure under root ~~`calva.selectCurrentForm`~~ commands, into a rewritten version in `src/cursor-doc/paredit.ts`/`commands.ts`/`src/paredit/extension.ts` like the other paredit multicursor rewrites exposed as `paredit.selectCurrentForm`.
  - **[EDIT]**: **just keeps the previous command id for backwards compat, thanks @PEZ** 
- Adds tests for single and multi cursor

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2476 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
