### PR TITLE
Fix mkdocs materials social cards issue

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,17 +21,15 @@ extra:
 repo_name: Calva
 repo_url: https://github.com/BetterThanTomorrow/calva
 edit_uri: edit/published/docs/site
-strict: true
+#strict: true
 plugins:
   - search:
      separator: '[\s\-\._]'
   - social:
       cards: true
-      cards_layout_options:
-        background_color:
-          fill: "#db9550"
-        color:
-          text: "#fafafa"
+      cards_color:
+        fill: "#db9550"
+        text: "#fafafa"
 markdown_extensions:
   - meta
   - attr_list

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,9 +27,11 @@ plugins:
      separator: '[\s\-\._]'
   - social:
       cards: true
-      cards_color:
-        fill: "#db9550"
-        text: "#fafafa"
+      cards_layout_options:
+        background_color:
+          fill: "#db9550"
+        color:
+          text: "#fafafa"
 markdown_extensions:
   - meta
   - attr_list

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-CairoSVG==2.7.0
-mkdocs==1.4.2
-mkdocs-material==9.1.8
+mkdocs==1.5.3
+mkdocs-material==9.5.16
 Pillow==10.2.0
+CairoSVG==2.7.1


### PR DESCRIPTION
## What has changed?

Bumping to latest mkdocs materials and its dependencies. Had to disable config `strict` mode, because they have deprecated the old cards config, but using the new config crashes. Will check their issues list for clues about what that can be about.


## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
