### PR TITLE
Allow paredit commands to accept args - and use them for multicursor & copying when killing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Support command binding args to toggle multicursor per command or toggle copy per kill command. Closes #2485](https://github.com/BetterThanTomorrow/calva/issues/2485)
+
 ## [2.0.439] - 2024-04-11
 
 - Fix: [Refresh Changed Namespaces do not output to the selected output destination](https://github.com/BetterThanTomorrow/calva/issues/2506)

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -199,3 +199,18 @@ There is an ongoing effort to support simultaneous multicursor editing with Pare
 - Movement
 - Selection (except for `Select Current Form` - coming soon!)
 - Rewrap
+
+### Toggling Multicursor per command
+
+The experimental multicursor-supported commands support an optional command arg - like `copy` for the `kill*` commands [mentioned above](#command-args) - to control whether multicursor is enabled for that command. This is an alternative to, or supports binding-specific overrides for, `calva.paredit.multicursor`.
+
+For example:
+
+```json
+{
+  "key": "ctrl+k",
+  "command": "paredit.sexpRangeExpansion",
+  "when": "... your when conditions ...",
+  "args": {"multicursor": false}
+}
+```

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -161,6 +161,59 @@ There are some context keys you can utilize to configure keyboard shortcuts with
 
 In some instances built-in command defaults are the same as Paredit's defaults, and Paredit's functionality in a particular case is less than what the default is. This is true of *Expand Selection* and *Shrink Selection* for Windows/Linux when multiple lines are selected. In this particular case adding `!editorHasMultipleSelections` to the `when` clause of the binding makes for a better workflow. The point is that when the bindings overlap and default functionality is desired peaceful integration can be achieved with the right `when` clause. This is left out of Paredit's defaults to respect user preference, and ease of maintenance.
 
+### Command Args
+
+VSCode allows you to provide arguments to configured bindings, allowing, for example, different variants or behaviors for the same command, each bound to different shortcuts. Calva takes advantage of this by offering two commands with args:
+
+#### **1. `copy` for all `kill*` commands**
+
+When specified, will control whether killed text will be copied to the clipboard.
+This is an alternative to, or supports binding-specific overrides for, `calva.paredit.killAlsoCutsToClipboard`.
+
+For example, here's 2 keybindings for `paredit.killRight` with different `copy` args, allowing you to choose when or if you want killed text copied at keypress-time, regardless of global `calva.paredit.killAlsoCutsToClipboard` setting:
+
+```json
+{
+  "key": "ctrl+k",
+  "command": "paredit.killRight",
+  "when": "... your when conditions ...",
+  "args": {"copy": false}
+},
+{
+  "key": "cmd+k ctrl+k",
+  "command": "paredit.killRight",
+  "when": "... your when conditions ...",
+  "args": {"copy": true}
+},
+```
+
+Or, you can even have both of them use the **same `key`**, but **separate `when` conditions** to taste, to allow context-conditional copying.
+
+#### **2. `multicursor` for all experimental multicursor-enabled commands**
+
+When specified, will control whether multiple cursors are handled in supported paredit commands, or
+if cursors after the first are discarded. As mentioned in the [Multicursor section below](#experimental-feature-multicursor-support), this is an experimental feature and is not enabled by default. This arg allows you to toggle multicursor globally except for a few commands.
+This is an alternative to, or supports binding-specific overrides for, `calva.paredit.multcursor`.
+
+For example, here's 2 keybindings for `paredit.sexpRangeExpansion` with different `multicursor` args, allowing you to choose when or if you want multicursor handling at keypress-time, regardless of global `calva.paredit.multicursor` setting:
+
+```json
+{
+  "key": "ctrl+k",
+  "command": "paredit.sexpRangeExpansion",
+  "when": "... your when conditions ...",
+  "args": {"multicursor": false}
+},
+{
+  "key": "cmd+k ctrl+k",
+  "command": "paredit.sexpRangeExpansion",
+  "when": "... your when conditions ...",
+  "args": {"multicursor": true}
+},
+```
+
+Or, you can even have both of them use the **same `key`**, but **separate `when` conditions** to taste, allowing context-conditional multicursor.
+
 Happy Editing! ❤️
 
 ## Experimental Feature: Multicursor support

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -60,7 +60,7 @@ To make the command descriptions a bit clearer, each entry is animated. When you
 
 ### Command Args
 
-VSCode allows you to provide arguments to configured bindings, allowing, for example, different variants or behaviors for the same command, each bound to different shortcuts. Calva takes advantage of this by offering one official command with args:
+Some Paredit commands accept arguments. You can utilize this in keybindings and from [Joyride](https://github.com/BetterThanTomorrow/joyride).
 
 #### **`copy` for all `kill*` commands**
 

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -58,6 +58,34 @@ The Paredit commands are sorted into **Navigation**, **Selection**, and **Edit**
 
 To make the command descriptions a bit clearer, each entry is animated. When you try to figure out what is going on in the GIFs, focus on where the cursor is at the start of the animation loop.
 
+### Command Args
+
+VSCode allows you to provide arguments to configured bindings, allowing, for example, different variants or behaviors for the same command, each bound to different shortcuts. Calva takes advantage of this by offering one official command with args:
+
+#### **`copy` for all `kill*` commands**
+
+When specified, will control whether killed text will be copied to the clipboard.
+This is an alternative to, or supports binding-specific overrides for, `calva.paredit.killAlsoCutsToClipboard`.
+
+For example, here's 2 keybindings for `paredit.killRight` with different `copy` args, allowing you to choose when or if you want killed text copied at keypress-time, regardless of global `calva.paredit.killAlsoCutsToClipboard` setting:
+
+```json
+{
+  "key": "ctrl+k",
+  "command": "paredit.killRight",
+  "when": "... your when conditions ...",
+  "args": {"copy": false}
+},
+{
+  "key": "cmd+k ctrl+k",
+  "command": "paredit.killRight",
+  "when": "... your when conditions ...",
+  "args": {"copy": true}
+},
+```
+
+Or, you can even have both of them use the **same `key`**, but **separate `when` conditions** to taste, to allow context-conditional copying.
+
 ### Strings are not Lists, but Anyway...
 
 In Calva Paredit, strings are treated in much the same way as lists are. Here's an example showing **Slurp** and **Barf**, **Forward/Backward List**, and **Expand Selection**.
@@ -161,58 +189,6 @@ There are some context keys you can utilize to configure keyboard shortcuts with
 
 In some instances built-in command defaults are the same as Paredit's defaults, and Paredit's functionality in a particular case is less than what the default is. This is true of *Expand Selection* and *Shrink Selection* for Windows/Linux when multiple lines are selected. In this particular case adding `!editorHasMultipleSelections` to the `when` clause of the binding makes for a better workflow. The point is that when the bindings overlap and default functionality is desired peaceful integration can be achieved with the right `when` clause. This is left out of Paredit's defaults to respect user preference, and ease of maintenance.
 
-### Command Args
-
-VSCode allows you to provide arguments to configured bindings, allowing, for example, different variants or behaviors for the same command, each bound to different shortcuts. Calva takes advantage of this by offering two commands with args:
-
-#### **1. `copy` for all `kill*` commands**
-
-When specified, will control whether killed text will be copied to the clipboard.
-This is an alternative to, or supports binding-specific overrides for, `calva.paredit.killAlsoCutsToClipboard`.
-
-For example, here's 2 keybindings for `paredit.killRight` with different `copy` args, allowing you to choose when or if you want killed text copied at keypress-time, regardless of global `calva.paredit.killAlsoCutsToClipboard` setting:
-
-```json
-{
-  "key": "ctrl+k",
-  "command": "paredit.killRight",
-  "when": "... your when conditions ...",
-  "args": {"copy": false}
-},
-{
-  "key": "cmd+k ctrl+k",
-  "command": "paredit.killRight",
-  "when": "... your when conditions ...",
-  "args": {"copy": true}
-},
-```
-
-Or, you can even have both of them use the **same `key`**, but **separate `when` conditions** to taste, to allow context-conditional copying.
-
-#### **2. `multicursor` for all experimental multicursor-enabled commands**
-
-When specified, will control whether multiple cursors are handled in supported paredit commands, or
-if cursors after the first are discarded. As mentioned in the [Multicursor section below](#experimental-feature-multicursor-support), this is an experimental feature and is not enabled by default. This arg allows you to toggle multicursor globally except for a few commands.
-This is an alternative to, or supports binding-specific overrides for, `calva.paredit.multcursor`.
-
-For example, here's 2 keybindings for `paredit.sexpRangeExpansion` with different `multicursor` args, allowing you to choose when or if you want multicursor handling at keypress-time, regardless of global `calva.paredit.multicursor` setting:
-
-```json
-{
-  "key": "ctrl+k",
-  "command": "paredit.sexpRangeExpansion",
-  "when": "... your when conditions ...",
-  "args": {"multicursor": false}
-},
-{
-  "key": "cmd+k ctrl+k",
-  "command": "paredit.sexpRangeExpansion",
-  "when": "... your when conditions ...",
-  "args": {"multicursor": true}
-},
-```
-
-Or, you can even have both of them use the **same `key`**, but **separate `when` conditions** to taste, allowing context-conditional multicursor.
 
 Happy Editing! ❤️
 

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -187,8 +187,31 @@ There are some context keys you can utilize to configure keyboard shortcuts with
 
 *The Nuclear Option*: You can choose to disable all default key bindings by configuring `calva.paredit.defaultKeyMap` to `none`. (Then you probably also want to register your own shortcuts for the commands you often use.)
 
-In some instances built-in command defaults are the same as Paredit's defaults, and Paredit's functionality in a particular case is less than what the default is. This is true of *Expand Selection* and *Shrink Selection* for Windows/Linux when multiple lines are selected. In this particular case adding `!editorHasMultipleSelections` to the `when` clause of the binding makes for a better workflow. The point is that when the bindings overlap and default functionality is desired peaceful integration can be achieved with the right `when` clause. This is left out of Paredit's defaults to respect user preference, and ease of maintenance.
+### When Clauses and VSCode Default Bindings
 
+There are instances where VSCode's built-in command binding defaults are the same as Paredit's, where Paredit's version has less functionality. For example, Calva's _Expand Selection_ and _Shrink Selection_ doesn't support multiple selections (though this may change in the future - see Multicursor section below). In this particular case, adding `!editorHasMultipleSelections` to the `when` clause of the binding makes up for this gap by letting the binding fall back to VSCode's native grow/shrink selection.
+
+For example, here's the JSON version of the keybindings settings demonstrating the above. Note this can also specified in the Keyboard Shortcuts UI:
+
+```json
+{
+  "key": "shift+alt+right",
+  "command": "paredit.sexpRangeExpansion",
+  "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/ && !calva:cursorInComment"
+}
+```
+
+to
+
+```json
+{
+  "key": "shift+alt+right",
+  "command": "paredit.sexpRangeExpansion",
+  "when": "!editorHasMultipleSelections && calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && paredit:keyMap =~ /original|strict/ && !calva:cursorInComment"
+}
+```
+
+The point is that when the bindings overlap and default functionality is desired peaceful integration can be achieved with the right `when` clause. This is left out of Paredit's defaults to respect user preference, and ease of maintenance.
 
 Happy Editing! ❤️
 

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -48,8 +48,9 @@ function multiCursorEnabled() {
 
 type PareditCommand = {
   command: string;
-  handler: (doc: EditableDocument) => void | Promise<any>;
+  handler: (doc: EditableDocument, ...args: readonly any[]) => void | Promise<any> | Thenable<any>; // do we still need to return Thenable from paredit fns?
 };
+
 const pareditCommands: PareditCommand[] = [
   // NAVIGATING
   {
@@ -470,7 +471,7 @@ const pareditCommands: PareditCommand[] = [
 ];
 
 function wrapPareditCommand(command: PareditCommand) {
-  return async () => {
+  return async (...args: readonly any[]) => {
     try {
       const textEditor = window.activeTextEditor;
 
@@ -480,7 +481,7 @@ function wrapPareditCommand(command: PareditCommand) {
       if (!enabled || !languages.has(textEditor.document.languageId)) {
         return;
       }
-      return command.handler(mDoc);
+      return command.handler(mDoc, ...args);
     } catch (e) {
       console.error(e.message);
     }

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -48,11 +48,13 @@ function multiCursorEnabled(override?: boolean): boolean {
 
 type PareditCommand = {
   command: string;
-  // do we still need to return Thenable from paredit fns?
-  handler: (doc: EditableDocument, arg: any) => void | Promise<any> | Thenable<any>;
+  handler: (doc: EditableDocument, arg?: any) => void | Promise<any> | Thenable<any>;
 };
 
-const pareditCommands: PareditCommand[] = [
+// only grab the custom, additional args after the first doc arg from the given command's handler
+type CommandArgOf<C extends PareditCommand> = Parameters<C['handler']>[1];
+
+const pareditCommands = [
   // NAVIGATING
   {
     command: 'paredit.forwardSexp',
@@ -479,10 +481,12 @@ const pareditCommands: PareditCommand[] = [
       await paredit.insertSemiColon(doc);
     },
   },
-];
+] as const;
+// prefer next line if we upgrade to TS v4.9+
+//  ] as const satisfies readonly PareditCommand[];
 
-function wrapPareditCommand(command: PareditCommand) {
-  return async (arg) => {
+function wrapPareditCommand<C extends PareditCommand>(command: C) {
+  return async (arg: CommandArgOf<C>) => {
     try {
       const textEditor = window.activeTextEditor;
 

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -48,7 +48,8 @@ function multiCursorEnabled() {
 
 type PareditCommand = {
   command: string;
-  handler: (doc: EditableDocument, ...args: readonly any[]) => void | Promise<any> | Thenable<any>; // do we still need to return Thenable from paredit fns?
+  // do we still need to return Thenable from paredit fns?
+  handler: (doc: EditableDocument, arg: any) => void | Promise<any> | Thenable<any>;
 };
 
 const pareditCommands: PareditCommand[] = [
@@ -304,6 +305,7 @@ const pareditCommands: PareditCommand[] = [
       // TODO: support multicursor
       return handlers.killLeft(
         doc,
+        // TODO: actually implement multicursor
         multiCursorEnabled(),
         shouldKillAlsoCutToClipboard() ? copyRangeToClipboard : null
       );
@@ -471,7 +473,7 @@ const pareditCommands: PareditCommand[] = [
 ];
 
 function wrapPareditCommand(command: PareditCommand) {
-  return async (...args: readonly any[]) => {
+  return async (arg) => {
     try {
       const textEditor = window.activeTextEditor;
 
@@ -481,7 +483,7 @@ function wrapPareditCommand(command: PareditCommand) {
       if (!enabled || !languages.has(textEditor.document.languageId)) {
         return;
       }
-      return command.handler(mDoc, ...args);
+      return command.handler(mDoc, arg);
     } catch (e) {
       console.error(e.message);
     }

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -42,8 +42,8 @@ function shouldKillAlsoCutToClipboard() {
   return workspace.getConfiguration().get<boolean>('calva.paredit.killAlsoCutsToClipboard');
 }
 
-function multiCursorEnabled() {
-  return workspace.getConfiguration().get<boolean>('calva.paredit.multicursor');
+function multiCursorEnabled(override?: boolean): boolean {
+  return override ?? workspace.getConfiguration().get('calva.paredit.multicursor');
 }
 
 type PareditCommand = {
@@ -56,169 +56,179 @@ const pareditCommands: PareditCommand[] = [
   // NAVIGATING
   {
     command: 'paredit.forwardSexp',
-    handler: (doc: EditableDocument) => {
-      handlers.forwardSexp(doc, multiCursorEnabled());
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
+      handlers.forwardSexp(doc, isMulti);
     },
   },
   {
     command: 'paredit.backwardSexp',
-    handler: (doc: EditableDocument) => {
-      handlers.backwardSexp(doc, multiCursorEnabled());
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
+      handlers.backwardSexp(doc, isMulti);
     },
   },
   {
     command: 'paredit.forwardDownSexp',
-    handler: (doc: EditableDocument) => {
-      handlers.forwardDownSexp(doc, multiCursorEnabled());
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
+      handlers.forwardDownSexp(doc, isMulti);
     },
   },
   {
     command: 'paredit.backwardDownSexp',
-    handler: (doc: EditableDocument) => {
-      handlers.backwardDownSexp(doc, multiCursorEnabled());
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
+      handlers.backwardDownSexp(doc, isMulti);
     },
   },
   {
     command: 'paredit.forwardUpSexp',
-    handler: (doc: EditableDocument) => {
-      handlers.forwardUpSexp(doc, multiCursorEnabled());
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
+      handlers.forwardUpSexp(doc, isMulti);
     },
   },
   {
     command: 'paredit.backwardUpSexp',
-    handler: (doc: EditableDocument) => {
-      handlers.backwardUpSexp(doc, multiCursorEnabled());
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
+      handlers.backwardUpSexp(doc, isMulti);
     },
   },
   {
     command: 'paredit.forwardSexpOrUp',
-    handler: (doc: EditableDocument) => {
-      handlers.forwardSexpOrUp(doc, multiCursorEnabled());
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
+      handlers.forwardSexpOrUp(doc, isMulti);
     },
   },
   {
     command: 'paredit.backwardSexpOrUp',
-    handler: (doc: EditableDocument) => {
-      handlers.backwardSexpOrUp(doc, multiCursorEnabled());
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
+      handlers.backwardSexpOrUp(doc, isMulti);
     },
   },
   {
     command: 'paredit.closeList',
-    handler: (doc: EditableDocument) => {
-      handlers.closeList(doc, multiCursorEnabled());
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
+      handlers.closeList(doc, isMulti);
     },
   },
   {
     command: 'paredit.openList',
-    handler: (doc: EditableDocument) => {
-      handlers.openList(doc, multiCursorEnabled());
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
+      handlers.openList(doc, isMulti);
     },
   },
 
   // SELECTING
   {
     command: 'calva.selectCurrentForm', // legacy command id for backward compat
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.selectCurrentForm(doc, isMulti);
     },
   },
   {
     command: 'paredit.rangeForDefun',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.rangeForDefun(doc, isMulti);
     },
   },
   {
     command: 'paredit.sexpRangeExpansion',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.sexpRangeExpansion(doc, isMulti);
     },
   },
   {
     command: 'paredit.sexpRangeContraction',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.sexpRangeContraction(doc, isMulti);
     },
   },
 
   {
     command: 'paredit.selectForwardSexp',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.selectForwardSexp(doc, isMulti);
     },
   },
   {
     command: 'paredit.selectRight',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.selectRight(doc, isMulti);
     },
   },
   {
     command: 'paredit.selectBackwardSexp',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.selectBackwardSexp(doc, isMulti);
     },
   },
   {
     command: 'paredit.selectForwardDownSexp',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.selectForwardDownSexp(doc, isMulti);
     },
   },
   {
     command: 'paredit.selectBackwardDownSexp',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.selectBackwardDownSexp(doc, isMulti);
     },
   },
   {
     command: 'paredit.selectForwardUpSexp',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.selectForwardUpSexp(doc, isMulti);
     },
   },
   {
     command: 'paredit.selectForwardSexpOrUp',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.selectForwardSexpOrUp(doc, isMulti);
     },
   },
   {
     command: 'paredit.selectBackwardSexpOrUp',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.selectBackwardSexpOrUp(doc, isMulti);
     },
   },
   {
     command: 'paredit.selectBackwardUpSexp',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.selectBackwardUpSexp(doc, isMulti);
     },
   },
   {
     command: 'paredit.selectCloseList',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.selectCloseList(doc, isMulti);
     },
   },
   {
     command: 'paredit.selectOpenList',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       handlers.selectOpenList(doc, isMulti);
     },
   },
@@ -401,36 +411,36 @@ const pareditCommands: PareditCommand[] = [
   },
   {
     command: 'paredit.rewrapParens',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       return handlers.rewrapParens(doc, isMulti);
     },
   },
   {
     command: 'paredit.rewrapSquare',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       return handlers.rewrapSquare(doc, isMulti);
     },
   },
   {
     command: 'paredit.rewrapCurly',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       return handlers.rewrapCurly(doc, isMulti);
     },
   },
   {
     command: 'paredit.rewrapSet',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       return handlers.rewrapSet(doc, isMulti);
     },
   },
   {
     command: 'paredit.rewrapQuote',
-    handler: (doc: EditableDocument) => {
-      const isMulti = multiCursorEnabled();
+    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+      const isMulti = multiCursorEnabled(opts?.multicursor);
       return handlers.rewrapQuote(doc, isMulti);
     },
   },

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -38,8 +38,8 @@ export async function copyRangeToClipboard(doc: EditableDocument, [start, end]) 
  * Answers true when `calva.paredit.killAlsoCutsToClipboard` is enabled.
  * @returns boolean
  */
-function shouldKillAlsoCutToClipboard() {
-  return workspace.getConfiguration().get<boolean>('calva.paredit.killAlsoCutsToClipboard');
+function shouldKillAlsoCutToClipboard(override?: boolean): boolean {
+  return override ?? workspace.getConfiguration().get('calva.paredit.killAlsoCutsToClipboard');
 }
 
 function multiCursorEnabled(override?: boolean): boolean {
@@ -301,9 +301,9 @@ const pareditCommands: PareditCommand[] = [
   },
   {
     command: 'paredit.killRight',
-    handler: async (doc: EditableDocument) => {
+    handler: async (doc: EditableDocument, opts?: { copy: boolean }) => {
       const range = paredit.forwardHybridSexpRange(doc);
-      if (shouldKillAlsoCutToClipboard()) {
+      if (shouldKillAlsoCutToClipboard(opts?.copy)) {
         await copyRangeToClipboard(doc, range);
       }
       return paredit.killRange(doc, range);
@@ -311,21 +311,20 @@ const pareditCommands: PareditCommand[] = [
   },
   {
     command: 'paredit.killLeft',
-    handler: async (doc: EditableDocument) => {
-      // TODO: support multicursor
+    handler: async (doc: EditableDocument, opts?: { copy: boolean }) => {
       return handlers.killLeft(
         doc,
         // TODO: actually implement multicursor
         multiCursorEnabled(),
-        shouldKillAlsoCutToClipboard() ? copyRangeToClipboard : null
+        shouldKillAlsoCutToClipboard(opts?.copy) ? copyRangeToClipboard : null
       );
     },
   },
   {
     command: 'paredit.killSexpForward',
-    handler: async (doc: EditableDocument) => {
+    handler: async (doc: EditableDocument, opts?: { copy: boolean }) => {
       const range = paredit.forwardSexpRange(doc);
-      if (shouldKillAlsoCutToClipboard()) {
+      if (shouldKillAlsoCutToClipboard(opts?.copy)) {
         await copyRangeToClipboard(doc, range);
       }
       return paredit.killRange(doc, range);
@@ -333,9 +332,9 @@ const pareditCommands: PareditCommand[] = [
   },
   {
     command: 'paredit.killSexpBackward',
-    handler: async (doc: EditableDocument) => {
+    handler: async (doc: EditableDocument, opts?: { copy: boolean }) => {
       const range = paredit.backwardSexpRange(doc);
-      if (shouldKillAlsoCutToClipboard()) {
+      if (shouldKillAlsoCutToClipboard(opts?.copy)) {
         await copyRangeToClipboard(doc, range);
       }
       return paredit.killRange(doc, range);
@@ -343,9 +342,9 @@ const pareditCommands: PareditCommand[] = [
   },
   {
     command: 'paredit.killListForward',
-    handler: async (doc: EditableDocument) => {
+    handler: async (doc: EditableDocument, opts?: { copy: boolean }) => {
       const range = paredit.forwardListRange(doc);
-      if (shouldKillAlsoCutToClipboard()) {
+      if (shouldKillAlsoCutToClipboard(opts?.copy)) {
         await copyRangeToClipboard(doc, range);
       }
       return await paredit.killForwardList(doc, range);
@@ -353,9 +352,9 @@ const pareditCommands: PareditCommand[] = [
   }, // TODO: Implement with killRange
   {
     command: 'paredit.killListBackward',
-    handler: async (doc: EditableDocument) => {
+    handler: async (doc: EditableDocument, opts?: { copy: boolean }) => {
       const range = paredit.backwardListRange(doc);
-      if (shouldKillAlsoCutToClipboard()) {
+      if (shouldKillAlsoCutToClipboard(opts?.copy)) {
         await copyRangeToClipboard(doc, range);
       }
       return await paredit.killBackwardList(doc, range);
@@ -363,9 +362,9 @@ const pareditCommands: PareditCommand[] = [
   }, // TODO: Implement with killRange
   {
     command: 'paredit.spliceSexpKillForward',
-    handler: async (doc: EditableDocument) => {
+    handler: async (doc: EditableDocument, opts?: { copy: boolean }) => {
       const range = paredit.forwardListRange(doc);
-      if (shouldKillAlsoCutToClipboard()) {
+      if (shouldKillAlsoCutToClipboard(opts?.copy)) {
         await copyRangeToClipboard(doc, range);
       }
       await paredit.killForwardList(doc, range).then((isFulfilled) => {
@@ -375,9 +374,9 @@ const pareditCommands: PareditCommand[] = [
   },
   {
     command: 'paredit.spliceSexpKillBackward',
-    handler: async (doc: EditableDocument) => {
+    handler: async (doc: EditableDocument, opts?: { copy: boolean }) => {
       const range = paredit.backwardListRange(doc);
-      if (shouldKillAlsoCutToClipboard()) {
+      if (shouldKillAlsoCutToClipboard(opts?.copy)) {
         await copyRangeToClipboard(doc, range);
       }
       await paredit.killBackwardList(doc, range).then((isFulfilled) => {


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

The philosophy behind this was already described in the private calva team chat, but I can repost here if desired.

- Makes `/src/paredit/extension.ts` multicursor and kill cmds accept an arg, for now a map with a single key for each respective type of command.
- The multicursor paredit commands' args looks like `{multicursor: boolean}`
  - When this args map and entry are non-nil, override the workspace or user config for `calva.paredit.multicursor` for that particular keybinding.
- The kill commands' args looks like `{copy: boolean}`
  - When this args map and entry are non-nil, override the workspace or user config for `calva.paredit.killAlsoCutsToClipboard` for that particular keybinding.

This will only affect users that utilize these args. There have been no documentation additions so if merged as-is there should be no changes for anyone, but if we like this idea, we'll want to probably mention this somewhere.

I will do some more changes here, like fortifying the static typing and CHANGELOG entry, and aforementioned documentation, and perhaps some basic tests, if we like this idea overall.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

I'll create an issue if we like this idea.

Fixes #

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
