### PR TITLE
Eval output context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 Changes to Calva.
 
+
 ## [Unreleased]
 
-- [Implement experimental support for multicursor rewrap commands](https://github.com/BetterThanTomorrow/calva/issues/2448). Enable `calva.paredit.multicursor` in your settings to try it out. Closes [#2473](https://github.com/BetterThanTomorrow/calva/issues/2473) 
+- [Implement experimental support for multicursor rewrap commands](https://github.com/BetterThanTomorrow/calva/issues/2448). Enable `calva.paredit.multicursor` in your settings to try it out. Closes [#2473](https://github.com/BetterThanTomorrow/calva/issues/2473)
+- [Add a separator line between evaluation outputs to the Output terminal](https://github.com/BetterThanTomorrow/calva/issues/2483)
 
 ## [2.0.432] - 2024-03-26
 

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -124,7 +124,7 @@ async function evaluateCodeUpdatingUI(
       if (evaluationSendCodeToOutputWindow) {
         outputWindow.appendLine(code);
         if (output.getDestinationConfiguration().evalOutput !== 'repl-window') {
-          output.appendClojureEval(code, { ns, sessionType: session.sessionId });
+          output.appendClojureEval(code, { ns, replSessionType: session.replType });
         }
       }
 
@@ -134,7 +134,7 @@ async function evaluateCodeUpdatingUI(
       result = value;
 
       if (showResult) {
-        output.appendClojureEval(value, { ns, sessionType: session.sessionId }, async () => {
+        output.appendClojureEval(value, { ns, replSessionType: session.replType }, async () => {
           if (selection) {
             const c = selection.start.character;
             if (editor && options.replace) {
@@ -171,10 +171,10 @@ async function evaluateCodeUpdatingUI(
               outputWindow.markLastStacktraceRange(afterResultLocation);
             });
             if (output.getDestinationConfiguration().evalOutput !== 'repl-window') {
-              output.appendEvalErr(errMsg);
+              output.appendEvalErr(errMsg, { ns, replSessionType: session.replType });
             }
           } else {
-            output.appendLineEvalErr(errMsg);
+            output.appendEvalErr(errMsg, { ns, replSessionType: session.replType });
           }
         }
       }
@@ -222,7 +222,10 @@ async function evaluateCodeUpdatingUI(
             });
         });
         if (output.getDestinationConfiguration().evalOutput !== 'repl-window') {
-          output.appendLineEvalErr(err.length ? err.join('\n') : e);
+          output.appendEvalErr(err.length ? err.join('\n') : e, {
+            ns,
+            replSessionType: session.replType,
+          });
         }
       }
     }
@@ -535,7 +538,7 @@ async function loadFile(
     filePath,
     stdout: (m) => output.appendEvalOut(m),
     stderr: (m) => {
-      output.appendLineEvalErr(m);
+      output.appendEvalErr(m, { ns, replSessionType: session.replType });
       errorMessages.push(m);
     },
     pprintOptions: pprintOptions,
@@ -543,7 +546,7 @@ async function loadFile(
   try {
     const value = await res.value;
     if (value) {
-      output.appendClojureEval(value, { ns, sessionType: session.sessionId });
+      output.appendClojureEval(value, { ns, replSessionType: session.replType });
     } else {
       output.appendLineEvalOut('No results from file evaluation.');
     }
@@ -558,7 +561,7 @@ async function loadFile(
       }
     );
     if (output.getDestinationConfiguration().evalOutput !== 'repl-window') {
-      output.appendLineEvalErr(`Evaluation of file ${fileName} failed: ${e}`);
+      output.appendLineOtherErr(`Evaluation of file ${fileName} failed: ${e}`);
     }
     if (
       !vscode.window.visibleTextEditors.find((editor: vscode.TextEditor) =>
@@ -701,7 +704,7 @@ async function evaluateInOutputWindow(code: string, sessionType: string, ns: str
       column: evalPos.character,
     });
   } catch (e) {
-    output.appendLineEvalErr('Evaluation failed.');
+    output.appendLineOtherErr('Evaluation failed.');
   }
 }
 

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -124,7 +124,7 @@ async function evaluateCodeUpdatingUI(
       if (evaluationSendCodeToOutputWindow) {
         outputWindow.appendLine(code);
         if (output.getDestinationConfiguration().evalOutput !== 'repl-window') {
-          output.appendClojureEval(code);
+          output.appendClojureEval(code, { ns, sessionType: session.sessionId });
         }
       }
 
@@ -134,7 +134,7 @@ async function evaluateCodeUpdatingUI(
       result = value;
 
       if (showResult) {
-        output.appendClojureEval(value, async () => {
+        output.appendClojureEval(value, { ns, sessionType: session.sessionId }, async () => {
           if (selection) {
             const c = selection.start.character;
             if (editor && options.replace) {
@@ -171,7 +171,7 @@ async function evaluateCodeUpdatingUI(
               outputWindow.markLastStacktraceRange(afterResultLocation);
             });
             if (output.getDestinationConfiguration().evalOutput !== 'repl-window') {
-              output.appendClojureOther(errMsg);
+              output.appendEvalErr(errMsg);
             }
           } else {
             output.appendLineEvalErr(errMsg);
@@ -543,7 +543,7 @@ async function loadFile(
   try {
     const value = await res.value;
     if (value) {
-      output.appendClojureEval(value);
+      output.appendClojureEval(value, { ns, sessionType: session.sessionId });
     } else {
       output.appendLineEvalOut('No results from file evaluation.');
     }

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -292,7 +292,7 @@ export class NReplSession {
       if (msgData.out) {
         output.appendEvalOut(msgData.out);
       } else if (msgData.err) {
-        output.appendEvalErr(msgData.err);
+        output.appendEvalErr(msgData.err, { ns: msgData.ns, replSessionType: this.replType });
       }
     }
   }

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -18,6 +18,11 @@ type AppendOptions = {
   after?: AfterAppendCallback;
 };
 
+type AppendClojureOptions = {
+  ns?: string;
+  sessionType?: string;
+};
+
 const lightTheme = {
   evalOut: customChalk.gray,
   evalErr: customChalk.red,
@@ -165,7 +170,11 @@ export function maybePrintLegacyREPLWindowOutputMessage() {
   }
 }
 
-function appendClojure(options: AppendOptions, message: string, after?: AfterAppendCallback) {
+function appendClojure(
+  options: AppendOptions & AppendClojureOptions,
+  message: string,
+  after?: AfterAppendCallback
+) {
   const destination = options.destination;
   const didLastTerminateLine = didLastOutputTerminateLine[destination];
   didLastOutputTerminateLine[destination] = true;
@@ -203,9 +212,13 @@ function appendClojure(options: AppendOptions, message: string, after?: AfterApp
  * @param code The code to append
  * @param after Optional callback to run after the append
  */
-export function appendClojureEval(code: string, after?: AfterAppendCallback) {
+export function appendClojureEval(
+  code: string,
+  options: AppendClojureOptions,
+  after?: AfterAppendCallback
+) {
   const destination = getDestinationConfiguration().evalResults;
-  appendClojure({ destination, outputCategory: 'evalResults' }, code, after);
+  appendClojure({ destination, outputCategory: 'evalResults', ...options }, code, after);
 }
 
 /**

--- a/test-data/.calva/config.edn
+++ b/test-data/.calva/config.edn
@@ -1,4 +1,4 @@
-{:customREPLHoverSnippets
+{#_#_:customREPLHoverSnippets
  [{:name "edn hover symbol"
    :snippet (str "**EDN edn hover symbol**: " $hover-text)}
   {:name "edn hover symbol quoted"

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -22,26 +22,26 @@
     }
   ],
   "calva.customREPLHoverSnippets": [
-    {
-      "name": "Selection, closing brackets",
-      "snippet": "$selection-closing-brackets"
-    },
-    {
-      "name": "edn hover hover-text",
-      "snippet": "(str \"**JSON hover hover-text** \" \"$hover-text\")"
-    },
-    {
-      "name": "Show doc string",
-      "snippet": "(clojure.string/replace (with-out-str (clojure.repl/doc $hover-text)) \"\n\" \"\n\n\")"
-    },
-    {
-      "name": "Show current pair",
-      "snippet": "'\"Current pair: $hover-current-pair\""
-    },
-    {
-      "name": "Show current file text",
-      "snippet": "'(\"Current file text: $hover-file-text\")"
-    }
+    // {
+    //   "name": "Selection, closing brackets",
+    //   "snippet": "$selection-closing-brackets"
+    // },
+    // {
+    //   "name": "edn hover hover-text",
+    //   "snippet": "(str \"**JSON hover hover-text** \" \"$hover-text\")"
+    // },
+    // {
+    //   "name": "Show doc string",
+    //   "snippet": "(clojure.string/replace (with-out-str (clojure.repl/doc $hover-text)) \"\n\" \"\n\n\")"
+    // },
+    // {
+    //   "name": "Show current pair",
+    //   "snippet": "'\"Current pair: $hover-current-pair\""
+    // },
+    // {
+    //   "name": "Show current file text",
+    //   "snippet": "'(\"Current file text: $hover-file-text\")"
+    // }
   ],
   "calva.fiddleFilePaths": [
     {


### PR DESCRIPTION
## What has changed?

This introduces some knowledge to the output relay about the repl type (clj/cljs) and namespace an evaluation results or evaluation error output belongs to. It's used by the terminal output destination to decide if an info line should be prepending the output.

The info line is then added “if needed”, which is if the repl type + ns has changed since the last time the info line was printed.

<img width="560" alt="image" src="https://github.com/BetterThanTomorrow/calva/assets/30010/499f661e-6736-4586-90c3-5b88495936de">

The info line is prepended with a `;`, so that if some output is copied and then pasted into a Clojure buffer, the info line will be a line comment.

```

"HoHavove yoyou hohearordod aboboutot PoPiroratote totalolkok?"

Syntax error compiling at (src/pez/pirate_lang.clj:0:0).
Can't take value of a macro: #'clojure.core/comment

"HoHavove yoyou hohearordod aboboutot PoPiroratote totalolkok?"

; clj  clojure.core 
Syntax error compiling at (file:/Users/pez/.m2/repository/org/clojure/clojure/1.10.1/clojure-1.10.1.jar!/clojure/core.clj:0:0).
Can't take value of a macro: #'clojure.core/defmacro

"Evaluates exprs in a context in which *out* is bound to a fresh\n  StringWriter.  Returns the string created by any nested printing\n  calls."

; clj  pez.pirate-lang 
"HoHavove yoyou hohearordod aboboutot PoPiroratote totalolkok?"
HoHavove yoyou hohearordod aboboutot PoPiroratote totalolkok?

nil
```
* Fixes #2483 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~~[ ] Added to or updated docs in this branch, if appropriate~~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
