### PR TITLE
Emacs semi colon inspo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [The strict `;` (semi-colon) command comments out while protecting balance](https://github.com/BetterThanTomorrow/calva/issues/2490)
+
 ## [2.0.434] - 2024-04-03
 
 - [Add opt-in strict mode for `;` (semi-colon)](https://github.com/BetterThanTomorrow/calva/issues/2488)

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -2254,80 +2254,86 @@ describe('paredit', () => {
 });
 
 describe('paredit util', () => {
-  describe('semiColonWouldBreakStructure', () => {
+  describe('_semiColonWouldBreakStructureWhere', () => {
     it('returns false at the end of the document', () => {
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('a "b c" (d)|'))).toBe(
+      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" (d)|'))).toBe(
         false
       );
     });
     it('returns false at the end of the line', () => {
       expect(
-        paredit._semiColonWouldBreakStructure(docFromTextNotation('a "b c" (d)|• •   •'))
+        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" (d)|• •   •'))
       ).toBe(false);
     });
     it('returns false at in the whitespace at the end of the line', () => {
       expect(
-        paredit._semiColonWouldBreakStructure(docFromTextNotation('a "b c" (d)  | • •   •'))
+        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" (d)  | • •   •'))
       ).toBe(false);
     });
     it('returns false withing a string', () => {
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('a "b| c" d'))).toBe(false);
+      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b| c" d'))).toBe(
+        false
+      );
     });
     it('returns false a semicolon would be (illegally) escaped withing a string', () => {
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('a "b\\| c" d'))).toBe(
+      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b\\| c" d'))).toBe(
         false
       );
     });
     it('returns false withing a comment', () => {
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('a "b c" d ; e| f'))).toBe(
-        false
-      );
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('a "b c" d ; e f|•'))).toBe(
-        false
-      );
+      expect(
+        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" d ; e| f'))
+      ).toBe(false);
+      expect(
+        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" d ; e f|•'))
+      ).toBe(false);
     });
     it('returns false in whitespace before a comment', () => {
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('a "b c" d |; e f'))).toBe(
-        false
-      );
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('a "b c" d | ; e f•'))).toBe(
-        false
-      );
+      expect(
+        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" d |; e f'))
+      ).toBe(false);
+      expect(
+        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" d | ; e f•'))
+      ).toBe(false);
     });
     it('returns true inside a list ending on the same line', () => {
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('a (b |c)• d '))).toBe(true);
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('a (b {|} c•) d '))).toBe(
-        true
+      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a (b |c)• d '))).toBe(
+        6
       );
+      expect(
+        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a (b {|} c•) d '))
+      ).toBe(6);
     });
     it('returns false inside a list ending on some other line', () => {
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('a (b |•c)• d '))).toBe(
+      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a (b |•c)• d '))).toBe(
         false
       );
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('a (b {|•} c•) d '))).toBe(
-        false
-      );
+      expect(
+        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a (b {|•} c•) d '))
+      ).toBe(false);
     });
     it('returns true before a list ending on the same line', () => {
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('a "b c" | (d)'))).toBe(
+      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" | (d)'))).toBe(
         false
       );
     });
     it('returns false if can move by sexp to the end of the line', () => {
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('a "b c" | (d) • e'))).toBe(
-        false
-      );
       expect(
-        paredit._semiColonWouldBreakStructure(docFromTextNotation('a [b c• |(d) {[e]}•f g] • '))
+        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" | (d) • e'))
+      ).toBe(false);
+      expect(
+        paredit._semiColonWouldBreakStructureWhere(
+          docFromTextNotation('a [b c• |(d) {[e]}•f g] • ')
+        )
       ).toBe(false);
     });
     it('returns true before a list ending on some other line', () => {
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('a |(b •c)• d '))).toBe(
-        true
+      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a |(b •c)• d '))).toBe(
+        2
       );
-      expect(paredit._semiColonWouldBreakStructure(docFromTextNotation('|a (b {•} c•) d '))).toBe(
-        true
-      );
+      expect(
+        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('|a (b {•} c•) d '))
+      ).toBe(2);
     });
   });
 });


### PR DESCRIPTION
## What has changed?

Testing in Emacs paredit, which has a similar strict behaviour for semicolons, it was a bit more fancy than my crude first attempt of yesterday. It doesn't always insert the newline right after the semicolon, but rather where the structure would break. So I changed our version to do that too.

* Fixes #2490 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~~[ ] Added to or updated docs in this branch, if appropriate~~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
