### PR TITLE
Remove setting `calva.paredit.strictPreventUnmatchedClosingBracket`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Retire experimental setting for strict prevent unmatched closing bracket. Close: [Unexpected cursor movement when using 'Strict Prevent Unmatched Closing Brackets'](https://github.com/BetterThanTomorrow/calva/issues/2500)
+
 ## [2.0.436] - 2024-04-08
 
 - [Make the debugger present structural variables as traversable structures](https://github.com/BetterThanTomorrow/calva/issues/2494)

--- a/docs/site/customizing.md
+++ b/docs/site/customizing.md
@@ -26,6 +26,7 @@ Calva sets some VS Code settings for all Clojure files. Some of these are needed
         "editor.wordSeparators": "\t ()\"':,;~@#$%^&{}[]`",
         "editor.autoClosingBrackets": "always",
         "editor.autoClosingQuotes": "always",
+        "editor.autoClosingQuotes": "always",
         "editor.formatOnType": true,
         "editor.autoIndent": "full",
         "editor.formatOnPaste": true,

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -52,10 +52,6 @@ Bind it to the `;` key with a `when` clause that activates it together with the 
  },
 ```
 
-### Prevent Unbalanced Closing Brackets
-
-There is also a setting, `calva.paredit.strictPreventUnmatchedClosingBracket`, that will help you to not enter unbalanced closing brackets into the code.
-
 ## Commands
 
 The Paredit commands are sorted into **Navigation**, **Selection**, and **Edit**. As mentioned, **Slurp** and **Barf** are power commands, which go into the editing category. Learning to navigate structurally, using shortcuts, also saves time and adds precision to your editing. It has the double effect that you at the same time learn how to select structurally, because that is the same, just adding the shift key.

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
       "[clojure]": {
         "editor.wordSeparators": "\t ()\"':,;~@#$%^&{}[]`",
         "editor.autoClosingBrackets": "always",
+        "editor.autoClosingOvertype": "always",
         "editor.autoClosingQuotes": "always",
         "editor.formatOnType": true,
         "editor.autoIndent": "full",
@@ -1007,12 +1008,6 @@
             "type": "boolean",
             "markdownDescription": "When enabled, more VS Code built-in shortcuts are overridden with their ”corresponding” Paredit commands.",
             "default": true,
-            "scope": "window"
-          },
-          "calva.paredit.strictPreventUnmatchedClosingBracket": {
-            "type": "boolean",
-            "markdownDescription": "Experimental: Prevents you from entering unmatched closing brackets when in `strict` mode. (Does not work when there is an active selection.)",
-            "default": false,
             "scope": "window"
           },
           "calva.paredit.killAlsoCutsToClipboard": {

--- a/src/calva-fmt/src/providers/ontype_formatter.ts
+++ b/src/calva-fmt/src/providers/ontype_formatter.ts
@@ -1,9 +1,5 @@
 import * as vscode from 'vscode';
 import * as formatter from '../format';
-import * as docMirror from '../../../doc-mirror/index';
-import { EditableDocument } from '../../../cursor-doc/model';
-import * as paredit from '../../../cursor-doc/paredit';
-import { getConfig } from '../../../config';
 import * as util from '../../../utilities';
 import * as formatterConfig from '../../../formatter-config';
 import * as whenContexts from '../../../when-contexts';
@@ -33,24 +29,7 @@ export class FormatOnTypeEditProvider implements vscode.OnTypeFormattingEditProv
     if (isNewLineInComment(ch)) {
       return undefined;
     }
-    let keyMap = vscode.workspace.getConfiguration().get('calva.paredit.defaultKeyMap');
-    keyMap = String(keyMap).trim().toLowerCase();
-    if ([')', ']', '}'].includes(ch)) {
-      if (keyMap === 'strict' && getConfig().strictPreventUnmatchedClosingBracket) {
-        const mDoc: EditableDocument = docMirror.getDocument(document);
-        const tokenCursor = mDoc.getTokenCursor();
-        if (tokenCursor.withinComment()) {
-          return undefined;
-        }
-        // TODO: We should make a function in/for the MirrorDoc that can return
-        // edits instead of performing them. It is not awesome to perform edits
-        // here, since we are expected to return them.
-        await paredit.backspace(mDoc);
-        await paredit.close(mDoc, ch);
-      } else {
-        return undefined;
-      }
-    }
+
     const editor = util.getActiveTextEditor();
 
     const pos = editor.selections[0].active;

--- a/src/config.ts
+++ b/src/config.ts
@@ -234,9 +234,6 @@ function getConfig() {
     autoOpenREPLWindow: configOptions.get<boolean>('autoOpenREPLWindow'),
     autoOpenJackInTerminal: configOptions.get('autoOpenJackInTerminal'),
     referencesCodeLensEnabled: configOptions.get<boolean>('referencesCodeLens.enabled'),
-    strictPreventUnmatchedClosingBracket: pareditOptions.get<boolean>(
-      'strictPreventUnmatchedClosingBracket'
-    ),
     showCalvaSaysOnStart: configOptions.get<boolean>('showCalvaSaysOnStart'),
     enableClojureLspOnStart: configOptions.get<boolean>('enableClojureLspOnStart'),
     projectRootsSearchExclude: configOptions.get<string[]>('projectRootsSearchExclude', []),


### PR DESCRIPTION
Remove setting `calva.paredit.strictPreventUnmatchedClosingBracket` and all handling of it.

Replace with defaults of `editor.autoClosingOvertype` `always`.

* Fixes #2500

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
