### PR TITLE
Fix output channel for calva: Refresh Changed Namespaces action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 Changes to Calva.
 
-
 ## [Unreleased]
 
 - [Update default Jack-in nrepl dependencies](https://github.com/BetterThanTomorrow/calva/issues/2503), nrepl 1.1.1, cider-nrepl 0.47.1
 - Fix: [Throws error when debugging atoms](https://github.com/BetterThanTomorrow/calva/issues/2501)
+- Fix: [Refresh Changed Namespaces do not output to the selected output destination](https://github.com/BetterThanTomorrow/calva/issues/2506)
 
 ## [2.0.436] - 2024-04-08
 
@@ -26,7 +26,7 @@ Changes to Calva.
 
 - [Implement experimental support for multicursor rewrap commands](https://github.com/BetterThanTomorrow/calva/issues/2448). Enable `calva.paredit.multicursor` in your settings to try it out. Closes [#2473](https://github.com/BetterThanTomorrow/calva/issues/2473)
 - [Add a separator line between evaluation outputs to the Output terminal](https://github.com/BetterThanTomorrow/calva/issues/2483)
-- [Implement experimental support for multicursor selectCurrentForm command](https://github.com/BetterThanTomorrow/calva/issues/2476). Enable `calva.paredit.multicursor` in your settings to try it out. Closes [#2476](https://github.com/BetterThanTomorrow/calva/issues/2476) 
+- [Implement experimental support for multicursor selectCurrentForm command](https://github.com/BetterThanTomorrow/calva/issues/2476). Enable `calva.paredit.multicursor` in your settings to try it out. Closes [#2476](https://github.com/BetterThanTomorrow/calva/issues/2476)
 
 ## [2.0.432] - 2024-03-26
 
@@ -113,7 +113,7 @@ Changes to Calva.
 
 ## [2.0.414] - 2024-02-24
 
-- [HTML->Hiccup: Add option to always keep classes as attributes if so desired](https://github.com/BetterThanTomorrow/calva/issues/2398) 
+- [HTML->Hiccup: Add option to always keep classes as attributes if so desired](https://github.com/BetterThanTomorrow/calva/issues/2398)
 - [Support clojure-lsp Project Tree feature](https://github.com/BetterThanTomorrow/calva/issues/2406)
 
 ## [2.0.413] - 2024-02-20

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -3,21 +3,21 @@ import * as util from './utilities';
 import * as state from './state';
 import { NReplSession } from './nrepl';
 import * as replSession from './nrepl/repl-session';
-import { appendEvalOut } from './results-output/output';
+import { appendLineEvalOut } from './results-output/output';
 
 function report(res) {
   if (res.status == 'ok') {
-    appendEvalOut('Reloaded: (' + res.reloaded.join(' ') + ')');
-    appendEvalOut(':ok');
+    appendLineEvalOut('Reloaded: (' + res.reloaded.join(' ') + ')');
+    appendLineEvalOut(':ok');
   } else {
     if (res.status == 'error') {
-      appendEvalOut('Error reloading: ' + res.errorNs);
+      appendLineEvalOut('Error reloading: ' + res.errorNs);
       //chan.appendLine(res.error); // TODO: Moar error reporting
     }
     if (res.err != undefined) {
-      appendEvalOut(res.err);
+      appendLineEvalOut(res.err);
     }
-    appendEvalOut(':error 😿');
+    appendLineEvalOut(':error 😿');
   }
 }
 
@@ -26,7 +26,7 @@ function refresh(document = {}) {
     client: NReplSession = replSession.getSession(util.getFileType(doc));
 
   if (client != undefined) {
-    appendEvalOut('Reloading...');
+    appendLineEvalOut('Reloading...');
     void client.refresh().then((res) => {
       report(res);
     });
@@ -40,7 +40,7 @@ function refreshAll(document = {}) {
     client: NReplSession = replSession.getSession(util.getFileType(doc));
 
   if (client != undefined) {
-    appendEvalOut('Reloading all the things...');
+    appendLineEvalOut('Reloading all the things...');
     void client.refreshAll().then((res) => {
       report(res);
     });

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -3,32 +3,32 @@ import * as util from './utilities';
 import * as state from './state';
 import { NReplSession } from './nrepl';
 import * as replSession from './nrepl/repl-session';
+import { appendEvalOut } from './results-output/output';
 
-function report(res, chan: vscode.OutputChannel) {
+function report(res) {
   if (res.status == 'ok') {
-    chan.appendLine('Reloaded: (' + res.reloaded.join(' ') + ')');
-    chan.appendLine(':ok');
+    appendEvalOut('Reloaded: (' + res.reloaded.join(' ') + ')');
+    appendEvalOut(':ok');
   } else {
     if (res.status == 'error') {
-      chan.appendLine('Error reloading: ' + res.errorNs);
+      appendEvalOut('Error reloading: ' + res.errorNs);
       //chan.appendLine(res.error); // TODO: Moar error reporting
     }
     if (res.err != undefined) {
-      chan.appendLine(res.err);
+      appendEvalOut(res.err);
     }
-    chan.appendLine(':error 😿');
+    appendEvalOut(':error 😿');
   }
 }
 
 function refresh(document = {}) {
   const doc = util.tryToGetDocument(document),
-    client: NReplSession = replSession.getSession(util.getFileType(doc)),
-    chan: vscode.OutputChannel = state.outputChannel();
+    client: NReplSession = replSession.getSession(util.getFileType(doc));
 
   if (client != undefined) {
-    chan.appendLine('Reloading...');
+    appendEvalOut('Reloading...');
     void client.refresh().then((res) => {
-      report(res, chan);
+      report(res);
     });
   } else {
     void vscode.window.showErrorMessage('Not connected to a REPL.');
@@ -37,13 +37,12 @@ function refresh(document = {}) {
 
 function refreshAll(document = {}) {
   const doc = util.tryToGetDocument(document),
-    client: NReplSession = replSession.getSession(util.getFileType(doc)),
-    chan: vscode.OutputChannel = state.outputChannel();
+    client: NReplSession = replSession.getSession(util.getFileType(doc));
 
   if (client != undefined) {
-    chan.appendLine('Reloading all the things...');
+    appendEvalOut('Reloading all the things...');
     void client.refreshAll().then((res) => {
-      report(res, chan);
+      report(res);
     });
   } else {
     void vscode.window.showErrorMessage('Not connected to a REPL.');

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -3,21 +3,21 @@ import * as util from './utilities';
 import * as state from './state';
 import { NReplSession } from './nrepl';
 import * as replSession from './nrepl/repl-session';
-import { appendLineEvalOut } from './results-output/output';
+import * as output from './results-output/output';
 
 function report(res) {
   if (res.status == 'ok') {
-    appendLineEvalOut('Reloaded: (' + res.reloaded.join(' ') + ')');
-    appendLineEvalOut(':ok');
+    output.appendLineEvalOut('Reloaded: (' + res.reloaded.join(' ') + ')');
+    output.appendLineEvalOut(':ok');
   } else {
     if (res.status == 'error') {
-      appendLineEvalOut('Error reloading: ' + res.errorNs);
+      output.appendLineEvalOut('Error reloading: ' + res.errorNs);
       //chan.appendLine(res.error); // TODO: Moar error reporting
     }
     if (res.err != undefined) {
-      appendLineEvalOut(res.err);
+      output.appendLineEvalOut(res.err);
     }
-    appendLineEvalOut(':error 😿');
+    output.appendLineEvalOut(':error 😿');
   }
 }
 
@@ -26,7 +26,7 @@ function refresh(document = {}) {
     client: NReplSession = replSession.getSession(util.getFileType(doc));
 
   if (client != undefined) {
-    appendLineEvalOut('Reloading...');
+    output.appendLineEvalOut('Reloading...');
     void client.refresh().then((res) => {
       report(res);
     });
@@ -40,7 +40,7 @@ function refreshAll(document = {}) {
     client: NReplSession = replSession.getSession(util.getFileType(doc));
 
   if (client != undefined) {
-    appendLineEvalOut('Reloading all the things...');
+    output.appendLineEvalOut('Reloading all the things...');
     void client.refreshAll().then((res) => {
       report(res);
     });


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

When running Refresh Changed Namespaces, the output is always redirected to Calva Says, ignoring what the user set as their preferred output channel.

For example, I had set my output channel as a terminal with this config:

```
    "calva.outputDestinations": {
        "evalResults": "terminal",
        "evalOutput": "terminal",
        "otherOutput": "terminal"
    },
```

And with this PR, the output now goes to my terminal:

![image](https://github.com/BetterThanTomorrow/calva/assets/1094843/be41b716-7790-490a-9ea6-353412c0250b)

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2506 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
