### PR TITLE
Don't format on type when bracket typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix regression: [Version `2.0.437` introduces a jarring, and wrongful, reindent when typing closing brackets](https://github.com/BetterThanTomorrow/calva/issues/2509)
+
 ## [2.0.437] - 2024-04-11
 
 - Retire experimental setting for strict prevent unmatched closing bracket. Close: [Unexpected cursor movement when using 'Strict Prevent Unmatched Closing Brackets'](https://github.com/BetterThanTomorrow/calva/issues/2500)

--- a/src/calva-fmt/src/providers/ontype_formatter.ts
+++ b/src/calva-fmt/src/providers/ontype_formatter.ts
@@ -26,12 +26,10 @@ export class FormatOnTypeEditProvider implements vscode.OnTypeFormattingEditProv
     ch: string,
     _options
   ): Promise<vscode.TextEdit[] | undefined> {
-    if (isNewLineInComment(ch)) {
+    if (isNewLineInComment(ch) || [')', ']', '}'].includes(ch)) {
       return undefined;
     }
-
     const editor = util.getActiveTextEditor();
-
     const pos = editor.selections[0].active;
     if (formatterConfig.formatOnTypeEnabled()) {
       if (vscode.workspace.getConfiguration('calva.fmt').get('newIndentEngine')) {
@@ -44,7 +42,6 @@ export class FormatOnTypeEditProvider implements vscode.OnTypeFormattingEditProv
         }
       }
     }
-
     return undefined;
   }
 }


### PR DESCRIPTION
In v2.0.437 I removed the part where we skip on-type-formatting when a bracket is typed. We should probably rather fix the bug that prevents us from doing formatting there, but for now I just reinstated the guard.

* Fixes #2509

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
