### PR TITLE
dissoc :map-commas? from zprint conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Replace Current Form seems to stop working from v2.0.428 onwards](https://github.com/BetterThanTomorrow/calva/issues/2512)
+
 ## [2.0.442] - 2024-04-17
 
 - Fix: [Extra empty lines printed between lines of stderr from out-of-band nrepl messages](https://github.com/BetterThanTomorrow/calva/issues/2514)

--- a/src/cljs-lib/src/calva/pprint/printer.cljs
+++ b/src/cljs-lib/src/calva/pprint/printer.cljs
@@ -44,10 +44,12 @@
 
 
 (defn pretty-print-js [s {:keys [maxLength, maxDepth, map-commas?] :as all-opts}]
-  (let [opts (into {} (remove (comp nil? val) (-> all-opts
-                                                  (dissoc :maxLength :maxDepth :printEngine :enabled)
-                                                  (merge {:max-length maxLength
-                                                          :max-depth maxDepth}))))
+  (let [opts (into {}
+                   (remove (comp nil? val)
+                           (-> all-opts
+                               (dissoc :maxLength :maxDepth :printEngine :enabled :map-commas?)
+                               (merge {:max-length maxLength
+                                       :max-depth maxDepth}))))
         opts (if (nil? map-commas?)
                opts
                (assoc opts :map {:comma? map-commas?}))]
@@ -59,6 +61,7 @@
 
 ;; SCRAP
 (comment
+  (pretty-print-js-bridge "a s" #js {:enabled true :map-commas? true})
   (zprint/zprint-file-str "{:a 1, :b 2 :c 3} {:a 1, :b 2 :c 3}" "id" {:map {:comma? false}})
   (zprint/zprint-file-str "a s" "id" {})
   (zprint/zprint-str "a s" {:parse-string? true})

--- a/test-data/projects/pirate-lang/src/pez/long_text.fiddle
+++ b/test-data/projects/pirate-lang/src/pez/long_text.fiddle
@@ -1,0 +1,7 @@
+{(->Language "abcdefghijklmnopqrstuvwxyz" "aeiouåäö" "o") :l (->Point 10 20) {:alphabet    "abcdefghijklmnopqrstuvwxyz" :vowels      "aeiouåäö" :pirate-char "o"} :x "x" :a [1 2 3] :y "y" :z {:a "a" 'b :b "c" ['c]} [1 2 :a 11 12 68 :lök 12 68 "abcdef" {:alphabet    "abcdefghijklmnopqrstuvwxyz" :vowels      [{:foo "aeiou" :bar #{"å" "ä" "ö" [1 2 3]}}] :pirate-char "o"} [{:foo "aeiou" :bar #{"å" "ä" "ö" [1 2 3]}}] [1 2 3 #{:foo :bar "apa"}] {:foo "aeiou" :bar #{"å" "ä" "ö" [1 2 3]}}] (repeat 100 [1 '(1 2 3) #{1 2 3} true 'ab false "abcdef" :keyword #"regex" #inst "2021-10-10T00:00:00.000-00:00" (new java.awt.Point 10 20) (->Language "abcdefghijklmnopqrstuvwxyz" "aeiouåäö" "o") (->Point 10 20) [[[1 2 3] [4 5 6]] [7 8 [9 10 11]]] (with-meta {:alphabet    "abcdefghijklmnopqrstuvwxyz" :vowels      [{:foo "aeiou" :bar #{"å" "ä" "ö" [1 2 3]}}] :pirate-char "o"} {:a 1 :b 2 :c 3}) {{:a [{:foo "aeiou" :bar #{"å" "ä" "ö" [1 2 3] {["x" "y"] 1 :b 2 :c 3}}}]} {:b [1 2 3] :c "c"}} [{:foo "aeiou" :bar #{"å" "ä" "ö" [1 2 3] {:a 1 :b 2 :c 3}}}] [1 2 3 #{:foo :bar "apa"}] {:foo "aeiou" :bar #{"å" "ä" "ö" [1 2 3]}}])}
+
+(defn foo []
+            (let [x 1
+        y 2
+        z 3]
+    (println x y z)))


### PR DESCRIPTION
For some reason zprint started to croak when passed a key outside its conf. Anyway, now we dissoc it.

* Fixes #2512

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~~[ ] Added to or updated docs in this branch, if appropriate~~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
