### PR TITLE
Don't attempt to format top level form if we can't find it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Make list items in the inspector get a bit easier to read](https://github.com/BetterThanTomorrow/calva/issues/2521)
+- Fix: [Deleting the last form in document throws an error](https://github.com/BetterThanTomorrow/calva/issues/2523)
 
 ## [2.0.444] - 2024-04-19
 

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -148,9 +148,16 @@ interface CljFmtConfig {
   'remove-multiple-non-indenting-spaces?'?: boolean;
 }
 
-function _calculateFormatRange(config: CljFmtConfig, cursor: LispTokenCursor, index: number) {
+function _calculateFormatRange(
+  config: CljFmtConfig,
+  cursor: LispTokenCursor,
+  index: number
+): [number, number] {
   const formatDepth = config?.['format-depth'] ?? _formatDepth(cursor);
   const rangeForTopLevelForm = cursor.rangeForDefun(index, false);
+  if (!rangeForTopLevelForm) {
+    return;
+  }
   const topLevelStartCursor = cursor.doc.getTokenCursor(rangeForTopLevelForm[0]);
   const rangeForList = cursor.rangeForList(formatDepth);
   if (rangeForList) {

--- a/src/extension-test/unit/util/ns-form-test.ts
+++ b/src/extension-test/unit/util/ns-form-test.ts
@@ -224,6 +224,11 @@ describe('ns-form util', () => {
         fail(`Expected no error to be thrown, but got ${error}`);
       }
     });
+    // https://github.com/BetterThanTomorrow/calva/issues/2523
+    // (This wasn't the bug it seems, but it is a good test case.)
+    it('returns null when no text in the document', function () {
+      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('|'))).toBe(null);
+    });
   });
 
   describe('nsFromText', function () {


### PR DESCRIPTION
The formatter didn't check if it really found a range for the current top level form before attempting to format it.

* Fixes #2523


## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~~[ ] Added to or updated docs in this branch, if appropriate~~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
