### PR TITLE
Default to `indentation` folding strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 
 - [Make list items in the inspector get a bit easier to read](https://github.com/BetterThanTomorrow/calva/issues/2521)
 - Fix: [Deleting the last form in document throws an error](https://github.com/BetterThanTomorrow/calva/issues/2523)
+- Workaround: [Default to `indentation` folding strategy to dodge clojure-lsp bug](https://github.com/BetterThanTomorrow/calva/issues/2486)
 
 ## [2.0.444] - 2024-04-19
 

--- a/docs/site/customizing.md
+++ b/docs/site/customizing.md
@@ -22,22 +22,30 @@ Tip for VS Code newcomers: The search box in **Settings** is your friend. Also, 
 Calva sets some VS Code settings for all Clojure files. Some of these are needed for Calva to function correctly, which should not be tampered with unless you really know what you are doing, and some of them are convenient defaults. If you add a setting to your `settings.json` and accept the snippet help you get when you type `"[clojure]"`, you will get the Calva defaults pasted:
 
 ```json
-    "[clojure]": {
+      "[clojure]": {
         "editor.wordSeparators": "\t ()\"':,;~@#$%^&{}[]`",
         "editor.autoClosingBrackets": "always",
-        "editor.autoClosingQuotes": "always",
+        "editor.autoClosingOvertype": "always",
         "editor.autoClosingQuotes": "always",
         "editor.formatOnType": true,
         "editor.autoIndent": "full",
         "editor.formatOnPaste": true,
         "editor.matchBrackets": "never",
-        "editor.renderIndentGuides": false,
-        "editor.parameterHints.enabled": false
-    }
+        "editor.guides.indentation": false,
+        "editor.parameterHints.enabled": false,
+        "editor.unicodeHighlight.allowedCharacters": {
+          " ": true,
+          "꞉": true
+        },
+        "editor.foldingStrategy": "indentation"
+      }
 ```
 
-!!! Note
+!!! Note "`editor.wordSeparators`"
     The above `editor.wordSeparators` setting establish Clojure word boundaries. E.g `-` is considered to be part of words. This affects what happens when double-clicking symbols and other things. If you want to include `-` or something else as a word boundary, just add it to the setting.
+
+!!! Note "`editor.foldingStrategy`"
+    To use the folding levels provided by clojure-lsp, set this to `auto`. Though at the time of this writing there is a bug in clojure-lsp [making folding stop working with this setting](https://github.com/BetterThanTomorrow/calva/issues/2486).
 
 ## Pretty Printing
 

--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
         "editor.unicodeHighlight.allowedCharacters": {
           " ": true,
           "꞉": true
-        }
+        },
+        "editor.foldingStrategy": "indentation"
       }
     },
     "semanticTokenScopes": [


### PR DESCRIPTION
To dodge the clojure-lsp folding bug.

* Closes #2486

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
