### PR TITLE
2524 reindent inspector item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Re-indent text when copied from the inspector as well as tooltips](https://github.com/BetterThanTomorrow/calva/issues/2524)
+
 ## [2.0.445] - 2024-04-21
 
 - [Make list items in the inspector get a bit easier to read](https://github.com/BetterThanTomorrow/calva/issues/2521)

--- a/src/cljs-lib/src/calva/pprint/printer.cljs
+++ b/src/cljs-lib/src/calva/pprint/printer.cljs
@@ -44,10 +44,12 @@
 
 
 (defn pretty-print-js [s {:keys [maxLength, maxDepth, map-commas?] :as all-opts}]
+  (println "all-opts" all-opts)
   (let [opts (into {}
                    (remove (comp nil? val)
                            (-> all-opts
                                (dissoc :maxLength :maxDepth :printEngine :enabled :map-commas?)
+                               (update :style (partial mapv keyword))
                                (merge {:max-length maxLength
                                        :max-depth maxDepth}))))
         opts (if (nil? map-commas?)

--- a/src/cljs-lib/src/calva/pprint/printer.cljs
+++ b/src/cljs-lib/src/calva/pprint/printer.cljs
@@ -52,7 +52,7 @@
                                        :max-depth maxDepth}))))
         opts (if (nil? map-commas?)
                opts
-               (assoc opts :map {:comma? map-commas?}))]
+               (assoc-in opts [:map :comma?] map-commas?))]
     (jsify (pretty-print s opts))))
 
 (defn ^:export pretty-print-js-bridge [s ^js opts]


### PR DESCRIPTION
Made the inspector pretty print tooltips and copied values.

* Fixes #2524 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
