### PR TITLE
Fix bug in zprint option map, and add sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Make the inspector sort maps on the keys](https://github.com/BetterThanTomorrow/calva/issues/2534)
+- Fix: [The inspector fails to crate an inspectable tree on large results](https://github.com/BetterThanTomorrow/calva/issues/2535)
+
 ## [2.0.446] - 2024-04-21
 
 - [Re-indent text when copied from the inspector as well as tooltips](https://github.com/BetterThanTomorrow/calva/issues/2524)

--- a/src/providers/inspector.ts
+++ b/src/providers/inspector.ts
@@ -215,13 +215,10 @@ export function createTreeStructure(item: InspectorItem) {
         const printerOptions = {
           ...printer.prettyPrintingOptions(),
           width: 500,
-          map: { 'sort?': false, 'commas?': false },
+          map: { 'sort?': true, 'comma?': false },
         };
-        const firstLineLength = originalString.split('\n')[0].length;
-        const needPrettyPrint = firstLineLength > 10000;
-        const prettyString = needPrettyPrint
-          ? printer.prettyPrint(originalString, printerOptions)?.value || originalString
-          : originalString;
+        const prettyResults = printer.prettyPrint(originalString, printerOptions);
+        const prettyString = prettyResults?.value || originalString;
         const prettyPrintEndTime = performance.now();
         progress.report({ increment: 85 });
 


### PR DESCRIPTION
## What has changed?

There was a typo in the zprint options for the pretty printer used by the inspector, this made pretty printing fail and thus for large results we failed to parse lex it to tokens for the token cursor.

Also changed it so that the pretty printer sorts maps.

* Fixes #2534 
* Fixes #2535 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~~[ ] Added to or updated docs in this branch, if appropriate~~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
