### PR TITLE
2533 pretty print command option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 
 - [Make the inspector sort maps on the keys](https://github.com/BetterThanTomorrow/calva/issues/2534)
 - Fix: [The inspector fails to crate an inspectable tree on large results](https://github.com/BetterThanTomorrow/calva/issues/2535)
+- Fix: [Replace Current Form with Pretty Printed Form also sorts map entries alphabetically by key](https://github.com/BetterThanTomorrow/calva/issues/2535)
 
 ## [2.0.446] - 2024-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Replace Current Form with Pretty Printed Form also sorts map entries alphabetically by key](https://github.com/BetterThanTomorrow/calva/issues/2535)
+
 ## [2.0.447] - 2024-04-24
 
 - [Make the inspector sort maps on the keys](https://github.com/BetterThanTomorrow/calva/issues/2534)
 - Fix: [The inspector fails to crate an inspectable tree on large results](https://github.com/BetterThanTomorrow/calva/issues/2535)
-- Fix: [Replace Current Form with Pretty Printed Form also sorts map entries alphabetically by key](https://github.com/BetterThanTomorrow/calva/issues/2535)
 
 ## [2.0.446] - 2024-04-21
 

--- a/docs/site/formatting.md
+++ b/docs/site/formatting.md
@@ -70,6 +70,28 @@ Unlike with the ”real” Calva Formatter, which never breaks up lines, this on
 !!! Note "Applies to the other Current Form"
     Unlike the other Format commands, which applies to the current _enclosing_ form, this one applies to the [Current Form, same as with evaluations](evaluation.md#current-form). That is because this is not really part of the Calva formatter, but rather is a convenience command for tidying up code or data.
 
+#### Provide zprint config via keyboard shortcuts (or Joyride)
+
+The default options for the command are to not sort maps and to not insert commas between map entries. However, the command takes a map as an argument, expecting this map to be a [zprint configuration]((https://github.com/kkinnear/zprint/blob/main/doc/reference.md)) map. You can provide the argument map via keyboard shortcuts. In VS Code settings, you use JSON, but it will be converted to EDN before handed to zprint.
+
+Say you want to have maps sorted by their keys, and generally use community standard formating + justify maps and bindings. This keyboard shortcut does that.
+
+```json
+    {
+        "key": "ctrl+alt+p enter",
+        "command": "calva.prettyPrintReplaceCurrentForm",
+        "args": {
+            "style": ["community", "justified"],
+            "map": {
+                "comma?": false,
+                "sort?": true,
+            }
+        }
+    }
+```
+
+Note that we have to specify `"comma?": false` here, because this argument will replace the default options maps for the command.
+
 ## Configuration
 
 You can adjust the above mentioned defaults, and the default indents, by configuring the formatting using [cljfmt's configuration EDN](https://github.com/weavejester/cljfmt#configuration).

--- a/src/cljs-lib/src/calva/pprint/printer.cljs
+++ b/src/cljs-lib/src/calva/pprint/printer.cljs
@@ -40,7 +40,7 @@
                   (zprint/zprint-file-str s "Calva" (assoc opts :color-map colors))}
                  (catch js/Error e
                    {:value s
-                    :error (str "Plain printing, b/c pprint failed. (" (.-message e) ")")}))]
+                    :error (str "Pretty print failed. (" (.-message e) ")")}))]
     result))
 
 (defn string-to-keyword [x]
@@ -52,7 +52,6 @@
   (walk/postwalk string-to-keyword data))
 
 (defn pretty-print-js [s {:keys [maxLength, maxDepth, map-commas?] :as all-opts}]
-  (println "all-opts" all-opts)
   (let [opts (into {}
                    (remove (comp nil? val)
                            (-> all-opts

--- a/src/cljs-lib/src/calva/pprint/printer.cljs
+++ b/src/cljs-lib/src/calva/pprint/printer.cljs
@@ -1,7 +1,8 @@
 (ns calva.pprint.printer
   (:require [zprint.core :as zprint]
             [calva.js-utils :refer [jsify cljify]]
-            [clojure.string]))
+            [clojure.string]
+            [clojure.walk :as walk]))
 
 (def colors {:brace :white,
              :bracket :white,
@@ -42,6 +43,13 @@
                     :error (str "Plain printing, b/c pprint failed. (" (.-message e) ")")}))]
     result))
 
+(defn string-to-keyword [x]
+  (if (string? x)
+    (keyword x)
+    x))
+
+(defn strings->keywords [data]
+  (walk/postwalk string-to-keyword data))
 
 (defn pretty-print-js [s {:keys [maxLength, maxDepth, map-commas?] :as all-opts}]
   (println "all-opts" all-opts)
@@ -49,7 +57,7 @@
                    (remove (comp nil? val)
                            (-> all-opts
                                (dissoc :maxLength :maxDepth :printEngine :enabled :map-commas?)
-                               (update :style (partial mapv keyword))
+                               strings->keywords
                                (merge {:max-length maxLength
                                        :max-depth maxDepth}))))
         opts (if (nil? map-commas?)

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -66,7 +66,9 @@ export function replace(
   );
 }
 
-export function prettyPrintReplaceCurrentForm(options = { enabled: true }) {
+export function prettyPrintReplaceCurrentForm(
+  options = { map: { 'sort?': false, 'comma?': false } }
+) {
   const editor = util.getActiveTextEditor();
   const document = editor.document;
   const selection = editor.selections[0];
@@ -74,7 +76,7 @@ export function prettyPrintReplaceCurrentForm(options = { enabled: true }) {
     ? select.getFormSelection(document, selection.active, false)
     : selection;
   const text = document.getText(range);
-  const result = printer.prettyPrint(text, { ...options, 'map-commas?': false });
+  const result = printer.prettyPrint(text, options);
   if (result) {
     return replace(editor, range, result.value);
   }

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -77,7 +77,9 @@ export function prettyPrintReplaceCurrentForm(
     : selection;
   const text = document.getText(range);
   const result = printer.prettyPrint(text, options);
-  if (result) {
-    return replace(editor, range, result.value);
+  if (result.error) {
+    void vscode.window.showErrorMessage(`${result.error}`, 'OK');
+    return;
   }
+  return replace(editor, range, result.value);
 }


### PR DESCRIPTION
## What has changed?

Providing `{:map {:sort? false}` to zprint for the command **Replace Current form with Pretty Printed**.

* Fixes #2533 

Also documenting the argument that the command takes, so that people know that they can cook their own commands, which sorts maps or whatever (zprint is crazy rich on options!).

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
