### PR TITLE
Make REPL History work in a cleared window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [REPL History commands do not work in a cleared window](https://github.com/BetterThanTomorrow/calva/issues/2545)
+
 ## [2.0.449] - 2024-04-26
 
 - Fix: [The evaluated expression is printed twice to the REPL window with `evaluationSendCodeToOutputWindow` enabled](https://github.com/BetterThanTomorrow/calva/issues/2538)

--- a/src/extension-test/unit/util/string-test.ts
+++ b/src/extension-test/unit/util/string-test.ts
@@ -41,8 +41,8 @@ describe('string', () => {
   });
 
   describe('getTextAfterLastOccurrenceOfSubstring', () => {
-    it('returns undefined if substring does not exist', () => {
-      expect(getTextAfterLastOccurrenceOfSubstring('hello world', '123')).toBeUndefined();
+    it('returns text if substring does not exist', () => {
+      expect(getTextAfterLastOccurrenceOfSubstring('hello world', '123')).toBe('hello world');
     });
     it('returns text after last occurrence of substring', () => {
       expect('foo').toBe(getTextAfterLastOccurrenceOfSubstring('hello > world\nprompt >foo', '>'));

--- a/src/repl-window/repl-history.ts
+++ b/src/repl-window/repl-history.ts
@@ -73,14 +73,14 @@ function showReplHistoryEntry(
   historyEntry: string | undefined,
   resultsEditor: vscode.TextEditor
 ): void {
-  const prompt = getPrompt();
+  const prompt = promptLine();
   const resultsDoc = resultsEditor.document;
   const docText = resultsDoc.getText();
   const indexOfLastPrompt = docText.lastIndexOf(prompt);
   const insertOffset = indexOfLastPrompt === -1 ? 0 : indexOfLastPrompt + prompt.length;
   const startPosition = resultsDoc.positionAt(insertOffset);
   const range = new vscode.Range(startPosition, resultsDoc.positionAt(Infinity));
-  const entry = historyEntry || '\n';
+  const entry = historyEntry || '';
   const edit = new vscode.WorkspaceEdit();
   edit.replace(resultsDoc.uri, range, entry);
   void vscode.workspace.applyEdit(edit).then((_) => {
@@ -89,8 +89,8 @@ function showReplHistoryEntry(
   });
 }
 
-function prependNewline(text: string) {
-  return `\n${text}`;
+function promptLine() {
+  return `${getPrompt()}\n`;
 }
 
 function showPreviousReplHistoryEntry(): void {
@@ -101,7 +101,7 @@ function showPreviousReplHistoryEntry(): void {
   if (!isResultsDoc(doc) || historyIndex === 0 || history.length === 0) {
     return;
   }
-  const textAtPrompt = getTextAfterLastOccurrenceOfSubstring(doc.getText(), getPrompt());
+  const textAtPrompt = getTextAfterLastOccurrenceOfSubstring(doc.getText(), promptLine());
   if (isUndefined(historyIndex)) {
     historyIndex = history.length;
     lastTextAtPrompt = textAtPrompt;
@@ -110,7 +110,7 @@ function showPreviousReplHistoryEntry(): void {
     updateReplHistory(replSessionType, history, textAtPrompt, historyIndex);
   }
   historyIndex--;
-  showReplHistoryEntry(prependNewline(history[historyIndex]), editor);
+  showReplHistoryEntry(history[historyIndex], editor);
 }
 
 function showNextReplHistoryEntry(): void {
@@ -125,13 +125,13 @@ function showNextReplHistoryEntry(): void {
     historyIndex = undefined;
     showReplHistoryEntry(lastTextAtPrompt, editor);
   } else {
-    const textAtPrompt = getTextAfterLastOccurrenceOfSubstring(doc.getText(), getPrompt());
+    const textAtPrompt = getTextAfterLastOccurrenceOfSubstring(doc.getText(), promptLine());
     util.assertIsDefined(textAtPrompt, 'Expected to find text at the prompt!');
     util.assertIsDefined(historyIndex, 'Expected a value for historyIndex!');
     updateReplHistory(replSessionType, history, textAtPrompt, historyIndex);
     historyIndex++;
     const nextHistoryEntry = history[historyIndex];
-    showReplHistoryEntry(prependNewline(nextHistoryEntry), editor);
+    showReplHistoryEntry(nextHistoryEntry, editor);
   }
 }
 

--- a/src/repl-window/repl-history.ts
+++ b/src/repl-window/repl-history.ts
@@ -77,14 +77,7 @@ function showReplHistoryEntry(
   const resultsDoc = resultsEditor.document;
   const docText = resultsDoc.getText();
   const indexOfLastPrompt = docText.lastIndexOf(prompt);
-  if (indexOfLastPrompt === -1) {
-    // Prompt not found in results doc, so append a prompt and re-run this function
-    append(getPrompt(), (_) => {
-      showReplHistoryEntry(historyEntry, resultsEditor);
-    });
-    return;
-  }
-  const insertOffset = indexOfLastPrompt + prompt.length;
+  const insertOffset = indexOfLastPrompt === -1 ? 0 : indexOfLastPrompt + prompt.length;
   const startPosition = resultsDoc.positionAt(insertOffset);
   const range = new vscode.Range(startPosition, resultsDoc.positionAt(Infinity));
   const entry = historyEntry || '\n';

--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -30,7 +30,7 @@ function getTextAfterLastOccurrenceOfSubstring(
 ): string | undefined {
   const indexOfLastPrompt = text.lastIndexOf(substring);
   if (indexOfLastPrompt === -1) {
-    return undefined;
+    return text;
   }
   const indexOfEndOfPrompt = indexOfLastPrompt + substring.length;
   return text.substring(indexOfEndOfPrompt);


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

If I select all text in the `output.calva-repl` window and delete everything, "Calva: Show next REPL History Entry" and "Calva: Show previous REPL History Entry" commands will fail with "Expected to find text at the prompt!" message. This fixes the issue by assuming that if no prompt is found in the window, all of its content is after the last prompt.

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->


<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2545.

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
