### PR TITLE
Use separate jack-in command lines for Win/non-Win

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Create jack-in subshell the unix way on non-Windows](https://github.com/BetterThanTomorrow/calva/issues/2543)
+
 ## [2.0.449] - 2024-04-26
 
 - Fix: [The evaluated expression is printed twice to the REPL window with `evaluationSendCodeToOutputWindow` enabled](https://github.com/BetterThanTomorrow/calva/issues/2538)

--- a/src/nrepl/jack-in-terminal.ts
+++ b/src/nrepl/jack-in-terminal.ts
@@ -14,10 +14,9 @@ export interface JackInTerminalOptions extends vscode.TerminalOptions {
 }
 
 export function createCommandLine(options: JackInTerminalOptions): string {
-  const commandSeparator = options.isWin ? '&' : ';';
-  return `pushd ${options.cwd} ${commandSeparator} ${options.executable} ${options.args.join(
-    ' '
-  )} ${commandSeparator} popd`;
+  return options.isWin
+    ? `pushd ${options.cwd} & ${options.executable} ${options.args.join(' ')} & popd`
+    : `(cd ${options.cwd}; ${options.executable} ${options.args.join(' ')})`;
 }
 
 export class JackInTerminal implements vscode.Pseudoterminal {


### PR DESCRIPTION
* Fixes #2543

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
