### PR TITLE
Make the commands for opening output destinations accept arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Make the commands for opening output destinations accept arguments](https://github.com/BetterThanTomorrow/calva/issues/2547)
+
 ## [2.0.451] - 2024-04-30
 
 - Fix: [REPL History commands do not work in a cleared window](https://github.com/BetterThanTomorrow/calva/issues/2545)

--- a/docs/site/output.md
+++ b/docs/site/output.md
@@ -23,10 +23,26 @@ The reason there are several options for this is partly legacy and partly becaus
 
 These are the commands and their default keyboard shortcuts for revealing output destinations
 
-* **Calva: Show/Open the result output destination** - `ctrl+alt+o o`
-* **Calva: Show/Open the Calva says Output Channel** - `ctrl+alt+o c`
-* **Calva: Show/Open the Calva Output Terminal** - `ctrl+alt+o t`
-* **Calva: Show/Open REPL Window** - `ctrl+alt+o r`
+* **Calva: Show/Open the result output destination**, without focusing it - `ctrl+alt+o o`
+* **Calva: Show/Open the Calva says Output Channel**, without focusing it - `ctrl+alt+o c`
+* **Calva: Show/Open the Calva Output Terminal**, without focusing it - `ctrl+alt+o t`
+* **Calva: Show/Open REPL Window**, also focuses it - `ctrl+alt+o r`
+
+!!! Note "Focusing the output destination"
+    The commands for opening the result destination all take a boolean argument for wether they should preserve focus or not. You can register keybindings that behave differently than the default ones. E.g.:
+
+    ```json
+    {
+      "key": "ctrl+alt+o ctrl+alt+o",
+      "command": "calva.showResultOutputDestination",
+      "args": false
+    },
+    {
+      "key": "ctrl+alt+o ctrl+alt+r",
+      "command": "calva.showOutputWindow", // Show/Open REPL Window
+      "args": true
+    },
+    ```
 
 ## About stdout in the REPL Window
 

--- a/package.json
+++ b/package.json
@@ -2720,11 +2720,13 @@
       {
         "command": "calva.showOutputWindow",
         "key": "ctrl+alt+o r",
+        "args": false,
         "when": "calva:keybindingsEnabled && !calva:outputWindowActive"
       },
       {
         "command": "calva.showFileForOutputWindowNS",
         "key": "ctrl+alt+o r",
+        "args": false,
         "when": "calva:keybindingsEnabled && calva:connected && calva:outputWindowActive"
       },
       {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -270,11 +270,9 @@ async function activate(context: vscode.ExtensionContext) {
     openSourceFileForFiddle: fiddleFiles.openSourceFileForFiddle,
     sendCurrentTopLevelFormToOutputWindow: outputWindow.appendCurrentTopLevelForm,
     setOutputWindowNamespace: outputWindow.setNamespaceFromCurrentFile,
-    showFileForOutputWindowNS: () => {
-      return outputWindow.revealDocForCurrentNS(false);
-    },
+    showFileForOutputWindowNS: outputWindow.revealDocForCurrentNS,
     showNextReplHistoryEntry: replHistory.showNextReplHistoryEntry,
-    showOutputWindow: () => outputWindow.revealResultsDoc(false),
+    showOutputWindow: outputWindow.revealResultsDoc,
     showOutputChannel: output.showOutputChannel,
     showOutputTerminal: output.showOutputTerminal,
     showResultOutputDestination: output.showResultOutputDestination,

--- a/src/repl-window/repl-doc.ts
+++ b/src/repl-window/repl-doc.ts
@@ -270,13 +270,13 @@ export async function openResultsDoc(): Promise<vscode.TextDocument> {
   return resultsDoc;
 }
 
-export function revealResultsDoc(preserveFocus: boolean = true) {
+export function revealResultsDoc(preserveFocus = true) {
   return openResultsDoc().then((doc) => {
     return vscode.window.showTextDocument(doc, getViewColumn(), preserveFocus);
   });
 }
 
-export async function revealDocForCurrentNS(preserveFocus: boolean = true) {
+export async function revealDocForCurrentNS(preserveFocus = true) {
   const uri = await getUriForCurrentNamespace();
   return vscode.workspace.openTextDocument(uri).then((doc) =>
     vscode.window.showTextDocument(doc, {

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -116,25 +116,25 @@ export function initOutputChannel(channel: vscode.OutputChannel) {
   outputChannel = channel;
 }
 
-export function showOutputChannel() {
-  outputChannel.show(true);
+export function showOutputChannel(preserveFocus = true) {
+  outputChannel.show(preserveFocus);
 }
 
-export function showOutputTerminal() {
+export function showOutputTerminal(preserveFocus = true) {
   if (!outputTerminal) {
     getOutputPTY();
   }
-  outputTerminal.show(true);
+  outputTerminal.show(preserveFocus);
 }
 
-export function showResultOutputDestination() {
+export function showResultOutputDestination(preserveFocus = true) {
   if (getDestinationConfiguration().evalResults === 'output-channel') {
-    return showOutputChannel();
+    return showOutputChannel(preserveFocus);
   }
   if (getDestinationConfiguration().evalResults === 'terminal') {
-    return showOutputTerminal();
+    return showOutputTerminal(preserveFocus);
   }
-  return outputWindow.revealResultsDoc(true);
+  return outputWindow.revealResultsDoc(preserveFocus);
 }
 
 export function getDestinationConfiguration(): OutputDestinationConfiguration {


### PR DESCRIPTION
* Fixes #2547

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
