### PR TITLE
2561 html2hiccup style ws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [HTML->Hiccup fails on style attribute strings where the entries do not have whitespace](https://github.com/BetterThanTomorrow/calva/issues/2561)
+
 ## [2.0.453] - 2024-06-03
 
 - Bump deps.clj to v1.11.3.1463

--- a/src/cljs-lib/src/calva/html2hiccup.cljs
+++ b/src/cljs-lib/src/calva/html2hiccup.cljs
@@ -37,7 +37,7 @@
 
 (defn- mapify-style [style-str]
   (try
-    (into {} (for [[_ k v] (re-seq #"(\S+):\s*([^;]+);?" style-str)]
+    (into {} (for [[_ k v] (re-seq #"(\S+?)\s*:\s*([^;]+);?" style-str)]
                [(-> k string/lower-case keyword) (normalize-css-value v)]))
     (catch :default e
       (js/console.warn "Failed to mapify style: '" style-str "'." (.-message e))

--- a/src/cljs-lib/src/calva/html2hiccup.cljs
+++ b/src/cljs-lib/src/calva/html2hiccup.cljs
@@ -37,7 +37,7 @@
 
 (defn- mapify-style [style-str]
   (try
-    (into {} (for [[_ k v] (re-seq #"(\S+):\s+([^;]+);?" style-str)]
+    (into {} (for [[_ k v] (re-seq #"(\S+):\s*([^;]+);?" style-str)]
                [(-> k string/lower-case keyword) (normalize-css-value v)]))
     (catch :default e
       (js/console.warn "Failed to mapify style: '" style-str "'." (.-message e))
@@ -76,7 +76,7 @@
                     (string/split class #"\s+"))
           [kw-classes remaining-classes] (if-not (:add-classes-to-tag-keyword? options)
                                            [() classes]
-                                           (bisect-all-by valid-as-hiccup-kw? classes)) 
+                                           (bisect-all-by valid-as-hiccup-kw? classes))
           tag-w-id+classes (build-tag-with-classes tag+id kw-classes)
           remaining-attrs (cond-> normalized-attrs
                             :always (dissoc :class)

--- a/src/cljs-lib/test/calva/html2hiccup_test.cljs
+++ b/src/cljs-lib/test/calva/html2hiccup_test.cljs
@@ -101,7 +101,10 @@
            (sut/html->hiccup "<foo style='color:blue'></foo>" {:mapify-style? false}))))
   (testing "style attributes do not need whitespace between entries with mapify-style? enabled"
     (is (= [[:foo {:style {:color :blue}}]]
-           (sut/html->hiccup "<foo style='color:blue'></foo>" {:mapify-style? true})))))
+           (sut/html->hiccup "<foo style='color:blue'></foo>" {:mapify-style? true})))
+    (is (= [[:foo {:style {:color :blue
+                           :stroke :red}}]]
+           (sut/html->hiccup "<foo style='color:blue;stroke:red;'></foo>" {:mapify-style? true})))))
 
 (deftest html->hiccup-w-mapify-style?
   (testing "style attribute is mapified with :mapify-style? enabled"

--- a/src/cljs-lib/test/calva/html2hiccup_test.cljs
+++ b/src/cljs-lib/test/calva/html2hiccup_test.cljs
@@ -36,7 +36,7 @@
            (sut/html->hiccup "<foo class='clz1 clz[2]'></foo>"))))
   (testing "When only invalid kw-classes they all remain in class attr"
     (is (= [[:foo {:class ["a/b" "clz[2]"]}]]
-           (sut/html->hiccup "<foo class='a/b clz[2]'></foo>")))) 
+           (sut/html->hiccup "<foo class='a/b clz[2]'></foo>"))))
   (testing "Attributes other than `class` and `id` get tucked in 'props' position"
     (is (= [[:foo#foo-id.clz1.clz2 {:bar "2"} "baz"]]
            (sut/html->hiccup "<foo id='foo-id' class='clz1 clz2' bar=2>baz</foo>"))))
@@ -78,7 +78,7 @@
     (is (= [[:foo {:disabled "disabled"}]]
            (sut/html->hiccup "<foo disabled='disabled'></foo>")))))
 
-(deftest html->hiccup-wkebab-attrs?
+(deftest html->hiccup-kebab-attrs?
   (testing "camelCase attributes are kebab-cased with :kebab-attrs? enabled"
     (is (= [[:foo {:on-change "bar" :max-height "10px"}]]
            (sut/html->hiccup "<foo onChange='bar' maxHeight='10px'></foo>" {:kebab-attrs? true}))))
@@ -94,6 +94,14 @@
   (testing "UPPERCASE attributes are lowercased if :kebab-attrs? enabled"
     (is (= [[:foo {:onchange "bar"}]]
            (sut/html->hiccup "<foo ONCHANGE='bar'></foo>" {:kebab-attrs? true})))))
+
+(deftest html->hiccup-style
+  (testing "style attributes do not need whitespace between entries with mapify-style? disabled"
+    (is (= [[:foo {:style "color:blue"}]]
+           (sut/html->hiccup "<foo style='color:blue'></foo>" {:mapify-style? false}))))
+  (testing "style attributes do not need whitespace between entries with mapify-style? enabled"
+    (is (= [[:foo {:style {:color :blue}}]]
+           (sut/html->hiccup "<foo style='color:blue'></foo>" {:mapify-style? true})))))
 
 (deftest html->hiccup-w-mapify-style?
   (testing "style attribute is mapified with :mapify-style? enabled"
@@ -117,7 +125,7 @@
   (testing "style attribute non-bare-word, non bare-numeric is stringified"
     (is (= [[:foo {:style {:padding "var(--some-padding, 0 0)"}}]]
            (sut/html->hiccup "<foo style='padding: var(--some-padding, 0 0);'></foo>" {:mapify-style? true})))))
-  
+
   (deftest html->hiccup-wo-add-classes-to-tag-keyword?
     (testing "When the :add-classes-to-tag-keyword? option is false they all remain in class attr"
       (is (= [[:foo {:class ["clz1" "clz2"]}]]


### PR DESCRIPTION
## What has changed?

I updated the regex that splits the style attributes for when mapifying it to handle that whitespace may have been minified away.

* Fixes #2561

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
