### PR TITLE
Improve error message when drams are not reachable

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -115,7 +115,7 @@
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
-      "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--folder-uri=null"],
+      "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
       "stopOnEntry": false,
       "sourceMaps": true,
       "env": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Getting Started REPL fails when there is no folder open](https://github.com/BetterThanTomorrow/calva/issues/2572)
+
 ## [2.0.456] - 2024-06-15
 
 - [Start Getting Started/Quick Start REPLs in a proper VS Code foldered window](https://github.com/BetterThanTomorrow/calva/issues/2566)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- [Getting Started REPL fails when there is no folder open](https://github.com/BetterThanTomorrow/calva/issues/2572)
+- [Improve error message when tutorial files are unreachable](https://github.com/BetterThanTomorrow/calva/issues/2572)
 
 ## [2.0.456] - 2024-06-15
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -107,7 +107,11 @@ async function activate(context: vscode.ExtensionContext) {
       testRunner.onTestTree(testController, tree);
     },
   });
-  await clientProvider.init();
+  try {
+    await clientProvider.init();
+  } catch (e) {
+    console.error('Failed initializing LSP client provider: ' + e.message);
+  }
 
   lsp.registerGlobally(clientProvider);
   context.subscriptions.push(testController);

--- a/src/lsp/provider.ts
+++ b/src/lsp/provider.ts
@@ -191,7 +191,7 @@ export const createClientProvider = (params: CreateClientProviderParams) => {
   };
 
   const provisionClientInFirstWorkspaceRoot = async () => {
-    const folder = vscode.workspace.workspaceFolders[0];
+    const folder = vscode.workspace.workspaceFolders?.[0];
     if (!folder) {
       return;
     }

--- a/src/nrepl/dram-repl.ts
+++ b/src/nrepl/dram-repl.ts
@@ -186,6 +186,13 @@ export async function startStandaloneRepl(
     typeof dramTemplate.config === 'string'
       ? await fetchConfig(dramTemplate.config)
       : dramTemplate.config;
+
+  if (!config?.files) {
+    console.error(`Error fetching configuration from dram repository`);
+    void vscode.window.showErrorMessage(`Error fetching configuration from dram repository`);
+    return;
+  }
+
   const docNames = config.files.map((f) => f.path);
 
   const choice = await vscode.window.showInformationMessage(

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -1,4 +1,3 @@
-'use strict';
 import { StatusBar } from './statusbar';
 import * as vscode from 'vscode';
 import {


### PR DESCRIPTION
## What has changed?

When firing up the getting started repl, or any other command fetching files from the dram repository, and the fetch fails, an error was thrown without slightest clue about what was going wrong. Fixing that.

Fixes #2572 

## My Calva PR Checklist


I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
