### PR TITLE
2589 no temp reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Stop offering to use existing temp files when creating a project](https://github.com/BetterThanTomorrow/calva/issues/2589)
+
 ## [2.0.461] - 2024-07-01
 
 - Fix: [Powershell sometimes used for jack-in on windows, and it doesn't work](https://github.com/BetterThanTomorrow/calva/issues/2586)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,7 +81,7 @@ async function activate(context: vscode.ExtensionContext) {
   initializeState();
   state.setExtensionContext(context);
   state.initDepsEdnJackInExecutable();
-  const isDramReplStart = await drams.dramStartConfigExists();
+  const isDramStart = await drams.dramStartConfigExists();
 
   const inspectorDataProvider = eval.initInspectorDataProvider();
   const inspectorTreeView = vscode.window.createTreeView('calva.inspector', {
@@ -92,7 +92,7 @@ async function activate(context: vscode.ExtensionContext) {
 
   overrides.activate();
 
-  if (isDramReplStart) {
+  if (isDramStart) {
     overrides.addWarningExclusionRegexp(/classpath lookup failed/i);
     overrides.addErrorExclusionRegexp(/classpath lookup failed/i);
   }

--- a/src/joyride.ts
+++ b/src/joyride.ts
@@ -47,7 +47,7 @@ export function isJoyrideNReplServerRunning() {
 }
 
 export async function prepareForJackInOrConnect() {
-  await state.initProjectDir(ConnectType.JackIn, undefined, false, true).catch((e) => {
+  await state.initProjectDir(ConnectType.JackIn, undefined, false).catch((e) => {
     void vscode.window.showErrorMessage('Failed initializing project root directory: ', e);
   });
   inspector.revealOnConnect();


### PR DESCRIPTION
## What has changed?

Removing code dealing with reusing any existing project temp files.

* Fixes #2589

## My Calva PR Checklist

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
