### PR TITLE
2592 win jack in take one trillion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Stop offering to use existing temp files when creating a project](https://github.com/BetterThanTomorrow/calva/issues/2589)
+- Fix: [Version 2.0.461 of Calva breaks deps.edn jack-in on some Windows machines](https://github.com/BetterThanTomorrow/calva/issues/2592)
 
 ## [2.0.461] - 2024-07-01
 

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -159,7 +159,14 @@ export async function copyJackInCommandToClipboard(): Promise<void> {
       const options = await getJackInTerminalOptions(projectConnectSequence);
       if (options) {
         void vscode.env.clipboard.writeText(createCommandLine(options));
-        void vscode.window.showInformationMessage('Jack-in command line copied to the clipboard.');
+        const message = `Jack-in command line copied to the clipboard.${
+          projectTypes.isWin ? ' It is tailored for cmd.exe and may not work in other shells.' : ''
+        }`;
+        if (projectTypes.isWin) {
+          void vscode.window.showInformationMessage(message, 'OK');
+        } else {
+          void vscode.window.showInformationMessage(message);
+        }
       }
     } catch (e) {
       void vscode.window.showErrorMessage(`Error creating Jack-in command line: ${e}`, 'OK');

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -381,7 +381,7 @@ const projectTypes: { [id: string]: ProjectType } = {
     winCmd: clojureCmdWinFn,
     resolveBundledPathWin: depsCljWindowsPath,
     processShellUnix: true,
-    processShellWin: false,
+    processShellWin: 'cmd.exe',
     useWhenExists: ['deps.edn'],
     nReplPortFile: ['.nrepl-port'],
     /** Build the command line args for a clj-project.

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -378,7 +378,7 @@ const projectTypes: { [id: string]: ProjectType } = {
     winCmd: clojureCmdFn,
     resolveBundledPathWin: depsCljWindowsPath,
     processShellUnix: true,
-    processShellWin: false,
+    processShellWin: true,
     useWhenExists: ['deps.edn'],
     nReplPortFile: ['.nrepl-port'],
     /** Build the command line args for a clj-project.

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -329,7 +329,6 @@ function depsCljWindowsPath() {
 }
 
 const clojureCmdFn = () => {
-  const q = isWin ? '"' : "'";
   const configuredCmd =
     getConfig().depsEdnJackInExecutable === 'clojure or deps.clj'
       ? getStateValue('depsEdnJackInDefaultExecutable') ?? 'deps.clj'
@@ -337,6 +336,10 @@ const clojureCmdFn = () => {
   return configuredCmd === 'deps.clj'
     ? ['java', '-jar', `${path.join(state.extensionContext.extensionPath, 'deps.clj.jar')}`]
     : ['clojure'];
+};
+
+const clojureCmdWinFn = () => {
+  return ['java', '-jar', `${path.join(state.extensionContext.extensionPath, 'deps.clj.jar')}`];
 };
 
 const projectTypes: { [id: string]: ProjectType } = {
@@ -375,10 +378,10 @@ const projectTypes: { [id: string]: ProjectType } = {
       'ClojureScript built-in for node',
     ],
     cmd: clojureCmdFn,
-    winCmd: clojureCmdFn,
+    winCmd: clojureCmdWinFn,
     resolveBundledPathWin: depsCljWindowsPath,
     processShellUnix: true,
-    processShellWin: true,
+    processShellWin: false,
     useWhenExists: ['deps.edn'],
     nReplPortFile: ['.nrepl-port'],
     /** Build the command line args for a clj-project.
@@ -669,7 +672,7 @@ async function cljCommandLine(connectSequence: ReplConnectSequence, cljsType: Cl
   const aliasesOption =
     aliases.length > 0 ? `${aliasesFlag[0]}${aliases.join('')}` : aliasesFlag[1];
   const q = isWin ? '"' : "'";
-  const dQ = isWin ? '""' : '"';
+  const dQ = isWin ? '\\"' : '"';
   for (const dep in dependencies) {
     out.push(dep + ` {:mvn/version,${dQ}${dependencies[dep]}${dQ}}`);
   }


### PR DESCRIPTION
## What has changed?

On Windows:

* Explicitly using `cmd.exe` as the process shell (using no shell wasn't reliable across machines it seems)
* Using the bundled deps.clj.jar (regardless if `clojure` has been confirmed as installed, because we need it to work in `cmd.exe`)
* Changing the quoting of strings to be for `cmd.exe`, because different Powershell version treat this differently.
* Added info to the confirming message box about that the command may only work in `cmd.exe`.

So, with some luck:

* Fixes #2592

(But we will see, I guess...)

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
