### PR TITLE
2597 more visible jack in errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- Change how drams (projects that Calva can create) are bing defined. Preparing for ways to contribute drams to Calva.
+- Internal: Change how drams (projects that Calva can create) are bing defined. Preparing for ways to contribute drams to Calva.
+- [Make the user aware about errors during jack-in](https://github.com/BetterThanTomorrow/calva/issues/2597)
 
 ## [2.0.463] - 2024-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 
 - Internal: Change how drams (projects that Calva can create) are bing defined. Preparing for ways to contribute drams to Calva.
 - [Make the user aware about errors during jack-in](https://github.com/BetterThanTomorrow/calva/issues/2597)
+- [Report progress waiting for shadow-cljs runtimes without printing to output](https://github.com/BetterThanTomorrow/calva/issues/2599)
 
 ## [2.0.463] - 2024-07-08
 

--- a/src/extension-test/integration/suite/jack-in-test.ts
+++ b/src/extension-test/integration/suite/jack-in-test.ts
@@ -114,7 +114,7 @@ suite('Jack-in suite', () => {
       'calva.replConnectSequences': [
         {
           projectType: 'deps.edn',
-          name: 'string-afterCLJReplJackInCode',
+          name: 'array-afterCLJReplJackInCode',
           autoSelectForJackIn: true,
           projectRootPath: ['.'],
           afterCLJReplJackInCode: ['(println :hello)', '(println :world!)'],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -367,6 +367,7 @@ async function activate(context: vscode.ExtensionContext) {
       const selectedItem = inspectorTreeView.selection[0] || inspectorDataProvider.getTopMostItem();
       return inspectorTreeView.reveal(selectedItem, { select, focus, expand });
     },
+    revealJackInTerminal: jackIn.revealJackInTerminal,
   };
 
   function registerCalvaCommand([command, callback]) {

--- a/src/nrepl/jack-in-terminal.ts
+++ b/src/nrepl/jack-in-terminal.ts
@@ -3,7 +3,7 @@ import * as child from 'child_process';
 import * as kill from 'tree-kill';
 import * as output from '../results-output/output';
 
-export interface JackInTerminalOptions extends vscode.TerminalOptions {
+export interface JackInPTYOptions extends vscode.TerminalOptions {
   name: string;
   cwd: string;
   env: { [key: string]: string };
@@ -13,13 +13,13 @@ export interface JackInTerminalOptions extends vscode.TerminalOptions {
   useShell: boolean | string;
 }
 
-export function createCommandLine(options: JackInTerminalOptions): string {
+export function createCommandLine(options: JackInPTYOptions): string {
   return options.isWin
     ? `pushd ${options.cwd} & ${options.executable} ${options.args.join(' ')} & popd`
     : `(cd ${options.cwd}; ${options.executable} ${options.args.join(' ')})`;
 }
 
-export class JackInTerminal implements vscode.Pseudoterminal {
+export class JackInPTY implements vscode.Pseudoterminal {
   private writeEmitter = new vscode.EventEmitter<string>();
   onDidWrite: vscode.Event<string> = this.writeEmitter.event;
   private closeEmitter = new vscode.EventEmitter<void>();
@@ -27,14 +27,7 @@ export class JackInTerminal implements vscode.Pseudoterminal {
 
   private process: child.ChildProcess;
 
-  constructor(
-    private options: JackInTerminalOptions,
-    private whenREPLStarted: (p: child.ChildProcess, host: string, port: string) => void,
-    private whenError: (errorMessage: string) => void
-  ) {}
-
   open(initialDimensions: vscode.TerminalDimensions | undefined): void {
-    output.appendLineOtherOut(`Starting Jack-in Terminal: ${createCommandLine(this.options)}`);
     this.writeEmitter.fire(
       'This is a pseudo terminal, only used for hosting the Jack-in REPL process. It takes no input.\r\nPressing ctrl+c with this terminal focused, killing this terminal, or closing/reloading the VS Code window will all stop/kill the Jack-in REPL process.\r\n\r\n'
     );
@@ -43,6 +36,10 @@ export class JackInTerminal implements vscode.Pseudoterminal {
   close(): void {
     this.killProcess();
     this.closeEmitter.fire();
+  }
+
+  public clearTerminal() {
+    this.writeEmitter.fire('\x1b[2J\x1b[H');
   }
 
   handleInput(data: string) {
@@ -63,25 +60,30 @@ export class JackInTerminal implements vscode.Pseudoterminal {
     return data.toString().replace(/\r?\n/g, '\r\n').replace(/\r\n$/, '');
   }
 
-  public async startClojureProgram(): Promise<child.ChildProcess> {
+  public isProcessAlive(): boolean {
+    return this.process && !this.process.killed;
+  }
+
+  public async startClojureProgram(
+    options: JackInPTYOptions,
+    whenREPLStarted: (p: child.ChildProcess, host: string, port: string) => void,
+    whenError: (errorMessage: string) => void
+  ): Promise<child.ChildProcess> {
+    output.appendLineOtherOut(`Starting Jack-in: ${createCommandLine(options)}`);
     return new Promise<child.ChildProcess>(() => {
       let hasReplStarted = false;
-      const data = `${createCommandLine(this.options)}\r\n`;
-      this.writeEmitter.fire(`Process shell is: ${this.options.useShell}\r\n`);
+      const data = `${createCommandLine(options)}\r\n`;
+      this.writeEmitter.fire(`Process shell is: ${options.useShell}\r\n`);
       this.writeEmitter.fire('⚡️ Starting the REPL ⚡️ using the below command line:\r\n');
       this.writeEmitter.fire(data);
-      if (this.process && !this.process.killed) {
-        console.log('Restarting Jack-in process');
-        this.killProcess();
-      }
-      this.process = child.spawn(this.options.executable, this.options.args, {
-        env: this.options.env,
-        cwd: this.options.cwd,
-        shell: this.options.useShell,
+      this.process = child.spawn(options.executable, options.args, {
+        env: options.env,
+        cwd: options.cwd,
+        shell: options.useShell,
       });
       this.process.on('exit', (status) => {
         this.writeEmitter.fire(`Jack-in process exited. Status: ${status}\r\n`);
-        this.whenError(null);
+        whenError(null);
       });
       this.process.stdout.on('data', (data) => {
         const msg = this.dataToString(data);
@@ -96,7 +98,7 @@ export class JackInTerminal implements vscode.Pseudoterminal {
           const [_, port1, host1, host2, port2, port3] = msg.match(
             /(?:Started nREPL server|nREPL server started)[^\r\n]+?(?:(?:on port (\d+)(?: on host (\S+))?)|([^\s/]+):(\d+))|.*?(\d+) TODO/
           );
-          this.whenREPLStarted(
+          whenREPLStarted(
             this.process,
             host1 ? host1 : host2 ? host2 : 'localhost',
             port1 ? port1 : port2 ? port2 : port3
@@ -107,7 +109,7 @@ export class JackInTerminal implements vscode.Pseudoterminal {
         const msg = this.dataToString(data);
         this.writeEmitter.fire(`${msg}\r\n`);
         if (!hasReplStarted && msg.match(/error|exception/i)) {
-          this.whenError(msg);
+          whenError(msg);
         }
       });
     });
@@ -125,9 +127,10 @@ export class JackInTerminal implements vscode.Pseudoterminal {
         kill(this.process.pid, 'SIGTERM', (err) => {
           if (err) {
             console.log('Jack-in terminal killProcess(): Error killing process', err);
+          } else {
+            // The test for this.process.killed above needs this to have happened too
+            this.process.kill();
           }
-          // The test for this.process.killed above needs this to have happened too
-          this.process.kill();
         });
       });
     } else if (this.process && this.process.killed) {

--- a/src/nrepl/jack-in-terminal.ts
+++ b/src/nrepl/jack-in-terminal.ts
@@ -38,7 +38,6 @@ export class JackInTerminal implements vscode.Pseudoterminal {
     this.writeEmitter.fire(
       'This is a pseudo terminal, only used for hosting the Jack-in REPL process. It takes no input.\r\nPressing ctrl+c with this terminal focused, killing this terminal, or closing/reloading the VS Code window will all stop/kill the Jack-in REPL process.\r\n\r\n'
     );
-    void this.startClojureProgram();
   }
 
   close(): void {
@@ -64,7 +63,7 @@ export class JackInTerminal implements vscode.Pseudoterminal {
     return data.toString().replace(/\r?\n/g, '\r\n').replace(/\r\n$/, '');
   }
 
-  private async startClojureProgram(): Promise<child.ChildProcess> {
+  public async startClojureProgram(): Promise<child.ChildProcess> {
     return new Promise<child.ChildProcess>(() => {
       let hasReplStarted = false;
       const data = `${createCommandLine(this.options)}\r\n`;

--- a/src/nrepl/jack-in-terminal.ts
+++ b/src/nrepl/jack-in-terminal.ts
@@ -82,6 +82,7 @@ export class JackInTerminal implements vscode.Pseudoterminal {
       });
       this.process.on('exit', (status) => {
         this.writeEmitter.fire(`Jack-in process exited. Status: ${status}\r\n`);
+        this.whenError(null);
       });
       this.process.stdout.on('data', (data) => {
         const msg = this.dataToString(data);

--- a/src/nrepl/jack-in-terminal.ts
+++ b/src/nrepl/jack-in-terminal.ts
@@ -67,7 +67,8 @@ export class JackInPTY implements vscode.Pseudoterminal {
   public async startClojureProgram(
     options: JackInPTYOptions,
     whenREPLStarted: (p: child.ChildProcess, host: string, port: string) => void,
-    whenError: (errorMessage: string) => void
+    whenError: (errorMessage: string) => void,
+    whenJackInInterrupted: (status: number) => void
   ): Promise<child.ChildProcess> {
     output.appendLineOtherOut(`Starting Jack-in: ${createCommandLine(options)}`);
     return new Promise<child.ChildProcess>(() => {
@@ -83,7 +84,9 @@ export class JackInPTY implements vscode.Pseudoterminal {
       });
       this.process.on('exit', (status) => {
         this.writeEmitter.fire(`Jack-in process exited. Status: ${status}\r\n`);
-        whenError(null);
+        if (!hasReplStarted) {
+          whenJackInInterrupted(status);
+        }
       });
       this.process.stdout.on('data', (data) => {
         const msg = this.dataToString(data);

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -105,8 +105,8 @@ async function executeJackInTask(
             (errorMessage: string) => {
               if (errorMessage) {
                 void vscode.window
-                  .showErrorMessage(
-                    `Problems during jack-in. ${errorMessage}`,
+                  .showWarningMessage(
+                    `There is error output in the Jack-in terminal.`,
                     'Show Jack-in Terminal'
                   )
                   .then((item) => {

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -117,6 +117,10 @@ async function executeJackInTask(
               } else {
                 resolve();
               }
+            },
+            (status: number) => {
+              setJackedOutStatus();
+              resolve();
             }
           );
         } catch (exception) {
@@ -126,6 +130,12 @@ async function executeJackInTask(
       });
     }
   );
+}
+
+function setJackedOutStatus() {
+  utilities.setLaunchingState(null);
+  utilities.setJackedInState(false);
+  statusbar.update();
 }
 
 export function calvaJackout() {
@@ -150,9 +160,7 @@ export function calvaJackout() {
     }
     connector.default.disconnect();
     jackInPTY.killProcess();
-    utilities.setLaunchingState(null);
-    utilities.setJackedInState(false);
-    statusbar.update();
+    setJackedOutStatus();
   }
 
   liveShareSupport.didJackOut();

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -127,9 +127,10 @@ function executeJackInTask(
             jackInTerminal.show();
           }
           pty.onDidClose((e) => {
-            calvaJackout();
+            calvaJackout(pty);
             resolve();
           });
+          void pty.startClojureProgram();
         } catch (exception) {
           console.error('Failed executing task: ', exception.message);
           reject(exception);

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -131,6 +131,12 @@
       "nReplPortFile": ["foo", "bar", ".nrepl-port"],
       "customJackInCommandLine": "echo PROJECT-ROOT-PATH: 'JACK-IN-PROJECT-ROOT-PATH', NREPL-PORT-FILE: 'JACK-IN-NREPL-PORT-FILE', NREPL-PORT: 'JACK-IN-NREPL-PORT', LEIN-PROFILES: 'JACK-IN-LEIN-PROFILES', LEIN-LAUNCH-ALIAS 'JACK-IN-LEIN-LAUNCH-ALIAS', CLJ-MIDDLEWARE: 'JACK-IN-CLJ-MIDDLEWARE', CLJS-MIDDLEWARE: 'JACK-IN-CLJS-MIDDLEWARE' ; ../../custom-jack-in.bb --aliases JACK-IN-CLJS-LAUNCH-BUILDS --cider-nrepl-version JACK-IN-CIDER-NREPL-VERSION",
       "cljsType": "shadow-cljs"
+    },
+    {
+      "name": "Array jack-in code",
+      "projectType": "deps.edn",
+      "afterCL]ReplJackInCode": ["(println :hello)", "(println :world!)"],
+      "cljsType": "none"
     }
   ]
 }


### PR DESCRIPTION
## What has changed?

Added an error dialog with a button to reveal the jack-in terminal if something prints either `error` or `exception` on *stderr* before the nREPL server is started.

Also added a progress “dialog/toast” that opens when jack-in starts and closes when the nREPL server starts, or the jack-in process dies. The dialog has a cancel button, which kills the jack-in.

Changed the way we create the jack-in terminal and now we are reusing the same terminal if a new jack-in is issued. We also wait a bit when killing the process on re-jack-in.

* Fixes #2597

Changed to using a progress indicator while waiting for a shadow-cljs runtime. (Instead of printing messages to the output destination.)

* Fixes #2599

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
