### PR TITLE
Sort connect sequence configuration sources User last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Bump deps.clj to v1.11.3.1463
+- [Prioritize Workspace configured connect sequences over User configured dittos](https://github.com/BetterThanTomorrow/calva/issues/2606)
 
 ## [2.0.467] - 2024-07-14
 

--- a/docs/site/connect-sequences.md
+++ b/docs/site/connect-sequences.md
@@ -47,6 +47,13 @@ A connect sequence configures the following:
 
 The [Calva built-in sequences](https://github.com/BetterThanTomorrow/calva/blob/published/src/nrepl/connectSequence.ts) also use this format, check them out to get a clearer picture of how these settings work.
 
+!!! Note "How sequence configurations are merged"
+    The sequence configuration, `calva.replConnectSequences` is an array and the sequences in the array will be listed and processed in the order they appear. However, you can configure connect sequences in several places, even if they make most sense on the Workspace level. The configurations are merged in the following order:
+    
+    1. Workspace Folder settings
+    1. Workspace settings
+    1. User settings
+
 !!! Note "Force the project type menu to show"
     The convenience of `autoSelectForJackIn/Connect` can be an inconvenience when you want to use another project type/sequence for a project. For this reason, the `calva.connect` and `calva.jackIn` can be provided with an option `disableAutoSelect`, which forces the project root and project type menus to show. See [Options for the Connect Command](connect.md#options-for-the-jack-in-command) and [Options for the Jack-in Command](connect.md#options-for-the-connect-command) for more on this.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -183,9 +183,9 @@ function getConfig() {
   const replConnectSequencesConfig =
     configOptions.inspect<ReplConnectSequence[]>('replConnectSequences');
   const replConnectSequences = [
-    ...(replConnectSequencesConfig.globalValue ?? []),
-    ...(replConnectSequencesConfig.workspaceValue ?? []),
     ...(replConnectSequencesConfig.workspaceFolderValue ?? []),
+    ...(replConnectSequencesConfig.workspaceValue ?? []),
+    ...(replConnectSequencesConfig.globalValue ?? []),
   ].map((sequence) => {
     if (Array.isArray(sequence.afterCLJReplJackInCode)) {
       return {

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -75,6 +75,7 @@
       "projectType": "deps.edn",
       "projectRootPath": ["projects/pirate-lang"],
       "afterCLJReplJackInCode": ["(require 'repl)", "(println 1)", "(println 2)"],
+      // "autoSelectForJackIn": true,
       "cljsType": "none",
       "menuSelections": {
         "cljAliases": ["dev", "test"]


### PR DESCRIPTION
## What has changed?

Concatenating the configured connect sequences in the sources order:

- Workspace Folder
- Workspace
- User

* Fixes #2606

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
