### PR TITLE
Preserve whitespaces format of evaluation error in tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Preserve whitespaces format of evaluation error in tooltip](https://github.com/BetterThanTomorrow/calva/issues/2623)
+
 ## [2.0.471] - 2024-09-12
 
 - [Trim leading newlines from the result/error string before inline display](https://github.com/BetterThanTomorrow/calva/issues/2617)

--- a/src/extension-test/integration/suite/annotations-test.ts
+++ b/src/extension-test/integration/suite/annotations-test.ts
@@ -24,8 +24,6 @@ suite('Annotations suite', () => {
   });
 
   test('decorate result trims leading whitespaces', async function () {
-    testUtil.log(suite, 'activeEditor');
-
     // any file would do
     const testFilePath = path.join(testUtil.testDataDir, 'test.clj');
     const editor = await testUtil.openFile(testFilePath);
@@ -62,5 +60,77 @@ suite('Annotations suite', () => {
 
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     testUtil.log(suite, 'test.clj closed');
+  });
+
+  test('tooltip contents of evaluated result', async function () {
+    // any file would do
+    const testFilePath = path.join(testUtil.testDataDir, 'test.clj');
+    const editor = await testUtil.openFile(testFilePath);
+
+    // Any range will do, the range below happens to be around "hover-map".
+    const selection = new vscode.Selection(2, 5, 2, 14);
+    editor.selection = selection;
+    const proxyEditor = testUtil.createVscTextEditorProxy(editor);
+
+    // will eventually call on the editor's `setDecorations` fn with the text to render.
+    const setDecorationsSpy = sinon.spy(proxyEditor, 'setDecorations');
+
+    const resultString = ' :Line1 with a leading space\n:Line2 some text\n\nLine4 the end.';
+
+    // SUCCESS case, format should contain the result in a clojure code block
+    {
+      annotations.decorateSelection(
+        resultString,
+        selection,
+        proxyEditor,
+        null,
+        annotations.AnnotationStatus.SUCCESS
+      );
+
+      //await testUtil.sleep(60000);
+
+      assert.deepStrictEqual(
+        setDecorationsSpy.firstCall.args[0],
+        annotations._getEvalSelectionDecorationTypes(annotations.AnnotationStatus.SUCCESS)
+      );
+      assert.deepStrictEqual(setDecorationsSpy.firstCall.args[1], []);
+      assert.deepStrictEqual(
+        setDecorationsSpy.secondCall.args[0],
+        annotations._getEvalSelectionDecorationTypes(annotations.AnnotationStatus.SUCCESS)
+      );
+      const decorateOpts = setDecorationsSpy.secondCall.args[1] as vscode.DecorationOptions[];
+      const hoverMessage = decorateOpts[0].hoverMessage as vscode.MarkdownString;
+      const expectedResultSuccess = `${annotations._getDecorateSelectionHeader(
+        resultString
+      )}\n\`\`\`clojure\n${resultString}\n\`\`\``;
+      assert.strictEqual(hoverMessage.value, expectedResultSuccess);
+    }
+
+    sinon.reset();
+
+    // ERROR case, should contain the result in a plain code block (```)
+    {
+      annotations.decorateSelection(
+        resultString,
+        selection,
+        proxyEditor,
+        null,
+        annotations.AnnotationStatus.ERROR
+      );
+
+      assert.deepStrictEqual(
+        setDecorationsSpy.firstCall.args[0],
+        annotations._getEvalSelectionDecorationTypes(annotations.AnnotationStatus.ERROR)
+      );
+      assert.deepStrictEqual(setDecorationsSpy.firstCall.args[1], []);
+      const decorateOpts = setDecorationsSpy.secondCall.args[1] as vscode.DecorationOptions[];
+      const hoverMessage = decorateOpts[0].hoverMessage as vscode.MarkdownString;
+      const expectedResultSuccess = `${annotations._getDecorateSelectionHeader(
+        resultString
+      )}\n\`\`\`\n${resultString}\n\`\`\``;
+      assert.strictEqual(hoverMessage.value, expectedResultSuccess);
+    }
+
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
   });
 });


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- The tooltip of an evaluation error preserves the whitespaces format of the original error message. 
- It also displays the same commands at the top as the successful evaluation (copy error message to clipboard, show on the output repl). This is a new addition. Let me know if this might cause issues, and I can revert it.
- Exported some internal functions in `annotations.ts` prefixed with `_`, to assist with unit testing.
- Added tests for the same

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

fixes #2623 

evaluation error tooltip format before patch

![image](https://github.com/user-attachments/assets/c2e0ae63-15d9-48bc-9f91-d1f3885c3be1)

after patch

![image](https://github.com/user-attachments/assets/7cfe2780-04b2-41e7-ae84-a56521939c5c)

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
