### PR TITLE
2626 results comment styles

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@
 **/.shadow-cljs/
 **/out/
 clojure.tmLanguage.json
+*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Add some different types of comment styles when evaluating to comment](https://github.com/BetterThanTomorrow/calva/issues/2626)
+
 ## [2.0.472] - 2024-09-15
 
 - [Preserve whitespaces format of evaluation error in tooltip](https://github.com/BetterThanTomorrow/calva/issues/2623)

--- a/docs/site/evaluation.md
+++ b/docs/site/evaluation.md
@@ -22,12 +22,53 @@ Calva has many commands for evaluating forms, including the **current form** and
 Some of the commands also let you choose what should happen with the results:
 
 1. **Inline.** This will display the results (or some of it, if it is long) inline in the editor.
-   - This also creates a hover pane including the full results and a button which will copy the results to the clipboard.
-   - There is also a command for copying the last result to the clipboard.
-   - The full results are always available in the [output destination](output.md).
-     - There is a command for showing the output destination, allowing for a workflow where you either generally have it closed, or have it as one of the tabs in the same editor group as the files you are working with.
+     * This also creates a hover pane including the full results and a button which will copy the results to the clipboard.
+     * There is also a command for copying the last result to the clipboard.
+     * The full results are always available in the [output destination](output.md).
+         * There is a command for showing the output destination, allowing for a workflow where you either generally have it closed, or have it as one of the tabs in the same editor group as the files you are working with.
 1. **To comments.** This will add the results as line comments below the current line.
 1. **Replace the evaluated code.** This will do what it says, the evaluated code will be replaced with its results.
+
+??? Note "Evaluate to comments support different comment styles"
+    When using the commands for evaluating to comments, **Evaluate Top Level Form (defun) to Comment**, and **Evaluate Selection to Comment**, the commands will insert the results as line comments (`;; ...`) below the evaluated form. However, there are two additional comment styles available. To use these you need to execute the commands via VS Code API, typically from keybindings. The commands take an argument map with the key `commentStyle`. You can choose between three different comment styles: `line`, `ignore`, and `rcf`:
+
+    * The default is `line`.
+    * The `line` style is the default.
+    * The `ignore` style will put an ignore marker (`#_`) before the result.
+    * The `rcf` style will wrap the result in a rich comment form ( `(comment ...)`).
+    
+    Here are some example keybindings for using the different comment styles with the **Evaluate Top Level Form (defun) to Comment** command:
+
+    ```jsonc
+    {
+      "key": "ctrl+alt+c ctrl+space",
+      "command": "calva.evaluateTopLevelFormAsComment",
+      "when": "editorTextFocus && editorLangId == 'clojure'",
+      "args": {
+        "commentStyle": "line"
+      }
+    },
+    {
+      "key": "ctrl+alt+c ctrl+i",
+      "command": "calva.evaluateTopLevelFormAsComment",
+      // "command": "calva.evaluateSelectionAsComment",
+      "when": "editorTextFocus && editorLangId == 'clojure'",
+      "args": {
+        "commentStyle": "ignore"
+      }
+    },
+    {
+      "key": "ctrl+alt+c ctrl+r",
+      "command": "calva.evaluateTopLevelFormAsComment",
+      // "command": "calva.evaluateSelectionAsComment",
+      "when": "editorTextFocus && editorLangId == 'clojure'",
+      "args": {
+        "commentStyle": "rcf"
+      }
+    },
+    ```
+
+    The first keybinding there is the default for the command, and only included as an example.
 
 ## Wait, Current Form? Top-level Form?
 

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -61,9 +61,8 @@ async function addAsComment(
   editor: vscode.TextEditor,
   selection: vscode.Selection
 ) {
-  const c = codeSelection.start.character;
   const endOfLinePosition = editor.document.lineAt(codeSelection.end.line).range.end;
-  const commentText = resultAsComment(c, result);
+  const commentText = resultAsComment(codeSelection.start.character, result);
   await editor.edit((editBuilder) => {
     editBuilder.insert(endOfLinePosition, commentText);
   });

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -18,6 +18,7 @@ import * as customSnippets from './custom-snippets';
 import * as output from './results-output/output';
 import * as inspector from './providers/inspector';
 import { resultAsComment } from './util/string-result';
+import { highlight } from './highlight/src/extension';
 
 let inspectorDataProvider: inspector.InspectorDataProvider;
 
@@ -63,11 +64,11 @@ async function addAsComment(
   const c = codeSelection.start.character;
   const endOfLinePosition = editor.document.lineAt(codeSelection.end.line).range.end;
   const commentText = resultAsComment(c, result);
-  const edit = vscode.TextEdit.insert(endOfLinePosition, commentText);
-  const wsEdit = new vscode.WorkspaceEdit();
-  wsEdit.set(editor.document.uri, [edit]);
-  await vscode.workspace.applyEdit(wsEdit);
+  await editor.edit((editBuilder) => {
+    editBuilder.insert(endOfLinePosition, commentText);
+  });
   editor.selections = [selection];
+  highlight(editor);
 }
 
 // TODO: Clean up this mess

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -59,10 +59,11 @@ async function addAsComment(
   result: string,
   codeSelection: vscode.Selection,
   editor: vscode.TextEditor,
-  selection: vscode.Selection
+  selection: vscode.Selection,
+  commentStyle: string
 ) {
   const endOfLinePosition = editor.document.lineAt(codeSelection.end.line).range.end;
-  const commentText = resultAsComment(codeSelection.start.character, result);
+  const commentText = resultAsComment(codeSelection.start.character, result, commentStyle);
   await editor.edit((editBuilder) => {
     editBuilder.insert(endOfLinePosition, commentText);
   });
@@ -151,7 +152,13 @@ async function evaluateCodeUpdatingUI(
               void vscode.workspace.applyEdit(wsEdit);
             } else {
               if (editor && options.comment) {
-                await addAsComment(value, selection, editor, editor.selections[0]);
+                await addAsComment(
+                  value,
+                  selection,
+                  editor,
+                  editor.selections[0],
+                  options.commentStyle
+                );
               }
               if (editor && !outputWindow.isResultsDoc(editor.document)) {
                 annotations.decorateSelection(
@@ -194,7 +201,13 @@ async function evaluateCodeUpdatingUI(
             const editorError = util.stripAnsi(err.length ? err.join('\n') : e);
             const currentCursorPos = editor.selections[0].active;
             if (editor && options.comment) {
-              await addAsComment(editorError, selection, editor, editor.selections[0]);
+              await addAsComment(
+                editorError,
+                selection,
+                editor,
+                editor.selections[0],
+                options.commentStyle
+              );
             }
             if (editor && !outputWindow.isResultsDoc(editor.document)) {
               annotations.decorateSelection(

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -17,6 +17,7 @@ import * as getText from './util/get-text';
 import * as customSnippets from './custom-snippets';
 import * as output from './results-output/output';
 import * as inspector from './providers/inspector';
+import { resultAsComment } from './util/result-as-comment';
 
 let inspectorDataProvider: inspector.InspectorDataProvider;
 
@@ -60,13 +61,9 @@ async function addAsComment(
   editor: vscode.TextEditor,
   selection: vscode.Selection
 ) {
-  const indent = `${' '.repeat(c)}`,
-    output = result
-      .replace(/\n\r?$/, '')
-      .split(/\n\r?/)
-      .join(`\n${indent};;    `),
-    edit = vscode.TextEdit.insert(codeSelection.end, `\n${indent};; => ${output}\n`),
-    wsEdit = new vscode.WorkspaceEdit();
+  const commentText = resultAsComment(c, result);
+  const edit = vscode.TextEdit.insert(codeSelection.end, commentText);
+  const wsEdit = new vscode.WorkspaceEdit();
   wsEdit.set(editor.document.uri, [edit]);
   await vscode.workspace.applyEdit(wsEdit);
   editor.selections = [selection];

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -55,14 +55,15 @@ function interruptAllEvaluations() {
 }
 
 async function addAsComment(
-  c: number,
   result: string,
   codeSelection: vscode.Selection,
   editor: vscode.TextEditor,
   selection: vscode.Selection
 ) {
+  const c = codeSelection.start.character;
+  const endOfLinePosition = editor.document.lineAt(codeSelection.end.line).range.end;
   const commentText = resultAsComment(c, result);
-  const edit = vscode.TextEdit.insert(codeSelection.end, commentText);
+  const edit = vscode.TextEdit.insert(endOfLinePosition, commentText);
   const wsEdit = new vscode.WorkspaceEdit();
   wsEdit.set(editor.document.uri, [edit]);
   await vscode.workspace.applyEdit(wsEdit);
@@ -150,7 +151,7 @@ async function evaluateCodeUpdatingUI(
               void vscode.workspace.applyEdit(wsEdit);
             } else {
               if (editor && options.comment) {
-                await addAsComment(c, value, selection, editor, editor.selections[0]);
+                await addAsComment(value, selection, editor, editor.selections[0]);
               }
               if (editor && !outputWindow.isResultsDoc(editor.document)) {
                 annotations.decorateSelection(
@@ -193,13 +194,7 @@ async function evaluateCodeUpdatingUI(
             const editorError = util.stripAnsi(err.length ? err.join('\n') : e);
             const currentCursorPos = editor.selections[0].active;
             if (editor && options.comment) {
-              await addAsComment(
-                selection.start.character,
-                editorError,
-                selection,
-                editor,
-                editor.selections[0]
-              );
+              await addAsComment(editorError, selection, editor, editor.selections[0]);
             }
             if (editor && !outputWindow.isResultsDoc(editor.document)) {
               annotations.decorateSelection(

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -17,7 +17,7 @@ import * as getText from './util/get-text';
 import * as customSnippets from './custom-snippets';
 import * as output from './results-output/output';
 import * as inspector from './providers/inspector';
-import { resultAsComment } from './util/result-as-comment';
+import { resultAsComment } from './util/string-result';
 
 let inspectorDataProvider: inspector.InspectorDataProvider;
 

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -323,7 +323,16 @@ function evaluateSelectionReplace(document = {}, options = {}) {
   }
 }
 
-function evaluateSelectionAsComment(document = {}, options = {}) {
+function validateCommentStyle(commentStyle: string) {
+  if (!['line', 'ignore', 'rcf'].includes(commentStyle)) {
+    throw new Error(
+      `Invalid comment style: ${commentStyle}. Must be one of "line", "ignore", or "rcf".`
+    );
+  }
+}
+
+function evaluateSelectionAsComment(options = { commentStyle: 'line' }, document = {}) {
+  validateCommentStyle(options.commentStyle);
   if (util.getConnectedState()) {
     evaluateSelection(
       document,
@@ -338,7 +347,8 @@ function evaluateSelectionAsComment(document = {}, options = {}) {
   }
 }
 
-function evaluateTopLevelFormAsComment(document = {}, options = {}) {
+function evaluateTopLevelFormAsComment(options = { commentStyle: 'line' }, document = {}) {
+  validateCommentStyle(options.commentStyle);
   if (util.getConnectedState()) {
     evaluateSelection(
       document,

--- a/src/util/result-as-comment.ts
+++ b/src/util/result-as-comment.ts
@@ -1,0 +1,8 @@
+export function resultAsComment(indent: number, result: string) {
+  const prepend = `${' '.repeat(indent)}`,
+    output = result
+      .replace(/\n\r?$/, '')
+      .split(/\n\r?/)
+      .join(`\n${prepend};;    `);
+  return `\n${prepend};; => ${output}\n`;
+}

--- a/src/util/result-as-comment.ts
+++ b/src/util/result-as-comment.ts
@@ -1,8 +1,0 @@
-export function resultAsComment(indent: number, result: string) {
-  const prepend = `${' '.repeat(indent)}`,
-    output = result
-      .replace(/\n\r?$/, '')
-      .split(/\n\r?/)
-      .join(`\n${prepend};;    `);
-  return `\n${prepend};; => ${output}\n`;
-}

--- a/src/util/string-result.ts
+++ b/src/util/string-result.ts
@@ -1,0 +1,20 @@
+function indentAllLines(indent: number, result: string) {
+  const prepend = `${' '.repeat(indent)}`;
+  return result
+    .replace(/\n\r?$/, '')
+    .split(/\n\r?/)
+    .join(`\n${prepend}`);
+}
+
+function commentifyResult(firstPrefix: string, restPrefix: string, result: string) {
+  const lines = result.split(/\n\r?/);
+  const restPrefixed = lines.join(`\n${restPrefix}`);
+  return `${firstPrefix}${restPrefixed}`;
+}
+
+export function resultAsComment(indent: number, result: string) {
+  const commentified = commentifyResult(';; => ', ';;    ', result);
+  const indented = indentAllLines(indent, commentified);
+  const prepend = `${' '.repeat(indent)}`;
+  return `\n${prepend}${indented}`;
+}

--- a/src/util/string-result.ts
+++ b/src/util/string-result.ts
@@ -12,8 +12,13 @@ function commentifyResult(firstPrefix: string, restPrefix: string, result: strin
   return `${firstPrefix}${restPrefixed}`;
 }
 
-export function resultAsComment(indent: number, result: string) {
-  const commentified = commentifyResult(';;=> ', ';;   ', result);
+export function resultAsComment(indent: number, result: string, commentStyle: string) {
+  const commentified =
+    commentStyle === 'ignore'
+      ? commentifyResult('#_', '  ', result)
+      : commentStyle === 'rcf'
+      ? commentifyResult('(comment\n  ', '  ', result) + ')'
+      : commentifyResult(';;=> ', ';;   ', result);
   const indented = indentAllLines(indent, commentified);
   const prepend = `${' '.repeat(indent)}`;
   return `\n${prepend}${indented}`;

--- a/src/util/string-result.ts
+++ b/src/util/string-result.ts
@@ -13,7 +13,7 @@ function commentifyResult(firstPrefix: string, restPrefix: string, result: strin
 }
 
 export function resultAsComment(indent: number, result: string) {
-  const commentified = commentifyResult(';; => ', ';;    ', result);
+  const commentified = commentifyResult(';;=> ', ';;   ', result);
   const indented = indentAllLines(indent, commentified);
   const prepend = `${' '.repeat(indent)}`;
   return `\n${prepend}${indented}`;


### PR DESCRIPTION
## What has changed?

I've made the commands for evaluating to comment actually care about the arguments. So now you can include a `commentStyle` option to it to control which kind of comment should be used.

* Fixes #2626

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
