### PR TITLE
Delete `printFn` from options sent to zprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Synchronize the file extensions for Calva and Calva Spritz](https://github.com/BetterThanTomorrow/calva/issues/2629)
+- [Terminal output pretty printing fails when using `printerFn` pretty print option](https://github.com/BetterThanTomorrow/calva/issues/2630)
 
 ## [2.0.473] - 2024-09-21
 

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -3,14 +3,19 @@ import { BEncoderStream, BDecoderStream } from './bencode';
 import * as cider from './cider';
 import * as state from './../state';
 import * as util from '../utilities';
-import { PrettyPrintingOptions, disabledPrettyPrinter, getServerSidePrinter } from '../printer';
+import {
+  PrettyPrintingOptions,
+  disabledPrettyPrinter,
+  getServerSidePrinter,
+  prettyPrint,
+} from '../printer';
 import * as debug from '../debugger/calva-debug';
 import * as vscode from 'vscode';
 import debugDecorations from '../debugger/decorations';
 import * as outputWindow from '../repl-window/repl-doc';
 import { formatAsLineComments } from '../results-output/util';
 import type { ReplSessionType } from '../config';
-import { getStateValue, prettyPrint } from '../../out/cljs-lib/cljs-lib';
+import { getStateValue } from '../../out/cljs-lib/cljs-lib';
 import { getConfig } from '../config';
 import { log, Direction } from './logging';
 import * as string from '../util/string';

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -129,5 +129,7 @@ export function getServerSidePrinterDependencies() {
 }
 
 export function prettyPrint(value: any, options: any = prettyPrintingOptions()) {
-  return calvaLib.prettyPrint(value, options);
+  const optionsClone = JSON.parse(JSON.stringify(options));
+  delete optionsClone['printFn']; // Zprint croaks on options it doesn't understand
+  return calvaLib.prettyPrint(value, optionsClone);
 }

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -221,6 +221,7 @@ function appendClojure(
     }
   } else if (destination === 'terminal') {
     const printerOptions = { ...printer.prettyPrintingOptions(), 'color?': true };
+    delete printerOptions.printFn; // Zprint croaks on options it doesn't understand
     const prettyMessage = printer.prettyPrint(message, printerOptions)?.value || message;
     // TODO: Figure if it's worth a setting to opt-in on an ns info line
     getOutputPTY().write(`${didLastTerminateLine ? '' : '\n'}${nsInfoLine(destination, options)}`);

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -221,7 +221,6 @@ function appendClojure(
     }
   } else if (destination === 'terminal') {
     const printerOptions = { ...printer.prettyPrintingOptions(), 'color?': true };
-    delete printerOptions.printFn; // Zprint croaks on options it doesn't understand
     const prettyMessage = printer.prettyPrint(message, printerOptions)?.value || message;
     // TODO: Figure if it's worth a setting to opt-in on an ns info line
     getOutputPTY().write(`${didLastTerminateLine ? '' : '\n'}${nsInfoLine(destination, options)}`);


### PR DESCRIPTION
## What has changed?

Deleting `printFn` from the options we send along to zprint. To make it not croak when this option is specified by the user. (It is not used by zprint.)

* Fixes #2630

See also:
* #2621
Which runs into a problem with the default nrepl printer of Calva: `nrepl.middleware.print/print`, and can be somewhat worked around by specyfing the `printFn` of `cider.nrepl.pprint/pr`.

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
