### PR TITLE
Avoid tripping up tools.reader on backticked forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Can't start REPL in lein projects with backtick on project.clj](https://github.com/BetterThanTomorrow/calva/issues/2633)
+
 ## [2.0.474] - 2024-09-22
 
 - [Synchronize the file extensions for Calva and Calva Spritz](https://github.com/BetterThanTomorrow/calva/issues/2629)
-- [Terminal output pretty printing fails when using `printerFn` pretty print option](https://github.com/BetterThanTomorrow/calva/issues/2630)
+- Fix: [Terminal output pretty printing fails when using `printerFn` pretty print option](https://github.com/BetterThanTomorrow/calva/issues/2630)
 
 ## [2.0.473] - 2024-09-21
 

--- a/src/cljs-lib/src/calva/parse.cljs
+++ b/src/cljs-lib/src/calva/parse.cljs
@@ -23,7 +23,11 @@
   "Parses out all top level forms from `s`.
    Returns a vector with the parsed forms."
   [s]
-  (let [pbr (rt/string-push-back-reader (str/replace s #"#=\(" "nil #_("))]
+  (let [pbr (rt/string-push-back-reader (-> s ; tools.reader croaks on some Clojure constructs
+                                              ; at least the way we use it here
+                                              ; And we're not interested in actually parsing these
+                                            (str/replace #"#=\(" "nil #_(")
+                                            (str/replace #"`" "'")))]
     (loop [parsed-forms []]
       (let [parsed-form (tr/read {:eof 'CALVA-EOF
                                   :read-cond :preserve} pbr)]

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -158,7 +158,9 @@ async function leinDefProject(): Promise<any> {
     const parsed = parseForms(data);
     return parsed.find((x) => x[0] == 'defproject');
   } catch (e) {
-    void vscode.window.showErrorMessage('Could not parse project.clj');
+    void vscode.window.showErrorMessage(
+      "Could not parse project.clj. You'll need to start the REPL manually, and then use the Connect REPL command instead."
+    );
     throw e;
   }
 }


### PR DESCRIPTION
## What has changed?

Similar to have we handle `#_`, we replace backtick with single quote. This should probably be revisited, but I do not have the time to figure out `cljs.tools.reader` right now.

* Fixes #2633


## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
