### PR TITLE
Initiate dram start + jack-in if project is created in the current folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Autostart REPL in created projects, also when created in the current folder](https://github.com/BetterThanTomorrow/calva/issues/2644)
+
 ## [2.0.478] - 2024-09-30
 
 - [Add `extraNReplMiddleware` to `connectSequence`](https://github.com/BetterThanTomorrow/calva/issues/1691)

--- a/src/nrepl/drams.ts
+++ b/src/nrepl/drams.ts
@@ -226,7 +226,14 @@ export async function createAndOpenDram(
 
   await serializeDramStartConfig(projectRootUri, { config });
 
-  return vscode.commands.executeCommand('vscode.openFolder', projectRootUri, true);
+  const currentWorkspaceFolder = vscode.workspace.workspaceFolders?.[0];
+
+  if (currentWorkspaceFolder && currentWorkspaceFolder.uri.fsPath === projectRootUri.fsPath) {
+    await startDram();
+    return vscode.commands.executeCommand('calva.jackIn');
+  } else {
+    return vscode.commands.executeCommand('vscode.openFolder', projectRootUri, true);
+  }
 }
 
 function ARGS_FILE_PATH(projectRootUri: vscode.Uri) {


### PR DESCRIPTION
We detect if the created dram project is created in the current folder, and if so initiate dram start and jack-in.

* Fixes #2644


## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
