### PR TITLE
Add when contexts for ns, replType and projectRoot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Add extension when contexts for Calva states such as project root, session type, ns](https://github.com/BetterThanTomorrow/calva/issues/2652)
+
 ## [2.0.480] - 2024-10-21
 
 - Fix: [Custom command snippets use the wrong ns when repl sessions types do not match](https://github.com/BetterThanTomorrow/calva/issues/2653)

--- a/docs/site/when-clauses.md
+++ b/docs/site/when-clauses.md
@@ -19,4 +19,6 @@ description: Calva comes with batteries included and preconfigured, and if you d
 * `calva:cursorAfterComment`: `true` when the cursor is adjacent after a line comment
 * `calva:cursorAtStartOfLine`: `true` when the cursor is at the start of a line including any leading whitespace
 * `calva:cursorAtEndOfLine`: `true` when the cursor is at the end of a line including any trailing whitespace
-
+* `calva:projectRoot`: A string with the absolute path to the repl project root
+* `calva:ns`: A string with the current namespace
+* `calva:replSessionType`: `clj`, or `cljs` depending on the file type of the current file

--- a/src/state.ts
+++ b/src/state.ts
@@ -202,6 +202,8 @@ export async function initProjectDir(
     );
   }
   if (projectRootPath) {
+    console.log('Setting project root to: ', projectRootPath.fsPath);
+    void vscode.commands.executeCommand('setContext', 'calva:projectRoot', projectRootPath.fsPath);
     setStateValue(PROJECT_DIR_KEY, projectRootPath.fsPath);
     setStateValue(PROJECT_DIR_URI_KEY, projectRootPath);
     return projectRootPath;

--- a/src/when-contexts.ts
+++ b/src/when-contexts.ts
@@ -3,6 +3,9 @@ import { deepEqual } from './util/object';
 import * as docMirror from './doc-mirror';
 import * as context from './cursor-doc/cursor-context';
 import * as util from './utilities';
+import * as namespace from './namespace';
+import * as session from './nrepl/repl-session';
+import { cljsLib } from './utilities';
 
 export let lastContexts: context.CursorContext[] = [];
 export let currentContexts: context.CursorContext[] = [];
@@ -18,6 +21,10 @@ export function setCursorContextIfChanged(editor: vscode.TextEditor) {
   }
   const contexts = determineCursorContexts(editor.document, editor.selections[0].active);
   setCursorContexts(contexts);
+  const [ns, _form] = namespace.getDocumentNamespace(editor.document);
+  void vscode.commands.executeCommand('setContext', 'calva:ns', ns);
+  const sessionType = session.getReplSessionType(cljsLib.getStateValue('connected'));
+  void vscode.commands.executeCommand('setContext', 'calva:replSessionType', sessionType);
 }
 
 function determineCursorContexts(


### PR DESCRIPTION
## What has changed?

Adding `when` clause context:

* `calva:projectRoot`: A string with the absolute path to the repl project root
* `calva:ns`: A string with the current namespace
* `calva:replSessionType`: `clj`, or `cljs` depending on the file type of the current file

Fixes #2652 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
