### PR TITLE
Remove option to skip ignored forms moving backwards by sexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Add extension when contexts for Calva states such as project root, session type, ns](https://github.com/BetterThanTomorrow/calva/issues/2652)
+- Fix: [Calva internals: The `backwardSexp` can't handle skipping ignored forms, even though it says it can](https://github.com/BetterThanTomorrow/calva/issues/2657)
 
 ## [2.0.480] - 2024-10-21
 

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -316,12 +316,7 @@ export class LispTokenCursor extends TokenCursor {
    *
    * @returns true if the cursor was moved, false otherwise.
    */
-  backwardSexp(
-    skipComments = true,
-    skipMetadata = false,
-    skipIgnoredForms = false,
-    skipReaders = true
-  ) {
+  backwardSexp(skipComments = true, skipMetadata = false, skipReaders = true) {
     const stack = [];
     this.backwardWhitespace(skipComments);
     if (this.getPrevToken().type === 'open') {
@@ -345,9 +340,9 @@ export class LispTokenCursor extends TokenCursor {
           }
           if (skipMetadata) {
             const metaCursor = this.clone();
-            metaCursor.backwardSexp(true, false, false, false);
+            metaCursor.backwardSexp(true, false, false);
             if (metaCursor.tokenBeginsMetadata()) {
-              this.backwardSexp(skipComments, skipMetadata, skipIgnoredForms);
+              this.backwardSexp(skipComments, skipMetadata, skipReaders);
             }
           }
           if (skipReaders) {
@@ -376,9 +371,9 @@ export class LispTokenCursor extends TokenCursor {
           }
           if (skipMetadata) {
             const metaCursor = this.clone();
-            metaCursor.backwardSexp(true, false, false, false);
+            metaCursor.backwardSexp(true, false, false);
             if (metaCursor.tokenBeginsMetadata()) {
-              this.backwardSexp(skipComments, skipMetadata, skipIgnoredForms);
+              this.backwardSexp(skipComments, skipMetadata, skipReaders);
             }
           }
           if (skipReaders) {

--- a/src/cursor-doc/utilities.ts
+++ b/src/cursor-doc/utilities.ts
@@ -41,7 +41,7 @@ export function isRightSexpStructural(cursor: LispTokenCursor): boolean {
     return false;
   }
   cursor.forwardSexp(true, true, false);
-  cursor.backwardSexp(false, false, false, false);
+  cursor.backwardSexp(false, false, false);
 
   const token = cursor.getToken();
   if (token.type === 'open') {

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -228,6 +228,20 @@ describe('Token Cursor', () => {
       cursor.backwardSexp(true, true);
       expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
+    it('Does not skip ignored forms if skipIgnoredForms', () => {
+      const a = docFromTextNotation('(a #_1 #_2 |3)');
+      const b = docFromTextNotation('(a #_a #_|2 3)');
+      const cursor = a.getTokenCursor(a.selections[0].anchor);
+      cursor.backwardSexp(true, true);
+      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+    });
+    it('Does not skip stacked ignored forms', () => {
+      const a = docFromTextNotation('(a #_ #_ 1 2 |3)');
+      const b = docFromTextNotation('(a #_ #_ 1 |2 3)');
+      const cursor = a.getTokenCursor(a.selections[0].anchor);
+      cursor.backwardSexp(true, true);
+      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+    });
   });
 
   describe('downList', () => {


### PR DESCRIPTION
Removing the `skipIgnoredForms` parameter for `backwardSexp`, and added two tests that show that this skipping shouldn't be expected.

* Fixes #2657

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
