### PR TITLE
Add test for making sure the ignore marker is not included  in top le…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 
 - [Add extension when contexts for Calva states such as project root, session type, ns](https://github.com/BetterThanTomorrow/calva/issues/2652)
 - Fix: [Calva internals: The `backwardSexp` function can't handle skipping ignored forms, even though it says it can](https://github.com/BetterThanTomorrow/calva/issues/2657)
+- Fix: [Keep support for evaluating top level form in ignored forms when at top level](https://github.com/BetterThanTomorrow/calva/issues/2655)
 
 ## [2.0.480] - 2024-10-21
 

--- a/docs/site/evaluation.md
+++ b/docs/site/evaluation.md
@@ -35,7 +35,7 @@ Some of the commands also let you choose what should happen with the results:
     * The `line` style is the default.
     * The `ignore` style will put an ignore marker (`#_`) before the result.
     * The `rcf` style will wrap the result in a rich comment form ( `(comment ...)`).
-    
+
     Here are some example keybindings for using the different comment styles with the **Evaluate Top Level Form (defun) to Comment** command:
 
     ```jsonc
@@ -107,6 +107,8 @@ Default shortcut for evaluating the current top level form: `alt+enter`.
 The **current top-level form** means top-level in a structural sense. It is _not_ the topmost form in the file. Typically in a Clojure file you will find `def` and `defn` (and `defwhatever`) forms at the top level, which also is one major intended use for evaluating top level form: _to define and redefine variables_. However, Calva does not check the contents of the form in order to determine it as a top-level forms: _all forms not enclosed in any other form are top level forms_.
 
 An ”exception” is introduced by the `comment` form. It will create a new top level context, so that any forms immediately inside a `(comment ...)` form will be considered top-level by Calva. This is to support a workflow with what is often referred to the [Rich Comments](rich-comments.md).
+
+A special case is ignored forms (using the `#_` marker) at the top level. They will always be selected as top level forms separately from their ignore marker, enabling evaluating them as top level forms. Similar to Rich Comments.
 
 At the top level the selection of which form is the current top level form follows the same rules as those for [the current form](#current-form).
 

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -804,6 +804,13 @@ describe('Token Cursor', () => {
       const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
       expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
     });
+    // https://github.com/BetterThanTomorrow/calva/issues/2655
+    it('Does not include ignore marker', () => {
+      const a = docFromTextNotation('a #_ [b (c|)] [d]');
+      const b = docFromTextNotation('a #_ |[b (c)]| [d]');
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+      expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+    });
     describe('Rich Comment Form top level context', () => {
       it('Finds range for a top level form inside a comment', () => {
         const a = docFromTextNotation('aaa (comment [bbb cc|c]  ddd)');
@@ -953,6 +960,13 @@ describe('Token Cursor', () => {
         const b = docFromTextNotation('(comment |@(foo [bar])|)');
         const cursor: LispTokenCursor = a.getTokenCursor(0);
         expect(cursor.rangeForDefun(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      });
+      // https://github.com/BetterThanTomorrow/calva/issues/2655
+      it('Does not include ignore marker', () => {
+        const a = docFromTextNotation('aaa (comment #_ [bbb ccc|]  ddd)');
+        const b = docFromTextNotation('aaa (comment #_ |[bbb ccc]|  ddd)');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
       });
     });
   });


### PR DESCRIPTION
## What has changed?

Adding tests that guard against changing things so that selecting an ignored top level form would include the ignore marker.

Also documenting this special case.

* Fixes #2655 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
