### PR TITLE
2660 toplevel ignore style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes to Calva.
 - [Add extension when contexts for Calva states such as project root, session type, ns](https://github.com/BetterThanTomorrow/calva/issues/2652)
 - Fix: [Calva internals: The `backwardSexp` function can't handle skipping ignored forms, even though it says it can](https://github.com/BetterThanTomorrow/calva/issues/2657)
 - Fix: [Keep support for evaluating top level form in ignored forms when at top level](https://github.com/BetterThanTomorrow/calva/issues/2655)
+- [Enable separate styling for top level ignored forms](https://github.com/BetterThanTomorrow/calva/issues/2660)
 
 ## [2.0.480] - 2024-10-21
 

--- a/docs/site/syntax-highlighting.md
+++ b/docs/site/syntax-highlighting.md
@@ -44,6 +44,7 @@ You are in charge of how brackets and comments are highlighted via the `calva.hi
 | `misplacedBracketStyle` | Style of misplaced bracket | `{ "border": "2px solid #c33" }` |
 | `matchedBracketStyle` | Style of bracket pair highlight | `{"backgroundColor": "#E0E0E0"}` |
 | `ignoredFormStyle` | Style of `#_...` form | `{"textDecoration": "none; opacity: 0.5"}` |
+| `ignoredTopLevelFormStyle` | Style of `#_...` form. (If not set uses `ignoredFormStyle`) | `{ "textDecoration": "none; text-shadow: 2px 2px 5px rgba(255, 215, 0, 0.75)" }` |
 | `commentFormStyle` | Style of `(comment ...)` form | `{"fontStyle": "italic"}` |
 
 !!! Note "Calva disables the VS Code built-in indent guides"

--- a/docs/site/syntax-highlighting.md
+++ b/docs/site/syntax-highlighting.md
@@ -43,8 +43,8 @@ You are in charge of how brackets and comments are highlighted via the `calva.hi
 | `cycleBracketColors` | Whether same colors should be <br> reused for deeply nested brackets | `true` |
 | `misplacedBracketStyle` | Style of misplaced bracket | `{ "border": "2px solid #c33" }` |
 | `matchedBracketStyle` | Style of bracket pair highlight | `{"backgroundColor": "#E0E0E0"}` |
-| `ignoredFormStyle` | Style of `#_...` form | `{"textDecoration": "none; opacity: 0.5"}` |
-| `ignoredTopLevelFormStyle` | Style of `#_...` form. (If not set uses `ignoredFormStyle`) | `{ "textDecoration": "none; text-shadow: 2px 2px 5px rgba(255, 215, 0, 0.75)" }` |
+| `ignoredFormStyle` | Style of `#_...` forms | `{"textDecoration": "none; opacity: 0.5"}` |
+| `ignoredTopLevelFormStyle` | Style of `#_...` forms at the top level. (If not set, uses `ignoredFormStyle`) | `{ "textDecoration": "none; text-shadow: 2px 2px 5px rgba(255, 215, 0, 0.75)" }` |
 | `commentFormStyle` | Style of `(comment ...)` form | `{"fontStyle": "italic"}` |
 
 !!! Note "Calva disables the VS Code built-in indent guides"

--- a/package.json
+++ b/package.json
@@ -1142,6 +1142,12 @@
             "default": null,
             "description": "Style of `#_` ignored forms",
             "scope": "resource"
+          },
+          "calva.highlight.ignoredTopLevelFormStyle": {
+            "type": "object",
+            "default": null,
+            "markdownDescription": "Style of top level `#_` ignored forms. If not specified, it will be the same as what's set for `calva.highlight.ignoredFormStyle`",
+            "scope": "resource"
           }
         }
       }

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -139,5 +139,8 @@
       "afterCL]ReplJackInCode": ["(println :hello)", "(println :world!)"],
       "cljsType": "none"
     }
-  ]
+  ],
+  "calva.highlight.ignoredTopLevelFormStyle": {
+    "textDecoration": "none; text-shadow: 2px 2px 5px rgba(255, 215, 0, 0.75)"
+  }
 }

--- a/test-data/test-files/highlight_test.clj
+++ b/test-data/test-files/highlight_test.clj
@@ -22,7 +22,7 @@
 ;; \
 "()"
 ;; \
-;; 
+;;
 (((#((())))))
 ([ #{ }()[]])
 
@@ -54,10 +54,10 @@
   (println "I ❤️Clojure")
   ([{} () []]))
 
-    
+
     (comment
       (+ (* 2 2)
-         2)      
+         2)
       (Math/abs -1)
       (defn hello [s]
         (str "Hello " s))
@@ -143,7 +143,7 @@ bar
   [:c {:d :e}]]
  [:b
   [:c {:d :e}]]]
-(comment 
+(comment
   (foo #_"bar" baz))
 #_{:foo "foo"
    :bar (comment [["bar"]])}


### PR DESCRIPTION
## What has changed?

Added a separate highlight for ignored forms at the top level. It defaults to the same as all other ignored forms.

* Fixes #2660

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
