### PR TITLE
Highlighter stashes discovery of mismatched brackets in mirrorDoc[hig…

### DIFF
--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -416,6 +416,7 @@ function updateRainbowBrackets() {
     }
   }
   activeEditor.setDecorations(misplacedType, misplaced);
+  mirrorDoc["highlightFoundMisplacedBrackets"] = misplaced.length; // help tests 'see' that misplaced brackets are highlighted
   activeEditor.setDecorations(commentFormType, comment_forms);
   activeEditor.setDecorations(ignoredFormType, ignores);
   activeEditor.setDecorations(ignoredTopLevelFormType, topLevelIgnores);


### PR DESCRIPTION
## What has changed?

highlight's extension.ts stashes a flag of misplaced brackets in `mirrorDoc["highlightFoundMisplacedBrackets"]`.

This change supports a property-based integration test of potential race conditions in Paredit's deleteBackward for #2611. The property is "does the user see danger-flagged brackets?" 

A couple of alternative approaches (for the test of #2611) were considered. 
- Specific expected document content. However, when Paredit finds it has inconsistent inputs (which may be unavoidable in VS Code's asynchronous world), the only way for Paredit not to mess up the document might be work-shedding, i.e., ignoring a keypress. This doubles the number of possible expected outcomes with each keypress. And it may take dozens or hundreds of keypresses to spark the race conditions. 
- For property-based testing, an alternative potential property might be token-cursor's `docIsBalanced`. However, at least under the stressful circumstances of the test, `docIsBalanced` sometimes does not notice unmatched parentheses highlighted by the highlighter.

Addressing #2611

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [ ] Unworthy of mention ~Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing~.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Did not notice applicable docs ~Added to or updated docs in this branch, if appropriate~
- [ ] ~Tests~ - _forthcoming for #2611_
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
