### PR TITLE
2611 paredit delete backward races  sync registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Internally to Paredit, enabled commands to run synchronously, in preparation for fixing [Paredit garbles while backspacing rapidly](https://github.com/BetterThanTomorrow/calva/issues/2611)
+ 
 ## [2.0.482] - 2024-12-03
 
 - Fix: [Added 'replace-refer-all-with-alias' & 'replace-refer-all-with-refer' actions to calva.](https://github.com/BetterThanTomorrow/calva/issues/2667) 

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -8,6 +8,7 @@ import {
   ExtensionContext,
   workspace,
   ConfigurationChangeEvent,
+  TextEditorEdit,
 } from 'vscode';
 import * as paredit from '../cursor-doc/paredit';
 import * as handlers from './commands';
@@ -45,15 +46,20 @@ function multiCursorEnabled(override?: boolean): boolean {
   return override ?? workspace.getConfiguration().get('calva.paredit.multicursor');
 }
 
+// PareditCommand is for handlers that will not do anything async.
 type PareditCommand = {
   command: string;
-  handler?: (doc: EditableDocument, arg?: any) => void;
-  asyncHandler?: (doc: EditableDocument, arg?: any) => void | Promise<any> | Thenable<any>;
+  handler: (doc: EditableDocument, arg?: any, builder?: TextEditorEdit) => void;
+};
+// PareditAsyncCommand is for handlers that may do something async, e.g., TextEditor.edit
+type PareditAsyncCommand = {
+  command: string;
+  asyncHandler: (doc: EditableDocument, arg?: any) => Promise<any> | Thenable<any>;
 };
 
 // only grab the custom, additional args after the first doc arg from the given command's handler
 type CommandArgOf<C extends PareditCommand> = Parameters<C['handler']>[1];
-type AsyncCommandArgOf<C extends PareditCommand> = Parameters<C['asyncHandler']>[1];
+type AsyncCommandArgOf<C extends PareditAsyncCommand> = Parameters<C['asyncHandler']>[1];
 
 const pareditCommands = [
   // NAVIGATING
@@ -239,68 +245,68 @@ const pareditCommands = [
   // EDITING
   {
     command: 'paredit.slurpSexpForward',
-    handler: paredit.forwardSlurpSexp,
+    asyncHandler: paredit.forwardSlurpSexp,
   },
   {
     command: 'paredit.barfSexpForward',
-    handler: paredit.forwardBarfSexp,
+    asyncHandler: paredit.forwardBarfSexp,
   },
   {
     command: 'paredit.slurpSexpBackward',
-    handler: paredit.backwardSlurpSexp,
+    asyncHandler: paredit.backwardSlurpSexp,
   },
   {
     command: 'paredit.barfSexpBackward',
-    handler: paredit.backwardBarfSexp,
+    asyncHandler: paredit.backwardBarfSexp,
   },
   {
     command: 'paredit.splitSexp',
-    handler: paredit.splitSexp,
+    asyncHandler: paredit.splitSexp,
   },
   {
     command: 'paredit.joinSexp',
-    handler: paredit.joinSexp,
+    asyncHandler: paredit.joinSexp,
   },
   {
     command: 'paredit.spliceSexp',
-    handler: paredit.spliceSexp,
+    asyncHandler: paredit.spliceSexp,
   },
   // ['paredit.transpose', ], // TODO: Not yet implemented
   {
     command: 'paredit.raiseSexp',
-    handler: paredit.raiseSexp,
+    asyncHandler: paredit.raiseSexp,
   },
   {
     command: 'paredit.transpose',
-    handler: paredit.transpose,
+    asyncHandler: paredit.transpose,
   },
   {
     command: 'paredit.dragSexprBackward',
-    handler: paredit.dragSexprBackward,
+    asyncHandler: paredit.dragSexprBackward,
   },
   {
     command: 'paredit.dragSexprForward',
-    handler: paredit.dragSexprForward,
+    asyncHandler: paredit.dragSexprForward,
   },
   {
     command: 'paredit.dragSexprBackwardUp',
-    handler: paredit.dragSexprBackwardUp,
+    asyncHandler: paredit.dragSexprBackwardUp,
   },
   {
     command: 'paredit.dragSexprForwardDown',
-    handler: paredit.dragSexprForwardDown,
+    asyncHandler: paredit.dragSexprForwardDown,
   },
   {
     command: 'paredit.dragSexprForwardUp',
-    handler: paredit.dragSexprForwardUp,
+    asyncHandler: paredit.dragSexprForwardUp,
   },
   {
     command: 'paredit.dragSexprBackwardDown',
-    handler: paredit.dragSexprBackwardDown,
+    asyncHandler: paredit.dragSexprBackwardDown,
   },
   {
     command: 'paredit.convolute',
-    handler: paredit.convolute,
+    asyncHandler: paredit.convolute,
   },
   {
     command: 'paredit.killRight',
@@ -314,7 +320,7 @@ const pareditCommands = [
   },
   {
     command: 'paredit.killLeft',
-    handler: (doc: EditableDocument, opts?: { copy: boolean }) => {
+    asyncHandler: (doc: EditableDocument, opts?: { copy: boolean }) => {
       return handlers.killLeft(
         doc,
         // TODO: actually implement multicursor
@@ -389,59 +395,59 @@ const pareditCommands = [
   },
   {
     command: 'paredit.wrapAroundParens',
-    handler: (doc: EditableDocument) => {
+    asyncHandler: (doc: EditableDocument) => {
       return paredit.wrapSexpr(doc, '(', ')');
     },
   },
   {
     command: 'paredit.wrapAroundSquare',
-    handler: (doc: EditableDocument) => {
+    asyncHandler: (doc: EditableDocument) => {
       return paredit.wrapSexpr(doc, '[', ']');
     },
   },
   {
     command: 'paredit.wrapAroundCurly',
-    handler: (doc: EditableDocument) => {
+    asyncHandler: (doc: EditableDocument) => {
       return paredit.wrapSexpr(doc, '{', '}');
     },
   },
   {
     command: 'paredit.wrapAroundQuote',
-    handler: (doc: EditableDocument) => {
+    asyncHandler: (doc: EditableDocument) => {
       return paredit.wrapSexpr(doc, '"', '"');
     },
   },
   {
     command: 'paredit.rewrapParens',
-    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+    asyncHandler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
       const isMulti = multiCursorEnabled(opts?.multicursor);
       return handlers.rewrapParens(doc, isMulti);
     },
   },
   {
     command: 'paredit.rewrapSquare',
-    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+    asyncHandler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
       const isMulti = multiCursorEnabled(opts?.multicursor);
       return handlers.rewrapSquare(doc, isMulti);
     },
   },
   {
     command: 'paredit.rewrapCurly',
-    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+    asyncHandler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
       const isMulti = multiCursorEnabled(opts?.multicursor);
       return handlers.rewrapCurly(doc, isMulti);
     },
   },
   {
     command: 'paredit.rewrapSet',
-    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+    asyncHandler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
       const isMulti = multiCursorEnabled(opts?.multicursor);
       return handlers.rewrapSet(doc, isMulti);
     },
   },
   {
     command: 'paredit.rewrapQuote',
-    handler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
+    asyncHandler: (doc: EditableDocument, opts?: { multicursor: boolean }) => {
       const isMulti = multiCursorEnabled(opts?.multicursor);
       return handlers.rewrapQuote(doc, isMulti);
     },
@@ -460,13 +466,13 @@ const pareditCommands = [
   },
   {
     command: 'paredit.forceDeleteForward',
-    handler: () => {
+    asyncHandler: () => {
       return vscode.commands.executeCommand('deleteRight');
     },
   },
   {
     command: 'paredit.forceDeleteBackward',
-    handler: () => {
+    asyncHandler: () => {
       return vscode.commands.executeCommand('deleteLeft');
     },
   },
@@ -497,14 +503,14 @@ function wrapPareditCommand<C extends PareditCommand>(command: C) {
       if (!enabled || !languages.has(textEditor.document.languageId)) {
         return;
       }
-      return command.handler(mDoc, arg);
+      return command.handler(mDoc, arg, builder);
     } catch (e) {
       console.error(e.message);
     }
   };
 }
 
-function wrapPareditAsyncCommand<C extends PareditCommand>(command: C) {
+function wrapPareditAsyncCommand<C extends PareditAsyncCommand>(command: C) {
   return async (arg: AsyncCommandArgOf<C>) => {
     try {
       const textEditor = window.activeTextEditor;
@@ -560,11 +566,17 @@ export function activate(context: ExtensionContext) {
         setKeyMapConf();
       }
     }),
-    ...pareditCommands.map((command: PareditCommand) => {
-      if (command.handler) {
-        return commands.registerTextEditorCommand(command.command, wrapPareditCommand(command));
-      } else if (command.asyncHandler) {
-        return commands.registerCommand(command.command, wrapPareditAsyncCommand(command));
+    ...pareditCommands.map((command) => {
+      if (command['handler']) {
+        return commands.registerTextEditorCommand(
+          command.command,
+          wrapPareditCommand(command as PareditCommand)
+        );
+      } else if (command['asyncHandler']) {
+        return commands.registerCommand(
+          command.command,
+          wrapPareditAsyncCommand(command as PareditAsyncCommand)
+        );
       } else {
         throw 'Unexpected';
       }


### PR DESCRIPTION
_This pull request is mainly for review and comment. It is preparation for a fix to #2611. I don't know whether the change in this PR by itself would be noticeable._ 

This change adjusts paredit to allow non-async commands to be more responsive and reliable. Heretofore all Paredit commands are async, but this change registers commands as synchronous if their async was only nominal. The goal is to reduce race conditions among multiple commands concurrently in progress (e.g., when keyboard auto-repeat outruns execution), by opting-out of concurrent execution where possible. (Races between document-change notification events and command handlers are still possible, though.)

## What has changed?

- `pareditCommands` (data structure) distinguishes synchronous `handler` from `asyncHandler`.  For the time being, the handlers themselves are not rewritten in this patch to be less-asynchronous than they already were. Therefore, motion and selection commands are synchronous and document modification commands remain async. 
- `activate` uses `registerTextEditorCommand` for synchronous handlers, `registerCommand` for async.
- `wrapPareditCommand` passes to synchronous command handlers the `TextEditorEdit` provided by VS Code (removing the need for the handlers to use `TextEditor.edit`, which is async).  

Addressing #2611

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] N/A ~Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- [ ] N/A ~Added to or updated docs in this branch, if appropriate~
- [ ] I suppose Paredit features already have tests ~Tests~
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
