### PR TITLE
#2611: make LSP config available synchronously

### DIFF
--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -15,13 +15,13 @@ const FormatDepthDefaults = {
   defprotocol: 2,
 };
 
-export async function indentPosition(position: vscode.Position, document: vscode.TextDocument) {
+export /*async*/ function indentPosition(position: vscode.Position, document: vscode.TextDocument) {
   const editor = util.getActiveTextEditor();
   const pos = new vscode.Position(position.line, 0);
   const indent = getIndent(
     getDocument(document).model.lineInputModel,
     getDocumentOffset(document, position),
-    await config.getConfig(document)
+    config.getConfig(document)
   );
   const newPosition = new vscode.Position(position.line, indent);
   const delta = document.lineAt(position.line).firstNonWhitespaceCharacterIndex - indent;
@@ -97,7 +97,7 @@ export async function formatRange(document: vscode.TextDocument, range: vscode.R
   return vscode.workspace.applyEdit(wsEdit);
 }
 
-export async function formatPositionInfo(
+export /*async*/ function formatPositionInfo(
   editor: vscode.TextEditor,
   onType: boolean = false,
   extraConfig: CljFmtConfig = {}
@@ -122,7 +122,7 @@ export async function formatPositionInfo(
     _convertEolNumToStringNotation(doc.eol),
     onType,
     {
-      ...(await config.getConfig()),
+      ...config.getConfig(),
       ...extraConfig,
       'comment-form?': cursor.getFunctionName() === 'comment',
     }
@@ -207,7 +207,7 @@ export async function formatPosition(
   extraConfig: CljFmtConfig = {}
 ): Promise<boolean> {
   const doc: vscode.TextDocument = editor.document,
-    formattedInfo = await formatPositionInfo(editor, onType, extraConfig);
+    formattedInfo = formatPositionInfo(editor, onType, extraConfig);
   if (formattedInfo && formattedInfo.previousText != formattedInfo.formattedText) {
     return editor
       .edit(
@@ -262,11 +262,11 @@ export function trimWhiteSpacePositionCommand(editor: vscode.TextEditor) {
   void formatPosition(editor, false, { 'remove-multiple-non-indenting-spaces?': true });
 }
 
-export async function formatCode(code: string, eol: number) {
+export /*async*/ function formatCode(code: string, eol: number) {
   const d = {
     'range-text': code,
     eol: _convertEolNumToStringNotation(eol),
-    config: await config.getConfig(),
+    config: config.getConfig(),
   };
   const result = jsify(formatText(d));
   if (!result['error']) {
@@ -277,7 +277,7 @@ export async function formatCode(code: string, eol: number) {
   }
 }
 
-async function _formatRange(
+/*async*/ function _formatRange(
   rangeText: string,
   allText: string,
   range: number[],
@@ -288,7 +288,7 @@ async function _formatRange(
     'all-text': allText,
     range: range,
     eol: eol,
-    config: await config.getConfig(),
+    config: config.getConfig(),
   };
   const result = jsify(formatTextAtRange(d));
   if (!result['error']) {

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -453,7 +453,7 @@ const pareditCommands = [
   {
     command: 'paredit.deleteBackward',
     handler: async (doc: EditableDocument) => {
-      await paredit.backspace(doc, await config.getConfig());
+      await paredit.backspace(doc, config.getConfig());
     },
   },
   {


### PR DESCRIPTION
_This pull request is for review and comment. It is preparation for fixing #2611._

## What has changed?

`lsp.api.getCljFmtConfig(client)` is cached (forever) (cached once, covering all documents), in order for synchronous Paredit commands to use the format config - or in other words, to enable Paredit commands to be made synchronous and more reliable even if they want to refer to formatter config, which heretofore is async. 

- formatter-config.getConfig is no longer async. It includes LSP's settings if they're already cached, otherwise it starts an async retrieval that will eventually cache the LSP settings. 
- Consequently:
  - format.ts `indentPosition`, `formatPositionInfo`, and `formatCode` are no longer async. 
  - paredit/extension.ts's pareditCommands entry for paredit.deleteBackward can get started without waiting for LSP's config. This might be a partial fix for #2611 already but the effect, if noticeable at all, is pretty modest.

Addressing #2611

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [ ] Unworthy of mention ~Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.~
- [ ] N/A ~Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- [ ] N/A ~Added to or updated docs in this branch, if appropriate~
- [ ] I suppose features relying on formatter-config are already tested ~Tests~
  - [ ] N/A ~Tested the particular change~
  - [ ] **Don't Know** Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
