### PR TITLE
Unit-test paredit.backspace where start != end

### DIFF
--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -764,9 +764,14 @@ export class StringDocument implements EditableDocument {
   }
 
   backspace() {
-    const p = this.selections[0].anchor;
-    return this.model.edit([new ModelEdit('deleteRange', [p - 1, 1])], {
-      selections: [new ModelEditSelection(p - 1)],
+    const anchor = this.selections[0].anchor;
+    const active = this.selections[0].active;
+    const [left, right] =
+      anchor == active
+        ? [Math.max(0, anchor - 1), anchor]
+        : [Math.min(anchor, active), Math.max(anchor, active)];
+    return this.model.edit([new ModelEdit('deleteRange', [left, right - left])], {
+      selections: [new ModelEditSelection(left)],
     });
   }
 }

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1834,6 +1834,12 @@ describe('paredit', () => {
 
     describe('Kill character backwards (backspace)', () => {
       // TODO: Change to await instead of void
+      it('Deletes a selected range', async () => {
+        const a = docFromTextNotation('{::foo ()• :|:bar |:foo}');
+        const b = docFromTextNotation('{::foo ()• :|:foo}');
+        await paredit.backspace(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
       it('Leaves closing paren of empty list alone', async () => {
         const a = docFromTextNotation('{::foo ()|• ::bar :foo}');
         const b = docFromTextNotation('{::foo (|)• ::bar :foo}');


### PR DESCRIPTION
## What has changed?

A new unit test checks the first logic branch in paredit.backspce: a non-empty selection.

I suppose paredit.backspace works properly in practice, but the new test failed. The test's simulator (StringDocument) did not attend to the non-empty selection case and always removed one character. I gather EditableDocument.backspace is used only by paredit.backspace(?), so harmonizing it with the actual editor should be all right. Paredit backspace uses doc.backspace twice, under distinct circumstances, but the second usage was already trodden by unit tests.

Fixes #2681

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [ ] Beneath mention ~Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.~
- [x] (It does not) Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] n/a ~Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
