### PR TITLE
Update connect-sequences.md

### DIFF
--- a/docs/site/connect-sequences.md
+++ b/docs/site/connect-sequences.md
@@ -19,7 +19,7 @@ NB: _Connect sequence configuration affects Calva's Jack-in menu in the followin
 A connect sequence configures the following:
 
 * `name`: (required) This will show up in the Jack-in quick-pick menu when you start Jack-in (see above).
-* `projectType`: (required) This is either "Leiningen”, "deps.edn", "shadow-cljs", "lein-shadow", "Gradle", ”generic”, or  "custom".
+* `projectType`: (required) This is either "Leiningen”, "deps.edn", "shadow-cljs", "lein-shadow", "Gradle", "babashka", "nbb", "basilisp", "joyride", ”generic”, "custom" or "cljs-only".
 * `autoSelectForJackIn`: A boolean. If true, this sequence will be automatically selected at **Jack-in**, suppressing the Project Type. Use together with `projectRootPath` to also suppress the Project Root menu. Add usage of `menuSelections` to go for a prompt-less REPL Jack-in. If you have more than one sequence with `autoSelectForJackIn` set to true, the first one will be used.
 * `autoSelectForConnect`: A boolean. If true, this sequence will be automatically selected at **Connect**, suppressing the Project Type menu. Use together with `projectRootPath` to also suppress the Project Root menu. If you have more than one sequence with `autoSelectForConnect` set to true, the first one will be used.
 * `projectRootPath`: An array of path segments leading to the root of the project to which this connect sequence corresponds. Use together with `autoSelectForJackIn`/`autoSelectForConnect` to suppress the Project Root menu. The path can be absolute or relative to the workspace root. If there are several Workspace Folders, the workspace root is the path of the first folder, so relative paths will only work for this first folder.

--- a/docs/site/connect-sequences.md
+++ b/docs/site/connect-sequences.md
@@ -19,7 +19,7 @@ NB: _Connect sequence configuration affects Calva's Jack-in menu in the followin
 A connect sequence configures the following:
 
 * `name`: (required) This will show up in the Jack-in quick-pick menu when you start Jack-in (see above).
-* `projectType`: (required) This is either "Leiningen”, "deps.edn", "shadow-cljs", "lein-shadow", "Gradle", "babashka", "nbb", "basilisp", "joyride", ”generic”, "custom" or "cljs-only".
+* `projectType`: (required) This is either "Leiningen”, "deps.edn", "shadow-cljs", "lein-shadow", "Gradle", "babashka", "nbb", "basilisp", "joyride", ”generic”, "custom", or "cljs-only".
 * `autoSelectForJackIn`: A boolean. If true, this sequence will be automatically selected at **Jack-in**, suppressing the Project Type. Use together with `projectRootPath` to also suppress the Project Root menu. Add usage of `menuSelections` to go for a prompt-less REPL Jack-in. If you have more than one sequence with `autoSelectForJackIn` set to true, the first one will be used.
 * `autoSelectForConnect`: A boolean. If true, this sequence will be automatically selected at **Connect**, suppressing the Project Type menu. Use together with `projectRootPath` to also suppress the Project Root menu. If you have more than one sequence with `autoSelectForConnect` set to true, the first one will be used.
 * `projectRootPath`: An array of path segments leading to the root of the project to which this connect sequence corresponds. Use together with `autoSelectForJackIn`/`autoSelectForConnect` to suppress the Project Root menu. The path can be absolute or relative to the workspace root. If there are several Workspace Folders, the workspace root is the path of the first folder, so relative paths will only work for this first folder.


### PR DESCRIPTION

<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

If you have updated only the documentation, including README and GitHub templates, then we most often want those changes directed to the `published` branch (which is the default, so you probably don't have to do anything.
-->

## What has Changed?
<!-- Please tell us what the change is about and why and such. For simple typos, just say that. 😄 -->

On the "REPL Jack-in and Connect Sequences > Settings for adding Custom Sequences" doc page, added the following valid values for projectType

- babashka
- nbb
- basilisp
- joyride
- cljs-only

I assume these are valid based on the [ProjectType enum](https://github.com/BetterThanTomorrow/calva/blob/a038073d80f294eb09e2c33511f099a3af13d4c2/src/nrepl/connectSequence.ts#L11-L23)

<!-- Please consider creating an issue for your documentation update, if there isn't one already. Tell us which issue you are fixing. -->

Fixes #2687 

<!-- Also include `Fixes #12345` in the commit message. -->

## My Calva Documentation Only PR Checklist

<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [x] Read [Editing Documentation](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Hack-on-Calva#editing-documentation). Note: there is no "Editing Documentation section on this page.
- [x] Directed this pull request at the `published` branch.
- [] ~Built the site locally (if the changes were more involved than simple typo fixes), and verified that the site is presented as expected.~ (this was just a one-line text change so I didn't try to build it)
- [x] Referenced the issue I am fixing/addressing _in a commit message for the pull request_ (if there was is an issue for the documentation change)
  - [x] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [ ] ~If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik

