### PR TITLE
2686 delete forward from comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Del key, after emptying a comment line, then imbalances the next form](https://github.com/BetterThanTomorrow/calva/issues/2686)
+
 ## [2.0.482] - 2024-12-03
 
 - Fix: [Added 'replace-refer-all-with-alias' & 'replace-refer-all-with-refer' actions to calva.](https://github.com/BetterThanTomorrow/calva/issues/2667) 


### PR DESCRIPTION
## What has changed?

`whenContexts.setCursorContextIfChanged` is called not upon only `changeTextEditorSelection` and `changeActiveTextEditor` (as before), but also `changeTextDocument` - to account for the case where a document change affected the meaning of the active point without moving it.

Since most edits also move the active point, a check is added to avoid redundant calls to `setCursorContextIfChanged`. The check compares the event's editor, document version, and active point with those of the previous event. 

Tests: I have not figured out how to automate keypresses. The test would start with the document `|;•(foo)` where `|` signifies the active point and `•` is a newline; press Del (removing the semicolon), Del again (removing the newline), and Del again (passing harmlessly over the open-paren? or erroneously deleting it?).  

Alternative: There is also a changeTextDocument handler in mirror-doc. It might be a more robust place to adjust cursor context, although it would complicate coordination of edit- vs selection-occasioned adjustment. The thing is that the mirror-doc handler updates the model, which is used in `whenContexts.setCursorContextIfChanged`. Luckily, the problematic case involves TWO presses of Del and therefore in practice the present, un-tangled, change will address it. 

Fixes #2686

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] (No docs changes) Added to or updated docs in this branch, if appropriate
- [ ] Tests (see above)
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
