### PR TITLE
#1007: show diff between expected and actual in repl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Have test runner show diff between "actual" and "expected"](https://github.com/BetterThanTomorrow/calva/issues/1007)
+
 ## [2.0.483] - 2025-01-08
 
 - Fix: [Paredit garbles while backspacing rapidly](https://github.com/BetterThanTomorrow/calva/issues/2611)
@@ -12,7 +14,7 @@ Changes to Calva.
 
 ## [2.0.482] - 2024-12-03
 
-- Fix: [Added 'replace-refer-all-with-alias' & 'replace-refer-all-with-refer' actions to calva.](https://github.com/BetterThanTomorrow/calva/issues/2667) 
+- Fix: [Added 'replace-refer-all-with-alias' & 'replace-refer-all-with-refer' actions to calva.](https://github.com/BetterThanTomorrow/calva/issues/2667)
 
 ## [2.0.481] - 2024-10-29
 

--- a/src/extension-test/unit/test-runner-test.ts
+++ b/src/extension-test/unit/test-runner-test.ts
@@ -167,4 +167,35 @@ orange`
 apple`
     );
   });
+
+  it('can produce detailed messages with diffs', () => {
+    expect(
+      cider.detailedMessage({
+        type: 'fail',
+        ns: 'core',
+        context: 'ctx',
+        index: 2,
+        expected: '{:key1 "value1", :key2 "value2"}',
+        actual: '{:key1 "wrongValue", :key2 "value2"}',
+        var: 'test',
+        file: 'core.clj',
+        line: 10,
+        message: 'Values do not match',
+        diffs: [
+          [
+            '{:key1 "wrongValue", :key2 "value2"}',
+            ['{:key1 "value1", :key2 "value2"}', '{:key1 "wrongValue"}'],
+          ],
+        ],
+      })
+    ).toBe(`; FAIL in core/test (core.clj:10):
+; ctx: Values do not match
+; expected:
+{:key1 "value1", :key2 "value2"}
+; actual:
+{:key1 "wrongValue", :key2 "value2"}
+; diff:
+- {:key1 "value1", :key2 "value2"}
++ {:key1 "wrongValue"}`);
+  });
 });

--- a/src/nrepl/cider.ts
+++ b/src/nrepl/cider.ts
@@ -142,6 +142,33 @@ export function lineInformation(result: TestResult): string {
   return ` (${result.file}:${result.line})`;
 }
 
+function getDiffMessages(result: TestResult): string[] {
+  const diffs = result.diffs;
+  const messages: string[] = [];
+
+  if (!diffs || !Array.isArray(diffs) || diffs.length === 0) {
+    return messages;
+  }
+
+  diffs.forEach((diffPair: [string, [string, string]]) => {
+    if (Array.isArray(diffPair) && diffPair.length === 2) {
+      const [_, [removed, added]] = diffPair;
+
+      if (removed || added) {
+        messages.push('; diff:');
+        messages.push(removed ? `- ${removed}` : '');
+        if (added) {
+          messages.push(`+ ${added}`);
+        }
+      }
+    } else {
+      console.warn('Invalid diff pair format:', diffPair);
+    }
+  });
+
+  return messages;
+}
+
 // Return a detailed message about why a test failed.
 // If the test passed, return the empty string.
 // The message contains "comment" lines that are prepended with ;
@@ -172,6 +199,11 @@ export function detailedMessage(result: TestResult): string | undefined {
     }
     if (result.actual) {
       messages.push(`; actual:\n${result.actual}`);
+    }
+
+    const diffMessages = getDiffMessages(result);
+    if (diffMessages.length > 0) {
+      messages.push(...diffMessages);
     }
   }
   return messages.length > 0 ? messages.join('\n') : undefined;

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -139,6 +139,8 @@ async function onTestResult(
         run.errored(assertion, new vscode.TestMessage(cider.shortMessage(result)));
         break;
       case 'fail':
+        run.failed(assertion, new vscode.TestMessage(cider.detailedMessage(result)));
+        break;
       default:
         run.failed(assertion, new vscode.TestMessage(cider.shortMessage(result)));
         break;


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Show diff on failed tests as describe in #1007 
- The diff object is already present from cider-nrepl, so it only needs to be show. Mimicks format of cider-nrepl, which is based on [humane-test-output](https://github.com/pjstadig/humane-test-output)

This is how the displayed diff will look in the repl:
<img width="550" alt="Screenshot 2025-01-20 at 07 24 42" src="https://github.com/user-attachments/assets/161a7cfb-c5f2-4b98-8949-93474ccea73b" />

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #1007 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR. 
- [ ] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
