### PR TITLE
2708 cursor context ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Have test runner show diff between "actual" and "expected"](https://github.com/BetterThanTomorrow/calva/issues/1007)
+- Fix: [cursor-context calva:ns is less accurate than the *ns* used by calva.evaluateSelection](https://github.com/BetterThanTomorrow/calva/issues/2708)
 
 ## [2.0.483] - 2025-01-08
 

--- a/src/when-contexts.ts
+++ b/src/when-contexts.ts
@@ -21,7 +21,7 @@ export function setCursorContextIfChanged(editor: vscode.TextEditor) {
   }
   const contexts = determineCursorContexts(editor.document, editor.selections[0].active);
   setCursorContexts(contexts);
-  const [ns, _form] = namespace.getDocumentNamespace(editor.document);
+  const [ns, _form] = namespace.getNamespace(editor.document, editor.selections[0].active);
   void vscode.commands.executeCommand('setContext', 'calva:ns', ns);
   const sessionType = session.getReplSessionType(cljsLib.getStateValue('connected'));
   void vscode.commands.executeCommand('setContext', 'calva:replSessionType', sessionType);


### PR DESCRIPTION
Search-backward for ns by starting from the cursor position (not the end of the document) for consistency with evaluateSelection

## What has changed?

- In when-contexts.ts, find current ns using the same technique as in evaluate.ts; i.e., instead of calling getDocumentNamespace, which is a wrapper around getNamespace that compels it to search from the end of the document, call getNamespace directly and start the search at the cursor position.

Folks should perceive a change only if they have customized key bindings to make use of calva:ns in a "when" clause.
No change is necessary to the documentation.

I do not know how to test key maps.

There remain some uses of getDocumentNamespace, the function this PR bypassed instead of changing. Do they really want the document's last declared namespace, as opposed to the first one? In any case, they are outside the scope of #2708.

- src/api/document.ts (getNamespace)
- src/evaluate.ts (requireREPLUtilitiesCommand)
- src/fiddle-files.ts (evaluateFiddleForSourceFile)

Fixes #2708

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [-] Tests
  - [-] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
