### PR TITLE
#2707: debounce cursor context calva:ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 
 - Fix: [Have test runner show diff between "actual" and "expected"](https://github.com/BetterThanTomorrow/calva/issues/1007)
 - Fix: [cursor-context calva:ns is less accurate than the *ns* used by calva.evaluateSelection](https://github.com/BetterThanTomorrow/calva/issues/2708)
+- Fix: [Computing cursor-context calva:ns slows down editing and moving the cursor](https://github.com/BetterThanTomorrow/calva/issues/2707)
 
 ## [2.0.483] - 2025-01-08
 

--- a/src/when-contexts.ts
+++ b/src/when-contexts.ts
@@ -7,6 +7,49 @@ import * as namespace from './namespace';
 import * as session from './nrepl/repl-session';
 import { cljsLib } from './utilities';
 
+/* Determining the "calva:ns" cursor context takes time,
+so figure it out after x milliseconds of quiet. */
+
+const nsCursorContextDelayMs = 800;
+
+/*
+Quiet means no changes to document content or cursor position.
+So whenever either of those changes: 
+- Set a new timer for x milliseconds and cancel any outstanding timer. 
+- When the timer expires, 
+-- if the relevant document is still active, 
+--- Calculate calva:ns
+--- Put it in effect with setContext
+One timer is sufficient to cover all documents.
+*/
+
+const setNsCursorContextSoon = (function () {
+  let nsCursorContextTimer = undefined;
+  return function (
+    baselineEditor: vscode.TextEditor,
+    baselineDocument: vscode.TextDocument,
+    baselinePosition: vscode.Position
+  ): void {
+    const baselineVersion = baselineDocument.version;
+    if (nsCursorContextTimer) {
+      clearTimeout(nsCursorContextTimer);
+    }
+    nsCursorContextTimer = setTimeout(function () {
+      const newEditor = util.tryToGetActiveTextEditor();
+      if (baselineEditor === newEditor) {
+        if (baselineDocument === newEditor.document) {
+          if (baselineVersion == newEditor.document.version) {
+            if (baselinePosition == newEditor.selections[0].active) {
+              const [ns, _form] = namespace.getNamespace(baselineEditor.document, baselinePosition);
+              void vscode.commands.executeCommand('setContext', 'calva:ns', ns);
+            }
+          }
+        }
+      }
+    }, nsCursorContextDelayMs);
+  };
+})();
+
 export let lastContexts: context.CursorContext[] = [];
 export let currentContexts: context.CursorContext[] = [];
 
@@ -21,8 +64,7 @@ export function setCursorContextIfChanged(editor: vscode.TextEditor) {
   }
   const contexts = determineCursorContexts(editor.document, editor.selections[0].active);
   setCursorContexts(contexts);
-  const [ns, _form] = namespace.getNamespace(editor.document, editor.selections[0].active);
-  void vscode.commands.executeCommand('setContext', 'calva:ns', ns);
+  setNsCursorContextSoon(editor, editor.document, editor.selections[0].active);
   const sessionType = session.getReplSessionType(cljsLib.getStateValue('connected'));
   void vscode.commands.executeCommand('setContext', 'calva:replSessionType', sessionType);
 }


### PR DESCRIPTION
## What has changed?

- Computing cursor context "calva:ns" and putting it into effect are debounced: that is, are performed after a short period of quiet time (if the relevant editor and document are still active).
  - Quiet is defined as no change to document content or active position. 
  - The quiet time is fixed arbitrarily at 800ms. 

- No change to the documentation at https://calva.io/when-clauses/ as the change is meant to be unobtrusive.
- No new tests. I do not know how to test asynchronous effects on cursor contexts.

Fixes #2707

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [-] Tests
  - [-] Tested the particular change
  - [-] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
