### PR TITLE
#2712 Don't consider clj-kondo config as a valid Clojure project to start LSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [Stop considering a clj-kondo config as a valid project to start LSP processes](https://github.com/BetterThanTomorrow/calva/issues/2712)
 
 ## [2.0.484] - 2025-01-26
 

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -47,7 +47,7 @@ type FindRootParams = {
  * selection menus to help the user.
  */
 export async function findProjectRootsWithReasons(params?: FindRootParams) {
-  const lspDirectories = ['.lsp/config.edn', '.clj-kondo/config.edn'];
+  const lspDirectories = ['.lsp/config.edn'];
 
   const projectFileNames: string[] = [
     'project.clj',


### PR DESCRIPTION
## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- The change was simply to remove the '.clj-kondo/config.edn' entry from the added list to the valid uri candidates.
- I didn't change the type of lspDirectories even though it is now a single element, should I or do I leave it that way in case anything else is added ? 
- Should I comment next to it the fact the '.clj-kondo/config.edn' was removed in case someone ever looks for it ?
- This was tested on Linux.

Hope I didn't forget anything and thanks @PEZ for your help figuring this out ! 


Fixes #2712

## My Calva PR Checklist

I have:

- [X] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [X] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [X] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [X] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [X] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] ~Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- [ ] ~Added to or updated docs in this branch, if appropriate~
- [ ] ~Tests~
  - [ ] ~Tested the particular change~
  - [ ] ~Figured if the change might have some side effects and tested those as well.~
- [X] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [X] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
