### PR TITLE
Fixes #2714: Typo "outher" -> "other"

### DIFF
--- a/docs/site/output.md
+++ b/docs/site/output.md
@@ -1,5 +1,5 @@
 ---
-title: Evaluation results and outher output
+title: Evaluation results and other output
 description: Calva displays the first line of the evaluation results inline, and also prints results, other REPL output and more to the configured Output Destination.
 ---
 


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

If you have updated only the documentation, including README and GitHub templates, then we most often want those changes directed to the `published` branch (which is the default, so you probably don't have to do anything.
-->

## What has Changed?
<!-- Please tell us what the change is about and why and such. For simple typos, just say that. 😄 -->

- Fix typo in `docs/site/output.md`. Currently says "[Evaluation results and outher output](https://calva.io/output/)" and should be "Evaluation results and other output" 😄 

<!-- Please consider creating an issue for your documentation update, if there isn't one already. Tell us which issue you are fixing. -->

Fixes #2714

<!-- Also include `Fixes #12345` in the commit message. -->

## My Calva Documentation Only PR Checklist

<!-- Strike out (using `~`) items that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [X] Read [Editing Documentation](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Hack-on-Calva#editing-documentation)
- [X] Directed this pull request at the `published` branch.
- [ ] ~Built the site locally (if the changes were more involved than simple typo fixes), and verified that the site is presented as expected.~
- [X] Referenced the issue I am fixing/addressing _in a commit message for the pull request_ (if there was is an issue for the documentation change)
  - [X] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
  - [ ] ~If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.~

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik

