### PR TITLE
2726 rewrap imbalance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Fix description of calva.autoOpenResultOutputDestination setting](https://github.com/BetterThanTomorrow/calva/pull/2721)
+- Fix: [Rewrapping to or from a Set introduces imbalance](https://github.com/BetterThanTomorrow/calva/issues/2726)
 
 ## [2.0.485] - 2025-01-27
 

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -587,10 +587,12 @@ export class LineInputModel implements EditableModel {
   edit(edits: ModelEdit<ModelEditFunction>[], options: ModelEditOptions): Thenable<boolean> {
     return new Promise((resolve, reject) => {
       this.editTextNow(edits, options);
-      if (this.document && options.selections) {
-        this.document.selections = options.selections;
-      } else {
-        this.document.selections = selectionsAfterEdits(edits, this.document.selections);
+      if (this.document) {
+        if (options.selections) {
+          this.document.selections = options.selections;
+        } else {
+          this.document.selections = selectionsAfterEdits(edits, this.document.selections);
+        }
       }
       resolve(true);
     });

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -318,7 +318,9 @@ const selectionsAfterEdits = (function () {
           : decodeInsertString(edits[ic]);
       const [point, delta] = affected;
       if (monotonicallyDecreasing != -1 && point >= monotonicallyDecreasing) {
-        throw new Error('Edits not back-to-front');
+        console.error(
+          'Edits not back-to-front. Inference of resulting selection might be inaccurate'
+        ); // TBD take the time to sort? or should commands emit edits in back-to-front order?
       }
       monotonicallyDecreasing = point;
       if (delta != 0) {

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -752,7 +752,7 @@ export function rewrapSexpr(
     .sortBy((e) => -e.args[0])
     .value();
   return doc.model.edit(editsToApply, {
-    skipFormat: true,
+    skipFormat: selections.length > 1, // reformat-as-you-type works with only 1 selection
   });
 }
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -752,7 +752,7 @@ export function rewrapSexpr(
     .sortBy((e) => -e.args[0])
     .value();
   return doc.model.edit(editsToApply, {
-    skipFormat: selections.length > 1, // reformat-as-you-type works with only 1 selection
+    //skipFormat: selections.length > 1, // reformat-as-you-type works with only 1 selection
   });
 }
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -708,8 +708,7 @@ export async function wrapSexpr(
  * - For each cursor, find the offsets/ranges for its containing list's open/close tokens.
  * - Make 2 ModelEdits for each token's replacement +  1 Selection; record the offset change.
  * - Dedupe each edit (as multi cursors could be in the same list).
- * - Then, reposition the edits and selections by the preceding edits' offset changes.
- * - Finally, apply the edits and update the selections.
+ * - Finally, apply the edits.
  *
  * @param doc
  * @param open
@@ -723,37 +722,23 @@ export function rewrapSexpr(
   close: string,
   selections = [doc.selections[0]]
 ) {
-  const edits: { type: 'open' | 'close'; change: number; edit: ModelEdit<'changeRange'> }[] = [],
-    newSelections = _.clone(selections).map((s) => ({ selection: s, change: 0 }));
+  const edits: ModelEdit<'changeRange'>[] = [];
 
   selections.forEach((sel, index) => {
     const { active } = sel;
     const cursor = doc.getTokenCursor(active);
     if (cursor.backwardList()) {
       cursor.backwardUpList();
-      const oldOpenStart = cursor.offsetStart;
+      const openStart = cursor.offsetStart;
       const oldOpenLength = cursor.getToken().raw.length;
-      const oldOpenEnd = oldOpenStart + oldOpenLength;
+      const oldOpenEnd = openStart + oldOpenLength;
       if (cursor.forwardSexp()) {
-        const oldCloseStart = cursor.offsetStart - close.length;
-        const oldCloseEnd = cursor.offsetStart;
-        const openChange = open.length - oldOpenLength;
+        const closeStart = cursor.offsetStart - close.length;
+        const closeEnd = cursor.offsetStart;
         edits.push(
-          {
-            edit: new ModelEdit('changeRange', [oldCloseStart, oldCloseEnd, close]),
-            change: 0,
-            type: 'close',
-          },
-          {
-            edit: new ModelEdit('changeRange', [oldOpenStart, oldOpenEnd, open]),
-            change: openChange,
-            type: 'open',
-          }
+          new ModelEdit('changeRange', [closeStart, closeEnd, close]),
+          new ModelEdit('changeRange', [openStart, oldOpenEnd, open])
         );
-        newSelections[index] = {
-          selection: new ModelEditSelection(active),
-          change: openChange,
-        };
       }
     }
   });
@@ -762,39 +747,12 @@ export function rewrapSexpr(
   // the same lists, which will result in attempting to delete the same ranges twice. So we dedupe.
   const uniqEdits = _.uniqWith(edits, _.isEqual);
 
-  // for both edits and new selections, get the offset by which to move each based on prior edits
-  function getOffset(cursorOffset: number) {
-    return _(uniqEdits)
-      .filter((x) => {
-        const [xStart] = x.edit.args;
-        return xStart < cursorOffset;
-      })
-      .map(({ change }) => change)
-      .sum();
-  }
-
+  // edit needs the ModelEdit array in order from end-of-doc to start
   const editsToApply = _(uniqEdits)
-    // First, importantly, sort by list open char offset
-    .sortBy((e) => e.edit.args[0])
-    // now, let's iterate thru each cursor and adjust their positions if earlier chars are delete/added
-    .map((e) => {
-      const [oldStart, oldEnd, text] = e.edit.args;
-      const offset = getOffset(oldStart);
-      const newStart = oldStart + offset;
-      const newEnd = oldEnd + offset;
-      return { ...e.edit, args: [newStart, newEnd, text] as const };
-    })
+    .sortBy((e) => -e.args[0])
     .value();
-  const selectionsToApply = newSelections.map(({ selection }) => {
-    const { active } = selection;
-    const newSel = selection.clone();
-    const offset = getOffset(active);
-    newSel.reposition(offset);
-    return newSel;
-  });
-
   return doc.model.edit(editsToApply, {
-    selections: selectionsToApply,
+    skipFormat: true,
   });
 }
 


### PR DESCRIPTION
## What has changed?

- rewrap has been corrected, to position the brackets accurately even when the opening bracket changes in size. This was done by _removing_ code that compensated for the size change when composing a ModelEdit plan. VS Code apparently wants all positions in a transaction of edits to be specified with reference to the unchanged document; as though it sorted edits by position and executed them from end-to-start of the document. To get the same result from the tests' TextEditorEdit emulator in LineInputModel, rewrap sorts its edits back-to-front.* 

- rewrap has been improved, not to override VS Code's default adjustment to (multi-) selections following the edit transaction. There was a race condition when rewrap calculated selections before arranging the edit transaction and asynchronously reasserted them later. A generalization of the selection-adjustment-inference code has been moved to LineInputModel, which has a role in emulating VS Code's TextEditorEdit for unit tests.  

- rewrap still triggers reformat-as-you-type. It seems to actually reformat at only 1 cursor, but that issue is beyond the scope of rewrap.

- No changes to docs or tests. The tests were already well-specified, - they passed erroneously due to complementary quirks of LineInputModel and rewrap.
 
*Perhaps, instead of rewrap sorting its edits back-to-front so LineInputModel will come up with the same result as TextEditorEdit, the sorting should be done by LineInputModel, for all commands (even though, to date, only rewrap is known to have run into trouble)?

Fixes #2726 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
