### PR TITLE
#2730: test cases where slurp hunts for a list to enlarge

### DIFF
--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1745,6 +1745,18 @@ describe('paredit', () => {
           await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
+        it('slurps in the nearest enclosing list that has a next member (1)', async () => {
+          const a = docFromTextNotation('#{([a|]) b}');
+          const b = docFromTextNotation('#{([a|] b)}');
+          await paredit.forwardSlurpSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('slurps in the nearest enclosing list that has a next member (2)', async () => {
+          const a = docFromTextNotation('#{[([a|])] b}');
+          const b = docFromTextNotation('#{[([a|]) b]}');
+          await paredit.forwardSlurpSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
       });
 
       describe('Slurping backwards', () => {
@@ -1765,6 +1777,18 @@ describe('paredit', () => {
           // TODO: Figure out how to test result after format
           //       (Because that last space is then removed)
           const b = docFromTextNotation('(^{:a b} #c ^d "foo" |)');
+          await paredit.backwardSlurpSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('slurps in the nearest enclosing list that has a previous member (1)', async () => {
+          const a = docFromTextNotation('#{a ([b|])}');
+          const b = docFromTextNotation('#{(a [b|])}');
+          await paredit.backwardSlurpSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('slurps in the nearest enclosing list that has a previous member (2)', async () => {
+          const a = docFromTextNotation('#{a [([b|])]}');
+          const b = docFromTextNotation('#{[a ([b|])]}');
           await paredit.backwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });


### PR DESCRIPTION
## What has changed?

- New unit tests for cases where paredit slurp-forward and slurp-backward hunt for the nearest enclosing list that can be expanded. (As insurance against accidental damage to the hunting feature if slurp were improved to support multiple cursors.)
- No CHANGELOG entry.

Fixes #2730 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [ ] (Did not) Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik