### PR TITLE
2732 slurp barf multicursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Paredit slurp and barf for multiple cursors](https://github.com/BetterThanTomorrow/calva/issues/2732)
+
 ## [2.0.486] - 2025-02-16
 
 - Fix: [Rewrapping to or from a Set introduces imbalance](https://github.com/BetterThanTomorrow/calva/issues/2726)

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -223,6 +223,7 @@ There is an ongoing effort to support simultaneous multicursor editing with Pare
 - Selection (except for `Select Current Form` - coming soon!)
 - Rewrap
 - Slurp and Barf
+- Format Current Form
 
 ### Toggling Multicursor per command
 

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -222,6 +222,7 @@ There is an ongoing effort to support simultaneous multicursor editing with Pare
 - Movement
 - Selection (except for `Select Current Form` - coming soon!)
 - Rewrap
+- Slurp and Barf
 
 ### Toggling Multicursor per command
 

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -80,7 +80,14 @@ export function formatRangeEdits(
     const newText = `${formattedText.startsWith(leadingWs) ? '' : leadingWs}${formattedText}${
       formattedText.endsWith(trailingWs) ? '' : trailingWs
     }`;
-    return [vscode.TextEdit.replace(originalRange, newText)];
+    const whitespaceEdits =
+      originalText == newText ? [] : reformatChanges(startIndex, originalText, newText);
+    return whitespaceEdits.map((chg) =>
+      vscode.TextEdit.replace(
+        new vscode.Range(document.positionAt(chg.start), document.positionAt(chg.end)),
+        chg.text
+      )
+    );
   }
 }
 

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -119,10 +119,11 @@ export function formatDocIndexInfo(
   }
   const cursor = mDoc.getTokenCursor(index);
 
-  const formatRange = _calculateFormatRange(extraConfig, cursor, index);
-  if (!formatRange) {
-    return;
-  }
+  // If a top-level form "needs" formatting and is indented, reformat the whole document:
+  const formatRangeSmall = _calculateFormatRange(extraConfig, cursor, index);
+  const formatRange: [number, number] = formatRangeSmall
+    ? formatRangeSmall
+    : [0, doc.getText().length];
 
   const formatted: {
     'range-text': string;
@@ -167,6 +168,10 @@ interface CljFmtConfig {
   'remove-multiple-non-indenting-spaces?'?: boolean;
 }
 
+/** [Start,end] of the range to reformat around the cursor, with special cases:
+ * - Undefined if not within a top-level form.
+ * - Undefined if the form to reformat would be a top-level form that is indented.
+ */
 function _calculateFormatRange(
   config: CljFmtConfig,
   cursor: LispTokenCursor,

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -257,18 +257,27 @@ function _formatDepth(cursor: LispTokenCursor) {
   return FormatDepthDefaults?.[cursorClone.getFunctionName()] ?? 1;
 }
 
+//----------
+
 export type ReformatChange = {
   start: number;
   end: number;
   text: string;
 };
 
+/** whitespace and substance. Pre-format and re-formatted text can be expressed
+ * as a series of SpacedUnit. The substance parts can be aligned and then
+ * changes in size can be translated to TextEdits.
+ */
 type SpacedUnit = [spaces: string, stuff: string];
 
+/** Array of [spaces, nonspaces] which if concatenated would equal s.
+ * Treats comma and JS regex \s as spaces.
+ */
 function spacedUnits(s: string): SpacedUnit[] {
-  const frags = s.match(/\s+|\S+/g);
+  const frags = s.match(/[\s,]+|[^\s,]+/g);
   // Ensure 1st item is of whitespace:
-  if (frags[0].match(/\S+/)) {
+  if (frags[0].match(/[^\s,]/)) {
     frags.unshift('');
   }
   // Ensure last item is of non-whitespace stuff:

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -304,28 +304,42 @@ export function reformatChanges(doc: vscode.TextDocument, position: number): Ref
       a.shift();
       b.shift();
     } else if (a[0][1].length < b[0][1].length) {
+      const aWhole = a[0][1];
       const bPart = b[0][1].slice(0, a[0][1].length);
-      if (a[0][1] == bPart) {
+      if (aWhole == bPart) {
         a2.push(a[0]);
         a.shift();
         b2.push([b[0][0], bPart]);
-        b[0][0] = '';
-        b[0][1] = b[0][1].slice(a[0][1].length);
+        b[0] = ['', b[0][1].slice(aWhole.length)];
       } else {
-        console.error('a/b mismatch', a[0], b[0]);
-        break;
+        console.error('a/b mismatch wherein a is shorter', {
+          'a-next': a[0],
+          'b-next': b[0],
+          'a-past': a2,
+          'b-past': b2,
+          'a-whole': formattedInfo.previousText,
+          'b-whole': formattedInfo.formattedText,
+        });
+        return [];
       }
     } else {
+      const bWhole = b[0][1];
       const aPart = a[0][1].slice(0, b[0][1].length);
-      if (b[0][1] == aPart) {
+      if (bWhole == aPart) {
         b2.push(b[0]);
         b.shift();
         a2.push([a[0][0], aPart]);
-        a[0][0] = '';
-        a[0][1] = a[0][1].slice(b[0][1].length);
+        a[0] = ['', a[0][1].slice(bWhole.length)];
       } else {
-        console.error('a/b mismatch', a[0], b[0]);
-        break;
+        console.error('a/b mismatch wherein b is shorter', {
+          'a-next': a[0],
+          'b-next': b[0],
+          'a-past': a2,
+          'b-past': b2,
+          'a-whole': formattedInfo.previousText,
+          'b-whole': formattedInfo.formattedText,
+        });
+        return [];
       }
     }
   }

--- a/src/calva-fmt/src/providers/range_formatter.ts
+++ b/src/calva-fmt/src/providers/range_formatter.ts
@@ -8,6 +8,6 @@ export class RangeEditProvider implements vscode.DocumentRangeFormattingEditProv
     _options,
     _token
   ) {
-    return formatter.formatRangeEdits(document, range);
+    return formatter.formatRangeTextEdits(document, range);
   }
 }

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -290,7 +290,7 @@ export interface EditableDocument {
 // An editing transaction - array of ModelEdit - shifts the selection(s)
 // to compensate for insertions or deletions to their left.
 // Here we predict how edits will affect selections.
-const selectionsAfterEdits = (function () {
+export const selectionsAfterEdits = (function () {
   // 'Decoders' of ModelEdit:
   //  [point, change-in-size, inserted-text-or-undefined]
   const decodeChangeRange = function (edit): [any, any, any] {
@@ -315,8 +315,6 @@ const selectionsAfterEdits = (function () {
         return n;
       }
     }
-    // A Missing Detail: When inserting a list-open, the bump condition should be >=
-    //return n != undefined ? (n > point ? n + delta : n) : undefined;
   };
   return function (edits, selections: ModelEditSelection[]) {
     // The ModelEdit array is in order by end-of-doc to start.

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -343,7 +343,6 @@ const selectionsAfterEdits = (function () {
           : edits[ic].editFn == 'changeRange'
           ? decodeChangeRange(edits[ic])
             : decodeInsertString(edits[ic]);
-      console.log("Adjusting for edit no.", ic, edits[ic], "decoded to", affected);
       const [point, delta] = affected;
       if (monotonicallyDecreasing != -1 && point >= monotonicallyDecreasing) {
         console.error(
@@ -359,7 +358,6 @@ const selectionsAfterEdits = (function () {
             bump(s.start, affected),
             bump(s.end, affected)
           );
-          console.log("  bumping", s, "to", r);
           return r;
         });
       }

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -4,7 +4,6 @@ import { deepEqual as equal } from '../util/object';
 import { isNumber, isUndefined } from 'lodash';
 import { TextDocument, Selection, TextEditorEdit } from 'vscode';
 import _ = require('lodash');
-import { jackIn } from '../nrepl/jack-in';
 
 let scanner: Scanner;
 

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -310,7 +310,7 @@ export const selectionsAfterEdits = (function () {
       // The bump condition is usually >, but it is >= when inserting a list-open
       const threshold = ['(', '[', '{', '#{'].includes(inserted) ? point - 1 : point;
       if (n > threshold) {
-        return n + delta;
+        return Math.max(n + delta, point);
       } else {
         return n;
       }

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -308,12 +308,10 @@ export const selectionsAfterEdits = (function () {
       return undefined;
     } else {
       // The bump condition is usually >, but it is >= when inserting a list-open
-      const threshold = ['(', '[', '{', '#{'].includes(inserted) ? point - 1 : point;
-      if (n > threshold) {
-        return Math.max(n + delta, point);
-      } else {
-        return n;
-      }
+      const lastInsertedChar = !inserted || inserted == '' ? '' : inserted[inserted.length - 1];
+      const threshold = ['(', '[', '{', '#{'].includes(lastInsertedChar) ? point - 1 : point;
+      const p = n > threshold ? Math.max(n + delta, point) : n;
+      return p;
     }
   };
   return function (edits, selections: ModelEditSelection[]) {
@@ -330,7 +328,7 @@ export const selectionsAfterEdits = (function () {
           ? decodeChangeRange(edits[ic])
           : decodeInsertString(edits[ic]);
       const [point, delta] = affected;
-      if (monotonicallyDecreasing != -1 && point >= monotonicallyDecreasing) {
+      if (monotonicallyDecreasing != -1 && point > monotonicallyDecreasing) {
         console.error(
           'Edits not back-to-front. Inference of resulting selection might be inaccurate'
         ); // TBD take the time to sort? or should commands emit edits in back-to-front order?

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -296,10 +296,7 @@ const selectionsAfterEdits = (function () {
   //  [point, change-in-size, inserted-text-or-undefined]
   const decodeChangeRange = function (edit): [any, any, any] {
     const delta = edit.args[2].length - (edit.args[1] - edit.args[0]);
-    return [edit.args[0],
-      delta,
-      (delta > 0 ? edit.args[2] : undefined)
-    ];
+    return [edit.args[0], delta, delta > 0 ? edit.args[2] : undefined];
   };
   const decodeDeleteRange = function (edit): [any, any, any] {
     return [edit.args[0], 0 - edit.args[1], undefined];
@@ -308,24 +305,18 @@ const selectionsAfterEdits = (function () {
     return [edit.args[0] + edit.args[1].length, edit.args[1].length, edit.args[1]];
   };
   const bump = function (n, [point, delta, inserted]) {
-    if (n == undefined)
-    {
-      return undefined;  
-    }
-    else
-    {
+    if (n == undefined) {
+      return undefined;
+    } else {
       // The bump condition is usually >, but it is >= when inserting a list-open
       const threshold = ['(', '[', '{', '#{'].includes(inserted) ? point - 1 : point;
-      if (n > threshold)
-      {
+      if (n > threshold) {
         return n + delta;
-      }
-      else
-      {
+      } else {
         return n;
       }
     }
-    // A Missing Detail: When inserting a list-open, the bump condition should be >= 
+    // A Missing Detail: When inserting a list-open, the bump condition should be >=
     //return n != undefined ? (n > point ? n + delta : n) : undefined;
   };
   return function (edits, selections: ModelEditSelection[]) {
@@ -334,15 +325,13 @@ const selectionsAfterEdits = (function () {
     // according to the growth or shrinkage of each edit.
     let monotonicallyDecreasing = -1; // check edit order
     let retSelections: ModelEditSelection[] = [...selections];
-    for (let ic = 0; ic < edits.length; ic++)
-    {
-      
+    for (let ic = 0; ic < edits.length; ic++) {
       const affected: [any, any, any] =
         edits[ic].editFn == 'deleteRange'
           ? decodeDeleteRange(edits[ic])
           : edits[ic].editFn == 'changeRange'
           ? decodeChangeRange(edits[ic])
-            : decodeInsertString(edits[ic]);
+          : decodeInsertString(edits[ic]);
       const [point, delta] = affected;
       if (monotonicallyDecreasing != -1 && point >= monotonicallyDecreasing) {
         console.error(

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1002,15 +1002,19 @@ function backwardBarfSexpEdits(doc: EditableDocument, start: number): ModelEdit<
   cursor.backwardList();
   const tk = cursor.getPrevToken();
   if (tk.type == 'open') {
+    const cBarfStart = cursor.clone();
     cursor.previous();
-    const offset = cursor.offsetStart;
+    const cOpen = cursor.clone();
     const open = cursor.getToken().raw;
     cursor.next();
     cursor.forwardSexp(true, true);
     cursor.forwardWhitespace(false);
+    const cBarfEnd = cursor.clone();
+    const barfedText = doc.model.getText(cBarfStart.offsetStart, cBarfEnd.offsetStart);
+    const insertText = barfedText + open;
     return [
-      new ModelEdit('changeRange', [cursor.offsetStart, cursor.offsetStart, open]),
-      new ModelEdit('changeRange', [offset, offset + tk.raw.length, '']),
+      new ModelEdit('changeRange', [cOpen.offsetStart, cBarfEnd.offsetStart, '']),
+      new ModelEdit('changeRange', [cOpen.offsetStart, cOpen.offsetStart, insertText]),
     ];
   } else {
     return [];

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -882,7 +882,7 @@ function multicursorModelEdits(
     const edits: ModelEdit<'changeRange'>[] = selections.flatMap((selection) =>
       featureEdits(doc, selection.start)
     );
-    
+
     // Due to the nature of dealing with list boundaries, multiple cursors could be targeting
     // the same lists, which will result in attempting to delete the same ranges twice. So we dedupe.
     const uniqEdits = _.uniqWith(edits, _.isEqual);

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -891,7 +891,7 @@ export async function forwardSlurpSexp(
           : ([wsStartOffset, wsEndOffset, ' '] as const);
       return doc.model.edit(
         [
-          new ModelEdit('insertString', [newCloseOffset, close]),
+          new ModelEdit('changeRange', [newCloseOffset, newCloseOffset, close]),
           new ModelEdit('changeRange', changeArgs),
         ],
         {
@@ -901,7 +901,9 @@ export async function forwardSlurpSexp(
           ...extraOpts,
         }
       );
-    } else {
+    } else
+    {
+      
       const formatDepth = extraOpts['formatDepth'] ? extraOpts['formatDepth'] : 1;
       return forwardSlurpSexp(doc, cursor.offsetStart, {
         formatDepth: formatDepth + 1,
@@ -924,10 +926,11 @@ export async function backwardSlurpSexp(
     cursor.previous();
     cursor.backwardSexp(true, true);
     cursor.forwardWhitespace(false);
-    if (offset !== cursor.offsetStart) {
+    if (offset !== cursor.offsetStart)
+    {
       return doc.model.edit(
         [
-          new ModelEdit('deleteRange', [offset, tk.raw.length]),
+          new ModelEdit('changeRange', [offset, offset+tk.raw.length, '']),
           new ModelEdit('changeRange', [cursor.offsetStart, cursor.offsetStart, open]),
         ],
         {
@@ -937,7 +940,9 @@ export async function backwardSlurpSexp(
           ...extraOpts,
         }
       );
-    } else {
+    } else
+    {
+      
       const formatDepth = extraOpts['formatDepth'] ? extraOpts['formatDepth'] : 1;
       return backwardSlurpSexp(doc, cursor.offsetStart, {
         formatDepth: formatDepth + 1,
@@ -959,15 +964,10 @@ export async function forwardBarfSexp(
     cursor.backwardWhitespace();
     return doc.model.edit(
       [
-        new ModelEdit('deleteRange', [offset, close.length]),
-        new ModelEdit('insertString', [cursor.offsetStart, close]),
+        new ModelEdit('changeRange', [offset, offset+close.length, '']),
+        new ModelEdit('changeRange', [cursor.offsetStart, cursor.offsetStart, close])
       ],
-      start >= cursor.offsetStart
-        ? {
-            selections: [new ModelEditSelection(cursor.offsetStart)],
-            formatDepth: 2,
-          }
-        : { formatDepth: 2 }
+      {formatDepth: 2}
     );
   }
 }
@@ -982,21 +982,16 @@ export async function backwardBarfSexp(
   if (tk.type == 'open') {
     cursor.previous();
     const offset = cursor.offsetStart;
-    const close = cursor.getToken().raw;
+    const open = cursor.getToken().raw;
     cursor.next();
     cursor.forwardSexp(true, true);
     cursor.forwardWhitespace(false);
     return doc.model.edit(
       [
-        new ModelEdit('changeRange', [cursor.offsetStart, cursor.offsetStart, close]),
-        new ModelEdit('deleteRange', [offset, tk.raw.length]),
+        new ModelEdit('changeRange', [cursor.offsetStart, cursor.offsetStart, open]),
+        new ModelEdit('changeRange', [offset, offset+tk.raw.length, ''])
       ],
-      start <= cursor.offsetStart
-        ? {
-            selections: [new ModelEditSelection(cursor.offsetStart)],
-            formatDepth: 2,
-          }
-        : { formatDepth: 2 }
+      {formatDepth: 2}
     );
   }
 }

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -42,24 +42,6 @@ const reformatListRangesForEdits = (function () {
       : pointsInsertString(e);
   };
 
-  const listAroundPoint = function (
-    model: DocumentModel,
-    offset: number
-  ): ModelEditRange | undefined {
-    const cursor = model.getTokenCursor(offset);
-    if (cursor.forwardList()) {
-      const end = cursor.offsetStart;
-      if (cursor.backwardList()) {
-        const start = cursor.offsetStart;
-        return [start, end];
-      } else {
-        return undefined;
-      }
-    } else {
-      return undefined;
-    }
-  };
-
   return function (model: DocumentModel, edits: ModelEdit<ModelEditFunction>[]): ModelEditRange[] {
     // (The edits' positions are as-of the moment *before* application of the edits.)
     // Translate each edit to a start- and end-point of new content.
@@ -67,7 +49,7 @@ const reformatListRangesForEdits = (function () {
     // Compute disjoint ranges.
     const listRanges: ModelEditRange[] = edits
       .flatMap(pointsModelEdit)
-      .map((n: number) => listAroundPoint(model, n))
+      .map((n: number) => model.getTokenCursor(n).rangeForList(1))
       .filter((r: ModelEditRange | undefined) => r != undefined)
       .sort((a: ModelEditRange, b: ModelEditRange) => b[1] - b[0] - (a[1] - a[0]));
     // Discard ranges embedded in other ranges. O(n2)
@@ -353,6 +335,36 @@ export class MirroredDocument implements EditableDocument {
       selection = editor.selections[0];
     return this.document.getText(selection);
   }
+}
+
+/** Disjoint ranges */
+export function nonOverlappingRangesForListsAroundOffsets(
+  doc: EditableDocument,
+  offsets: number[]
+): ModelEditRange[] {
+  const listRanges: ModelEditRange[] = offsets
+    .map((n: number) => doc.getTokenCursor(n).rangeForList(1))
+    .filter((r: ModelEditRange | undefined) => r != undefined)
+    .sort((a: ModelEditRange, b: ModelEditRange) => b[1] - b[0] - (a[1] - a[0]));
+  // Discard ranges embedded in other ranges. O(n2)
+  // -Sort by length. Then traverse the list once. At each step,
+  // -traverse the remainder of the list once, weeding out ranges included in the outer range.
+  // -Use start==-1 as sentinel of a weeded-out range.
+  for (let i = 0; i < listRanges.length; i++) {
+    const outerRange = listRanges[i];
+    if (outerRange[0] != -1) {
+      for (let j = i + 1; j < listRanges.length; j++) {
+        const innerRange = listRanges[j];
+        if (innerRange[0] != -1) {
+          if (innerRange[0] >= outerRange[0] && innerRange[1] <= outerRange[1]) {
+            listRanges[j][0] = -1;
+          }
+        }
+      }
+    }
+  }
+  const disjointListRanges = listRanges.filter((r: ModelEditRange) => r[0] != -1);
+  return disjointListRanges;
 }
 
 let registered = false;

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -97,7 +97,7 @@ export class DocumentModel implements EditableModel {
           if (!options.skipFormat) {
             // Reformatting exits multicursor mode. format-depth may vary among multiple selections.
             // Pending resolution of issues, kip formatting if there are multiple cursors:
-            if (1 < options.selections.length) {
+            if (1 < this.document.selections.length) {
               console.log('Skipping reformatting with multiple cursors.');
             } else {
               return formatter.formatPosition(editor, true, {

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -95,9 +95,15 @@ export class DocumentModel implements EditableModel {
             this.document.selections = options.selections;
           }
           if (!options.skipFormat) {
-            return formatter.formatPosition(editor, true, {
-              'format-depth': options.formatDepth ?? 1,
-            });
+            // Reformatting exits multicursor mode. format-depth may vary among multiple selections.
+            // Pending resolution of issues, kip formatting if there are multiple cursors:
+            if (1 < options.selections.length) {
+              console.log('Skipping reformatting with multiple cursors.');
+            } else {
+              return formatter.formatPosition(editor, true, {
+                'format-depth': options.formatDepth ?? 1,
+              });
+            }
           }
         }
         return isFulfilled;

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1835,6 +1835,18 @@ describe('paredit', () => {
           await paredit.forwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
+        it('keeps cursor within the list that lost a member (1)', async () => {
+          const a = docFromTextNotation('(str |"foo")');
+          const b = docFromTextNotation('(str|) "foo"');
+          await paredit.forwardBarfSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('keeps cursor within the list that lost a member (2)', async () => {
+          const a = docFromTextNotation('(str "foo"|)');
+          const b = docFromTextNotation('(str|) "foo"');
+          await paredit.forwardBarfSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
         it('barfs forward at multiple cursors', async () => {
           const a = docFromTextNotation('(str| "foo")•(str|1 "foo")');
           const b = docFromTextNotation('(str|) "foo"•(str|1) "foo"');

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1874,6 +1874,12 @@ describe('paredit', () => {
           await paredit.backwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
+        it('keeps cursor within the list that lost its first member', async () => {
+          const a = docFromTextNotation('(|(str) foo)');
+          const b = docFromTextNotation('(str) (|foo)');
+          await paredit.backwardBarfSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
       });
     });
 

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1803,7 +1803,7 @@ describe('paredit', () => {
           const b = docFromTextNotation('((str) fo|o)•((str) fo|1o)');
           await paredit.backwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
-        })
+        });
       });
     });
 
@@ -1840,7 +1840,7 @@ describe('paredit', () => {
           const b = docFromTextNotation('(str|) "foo"•(str|1) "foo"');
           await paredit.forwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
-        })
+        });
       });
 
       describe('Barfing backwards', () => {
@@ -1861,7 +1861,7 @@ describe('paredit', () => {
           const b = docFromTextNotation('(str) (fo|o)•(str) (fo|1o)');
           await paredit.backwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
-        })
+        });
       });
     });
 

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1757,6 +1757,12 @@ describe('paredit', () => {
           await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
+        it('slurps forward at multiple cursors', async () => {
+          const a = docFromTextNotation('(str|) "foo"•(str|1) "foo"');
+          const b = docFromTextNotation('(str| "foo")•(str|1 "foo")');
+          await paredit.forwardSlurpSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
       });
 
       describe('Slurping backwards', () => {
@@ -1792,6 +1798,12 @@ describe('paredit', () => {
           await paredit.backwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
+        it('slurps backward at multiple cursors', async () => {
+          const a = docFromTextNotation('(str) (fo|o)•(str) (fo|1o)');
+          const b = docFromTextNotation('((str) fo|o)•((str) fo|1o)');
+          await paredit.backwardSlurpSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        })
       });
     });
 
@@ -1823,6 +1835,12 @@ describe('paredit', () => {
           await paredit.forwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
+        it('barfs forward at multiple cursors', async () => {
+          const a = docFromTextNotation('(str| "foo")•(str|1 "foo")');
+          const b = docFromTextNotation('(str|) "foo"•(str|1) "foo"');
+          await paredit.forwardBarfSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        })
       });
 
       describe('Barfing backwards', () => {
@@ -1838,6 +1856,12 @@ describe('paredit', () => {
           await paredit.backwardBarfSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
+        it('barfs backward at multiple cursors', async () => {
+          const a = docFromTextNotation('((str) fo|o)•((str) fo|1o)');
+          const b = docFromTextNotation('(str) (fo|o)•(str) (fo|1o)');
+          await paredit.backwardBarfSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        })
       });
     });
 

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1745,6 +1745,18 @@ describe('paredit', () => {
           await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
+        it('slurps in the nearest enclosing list that has a next member (1)', async () => {
+          const a = docFromTextNotation('#{([a|]) b}');
+          const b = docFromTextNotation('#{([a|] b)}');
+          await paredit.forwardSlurpSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('slurps in the nearest enclosing list that has a next member (2)', async () => {
+          const a = docFromTextNotation('#{[([a|])] b}');
+          const b = docFromTextNotation('#{[([a|]) b]}');
+          await paredit.forwardSlurpSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
       });
 
       describe('Slurping backwards', () => {
@@ -1765,6 +1777,18 @@ describe('paredit', () => {
           // TODO: Figure out how to test result after format
           //       (Because that last space is then removed)
           const b = docFromTextNotation('(^{:a b} #c ^d "foo" |)');
+          await paredit.backwardSlurpSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('slurps in the nearest enclosing list that has a previous member (1)', async () => {
+          const a = docFromTextNotation('#{a ([b|])}');
+          const b = docFromTextNotation('#{(a [b|])}');
+          await paredit.backwardSlurpSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('slurps in the nearest enclosing list that has a previous member (2)', async () => {
+          const a = docFromTextNotation('#{a [([b|])]}');
+          const b = docFromTextNotation('#{[a ([b|])]}');
           await paredit.backwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });


### PR DESCRIPTION
## What has changed?

- Slurp and barf support multi-cursor editing (backward and forward: four commands in all). 
- Internally (paredit.ts), multi-cursor concerns are factored out and separated from per-command strategy: 
  - The core algorithm of each command - the calculation of ModelEdits for a single cursor - is extracted to a new function. 
    - Following the example of rewrapSexpr, the new functions produce an array of changeRange edits. Previous use of deleteRange or insertString by slurp and barf is changed to changeRange. 
      - The 100% changeRange technique worked OK in VS Code but flunked the unit tests, exposing a bug and requiring a correction in the model's emulation of how VS Code moves cursors after edits. The emulator was used only(?) for tests, but, as described below, this PR involves it with post-edit reformatting too.
  - A single new shared multi-cursor-collation function to deduplicate and sort all cursors' ModelEdits is extracted from rewrapSexpr.  
  - In sum: rewrap, slurp, and barf all use the same multi-cursor coordination heuristics, which may be general enough to help extend further editing commands for multiple cursors. 
- Barf no longer requires an async touch-up of the selection positions: reducing likelihood of a race condition between two barf commands issued in rapid succession. Async touch-up is fraught in the multi-cursor case; simpler to let VS Code automatically float cursors on the surf of changeRange edits. (Slurp already did not require async touch-up of selections.) 
- New multi-cursor tests of slurp and barf, forward and backward, are based on the first, simplest single-cursor test of the four respective functions.
- Single-cursor unit tests of slurp and barf are not modified.
- Unit tests have been added to memorialize that forwardBarf and backwardBarf keep the cursor from being left outside the shortened form.

Slurp and barf trigger reformatting. This PR makes reformatting multicursor-capable (because reformatting had canceled multi-cursor mode).
- Structural-editing reformatting formats all edited points, and preserves all cursors so you can proceed to issue further multi-cursor editing commands.
  - Reformatting no longer relies on editing commands to provide a formatDepth. Instead, the ranges to reformat are computed from the list of edits. Specifically: each edit (such as insertion or removal of a parenthesis) affects a certain small range of the document. These edits are all performed in one transaction and therefore have positions relative to the pre-edit document (their position does not reflect insertions or removals to their left), as required by TextEditorEdit. After the edit transaction commits, the structural edits' positions are shifted to correspond to the expected post-edit document. Each of the resulting positions is considered ripe for reformatting, or more precisely, the list enclosing each position is considered ripe. Those lists may overlap, but the edit transaction that reformats is not permitted to mention overlapping ranges. Shortest disjoint lists are found that subsume all the lists that need reformatting. Those are submitted to the formatter. 
  - Reformatting preserves multiple cursors by not replacing the whole text blob with a formatted version of the same, but rather translating the difference between the two into little changeRange edits that only adjust the whitespace. The pre-formatting and re-formatted texts are translated into a series of (whitespace, non-whitespace) tuples, then those tuples are split as finely as necessary (in case reformatting inserted space where there was none) to result in the same number of tuples and same sequence of non-whitespace strings in the pre- and re-formatted versions. Then the non-whitespace bits are disregarded, the pre- and re- sequences of whitespace are compared, and TextEdits are composed to expand or shrink each pre- whitespace node to the corresponding re-formatted node.
    - Adjusting-whitespace-only appears to have the unexpected benefit of less syntax-color flickering. 
- The Format Current Form command shares some code with structural-editing reformatting and also now works with multiple cursors. Each cursor is translated to a range-to-reformat as before. Those might overlap, so minimal disjoint lists are found that encompass those ranges. The first character of each of those lists is used to seed a reformatting, which again computes a range-to-reformat, computes reformatted text, and computes a bunch of TextEdits to adjust whitespace. All whitespace edits resulting from those reformattings are executed in a single transaction.  
- The Format Selection command is a delegate of Format Current Form when the top-level needs attention, so Format Selection, too, adjusts the document not by replacing text with formatted text, but by adjusting each little run of whitespace.   

Loose ends:

- Slurp, barf, and rewrap do not check whether the user enabled multi-cursor features (nor is a `{multicursor:false}` option heeded), because the single-cursor case is not a distinct procedure. This deviation from documentation could be remedied in the documentation... but on the other hand, paredit's other multi-cursor support has been established for two or three years and the burden of supporting a feature flag might no longer be required? 

Wobbly parts:

- I did not find tests for reformatting. There might be differences around the fringes, related to the more indirect determination of ranges to reformat.  

Fixes #2732 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
