### PR TITLE
projectroot autoconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Auto-connect/Jack-in sequences fail if projectRootPath is not set](https://github.com/BetterThanTomorrow/calva/issues/2759)
+
 ## [2.0.493] - 2025-03-20
 
 - [Filter lsp semantic comment tokens](https://github.com/BetterThanTomorrow/calva/issues/2757)

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -396,8 +396,9 @@ async function getUserSpecifiedSequence(
   const autoSelectedSequence =
     autoSelectedSequences.find(
       (s) =>
+        s.projectRootPath &&
         vscode.workspace.asRelativePath(path.join(...s.projectRootPath)) ===
-        vscode.workspace.asRelativePath(closestRootPath)
+          vscode.workspace.asRelativePath(closestRootPath)
     ) || autoSelectedSequences.shift();
   const userSpecifiedProjectType = autoSelectedSequence?.name;
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -182,8 +182,9 @@ export async function initProjectDir(
   const defaultSequence =
     defaultSequences.find(
       (s) =>
+        s.projectRootPath &&
         vscode.workspace.asRelativePath(path.join(...s.projectRootPath)) ===
-        vscode.workspace.asRelativePath(closestRootPath)
+          vscode.workspace.asRelativePath(closestRootPath)
     ) || defaultSequences.shift();
 
   let projectRootPath: vscode.Uri;


### PR DESCRIPTION
## What has changed?

Checking for if projectRootPath is set on the sequence before using it for comparing to closest root.

Fixes #2759

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
