### PR TITLE
[cider-nrepl] Replace deprecated 'stacktrace' op with 'analyze-last-stacktrace'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Replace deprecated cider-nrepl 'stacktrace' op with 'analyze-last-stacktrace'](https://github.com/BetterThanTomorrow/calva/pull/2775)
+
 ## [2.0.496] - 2025-04-06
 
 - Fix: [Broken characters in "Calva REPL Commands" menu](https://github.com/BetterThanTomorrow/calva/issues/2765)

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -358,11 +358,11 @@ export class NReplSession {
   }
 
   stacktrace() {
-    // https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#stacktrace
+    // https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#analyze-last-stacktrace
     return new Promise<any>((resolve, reject) => {
       const id = this.client.nextId;
       const msg = {
-        op: 'stacktrace',
+        op: 'analyze-last-stacktrace',
         id,
         session: this.sessionId,
       };


### PR DESCRIPTION
## What has changed?

`stacktrace` op name has been deprecated for a few years now. `analyze-last-stacktrace` behaves exactly the same, it's only the old name that got deprecated.

https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#analyze-last-stacktrace
https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#stacktrace

---

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [ ] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [ ] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [ ] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

---

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
