### PR TITLE
Don't trim when onType-reformatting the document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Can't add new lines at the end of files](https://github.com/BetterThanTomorrow/calva/issues/2778)
+
 ## [2.0.499] - 2025-04-11
 
 - Fix: [Reformat all edited locations after multicursor structural edit](https://github.com/BetterThanTomorrow/calva/issues/2738)

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -54,7 +54,8 @@ export async function indentPosition(position: vscode.Position, document: vscode
 /** undefined if range starts in a string or comment */
 function rangeReformatChanges(
   document: vscode.TextDocument,
-  originalRange: vscode.Range
+  originalRange: vscode.Range,
+  onType: boolean
 ): respacer.WhitespaceChange[] | undefined {
   const mirrorDoc = getDocument(document);
   const startIndex = document.offsetAt(originalRange.start);
@@ -69,7 +70,8 @@ function rangeReformatChanges(
     const newTextDraft = healer.unbandage(healing, formattedHealedText);
     // unbandage aligned top-level forms flush-left, except the first one.
     // When formatting the whole document, align the first form flush-left.
-    const newText = startIndex == 0 ? newTextDraft.trim() : newTextDraft;
+    // However, onType, one must be able to add a newline to a document, so don't trim.
+    const newText = onType ? newTextDraft : startIndex == 0 ? newTextDraft.trim() : newTextDraft;
     return originalText == newText
       ? []
       : respacer.whitespaceEdits(eol, startIndex, originalText, newText);
@@ -83,7 +85,7 @@ export function formatRangeEdits(
   document: vscode.TextDocument,
   originalRange: vscode.Range
 ): vscode.TextEdit[] | undefined {
-  return rangeReformatChanges(document, originalRange).map((chg) =>
+  return rangeReformatChanges(document, originalRange, false).map((chg) =>
     vscode.TextEdit.replace(
       new vscode.Range(document.positionAt(chg.start), document.positionAt(chg.end)),
       chg.text
@@ -238,7 +240,8 @@ export async function formatPosition(
   if (isWholeDoc) {
     orderedChanges = rangeReformatChanges(
       doc,
-      new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length))
+      new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length)),
+      onType
     );
   } else {
     const dedupedRanges = nonOverlappingRanges(ranges);


### PR DESCRIPTION
## What has changed?

One must be able to add a newline to the end of a document, but doing so triggers format-on-type, which therefore should not briskly remove the new newline.

Format-as-you-type reformats the entire document under some circumstances. In that case it did not check whether the reason for reformatting was format-as-you-type. The change reduces trimming in that case.

Fixes #2778

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
