### PR TITLE
Add some formatter integration tests

### DIFF
--- a/src/extension-test/unit/formatting-test.ts
+++ b/src/extension-test/unit/formatting-test.ts
@@ -49,17 +49,29 @@ describe('formatter, indenter and paredit comparison', () => {
 });
 
 describe('formatter trimming', () => {
-  const config = mkConfig({
-    'remove-surrounding-whitespace?': false,
-    'remove-trailing-whitespace?': false,
-    indents: {
-      '#"\\S+"': [['inner', 0]],
-    },
-  });
-
-  it('formatter does not trim surrounding space when config disables that', () => {
-    const formattedText = getFormattedText(' |(and x\ny) ', config);
+  it('formatter does not trim trailing space when config disables that', () => {
+    const formattedText = getFormattedText(
+      ' |(and x\ny) ',
+      mkConfig({
+        'remove-trailing-whitespace?': false,
+        indents: {
+          '#"\\S+"': [['inner', 0]],
+        },
+      })
+    );
     expect(formattedText).toEqual(' (and x\n   y) ');
+  });
+  it('formatter trims trailing space when config enables that', () => {
+    const formattedText = getFormattedText(
+      ' |(and x\ny) ',
+      mkConfig({
+        'remove-trailing-whitespace?': true,
+        indents: {
+          '#"\\S+"': [['inner', 0]],
+        },
+      })
+    );
+    expect(formattedText).toEqual(' (and x\n   y)');
   });
 });
 

--- a/src/extension-test/unit/formatting-test.ts
+++ b/src/extension-test/unit/formatting-test.ts
@@ -7,13 +7,19 @@ import { docFromTextNotation, textAndSelection } from './common/text-notation';
 describe('formatter, indenter and paredit comparison', () => {
   const configs = [
     mkConfig({
-      '#"\\S+"': [['inner', 0]],
+      indents: {
+        '#"\\S+"': [['inner', 0]],
+      },
     }),
     mkConfig({
-      '#"\\S+"': [['block', 0]],
+      indents: {
+        '#"\\S+"': [['block', 0]],
+      },
     }),
     mkConfig({
-      '#"\\S+"': [['inner', 1]],
+      indents: {
+        '#"\\S+"': [['inner', 1]],
+      },
     }),
   ];
 
@@ -42,34 +48,56 @@ describe('formatter, indenter and paredit comparison', () => {
   });
 });
 
+describe('formatter trimming', () => {
+  const config = mkConfig({
+    'remove-surrounding-whitespace?': false,
+    'remove-trailing-whitespace?': false,
+    indents: {
+      '#"\\S+"': [['inner', 0]],
+    },
+  });
+
+  it('formatter does not trim surrounding space when config disables that', () => {
+    const formattedText = getFormattedText(' |(and x\ny) ', config);
+    expect(formattedText).toEqual(' (and x\n   y) ');
+  });
+});
+
 function getIndenterIndent(form: string, config: ReturnType<typeof mkConfig>) {
   const doc = docFromTextNotation(form);
   const p = textAndSelection(doc)[1][0];
   return indent.getIndent(doc.model, p, config);
 }
 
-function getFormatterIndent(notation: string, config: ReturnType<typeof mkConfig>) {
+function getFormattedText(notation: string, config: ReturnType<typeof mkConfig>) {
   const doc = docFromTextNotation(notation);
   const form = textAndSelection(doc)[0];
   const p = textAndSelection(doc)[1][0];
   const docText = doc.model.getText(0, 999, false);
 
   const formatterResult = formatIndexes(form, [0, notation.length], [p], '\n', false, config);
-  const formattedText =
+  return (
     docText.substring(0, formatterResult.range[0]) +
     formatterResult['range-text'] +
-    docText.substring(formatterResult.range[1]);
+    docText.substring(formatterResult.range[1])
+  );
+}
 
-  // Indentation:
+function getFormatterIndent(notation: string, config: ReturnType<typeof mkConfig>) {
+  const formattedText = getFormattedText(notation, config);
+
   // (1) Find point p in the formatted result by counting nonspace chars to the left.
   //     Overshoot to the next substantive character because the tests all
   //     concern a cursor at the end of a run of spaces.
   // (2) Count spaces to its left.
 
   // Non-space chars before p:
-  const docTextBeforeP = docText.substring(0, p);
+  const doc = docFromTextNotation(notation);
+  const p = textAndSelection(doc)[1][0];
+  const docTextBeforeP = doc.model.getText(0, p, false);
   const rxSpace = new RegExp(/[\s,]/, 'g');
   const nSolidsBeforeP = docTextBeforeP.replace(rxSpace, '').length;
+
   let pFormatted = 0;
   while (nSolidsBeforeP >= formattedText.substring(0, pFormatted).replace(rxSpace, '').length) {
     pFormatted++;
@@ -88,12 +116,23 @@ function getPareditIndent(notation: string, config: ReturnType<typeof mkConfig>)
   return backspaceOnWhitespace(doc, doc.getTokenCursor(p), config).indent;
 }
 
-function mkConfig(rules: indent.IndentRules) {
-  const cljRules = jsRulesToCljsRulesString(rules);
+function mkConfig(options: { indents?: indent.IndentRules } & Record<string, any>) {
+  const indentRules = options.indents || {};
+  const cljRules = jsRulesToCljsRulesString(indentRules);
+  const fullOptions = {
+    ...options,
+    ...(options.indents && { indents: undefined }),
+  };
+  const optionsString = `{:indents {${cljRules}} ${Object.entries(fullOptions)
+    .filter(([key, value]) => key !== 'indents' && value !== undefined)
+    .map(([key, value]) => `:${key} ${JSON.stringify(value)}`)
+    .join(' ')}}`;
+
   return {
-    'cljfmt-options-string': `{:indents {${cljRules}}}`,
+    'cljfmt-options-string': optionsString.trim(),
     'cljfmt-options': {
-      indents: rules,
+      ...fullOptions,
+      indents: indentRules,
     },
   };
 }


### PR DESCRIPTION
## What has changed?

Adding two tests that checks that the Calva formatter honors cljfmt config provided, specifically `:remove-trailing-whitespace` in this case.

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- ~[ ] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).~
    - ~[ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.~
- ~[ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
