### PR TITLE
2781 retain initial-leading and final-trailing space when reformatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Formatting top level trims empty lines at the start and end of the document](https://github.com/BetterThanTomorrow/calva/issues/2780)
+
 ## [2.0.500] - 2025-04-12
 
 - Fix: [Can't add new lines at the end of files](https://github.com/BetterThanTomorrow/calva/issues/2778)

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -69,12 +69,9 @@ function rangeReformatChanges(
     const formattedHealedText = formatCode(healing.healedText, document.eol);
     const newTextDraft = healer.unbandage(healing, formattedHealedText);
     // unbandage aligned top-level forms flush-left, except the first one.
-    // When formatting the whole document, align the first form flush-left.
-    // However, onType, one must be able to add a newline to a document, so don't trim.
-    const newText = onType ? newTextDraft : startIndex == 0 ? newTextDraft.trim() : newTextDraft;
-    return originalText == newText
+    return originalText == newTextDraft
       ? []
-      : respacer.whitespaceEdits(eol, startIndex, originalText, newText);
+      : respacer.whitespaceEdits(eol, startIndex, originalText, newTextDraft);
   } else {
     console.warn('Range starting in comment or string is not being formatted');
     return [];

--- a/src/calva-fmt/src/healer.ts
+++ b/src/calva-fmt/src/healer.ts
@@ -50,7 +50,7 @@ export function bandage(originalText: string, originalIndent: number, eol: strin
 export function unbandage(context: BandageContext, formattedHealedText: string) {
   const d = context.details;
   const leadingWs = d.originalText.match(/^\s*/)[0];
-  const trailingWs = d.originalText.match(/\s*$/)[0];
+  const trailingWs = leadingWs == d.originalText ? '' : d.originalText.match(/\s*$/)[0];
   const leadingEolPos = leadingWs.lastIndexOf(d.eol);
   const startIndent =
     leadingEolPos === -1 ? d.originalIndent : leadingWs.length - leadingEolPos - d.eol.length;

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -101,6 +101,7 @@ export class DocumentModel implements EditableModel {
   constructor(private document: MirroredDocument) {
     this.lineEndingLength = document.document.eol == vscode.EndOfLine.CRLF ? 2 : 1;
     this.lineInputModel = new LineInputModel(this.lineEndingLength);
+    this.documentVersion = document.document.version;
   }
 
   get lineEnding() {


### PR DESCRIPTION
## What has changed?

Note - I may have misinterpreted #2781. It looks odd to me, that reformatting the top level corrects the indentation (to 0) of all top-level forms *except* the first one.

- Retain initial leading & final trailing space when reformatting - not only in format-on-type, but also in on-demand reformatting, and even when cljfmt option ":remove-trailing-whitespace?" is true.
- Initialize the model's documentVersion, so reformatting can be done immediately upon opening the document.
- In "bandaging & healing", avoid double-counting the same whitespace as both leading and trailing, when the document is all blank.

Fixes #2781

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
