### PR TITLE
Do not reformat the whole output-window document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [formatCode throws an error when output output is printed in the output window](https://github.com/BetterThanTomorrow/calva/issues/2791)
+
 ## [2.0.501] - 2025-04-15
 
 - Fix: [Formatting top level trims empty lines at the start and end of the document](https://github.com/BetterThanTomorrow/calva/issues/2780)

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -231,10 +231,6 @@ export async function formatPosition(
   onType: boolean = false,
   extraConfig: CljFmtConfig = {}
 ): Promise<boolean> {
-  // Output/REPL window holds prompts etc. The formatter cannot format it. Do not try.
-  if (outputWindow.isResultsDoc(editor.document)) {
-    return Promise.resolve(false);
-  }
   const doc: vscode.TextDocument = editor.document;
   const ranges = editor.selections
     .map((sel) => doc.offsetAt(sel.active))
@@ -243,6 +239,10 @@ export async function formatPosition(
   const isWholeDoc = ranges.filter((r) => r[0] == -1 && r[1] == -1).length > 0;
   let orderedChanges = undefined;
   if (isWholeDoc) {
+    // Output/REPL window holds prompts etc. The formatter cannot format it. Do not try.
+    if (outputWindow.isResultsDoc(editor.document)) {
+      return Promise.resolve(false);
+    }
     orderedChanges = rangeReformatChanges(
       doc,
       new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length)),

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -82,6 +82,10 @@ export function formatRangeEdits(
   document: vscode.TextDocument,
   originalRange: vscode.Range
 ): vscode.TextEdit[] | undefined {
+  // Output/REPL window holds prompts etc. The formatter cannot format it. Do not try.
+  if (outputWindow.isResultsDoc(document)) {
+    return [];
+  }
   return rangeReformatChanges(document, originalRange, false).map((chg) =>
     vscode.TextEdit.replace(
       new vscode.Range(document.positionAt(chg.start), document.positionAt(chg.end)),
@@ -227,6 +231,10 @@ export async function formatPosition(
   onType: boolean = false,
   extraConfig: CljFmtConfig = {}
 ): Promise<boolean> {
+  // Output/REPL window holds prompts etc. The formatter cannot format it. Do not try.
+  if (outputWindow.isResultsDoc(editor.document)) {
+    return Promise.resolve(false);
+  }
   const doc: vscode.TextDocument = editor.document;
   const ranges = editor.selections
     .map((sel) => doc.offsetAt(sel.active))


### PR DESCRIPTION
## What has changed?

The Format Document command skips formatting the output window; and likewise the Format Current Form command, if it would need to format the document.

I did not see the problem reported in No.2791 when following its instructions - therefore I have not checked the box for "tested the particular change" - but I noticed that pressing the Tab key in the output-REPL window evinced the same error message. Perhaps, this PR will address #2791.

Fixes #2791

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
