### PR TITLE
multicursor format kluge for sort-ns-references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Reformat may do nothing if cljfmt's :sort-ns-references? is true](https://github.com/BetterThanTomorrow/calva/issues/2789)
+
 ## [2.0.502] - 2025-04-26
 
 - Fix: [formatCode throws an error when output output is printed in the output window](https://github.com/BetterThanTomorrow/calva/issues/2791)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ Changes to Calva.
 ## [2.0.503] - 2025-04-27
 
 - Fix: [Release 2.0.502 repl connection fails, breaking Jack-In](https://github.com/BetterThanTomorrow/calva/issues/2799) (Hopefully)
->>>>>>> dev
 
 ## [2.0.502] - 2025-04-26
 

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -16,6 +16,7 @@ import { LispTokenCursor } from '../../cursor-doc/token-cursor';
 import { formatIndexes } from './format-index';
 import * as state from '../../state';
 import * as healer from './healer';
+import { nsRangeFromText } from '../../util/ns-form';
 
 export async function indentPosition(position: vscode.Position, document: vscode.TextDocument) {
   const editor = util.getActiveTextEditor();
@@ -51,6 +52,54 @@ export async function indentPosition(position: vscode.Position, document: vscode
   }
 }
 
+/** Micro-edits to change previousText to formattedText.
+ * The formatter usually changes only whitespace.
+ * However, its :sort-ns-references? may change text too.
+ * Computation of micro-edits is more efficient for whitespace-only changes.
+ * Therefore, if a ns form is found,
+ * we compute one set of edits for the ns form
+ * (which is 1 large, degenerate edit if more than whitespace changed)
+ * plus another set of edits for the rest of the document.
+ * In the worst case, there are multiple ns forms
+ * and the "rest-of-document" changes also degenerate
+ * to a single large edit.
+ * Micro-edits are preferable because they nudge all cursors
+ * and they seem to avoid re-syntax-highlighting,
+ * compared with replacing swaths of substantive text.
+ */
+function whitespaceAndNsEdits(
+  eol: string,
+  startIndex: number,
+  previousText: string,
+  formattedText: string
+): respacer.WhitespaceChange[] {
+  if (previousText == formattedText) {
+    return [];
+  } else {
+    const previousNsInfo = nsRangeFromText(previousText);
+    const formattedNsInfo = nsRangeFromText(formattedText);
+    if (previousNsInfo && formattedNsInfo) {
+      const [previousNsName, previousNsRange] = previousNsInfo;
+      const [formattedNsName, formattedNsRange] = formattedNsInfo;
+      const nsEdits = respacer.whitespaceEdits(
+        eol,
+        startIndex,
+        previousText.substring(0, previousNsRange[1]),
+        formattedText.substring(0, formattedNsRange[1])
+      );
+      const otherEdits = respacer.whitespaceEdits(
+        eol,
+        startIndex + previousNsRange[1],
+        previousText.substring(previousNsRange[1]),
+        formattedText.substring(formattedNsRange[1])
+      );
+      return [...otherEdits, ...nsEdits];
+    } else {
+      return respacer.whitespaceEdits(eol, startIndex, previousText, formattedText);
+    }
+  }
+}
+
 /** undefined if range starts in a string or comment */
 function rangeReformatChanges(
   document: vscode.TextDocument,
@@ -69,9 +118,7 @@ function rangeReformatChanges(
     const formattedHealedText = formatCode(healing.healedText, document.eol);
     const newTextDraft = healer.unbandage(healing, formattedHealedText);
     // unbandage aligned top-level forms flush-left, except the first one.
-    return originalText == newTextDraft
-      ? []
-      : respacer.whitespaceEdits(eol, startIndex, originalText, newTextDraft);
+    return whitespaceAndNsEdits(eol, startIndex, originalText, newTextDraft);
   } else {
     console.warn('Range starting in comment or string is not being formatted');
     return [];
@@ -156,12 +203,7 @@ export function formatDocIndexesInfo(
     new vscode.Range(doc.positionAt(formatRange[0]), doc.positionAt(formatRange[1]))
   );
   const formattedText = formatted['range-text'];
-  const changes = respacer.whitespaceEdits(
-    eol,
-    doc.offsetAt(range.start),
-    previousText,
-    formattedText
-  );
+  const changes = whitespaceAndNsEdits(eol, doc.offsetAt(range.start), previousText, formattedText);
   return {
     formattedText: formattedText,
     range: range,

--- a/src/calva-fmt/src/respacer.ts
+++ b/src/calva-fmt/src/respacer.ts
@@ -59,6 +59,10 @@ function spacedUnits(s: string): SpacedUnit[] {
  * multiple words in the other (eg at punctuation).
  * Adjust a and b to the finest granularity of words
  * in either of them.
+ * If the strings diverge by text substance, not just whitespace,
+ * the final member of each array of SpacedUnits contains
+ * the entire irreconcilable remainder of the respective string
+ * in the 'space' member, and empty for the text.
  */
 function alignSpacedUnits(
   eol: string,
@@ -103,8 +107,10 @@ function alignSpacedUnits(
         b2.push([b[0][0], bPart, false]);
         b[0] = ['', b[0][1].slice(aWhole.length), false];
       } else {
-        console.error('alignSpacedUnits: a/b mismatch wherein a is shorter');
-        return [undefined, undefined];
+        // mismatched text. Stuff entire remainder in the next 'space' item:
+        a2.push([a.map((a_item) => a_item[0] + a_item[1]).join(''), '', false]);
+        b2.push([b.map((b_item) => b_item[0] + b_item[1]).join(''), '', false]);
+        break;
       }
     } else {
       // b's substance is a prefix of a's
@@ -116,8 +122,10 @@ function alignSpacedUnits(
         a2.push([a[0][0], aPart, false]);
         a[0] = ['', a[0][1].slice(bWhole.length), false];
       } else {
-        console.error('alignSpacedUnits: a/b mismatch wherein b is shorter');
-        return [undefined, undefined];
+        // mismatched text. Stuff entire remainder in the next 'space' item:
+        a2.push([a.map((a_item) => a_item[0] + a_item[1]).join(''), '', false]);
+        b2.push([b.map((b_item) => b_item[0] + b_item[1]).join(''), '', false]);
+        break;
       }
     }
   }
@@ -147,9 +155,7 @@ export function whitespaceEdits(
   const [a2, b2] = alignSpacedUnits(eol, a, b);
   // The result should be an equal number of words in a and b:
   if (!a2 || !b2 || a2.length != b2.length) {
-    // happens when cljfmt changes more than whitespace:
-    // e.g., {:sort-ns-references? true}
-    return [{ start: 0, end: previousText.length, text: formattedText }];
+    return [];
   }
   const ret: WhitespaceChange[] = [];
   let aPos = offset;

--- a/src/calva-fmt/src/respacer.ts
+++ b/src/calva-fmt/src/respacer.ts
@@ -147,14 +147,9 @@ export function whitespaceEdits(
   const [a2, b2] = alignSpacedUnits(eol, a, b);
   // The result should be an equal number of words in a and b:
   if (!a2 || !b2 || a2.length != b2.length) {
-    console.error(
-      'Formatting encountered a mix-up. Only spaces should have changed',
-      'pre',
-      a2,
-      'post',
-      b2
-    );
-    return [];
+    // happens when cljfmt changes more than whitespace:
+    // e.g., {:sort-ns-references? true}
+    return [{ start: 0, end: previousText.length, text: formattedText }];
   }
   const ret: WhitespaceChange[] = [];
   let aPos = offset;

--- a/src/extension-test/unit/calva-fmt/respacer-test.ts
+++ b/src/extension-test/unit/calva-fmt/respacer-test.ts
@@ -103,4 +103,15 @@ describe('respacer', () => {
     );
     expect(textNotationFromDoc(actual)).toEqual(textNotationFromDoc(expected));
   });
+  it('Reformats but may lose cursors if document text changes', () => {
+    const actual = docFromTextNotation(';;a•(foo••:a)');
+    const expected = docFromTextNotation(';;bbb•(foo•  •:a)');
+    const eol = actual.model.lineEnding;
+    const spaceEdits = respacer.whitespaceEdits(eol, 0, getText(actual), getText(expected));
+    actual.model.editNow(
+      spaceEdits.map((se) => new model.ModelEdit('changeRange', [se.start, se.end, se.text])),
+      { skipFormat: true }
+    );
+    expect(textNotationFromDoc(actual)).toEqual(textNotationFromDoc(expected));
+  });
 });

--- a/src/util/ns-form.ts
+++ b/src/util/ns-form.ts
@@ -48,14 +48,15 @@ function nsSymbolOfCurrentForm(
   }
 }
 
-export function nsFromCursorDoc(
+/** [Namespace name, [start, end offset of range of the ns form]] or null */
+export function nsRangeFromCursorDoc(
   cursorDoc: model.EditableDocument,
   p: number = cursorDoc.selections[0].active,
   _maxRecursionDepth: number = 100, // used internally for recursion
   _depth: number = 0 // used internally for recursion
-): [string, string] | null {
+): [string, [number, number]] | null {
   if (_depth > _maxRecursionDepth) {
-    console.error(`nsFromCursorDoc: recursion depth, ${_maxRecursionDepth} , exceeded`);
+    console.error(`nsRangeFromCursorDoc: recursion depth, ${_maxRecursionDepth} , exceeded`);
     return null;
   }
   const cursor: tokenCursor.LispTokenCursor = cursorDoc.getTokenCursor(p);
@@ -65,7 +66,7 @@ export function nsFromCursorDoc(
     const topLevelRangeCursor = cursorDoc.getTokenCursor(topLevelRange[0]);
     const ns = nsSymbolOfCurrentForm(topLevelRangeCursor, 'downList');
     if (ns) {
-      return [ns, cursorDoc.model.getText(...topLevelRange)];
+      return [ns, topLevelRange];
     }
   }
   // Special case 2, find ns form from start of document
@@ -76,7 +77,7 @@ export function nsFromCursorDoc(
     while (cursor.forwardSexp(true, true, true)) {
       const ns = nsSymbolOfCurrentForm(cursor, 'backwardDownList');
       if (ns) {
-        return [ns, cursorDoc.model.getText(...cursor.rangeForCurrentForm(cursor.offsetEnd))];
+        return [ns, cursor.rangeForCurrentForm(cursor.offsetEnd)];
       }
     }
     return null;
@@ -87,7 +88,7 @@ export function nsFromCursorDoc(
     while (cursor.backwardSexp()) {
       const ns = nsSymbolOfCurrentForm(cursor, 'downList');
       if (ns) {
-        return [ns, cursorDoc.model.getText(...cursor.rangeForCurrentForm(cursor.offsetStart))];
+        return [ns, cursor.rangeForCurrentForm(cursor.offsetStart)];
       }
     }
   }
@@ -100,12 +101,33 @@ export function nsFromCursorDoc(
   // Special case 3, the structure of the document is unbalanced
   // We try to find the ns from the start of the document
   if (!cursor.docIsBalanced()) {
-    return nsFromCursorDoc(cursorDoc, 0, _maxRecursionDepth, _depth + 1);
+    return nsRangeFromCursorDoc(cursorDoc, 0, _maxRecursionDepth, _depth + 1);
   }
   // General case, continue look for ns form closest before p
-  return nsFromCursorDoc(cursorDoc, cursor.offsetStart, _maxRecursionDepth, _depth + 1);
+  return nsRangeFromCursorDoc(cursorDoc, cursor.offsetStart, _maxRecursionDepth, _depth + 1);
 }
 
+/** [Namespace name, text of the ns form] or null */
+export function nsFromCursorDoc(
+  cursorDoc: model.EditableDocument,
+  p: number = cursorDoc.selections[0].active
+): [string, string] | null {
+  const a = nsRangeFromCursorDoc(cursorDoc, p);
+  if (a === null) {
+    return null;
+  } else {
+    const [nsName, nsRange] = a;
+    return [nsName, cursorDoc.model.getText(...nsRange)];
+  }
+}
+
+/** [Namespace name, [start, end offset of range of the ns form]] or null */
+export function nsRangeFromText(text: string, p = text.length): [string, [number, number]] | null {
+  const stringDoc: model.StringDocument = new model.StringDocument(text);
+  return nsRangeFromCursorDoc(stringDoc, p);
+}
+
+/** [Namespace name, text of the ns form] or null */
 export function nsFromText(text: string, p = text.length): [string, string] | null {
   const stringDoc: model.StringDocument = new model.StringDocument(text);
   return nsFromCursorDoc(stringDoc, p);


### PR DESCRIPTION
## What has changed?

cljfmt sorting of namespace references is restored, but the cursor may wind up in an unexpected place if it does so.

The issue title was "Format on save + cljfmt fails..." but the particular problem was that multicursor-capable formatting relied on cljfmt to change only whitespace.

The multicursor-capable formatter used "console.error" when that condition was violated, but the messages may not have been noticed.

This PR makes the multicursor-capable formatter fall back to replacing the whole range if it cannot calculate micro-edits of whitespace. Whole-range replacement will be unkind to cursors that were within the range.

Edits 2025-04-27: The PR is revised to refine the kluge slightly: using the same technique as for cursor-contexts, it locates a `(ns...)` form, and if there is one, then it formats that form separately from the remainder of the document. In that way, each of the two parts produces efficient spaces-only edits that allow cursors to float, or degenerates to making a whole replacement that may shove cursors to the end; but an `(ns...)` form that gets sorted does not prevent cursors after that form from floating.

A test case is added for the "respacer" module for the case in which it stuffs the remainder of the substantively-differing document into a single edit.
 
The CHANGELOG wishfully renames the issue for clarity, saying, (Fixes) "Reformat may do nothing if cljfmt's :sort-ns-references? is true".

Addresses #2789

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [x] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
