### PR TITLE
2795 add info api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Experimental: [Add `info` namespace to Calva API](https://github.com/BetterThanTomorrow/calva/issues/2795)
+
 ## [2.0.502] - 2025-04-21
 
 - Fix: [formatCode throws an error when output output is printed in the output window](https://github.com/BetterThanTomorrow/calva/issues/2791)

--- a/docs/site/api.md
+++ b/docs/site/api.md
@@ -101,7 +101,7 @@ type Result = {
   output: string;
   errorOutput: string;
   sessionKey: string;  // Actual session key used
-  error?: string;      // If present, will include raw nrepl stacktrace object
+  error?: any;      // If present, will include raw nrepl stacktrace object
 };
 ```
 

--- a/docs/site/api.md
+++ b/docs/site/api.md
@@ -30,12 +30,12 @@ When using Joyride you can use its unique `require` API, for which one of the be
 
     ```clojure
     (def calvaExt (vscode/extensions.getExtension "betterthantomorrow.calva"))
-    
+
     (def calva (-> calvaExt
                  .-exports
                  .-v1
                  (js->clj :keywordize-keys true)))
-    
+
     ((get-in calva [:repl :currentSessionKey])) => "cljs" ; or "clj", depending
     ```
 
@@ -100,6 +100,8 @@ type Result = {
   ns: string;
   output: string;
   errorOutput: string;
+  sessionKey: string;  // Actual session key used
+  error?: string;      // If present, will include raw nrepl stacktrace object
 };
 ```
 
@@ -139,9 +141,9 @@ An example:
 
 #### Handling Output
 
-The `output` member on the `Result` object will have any output produced during evaluation. (The `errorOutput` member should contain error output produced, but currently some Calva bug makes this not work.) By default the stdout and stderr output is not printed anywhere.
+The `output` member on the `Result` object will have any output produced during evaluation. By default the stdout and stderr output is not printed anywhere.
 
-If you want to do something with either regular output or error output during, or after, evaluation, you'll need to provide the `output` argument to `evaluateCode()`. (The `stderr` callback function works, so this is the only way to get at any error output, until the above mentioned Calva bug is fixed.)
+If you want to do something with either regular output or error output during, or after, evaluation, you'll need to provide the `output` argument to `evaluateCode()`.
 
 An example:
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,6 +5,7 @@ import * as calvaVsCode from './vscode';
 import * as editor from './editor';
 import * as document from './document';
 import * as pprint from './pprint';
+import * as info from './info';
 
 export function getApi() {
   return {
@@ -23,6 +24,7 @@ export function getApi() {
       editor,
       document,
       pprint,
+      info,
     },
   };
 }

--- a/src/api/info.ts
+++ b/src/api/info.ts
@@ -1,6 +1,8 @@
 import { clojureDocsCiderNReplLookup } from '../clojuredocs';
 import * as replSession from '../nrepl/repl-session';
 
+// TODO: Only nRepl lookups for now. Figure out how to enable clojure-lsp.
+
 export const getClojureDocsDotOrg = async (symbol: string, ns = 'user') => {
   const session = replSession.getSession('clj');
   if (!session) {

--- a/src/api/info.ts
+++ b/src/api/info.ts
@@ -1,0 +1,20 @@
+import { clojureDocsCiderNReplLookup } from '../clojuredocs';
+import * as replSession from '../nrepl/repl-session';
+
+export const getClojureDocsDotOrg = async (symbol: string, ns = 'user') => {
+  const session = replSession.getSession('clj');
+  if (!session) {
+    return { error: "Can't retrieve REPL session for session key. Is the REPL connected?" };
+  }
+  const clojureDocs = await clojureDocsCiderNReplLookup(session, symbol, ns);
+  return clojureDocs;
+};
+
+export const getSymbolInfo = async (symbol: string, sessionKey: string, ns = 'user') => {
+  const client = replSession.getSession(sessionKey);
+  if (!client || !client.supports('info')) {
+    return { error: "Can't retrieve REPL session for session key. Is the REPL connected?" };
+  }
+  const res = await client.info(ns, symbol);
+  return res;
+};

--- a/src/api/repl-v1.ts
+++ b/src/api/repl-v1.ts
@@ -7,6 +7,8 @@ type Result = {
   ns: string;
   output: string;
   errorOutput: string;
+  sessionKey: string;
+  error?: string;
 };
 
 export const evaluateCode = async (
@@ -19,9 +21,12 @@ export const evaluateCode = async (
   },
   nReplEvalOptions = {}
 ): Promise<Result> => {
-  const session = replSession.getSession(sessionKey || undefined);
+  const sessionKeyToUse = replSession.getSessionKey(sessionKey);
+  const session = replSession.getSession(sessionKeyToUse || undefined);
   if (!session) {
-    throw new Error(`Can't retrieve REPL session for session key: ${sessionKey}.`);
+    throw new Error(
+      `Can't retrieve REPL session for session key: ${sessionKey} (used ${sessionKeyToUse}).`
+    );
   }
   const stdout = output
     ? output.stdout
@@ -39,12 +44,35 @@ export const evaluateCode = async (
     pprintOptions: printer.disabledPrettyPrinter,
     ...nReplEvalOptions,
   });
-  return {
-    result: await evaluation.value,
-    ns: evaluation.ns,
-    output: evaluation.outPut,
-    errorOutput: evaluation.errorOutput,
-  };
+  let result: Result;
+  try {
+    result = {
+      result: await evaluation.value,
+      ns: evaluation.ns,
+      output: evaluation.outPut,
+      errorOutput: evaluation.errorOutput,
+      sessionKey: sessionKeyToUse,
+    };
+  } catch (evalError) {
+    let error = `${evalError}`;
+    try {
+      const stacktrace = await session.stacktrace();
+      const printableStacktrace = JSON.stringify(stacktrace);
+      error += `\n\n${printableStacktrace}`;
+    } catch (fetchStacktraceError) {
+      console.error(`Calva API eval: failed to output stacktrace. ${fetchStacktraceError}`);
+    } finally {
+      result = {
+        result: 'nil',
+        ns: evaluation.ns,
+        output: evaluation.outPut,
+        errorOutput: evaluation.errorOutput,
+        sessionKey: sessionKeyToUse,
+        error,
+      };
+    }
+  }
+  return result;
 };
 
 export const currentSessionKey = () => {

--- a/src/api/repl-v1.ts
+++ b/src/api/repl-v1.ts
@@ -9,6 +9,7 @@ type Result = {
   errorOutput: string;
   sessionKey: string;
   error?: string;
+  stacktrace?: any;
 };
 
 export const evaluateCode = async (
@@ -54,11 +55,9 @@ export const evaluateCode = async (
       sessionKey: sessionKeyToUse,
     };
   } catch (evalError) {
-    let error = `${evalError}`;
+    let stacktrace;
     try {
-      const stacktrace = await session.stacktrace();
-      const printableStacktrace = JSON.stringify(stacktrace);
-      error += `\n\n${printableStacktrace}`;
+      stacktrace = await session.stacktrace();
     } catch (fetchStacktraceError) {
       console.error(`Calva API eval: failed to output stacktrace. ${fetchStacktraceError}`);
     } finally {
@@ -68,7 +67,8 @@ export const evaluateCode = async (
         output: evaluation.outPut,
         errorOutput: evaluation.errorOutput,
         sessionKey: sessionKeyToUse,
-        error,
+        error: `${evalError}`,
+        stacktrace,
       };
     }
   }

--- a/src/clojuredocs.ts
+++ b/src/clojuredocs.ts
@@ -191,7 +191,7 @@ async function clojureDocsLookup(
   }
 }
 
-async function clojureDocsCiderNReplLookup(
+export async function clojureDocsCiderNReplLookup(
   session: nrepl.NReplSession,
   symbol: string,
   ns: string

--- a/src/nrepl/repl-session.ts
+++ b/src/nrepl/repl-session.ts
@@ -3,20 +3,40 @@ import { cljsLib, tryToGetDocument, getFileType } from '../utilities';
 import * as outputWindow from '../repl-window/repl-doc';
 import { isUndefined } from 'lodash';
 
-function getSession(fileType?: string): NReplSession {
+/**
+ * Determines the appropriate session key based on file type and context
+ */
+function getSessionKey(fileType?: string): string {
   const doc = tryToGetDocument({});
 
   if (isUndefined(fileType)) {
     fileType = getFileType(doc);
   }
+
+  // If we're in the REPL window, use its session type
+  if (outputWindow.isResultsDoc(doc)) {
+    return outputWindow.getSessionType();
+  }
+
+  // Return the detected file type if valid
   if (fileType.match(/^clj[sc]?/) && cljsLib.getStateValue(fileType)) {
-    return cljsLib.getStateValue(fileType);
+    return fileType;
+  }
+
+  // Default to cljc for all other cases
+  return 'cljc';
+}
+
+function getSession(fileType?: string): NReplSession {
+  const sessionKey = getSessionKey(fileType);
+
+  if (
+    sessionKey === outputWindow.getSessionType() &&
+    outputWindow.isResultsDoc(tryToGetDocument({}))
+  ) {
+    return outputWindow.getSession();
   } else {
-    if (outputWindow.isResultsDoc(doc)) {
-      return outputWindow.getSession();
-    } else {
-      return cljsLib.getStateValue('cljc');
-    }
+    return cljsLib.getStateValue(sessionKey);
   }
 }
 
@@ -53,4 +73,10 @@ function getReplSessionTypeFromState() {
   return cljsLib.getStateValue('current-session-type');
 }
 
-export { getSession, getReplSessionType, updateReplSessionType, getReplSessionTypeFromState };
+export {
+  getSession,
+  getReplSessionType,
+  updateReplSessionType,
+  getReplSessionTypeFromState,
+  getSessionKey,
+};


### PR DESCRIPTION
## What has changed?

- Experimental add of an `info` module to the API, containing `getSymbolInfo` and `getClojureDocsDotOrg`.
  - Only using nrepl for now. We probably should fall back on clojure-lsp when the repl is not available.
  - Not added docs for this, as it is experimental and subject to change while we figure out the right API.
- Fix for the problem that the evaluation API crashed when an evaluation failed in the REPL. (For some reason we treat this as an error in the Calva nrepl code, and the error was not handled in the API.)
  - Updated docs about this. 
 
* Addresses #2795

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
