### PR TITLE
Use vscode testmessage.diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Use VSCode test message diff view to see side-by-side test results](https://github.com/BetterThanTomorrow/calva/issues/2797)
+
 ## [2.0.502] - 2025-04-26
 
 - Fix: [formatCode throws an error when output output is printed in the output window](https://github.com/BetterThanTomorrow/calva/issues/2791)

--- a/package.json
+++ b/package.json
@@ -489,7 +489,7 @@
             },
             "default": {
               "nrepl": "1.3.1",
-              "cider-nrepl": "0.52.1",
+              "cider-nrepl": "0.55.4",
               "cider/piggieback": "0.6.0"
             }
           },

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -136,13 +136,22 @@ async function onTestResult(
 
     switch (result.type) {
       case 'error':
-        run.errored(assertion, vscode.TestMessage.diff(cider.shortMessage(result), result.expected, result.actual));
+        run.errored(
+          assertion,
+          vscode.TestMessage.diff(cider.shortMessage(result), result.expected, result.actual)
+        );
         break;
       case 'fail':
-        run.failed(assertion, vscode.TestMessage.diff(cider.detailedMessage(result), result.expected, result.actual));
+        run.failed(
+          assertion,
+          vscode.TestMessage.diff(cider.detailedMessage(result), result.expected, result.actual)
+        );
         break;
       default:
-        run.failed(assertion, vscode.TestMessage.diff(cider.shortMessage(result), result.expected, result.actual));
+        run.failed(
+          assertion,
+          vscode.TestMessage.diff(cider.shortMessage(result), result.expected, result.actual)
+        );
         break;
     }
   });

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -136,13 +136,13 @@ async function onTestResult(
 
     switch (result.type) {
       case 'error':
-        run.errored(assertion, new vscode.TestMessage(cider.shortMessage(result)));
+        run.errored(assertion, vscode.TestMessage.diff(cider.shortMessage(result), result.expected, result.actual));
         break;
       case 'fail':
-        run.failed(assertion, new vscode.TestMessage(cider.detailedMessage(result)));
+        run.failed(assertion, vscode.TestMessage.diff(cider.detailedMessage(result), result.expected, result.actual));
         break;
       default:
-        run.failed(assertion, new vscode.TestMessage(cider.shortMessage(result)));
+        run.failed(assertion, vscode.TestMessage.diff(cider.shortMessage(result), result.expected, result.actual));
         break;
     }
   });


### PR DESCRIPTION
I feel this is an improvement in the test output, but if there are folks that would prefer to stay on the text version, or if we'd like to leave that as an option, I'd be happy to put this behind an extension setting. See #2797 for before/after screenshots.

This requires at least `cider-nrepl 0.54.0` to bring in this change: https://github.com/clojure-emacs/cider-nrepl/pull/917
I've bumped the cider dependency to latest.

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Use `TestMessage.diff` to show a side-by-side view of the expected vs actual test results
- Bump cider-nrepl version to 0.55.4

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2797 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
