### PR TITLE
Restore behaviour of getSession from before refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Release 2.0.502 repl connection fails, breaking Jack-In](https://github.com/BetterThanTomorrow/calva/issues/2799) (Hopefully)
+
 ## [2.0.502] - 2025-04-26
 
 - Fix: [formatCode throws an error when output output is printed in the output window](https://github.com/BetterThanTomorrow/calva/issues/2791)

--- a/src/nrepl/repl-session.ts
+++ b/src/nrepl/repl-session.ts
@@ -36,7 +36,8 @@ function getSession(fileType?: string): NReplSession {
   ) {
     return outputWindow.getSession();
   } else {
-    return cljsLib.getStateValue(sessionKey);
+    const session = cljsLib.getStateValue(sessionKey);
+    return session || null; // Return null instead of undefined when session doesn't exist
   }
 }
 


### PR DESCRIPTION
Seems a refactor in the repl-session.ts module broke jack-in for some users!

* Fixes #2799 (hopefully)

Specifically I had changed the return value of getSession(), and we are doing some non-strict checks at the call sites. (Should be fixed, but for now, return what we used to return.
 
* Returning `null` instead of `undefined` if the state has no session


## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
