### PR TITLE
Fixes for strange connect issue when repl window is active in a freshly opened project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [REPL fails to connet in v2.0.503](https://github.com/BetterThanTomorrow/calva/issues/2806) (Hopefully)
+
 ## [2.0.503] - 2025-04-27
 
 - Fix: [Release 2.0.502 repl connection fails, breaking Jack-In](https://github.com/BetterThanTomorrow/calva/issues/2799) (Hopefully)

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -130,9 +130,9 @@ export function formatRangeEdits(
   originalRange: vscode.Range
 ): vscode.TextEdit[] | undefined {
   // Output/REPL window holds prompts etc. The formatter cannot format it. Do not try.
-  if (outputWindow.isResultsDoc(document)) {
-    return [];
-  }
+  // if (outputWindow.isResultsDoc(document)) {
+  //   return [];
+  // }
   return rangeReformatChanges(document, originalRange, false).map((chg) =>
     vscode.TextEdit.replace(
       new vscode.Range(document.positionAt(chg.start), document.positionAt(chg.end)),
@@ -282,9 +282,9 @@ export async function formatPosition(
   let orderedChanges = undefined;
   if (isWholeDoc) {
     // Output/REPL window holds prompts etc. The formatter cannot format it. Do not try.
-    // if (outputWindow.isResultsDoc(editor.document)) {
-    //   return Promise.resolve(false);
-    // }
+    if (outputWindow.isResultsDoc(editor.document)) {
+      return Promise.resolve(false);
+    }
     orderedChanges = rangeReformatChanges(
       doc,
       new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length)),

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -130,9 +130,9 @@ export function formatRangeEdits(
   originalRange: vscode.Range
 ): vscode.TextEdit[] | undefined {
   // Output/REPL window holds prompts etc. The formatter cannot format it. Do not try.
-  // if (outputWindow.isResultsDoc(document)) {
-  //   return [];
-  // }
+  if (outputWindow.isResultsDoc(document)) {
+    return [];
+  }
   return rangeReformatChanges(document, originalRange, false).map((chg) =>
     vscode.TextEdit.replace(
       new vscode.Range(document.positionAt(chg.start), document.positionAt(chg.end)),

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -282,9 +282,9 @@ export async function formatPosition(
   let orderedChanges = undefined;
   if (isWholeDoc) {
     // Output/REPL window holds prompts etc. The formatter cannot format it. Do not try.
-    if (outputWindow.isResultsDoc(editor.document)) {
-      return Promise.resolve(false);
-    }
+    // if (outputWindow.isResultsDoc(editor.document)) {
+    //   return Promise.resolve(false);
+    // }
     orderedChanges = rangeReformatChanges(
       doc,
       new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length)),

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -18,6 +18,7 @@ export function getNamespace(
     if (outputWindowNs) {
       return [outputWindowNs, `(in-ns '${outputWindowNs})`];
     }
+  }
   if (doc && doc.languageId == 'clojure') {
     try {
       const cursorDoc = docMirror.getDocument(doc);

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -15,9 +15,9 @@ export function getNamespace(
 ): NsAndNsForm {
   if (outputWindow.isResultsDoc(doc)) {
     const outputWindowNs = outputWindow.getNs();
-    utilities.assertIsDefined(outputWindowNs, 'Expected repl window to have a namespace!');
-    return [outputWindowNs, `(in-ns '${outputWindowNs})`];
-  }
+    if (outputWindowNs) {
+      return [outputWindowNs, `(in-ns '${outputWindowNs})`];
+    }
   if (doc && doc.languageId == 'clojure') {
     try {
       const cursorDoc = docMirror.getDocument(doc);

--- a/src/nrepl/repl-session.ts
+++ b/src/nrepl/repl-session.ts
@@ -37,7 +37,7 @@ function getSession(fileType?: string): NReplSession {
     return outputWindow.getSession();
   } else {
     const session = cljsLib.getStateValue(sessionKey);
-    return session || null; // Return null instead of undefined when session doesn't exist
+    return session || cljsLib.getStateValue('cljc') || null;
   }
 }
 

--- a/src/nrepl/repl-session.ts
+++ b/src/nrepl/repl-session.ts
@@ -13,31 +13,27 @@ function getSessionKey(fileType?: string): string {
     fileType = getFileType(doc);
   }
 
-  // If we're in the REPL window, use its session type
-  if (outputWindow.isResultsDoc(doc)) {
-    return outputWindow.getSessionType();
-  }
-
-  // Return the detected file type if valid
   if (fileType.match(/^clj[sc]?/) && cljsLib.getStateValue(fileType)) {
     return fileType;
   }
 
-  // Default to cljc for all other cases
+  if (outputWindow.isResultsDoc(doc)) {
+    return outputWindow.getSessionType();
+  }
+
   return 'cljc';
 }
 
 function getSession(fileType?: string): NReplSession {
   const sessionKey = getSessionKey(fileType);
+  const session = cljsLib.getStateValue(sessionKey);
 
-  if (
-    sessionKey === outputWindow.getSessionType() &&
-    outputWindow.isResultsDoc(tryToGetDocument({}))
-  ) {
+  if (session) {
+    return session;
+  } else if (outputWindow.isResultsDoc(tryToGetDocument({}))) {
     return outputWindow.getSession();
   } else {
-    const session = cljsLib.getStateValue(sessionKey);
-    return session || cljsLib.getStateValue('cljc') || null;
+    return cljsLib.getStateValue('cljc') || null;
   }
 }
 

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -91,7 +91,7 @@ function update() {
       typeStatus.text = ['cljc', config.REPL_FILE_EXT, config.FIDDLE_FILE_EXT].includes(fileType)
         ? `cljc/${replType}`
         : replType;
-      if (cljSession.replType !== cljsSession?.replType) {
+      if (cljSession?.replType !== cljsSession?.replType) {
         typeStatus.command = 'calva.toggleCLJCSession';
         typeStatus.tooltip = `Click to use ${replType === 'clj' ? 'cljs' : 'clj'} REPL for cljc`;
       } else {


### PR DESCRIPTION
## What has changed?

* A fix for the unchecked access that caused the connect failure (in status bar update...)
* Fixes for the regression from #2795 causing us to fail get a valid repl session when there actually was one
* Fix for an unrelated error thrown during startup that @jennek reported [here](https://github.com/BetterThanTomorrow/calva/issues/2806#issuecomment-2844582416). (It probably has a shared root cause, but we were unnecessarily throwing in the towel, me thinks.)

The root cause is still to be chased out, but I think we actually can say that this PR:

* Fixes #2806

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
