### PR TITLE
Close Rich Comment Form on next line *if* formatting current form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Runtime status error reported](https://github.com/BetterThanTomorrow/calva/issues/2808)
-
+- Fix: Rich Comment Forms in [Reformat all edited locations after multicursor structural edit](https://github.com/BetterThanTomorrow/calva/issues/2738)
 
 ## [2.0.504] - 2025-05-01
 

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -180,13 +180,13 @@ export function formatDocIndexesInfo(
   extraConfig: CljFmtConfig = {}
 ) {
   const mDoc = getDocument(doc);
-  const cursor = mDoc.getTokenCursor(indexOfRange);
   const formatRange = formatDocIndexRange(doc, indexOfRange, extraConfig);
   if (!formatRange || (formatRange[0] == -1 && formatRange[1] == -1)) {
     return;
   }
   const eol = _convertEolNumToStringNotation(doc.eol);
 
+  const cursor = mDoc.getTokenCursor(1 + formatRange[0]);
   const formatted: {
     'range-text': string;
     range: number[];

--- a/src/extension-test/integration/integration-text-notation.ts
+++ b/src/extension-test/integration/integration-text-notation.ts
@@ -1,0 +1,125 @@
+// Adapted from unit test text-notation.ts
+import { clone, entries, first, last, orderBy, toInteger } from 'lodash';
+
+// textNotationToTextAndSelection duplicated and adapted from text-notation.ts
+/**
+ * Text Notation for expressing states of a document, including
+ * current text and selection.
+ * See this video for an intro: https://www.youtube.com/watch?v=Sy3arG-Degw
+ * * Since JavasScript makes it clumsy with multiline strings,
+ *   newlines are denoted with a middle dot character: `•`
+ * * Selections are denoted like so
+ *   * Cursors, (which are actually selections with identical start and end) are denoted with a single `|`, with <= 10 multiple cursors defined by `|1`, `|2`, ... `|9`, etc, or in regex: /\|\d/. 0-indexed, so `|` is 0, `|1` is 1, etc.
+ *   * This is however actually an alternative for the following `>\d?` notation, it has the same left->right semantics, but looks more like a cursor/caret lol, and more importantly, drops the 0 for the first cursor.
+ *   * Selections with direction left->right are denoted with `>0`, `>1`, `>2`, ... `>9` etc at the range boundaries
+ *   * Selections with direction right->left are denoted with `<0`, `<1`, `<2`, ... `<9` etc at the range boundaries
+ */
+export function textNotationToTextAndSelection(content: string): [string, [number, number][]] {
+  const cursorSymbolRegExPattern =
+    /(?<cursorType>(?:(?<selectionDirection><|>(?=\d{1})))|(?:\|))(?<cursorNumber>\d{1})?/g;
+  const text = clone(content).replace(/•/g, '\n').replace(cursorSymbolRegExPattern, '');
+
+  /**
+   * 3 capture groups:
+   * 0 = total cursor, with number,
+   * 1 = just the cursor type, no number,
+   * 2 = only for directional selection cursors:
+   *     the > or <,
+   * 3 = only if there's a number, the number itself (eg multi cursor)
+   */
+  const matches = Array.from(content.matchAll(cursorSymbolRegExPattern));
+
+  // a map of cursor symbols (eg '>3' - including the cursor number if >1 ) to an an array of matches (for their positions mostly) in content string where that cursor is
+  // for now, we hope that there are at most two positions per symbol
+  const cursorMatchInstances = matches.reduce((acc, curr, index) => {
+    const nextAcc = { ...acc };
+
+    const sumOfPreviousCursorOffsets = Array.from(matches)
+      .slice(0, index)
+      .reduce((sum, m) => sum + m[0].length, 0);
+
+    curr.index = curr.index - sumOfPreviousCursorOffsets;
+
+    const cursorMatchStr = curr[0];
+    const matchesForCursor = nextAcc[cursorMatchStr] ?? [];
+    nextAcc[cursorMatchStr] = [...matchesForCursor, curr];
+    return nextAcc;
+  }, {} as { [key: string]: RegExpMatchArray[] });
+
+  const selections: [number, number][] = [].fill(0, matches.length, undefined);
+
+  entries(cursorMatchInstances).forEach(([_, matches]) => {
+    const firstMatch = first(matches);
+    const secondMatch = last(matches) ?? firstMatch;
+
+    const isReversed =
+      (firstMatch.groups['selectionDirection'] ?? firstMatch[2] ?? '') === '<' ? true : false;
+
+    const start = firstMatch.index;
+    const end = secondMatch.index === firstMatch.index ? secondMatch.index : secondMatch.index;
+
+    const anchor = isReversed ? end : start;
+    const active = isReversed ? start : end;
+
+    const cursorNumber = toInteger(firstMatch.groups['cursorNumber'] ?? firstMatch[3] ?? '0');
+
+    selections[cursorNumber] = [anchor, active]; //new model.ModelEditSelection(anchor, active, start, end, isReversed);
+  });
+
+  return [text, selections];
+}
+
+/** Text+selections string indicating cursors by |, |1, |2, etc.
+ * @param ranges Array of selections' [anchor,active]
+ * @param prettyPrint False to represent newline by a dot, true for a newline
+ */
+export function textNotationFromTextAndSelections(
+  text: string,
+  ranges: Array<[number, number]>,
+  prettyPrint = false
+): string {
+  let cursorSymbols: [number, string][] = [];
+  ranges.forEach((r, cursorNumber) => {
+    const [anchor, active] = r;
+    const isReversed = anchor > active;
+    const isSelection = anchor - active !== 0;
+    const start = Math.min(anchor, active);
+    const end = Math.max(anchor, active);
+
+    const cursorType = isReversed ? '<' : '|';
+    cursorSymbols.push([start, `${cursorType}${cursorNumber || ''}`]);
+    if (isSelection) {
+      cursorSymbols.push([end, `${cursorType}${cursorNumber || ''}`]);
+    }
+  });
+
+  cursorSymbols = orderBy(cursorSymbols, (c) => c[0]);
+
+  // split the text into chunks separated by where they'd have had cursor symbols, and append cursor symbols after each chunk, before joining back together
+  // this way we can insert the cursor symbols in the right place without having to worry about the cumulative offsets created by appending the cursor symbols
+  const textSegments = cursorSymbols
+    .reduce(
+      (acc, [offset, symbol], index) => {
+        const lastSection = last(acc)[1];
+        const sections = acc.slice(0, -1);
+
+        const lastSectionOffset =
+          offset - sections.filter((s) => s[0]).reduce((sum, sec) => sum + sec[1].length, 0);
+        const newSectionOfText = [true, lastSection.slice(0, lastSectionOffset)];
+        const newSectionWithCursor = [false, symbol];
+        const restOfText = lastSection.slice(lastSectionOffset);
+
+        return [...sections, newSectionOfText, newSectionWithCursor, [true, restOfText]];
+      },
+      [
+        [true, text] as [
+          boolean /* is an actual text segment instead of cursor symbol? */,
+          string /* text segment or cursor symbol */
+        ],
+      ]
+    )
+    .map((s) => s[1]);
+
+  const textNotation = textSegments.join('');
+  return prettyPrint ? textNotation.replace(/•/g, '\n') : textNotation;
+}

--- a/src/extension-test/integration/suite/format-test.ts
+++ b/src/extension-test/integration/suite/format-test.ts
@@ -39,18 +39,24 @@ function textNotationFromDocAndSelections(
   return textNotation.textNotationFromTextAndSelections(text, ranges, prettyPrint);
 }
 
+const pauseMs = 1000;
+
 /** Cursor positions indicated in textAndSelections by |, |1, |2, etc. */
 async function reformat(editor: vscode.TextEditor, textAndSelections: string) {
   const [text, selectionsAsOffsets] =
     textNotation.textNotationToTextAndSelection(textAndSelections);
   await vscode.commands.executeCommand('editor.action.selectAll');
-  await new Promise((resolve) => setTimeout(resolve, 125));
-  await vscode.commands.executeCommand('editor.action.clipboardCutAction');
-  await new Promise((resolve) => setTimeout(resolve, 125));
+  await new Promise((resolve) => setTimeout(resolve, pauseMs));
+  await vscode.commands.executeCommand(
+    'paredit.deleteForward' /*'editor.action.clipboardCutAction'*/
+  );
+  await new Promise((resolve) => setTimeout(resolve, pauseMs));
+  const emptiedText = getText(editor.document);
+  if (emptiedText != '') { console.error("Supposedly emptied document contains", emptiedText) };
   await editor.edit((ed) => {
     ed.insert(new vscode.Position(0, 0), text);
   });
-  await new Promise((resolve) => setTimeout(resolve, 125));
+  await new Promise((resolve) => setTimeout(resolve, pauseMs));
   editor.selections = selectionsAsOffsets.map(
     ([anchorOffset, activeOffset]) =>
       new vscode.Selection(
@@ -58,9 +64,9 @@ async function reformat(editor: vscode.TextEditor, textAndSelections: string) {
         editor.document.positionAt(activeOffset)
       )
   );
-  await new Promise((resolve) => setTimeout(resolve, 125));
+  await new Promise((resolve) => setTimeout(resolve, pauseMs));
   await vscode.commands.executeCommand('calva-fmt.formatCurrentForm');
-  await new Promise((resolve) => setTimeout(resolve, 125));
+  await new Promise((resolve) => setTimeout(resolve, pauseMs));
   return textNotationFromDocAndSelections(editor.document, editor.selections);
 }
 

--- a/src/extension-test/integration/suite/format-test.ts
+++ b/src/extension-test/integration/suite/format-test.ts
@@ -1,0 +1,134 @@
+import * as assert from 'assert';
+import { before, after, it } from 'mocha';
+import * as path from 'path';
+import * as testUtil from './util';
+import * as vscode from 'vscode';
+import * as textNotation from '../integration-text-notation';
+
+const suiteName = 'Format suite';
+
+// Test data: a short .clj:
+const testFilePath = path.join(testUtil.testDataDir, 'reformattable.clj');
+
+/** Document text
+ * @param replaceNewLine Whether to represent newlines by a dot
+ */
+function getText(doc: vscode.TextDocument, replaceNewLine = false): string {
+  const text = doc.getText(
+    doc.validateRange(
+      new vscode.Range(new vscode.Position(0, 0), new vscode.Position(99999, 99999))
+    )
+  );
+  return replaceNewLine ? text.split(doc.eol == 1 ? '\n' : '\r\n').join('•') : text;
+}
+
+/** Text+selections string indicating cursors by |, |1, |2, etc.
+ * @param ranges Array of selections' [anchor,active]
+ * @param prettyPrint False to represent newline by a dot, true for a newline
+ */
+function textNotationFromDocAndSelections(
+  doc: vscode.TextDocument,
+  selections: readonly vscode.Selection[],
+  prettyPrint = false
+): string {
+  const ranges: [number, number][] = selections.map((s) => [
+    doc.offsetAt(s.start),
+    doc.offsetAt(s.end),
+  ]);
+  const text = getText(doc, true);
+  return textNotation.textNotationFromTextAndSelections(text, ranges, prettyPrint);
+}
+
+/** Cursor positions indicated in textAndSelections by |, |1, |2, etc. */
+async function reformat(editor: vscode.TextEditor, textAndSelections: string) {
+  const [text, selectionsAsOffsets] =
+    textNotation.textNotationToTextAndSelection(textAndSelections);
+  await vscode.commands.executeCommand('editor.action.selectAll');
+  await new Promise((resolve) => setTimeout(resolve, 125));
+  await vscode.commands.executeCommand('editor.action.clipboardCutAction');
+  await new Promise((resolve) => setTimeout(resolve, 125));
+  await editor.edit((ed) => {
+    ed.insert(new vscode.Position(0, 0), text);
+  });
+  await new Promise((resolve) => setTimeout(resolve, 125));
+  editor.selections = selectionsAsOffsets.map(
+    ([anchorOffset, activeOffset]) =>
+      new vscode.Selection(
+        editor.document.positionAt(anchorOffset),
+        editor.document.positionAt(activeOffset)
+      )
+  );
+  await new Promise((resolve) => setTimeout(resolve, 125));
+  await vscode.commands.executeCommand('calva-fmt.formatCurrentForm');
+  await new Promise((resolve) => setTimeout(resolve, 125));
+  return textNotationFromDocAndSelections(editor.document, editor.selections);
+}
+
+/** Cursor positions indicated in textAndSelections by |, |1, |2, etc. */
+async function reformatUsingActiveEditor(textAndSelections: string) {
+  return reformat(vscode.window.activeTextEditor, textAndSelections);
+}
+
+suite(suiteName, () => {
+  before(async () => {
+    testUtil.showMessage(suiteName, `suite starting`);
+    return testUtil.openFile(testFilePath).then((x) => {
+      return new Promise((resolve) => setTimeout(resolve, 1000));
+    });
+  });
+
+  after(async () => {
+    console.log('Finally, format suite is closing the active editor');
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    testUtil.showMessage(suiteName, `suite done!`);
+  });
+
+  it('should add indenting spaces on lines where cursors are', async () => {
+    assert.equal(await reformatUsingActiveEditor('(foo•|•|1 :a)'), '(foo•  |•|1  :a)');
+  });
+
+  it('should advance indented cursors to proper indentation spot', async () => {
+    assert.equal(await reformatUsingActiveEditor('(foo•|• |1:a)'), '(foo•  |•  |1:a)');
+  });
+
+  it('should remove spaces and commas from an empty list', async () => {
+    assert.equal(await reformatUsingActiveEditor('(•|•,)'), '(|)');
+  });
+
+  it('should format deftype', async () => {
+    assert.equal(
+      await reformatUsingActiveEditor(
+        '(deftype MyType [arg1 arg2]•  IMyProto•  (method1 [this]•           |(smth)))'
+      ),
+      '(deftype MyType [arg1 arg2]•  IMyProto•  (method1 [this]•    |(smth)))'
+    );
+  });
+
+  it('should not remove a single blank line', async () => {
+    assert.equal(
+      await reformatUsingActiveEditor('(defn bar• |   [x]••    baz)'),
+      '(defn bar• | [x]••  baz)'
+    );
+  });
+
+  it('should collapse consecutive blank lines to a single line', async () => {
+    assert.equal(
+      await reformatUsingActiveEditor('(defn bar• |   [x]• •,••    baz)'),
+      '(defn bar• | [x]••  baz)'
+    );
+  });
+
+  it('should close a rich comment form on a new line (1)', async () => {
+    assert.equal(
+      await reformatUsingActiveEditor('(comment•  (def foo•:foo)|)'),
+      '(comment•  (def foo•    :foo)•  |)'
+    );
+  });
+
+  it('should close a rich comment form on a new line (2)', async () => {
+    assert.equal(
+      await reformatUsingActiveEditor('(comment•  |(def foo•:foo))'),
+      '(comment•  |(def foo•    :foo)•  )'
+    );
+  });
+});

--- a/src/extension-test/integration/suite/format-test.ts
+++ b/src/extension-test/integration/suite/format-test.ts
@@ -52,7 +52,9 @@ async function reformat(editor: vscode.TextEditor, textAndSelections: string) {
   );
   await new Promise((resolve) => setTimeout(resolve, pauseMs));
   const emptiedText = getText(editor.document);
-  if (emptiedText != '') { console.error("Supposedly emptied document contains", emptiedText) };
+  if (emptiedText != '') {
+    console.error('Supposedly emptied document contains', emptiedText);
+  }
   await editor.edit((ed) => {
     ed.insert(new vscode.Position(0, 0), text);
   });

--- a/src/extension-test/integration/suite/format-test.ts
+++ b/src/extension-test/integration/suite/format-test.ts
@@ -92,6 +92,7 @@ suite(suiteName, () => {
   });
 
   it('should add indenting spaces on lines where cursors are', async () => {
+    await new Promise((resolve) => setTimeout(resolve, 5 * pauseMs));
     assert.equal(await reformatUsingActiveEditor('(foo•|•|1 :a)'), '(foo•  |•|1  :a)');
   });
 

--- a/test-data/integration-test/reformattable.clj
+++ b/test-data/integration-test/reformattable.clj
@@ -1,0 +1,11 @@
+(ns test)
+
+(def hover-map
+  {:stuff "in-here"
+   :ohter "yeah"
+   :deeper {:a 1, "foo" :bar, [1 2 3] (vec (range 2000))}})
+
+(defn foo []
+  (println "bar"))
+
+(foo)


### PR DESCRIPTION
## What has changed?

This is a small correction to the multicursor formatting PR in Calva 2.0.499.

https://calva.io/rich-comments/#special-formatting says, "To invite a Rich comments workflow, the Calva command Format Current Form will not fold the closing bracket of the (comment ...) form. Instead it will place this bracket on a line of its own (or keep it there)..."

So for example
```
(comment
  (def foo
:foo)|)
```
tab -> Expected
```
(comment
  (def foo
    :foo)
  |)
```

Actual in v 2.0.503:

```
(comment
  (def foo
    :foo)|)
```

- This PR corrects format-current-form's check of whether it is formatting a rich comment form so the above example comes out as expected. It was looking at the "def", but it should look at the "comment".

I did not make a new issue, because this is a continuation of #2738.

Addresses #2738 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

Ping @pez, @bpringe, @corasaurus-hex, @Cyrik
