### PR TITLE
Fix 2820 newlines in flare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Allow newlines in flares](https://github.com/BetterThanTomorrow/calva/issues/2820)
 - Fix: [Reformat may do nothing if cljfmt's :sort-ns-references? is true](https://github.com/BetterThanTomorrow/calva/issues/2789) when formatting only a (ns ...) form
 
 ## [2.0.509] - 2025-05-10

--- a/src/flare-handler.ts
+++ b/src/flare-handler.ts
@@ -29,7 +29,7 @@ export function inspect(edn: string, evaluate: EvaluateFunction): any {
   ) {
     try {
       // decompose the flare into the tag and the literal
-      const match = edn.match(/^#(?:flare|cursive)\/(\w+)\s*(\{.*}$)/s);
+      const match = edn.match(/^#(?:flare|cursive)\/(\w+)\s*(\{.*})\s*$/s);
       if (match) {
         const tag = match[1];
         const flare = parseEdn(match[2]);

--- a/src/flare-handler.ts
+++ b/src/flare-handler.ts
@@ -29,7 +29,7 @@ export function inspect(edn: string, evaluate: EvaluateFunction): any {
   ) {
     try {
       // decompose the flare into the tag and the literal
-      const match = edn.match(/^#(?:flare|cursive)\/(\w+)\s*(\{.*}$)/);
+      const match = edn.match(/^#(?:flare|cursive)\/(\w+)\s*(\{.*}$)/s);
       if (match) {
         const tag = match[1];
         const flare = parseEdn(match[2]);


### PR DESCRIPTION
## What has changed?

Loosened the regex for flare detection to allow for newlines inside the map.
Some REPLs may format flares.

Fixes #2820 

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
