### PR TITLE
Make flare webviews retain context when moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Flare webviews lose their state when they are not visible or moved](https://github.com/BetterThanTomorrow/calva/issues/2832)
+
 ## [2.0.511] - 2025-05-15
 
 - Fix: [The command for evaluating the Fiddle for the current file doesn't use the file's repl session](https://github.com/BetterThanTomorrow/calva/issues/2828)

--- a/src/flare-handler.ts
+++ b/src/flare-handler.ts
@@ -50,6 +50,7 @@ export function inspect(edn: string, evaluate: EvaluateFunction): any {
 
 const defaultWebviewOptions = {
   enableScripts: true,
+  retainContextWhenHidden: true,
 };
 
 interface CalvaWebPanel extends vscode.WebviewPanel {


### PR DESCRIPTION
## What has changed?

Adding an option to the flare webviews so that they retain their state when moved or hidden.

* Fixes #2832

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
