### PR TITLE
Make the evaluateCode API check for if the repl is connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [The API repl evaluation doesn't detect non-connected state](https://github.com/BetterThanTomorrow/calva/issues/2848)
+
 ## [2.0.513] - 2025-05-19
 
 - Fix: [Whitespace is not preserved in non-code output in output view](https://github.com/BetterThanTomorrow/calva/issues/2825)

--- a/src/api/repl-v1.ts
+++ b/src/api/repl-v1.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as printer from '../printer';
 import * as replSession from '../nrepl/repl-session';
 import * as resultOutput from '../results-output/output';
-import { cljsLib } from '../utilities';
+import * as util from '../utilities';
 
 type Result = {
   result: string;
@@ -27,9 +27,13 @@ export const evaluateCode = async (
   const sessionKeyToUse = replSession.getSessionKey(sessionKey);
   const session = replSession.getSession(sessionKeyToUse || undefined);
   if (!session) {
-    throw new Error(
-      `Can't retrieve REPL session for session key: ${sessionKey} (used ${sessionKeyToUse}).`
-    );
+    if (!util.getConnectedState()) {
+      throw new Error(`The REPL is not connected.`);
+    } else {
+      throw new Error(
+        `Can't retrieve REPL session for session key: ${sessionKey}. (used ${sessionKeyToUse}).`
+      );
+    }
   }
   const stdout = output
     ? output.stdout
@@ -78,7 +82,7 @@ export const evaluateCode = async (
 };
 
 export const currentSessionKey = () => {
-  return replSession.getReplSessionType(cljsLib.getStateValue('connected'));
+  return replSession.getReplSessionType(util.getConnectedState());
 };
 
 //// OUTPUT ////


### PR DESCRIPTION
## What has changed?

Add a check in the API to check if the REPL is connected and respond with a better message if not.

* Fixes #2848
* Fixes https://github.com/BetterThanTomorrow/calva-backseat-driver/issues/10

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
