### PR TITLE
Fix printing of stderr and stdout in output view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Label evaluated code in output view so it's easy to differentiate it from results](https://github.com/BetterThanTomorrow/calva/issues/2839)
+- Fix: [Some output from stderr and/or stdout is being broken up in the output view](https://github.com/BetterThanTomorrow/calva/issues/2847)
+- Fix: [Extra newline is printed before error output in output view](https://github.com/BetterThanTomorrow/calva/issues/2846)
 
 ## [2.0.514] - 2025-05-23
 

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -63,7 +63,7 @@
 (defn repl-output-hiccup
   [state]
   (into [:div {:class "output-element-container"}]
-        (map repl-output-element-hiccup (:repl-output/elements state))))
+        (mapv repl-output-element-hiccup (:repl-output/elements state))))
 
 (defn render [state]
   (replicant/render output-dom-element (repl-output-hiccup state)))
@@ -102,8 +102,14 @@
 
 (defn add-stdout
   [content]
-  (add-repl-output-element (repl-output-element {:output-element/type :output-element.type/stdout
-                                                 :output-element/content (strip-ansi content)})))
+  (let [repl-output-elements (:repl-output/elements @state)
+        last-output-element-type (-> repl-output-elements last :output-element/type)]
+    ;; If the last output element is also stdout, append to it instead of creating a new one
+    (if (= last-output-element-type :output-element.type/stdout)
+      (swap! state update-in [:repl-output/elements (dec (count repl-output-elements)) :output-element/content]
+             str (strip-ansi content))
+      (add-repl-output-element (repl-output-element {:output-element/type :output-element.type/stdout
+                                                     :output-element/content (strip-ansi content)})))))
 
 (defn ^:export clear-webview []
   (swap! state assoc :repl-output/elements []))


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- When the output view receives a command to print stdout (which is also used for stderr, currently), if the last output element in the state is of type stdout, it will append the content of the message to that output element's content, so that consecutive stdout messages' contents are printed in the same `<pre>` html element in the output view.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2847, fixes #2846

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- ~[ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
