### PR TITLE
Reload content of output view when VS Code is reloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Reload contents of output view when VS Code window is reloaded](https://github.com/BetterThanTomorrow/calva/issues/2827)
+
 ## [2.0.519] - 2025-06-09
 
 - [Support `before` and `after` functions for refresh namespaces commands](https://github.com/BetterThanTomorrow/calva/issues/2862)

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "workspaceContains:**/project.clj",
     "workspaceContains:**/shadow-cljs.edn",
     "workspaceContains:**/deps.edn",
-    "onDebugResolve:type"
+    "onDebugResolve:type",
+    "onWebviewPanel:calva.output-view"
   ],
   "main": "./out/extension",
   "capabilities": {

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -28,7 +28,8 @@
                              :showReplOutputWebviewPanel calva.repl.webview.core/show-repl-output-webview-panel
                              :appendToReplOutputWebview calva.repl.webview.core/append
                              :appendStackTraceToReplOutputWebview calva.repl.webview.core/append-stacktrace
-                             :clearReplOutputView calva.repl.webview.core/clear-output-view}
+                             :clearReplOutputView calva.repl.webview.core/clear-output-view
+                             :registerOutputViewWebviewSerializer calva.repl.webview.core/register-output-view-webview-serializer}
                  :output-to "out/cljs-lib/cljs-lib.js"}
                 :test
                 {:target    :node-test

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -199,6 +199,7 @@
                      (post-message-to-webview webview-panel {:command/name "scroll-to"
                                                              :x scroll-left
                                                              :y scroll-top}))
+                   (post-message-to-webview webview-panel {:command/name "restore-copy-buttons"})
                    (resolve nil))))}))))
 
 (defn ^:export show-repl-output-webview-panel

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -156,6 +156,19 @@
   [^js webview-panel]
   (.. webview-panel (onDidDispose (fn [] (dispose-repl-output-webview-panel repl-output-webview-panel)))))
 
+(defn initialize-webview-panel
+  [context ^js webview-panel ^js state]
+  (add-listeners! webview-panel)
+  (add-subscriptions! context {:webview-panel webview-panel})
+  (if (and state (.-html state))
+    (set! (.. webview-panel -webview -html) (.-html state))
+    (set-webview-html! context {:webview-panel webview-panel}))
+  (let [[scroll-left scroll-top] (when state [(.-scrollLeft state) (.-scrollTop state)])]
+    (post-message-to-webview webview-panel {:command/name "scroll-to"
+                                            :x scroll-left
+                                            :y scroll-top}))
+  (post-message-to-webview webview-panel {:command/name "restore-copy-buttons"}))
+
 (defn create-repl-output-webview-panel
   [{:keys [vscode/vscode] :as context}]
   (let [webview-panel (.. ^js vscode -window
@@ -173,27 +186,15 @@
                                 ;; panel's context cannot be quickly saved and restored."
                                 :retainContextWhenHidden true
                                 :enableFindWidget true}))]
-    (add-listeners! webview-panel)
-    (set-webview-html! context {:webview-panel webview-panel})
-    (add-subscriptions! context {:webview-panel webview-panel})
-    webview-panel))
+    (initialize-webview-panel context webview-panel nil)
+    (reset! repl-output-webview-panel webview-panel)))
 
 ;; TODO: Add tests
 (defn deserialize-webview-panel
   [context ^js webview-panel ^js state]
   (js/Promise.
    (fn [resolve _reject]
-     (add-listeners! webview-panel)
-     (if (and state (.-html state))
-       (set! (.. webview-panel -webview -html) (.-html state))
-       (set-webview-html! context {:webview-panel webview-panel}))
-     (add-subscriptions! context {:webview-panel webview-panel})
-     (reset! repl-output-webview-panel webview-panel)
-     (let [[scroll-left scroll-top] (when state [(.-scrollLeft state) (.-scrollTop state)])]
-       (post-message-to-webview webview-panel {:command/name "scroll-to"
-                                               :x scroll-left
-                                               :y scroll-top}))
-     (post-message-to-webview webview-panel {:command/name "restore-copy-buttons"})
+     (initialize-webview-panel context webview-panel state)
      (resolve nil))))
 
 (defn register-output-view-webview-serializer!

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -128,7 +128,7 @@
                      nil)]
     (if code-theme
       (post-message-to-webview webview-panel {:command/name "set-code-theme"
-                                              :content code-theme})
+                                              :code-theme code-theme})
       (util/log-to-console
        :error
        "Cannot set code theme in output webview. There is no code theme set for the ColorThemeKind enum value of"
@@ -196,8 +196,8 @@
                 (reset! repl-output-webview-panel webview-panel)
                 (let [[scroll-left scroll-top] (when state [(.-scrollLeft state) (.-scrollTop state)])]
                   (post-message-to-webview webview-panel {:command/name "scroll-to"
-                                                          :content {:x scroll-left
-                                                                    :y scroll-top}}))
+                                                          :x scroll-left
+                                                          :y scroll-top}))
                 (js/Promise.
                  (fn [resolve _reject]
                    (resolve nil))))}))))
@@ -229,10 +229,10 @@
         command-name (get output-category->command-name output-category)]
     (if command-name
       (post-message-to-webview @repl-output-webview-panel {:command/name command-name
-                                                           :content message})
+                                                           :output message})
       (util/log-to-console
        :error
-       (str "Cannot append content to output webview. No outputCategory matches \"" output-category "\"")))))
+       (str "Cannot append output to output webview. No outputCategory matches \"" output-category "\"")))))
 
 (def stacktrace-classes-to-ignore
   #{"clojure.lang.RestFn"
@@ -258,7 +258,7 @@
   (let [stacktrace (js->clj stacktrace :keywordize-keys true)
         stacktrace-message (stacktrace->message stacktrace)]
     (post-message-to-webview @repl-output-webview-panel {:command/name "show-stdout"
-                                                         :content stacktrace-message})))
+                                                         :output stacktrace-message})))
 
 (defn ^:export clear-output-view []
   (post-message-to-webview @repl-output-webview-panel {:command/name "clear-output-view"}))

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -187,7 +187,6 @@
          "calva.output-view"
          #js {:deserializeWebviewPanel
               (fn [^js webview-panel ^js state]
-                (js/console.log "Deserializing webview panel with state:" state)
                 (add-listeners! webview-panel)
                 (if (and state (.-html state))
                   (set! (.. webview-panel -webview -html) (.-html state))

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -152,6 +152,10 @@
             (.. ^js vscode-context -subscriptions (push subscription)))
           subscriptions)))
 
+(defn add-listeners!
+  [^js webview-panel]
+  (.. webview-panel (onDidDispose (fn [] (dispose-repl-output-webview-panel repl-output-webview-panel)))))
+
 (defn create-repl-output-webview-panel
   [{:keys [vscode/vscode] :as context}]
   (let [webview-panel (.. ^js vscode -window
@@ -169,14 +173,13 @@
                                 ;; panel's context cannot be quickly saved and restored."
                                 :retainContextWhenHidden true
                                 :enableFindWidget true}))]
-    (.. ^js webview-panel (onDidDispose (fn [] (dispose-repl-output-webview-panel repl-output-webview-panel))))
+    (add-listeners! webview-panel)
     (set-webview-html! context {:webview-panel webview-panel})
     (add-subscriptions! context {:webview-panel webview-panel})
     webview-panel))
 
 (defn register-output-view-webview-serializer!
   [context]
-  (js/console.log "registering output view webview serializer")
   (let [vscode (:vscode/vscode context)]
     (.. vscode -window
         (registerWebviewPanelSerializer
@@ -184,16 +187,14 @@
          #js {:deserializeWebviewPanel
               (fn [^js webview-panel ^js state]
                 (js/console.log "Deserializing webview panel with state:" state)
-                (.. ^js webview-panel (onDidDispose
-                                       (fn [] (dispose-repl-output-webview-panel repl-output-webview-panel))))
-                ;; Set up the panel as you would for a new one:
-                #_(set-webview-html! context {:webview-panel webview-panel})
-                (set! (.. webview-panel -webview -html) (str "<html><body>" (.. state -message) "</body></html>"))
+                (add-listeners! webview-panel)
+                (if (and state (.. state -html))
+                  (set! (.. webview-panel -webview -html) (.. state -html))
+                  (set-webview-html! context {:webview-panel webview-panel}))
                 (add-subscriptions! context {:webview-panel webview-panel})
-                ;; If you need to restore state, do it here.
+                (reset! repl-output-webview-panel webview-panel)
                 (js/Promise.
                  (fn [resolve _reject]
-                   (js/console.log "Webview panel deserialized and ready.")
                    (resolve nil))))}))))
 
 (defn ^:export show-repl-output-webview-panel

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -174,21 +174,27 @@
     (add-subscriptions! context {:webview-panel webview-panel})
     webview-panel))
 
-(comment
-  ;; TODO: Try defining a class that implements the vscode.WebviewPanelSerializer interface
-  ;; since the serializer works when it's registered with TypeScript.
-  ;; https://search.brave.com/search?q=clojurescript+how+to+create+a+javascript+class&source=web&summary=1&conversation=09004192282d3a04e1a76b
-  (.. @util/vscode -window (registerWebviewPanelSerializer
-                            "calva.output-view"
-                            (clj->js {:deserializeWebviewPanel
-                                      (fn [webview-panel state]
-                                        (js/console.log "hello from outside the promise callback")
-                                        (set! (.. webview-panel -webview -html) "<html><body>Hello world</body></html>")
-                                        (js/Promise. (fn [resolve]
-                                                       (js/console.log "Hello from inside the promise callback")
-                                                       (js/console.log "Deserializing webview panel with state:" state)
-                                                       (resolve nil))))})))
-  :rcf)
+(defn register-output-view-webview-serializer!
+  [context]
+  (js/console.log "registering output view webview serializer")
+  (let [vscode (:vscode/vscode context)]
+    (.. vscode -window
+        (registerWebviewPanelSerializer
+         "calva.output-view"
+         #js {:deserializeWebviewPanel
+              (fn [^js webview-panel ^js state]
+                (js/console.log "Deserializing webview panel with state:" state)
+                (.. ^js webview-panel (onDidDispose
+                                       (fn [] (dispose-repl-output-webview-panel repl-output-webview-panel))))
+                ;; Set up the panel as you would for a new one:
+                #_(set-webview-html! context {:webview-panel webview-panel})
+                (set! (.. webview-panel -webview -html) (str "<html><body>" (.. state -message) "</body></html>"))
+                (add-subscriptions! context {:webview-panel webview-panel})
+                ;; If you need to restore state, do it here.
+                (js/Promise.
+                 (fn [resolve _reject]
+                   (js/console.log "Webview panel deserialized and ready.")
+                   (resolve nil))))}))))
 
 (defn ^:export show-repl-output-webview-panel
   [preserve-focus?]
@@ -250,3 +256,9 @@
 
 (defn ^:export clear-output-view []
   (post-message-to-webview @repl-output-webview-panel {:command/name "clear-output-view"}))
+
+(defn ^:export register-output-view-webview-serializer
+  []
+  (register-output-view-webview-serializer! {:vscode/vscode @util/vscode
+                                             :vscode/context @util/vscode-context
+                                             :env/is-debug (:is-debug util/env)}))

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -156,7 +156,7 @@
   [{:keys [vscode/vscode] :as context}]
   (let [webview-panel (.. ^js vscode -window
                           (createWebviewPanel
-                           "calva:repl-output"
+                           "calva.output-view"
                            "REPL Output"
                            #js {:preserveFocus true
                                 :viewColumn (.. ^js vscode -ViewColumn -Beside)}
@@ -173,6 +173,19 @@
     (set-webview-html! context {:webview-panel webview-panel})
     (add-subscriptions! context {:webview-panel webview-panel})
     webview-panel))
+
+(comment
+  (.. @util/vscode -window (registerWebviewPanelSerializer
+                            "calva.output-view"
+                            (clj->js {:deserializeWebviewPanel
+                                      (fn [webview-panel state]
+                                        (set! (.. webview-panel -webview -html) "<html><body>Hello world</body></html>")
+                                        (js/console.log "hello from outside the promise callback")
+                                        (js/Promise. (fn [resolve]
+                                                       (js/console.log "Hello from inside the promise callback")
+                                                       (js/console.log "Deserializing webview panel with state:" state)
+                                                       (resolve nil))))})))
+  :rcf)
 
 (defn ^:export show-repl-output-webview-panel
   [preserve-focus?]

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -175,12 +175,15 @@
     webview-panel))
 
 (comment
+  ;; TODO: Try defining a class that implements the vscode.WebviewPanelSerializer interface
+  ;; since the serializer works when it's registered with TypeScript.
+  ;; https://search.brave.com/search?q=clojurescript+how+to+create+a+javascript+class&source=web&summary=1&conversation=09004192282d3a04e1a76b
   (.. @util/vscode -window (registerWebviewPanelSerializer
                             "calva.output-view"
                             (clj->js {:deserializeWebviewPanel
                                       (fn [webview-panel state]
-                                        (set! (.. webview-panel -webview -html) "<html><body>Hello world</body></html>")
                                         (js/console.log "hello from outside the promise callback")
+                                        (set! (.. webview-panel -webview -html) "<html><body>Hello world</body></html>")
                                         (js/Promise. (fn [resolve]
                                                        (js/console.log "Hello from inside the promise callback")
                                                        (js/console.log "Deserializing webview panel with state:" state)

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -178,6 +178,7 @@
     (add-subscriptions! context {:webview-panel webview-panel})
     webview-panel))
 
+;; TODO: Add tests
 (defn register-output-view-webview-serializer!
   [context]
   (let [vscode (:vscode/vscode context)]
@@ -188,11 +189,15 @@
               (fn [^js webview-panel ^js state]
                 (js/console.log "Deserializing webview panel with state:" state)
                 (add-listeners! webview-panel)
-                (if (and state (.. state -html))
-                  (set! (.. webview-panel -webview -html) (.. state -html))
+                (if (and state (.-html state))
+                  (set! (.. webview-panel -webview -html) (.-html state))
                   (set-webview-html! context {:webview-panel webview-panel}))
                 (add-subscriptions! context {:webview-panel webview-panel})
                 (reset! repl-output-webview-panel webview-panel)
+                (let [[scroll-left scroll-top] (when state [(.-scrollLeft state) (.-scrollTop state)])]
+                  (post-message-to-webview webview-panel {:command/name "scroll-to"
+                                                          :content {:x scroll-left
+                                                                    :y scroll-top}}))
                 (js/Promise.
                  (fn [resolve _reject]
                    (resolve nil))))}))))

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -181,24 +181,24 @@
 ;; TODO: Add tests
 (defn register-output-view-webview-serializer!
   [context]
-  (let [vscode (:vscode/vscode context)]
+  (let [^js vscode (:vscode/vscode context)]
     (.. vscode -window
         (registerWebviewPanelSerializer
          "calva.output-view"
          #js {:deserializeWebviewPanel
               (fn [^js webview-panel ^js state]
-                (add-listeners! webview-panel)
-                (if (and state (.-html state))
-                  (set! (.. webview-panel -webview -html) (.-html state))
-                  (set-webview-html! context {:webview-panel webview-panel}))
-                (add-subscriptions! context {:webview-panel webview-panel})
-                (reset! repl-output-webview-panel webview-panel)
-                (let [[scroll-left scroll-top] (when state [(.-scrollLeft state) (.-scrollTop state)])]
-                  (post-message-to-webview webview-panel {:command/name "scroll-to"
-                                                          :x scroll-left
-                                                          :y scroll-top}))
                 (js/Promise.
                  (fn [resolve _reject]
+                   (add-listeners! webview-panel)
+                   (if (and state (.-html state))
+                     (set! (.. webview-panel -webview -html) (.-html state))
+                     (set-webview-html! context {:webview-panel webview-panel}))
+                   (add-subscriptions! context {:webview-panel webview-panel})
+                   (reset! repl-output-webview-panel webview-panel)
+                   (let [[scroll-left scroll-top] (when state [(.-scrollLeft state) (.-scrollTop state)])]
+                     (post-message-to-webview webview-panel {:command/name "scroll-to"
+                                                             :x scroll-left
+                                                             :y scroll-top}))
                    (resolve nil))))}))))
 
 (defn ^:export show-repl-output-webview-panel

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -189,7 +189,6 @@
     (initialize-webview-panel context webview-panel nil)
     (reset! repl-output-webview-panel webview-panel)))
 
-;; TODO: Add tests
 (defn deserialize-webview-panel
   [context ^js webview-panel ^js state]
   (js/Promise.

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -179,28 +179,30 @@
     webview-panel))
 
 ;; TODO: Add tests
+(defn deserialize-webview-panel
+  [context ^js webview-panel ^js state]
+  (js/Promise.
+   (fn [resolve _reject]
+     (add-listeners! webview-panel)
+     (if (and state (.-html state))
+       (set! (.. webview-panel -webview -html) (.-html state))
+       (set-webview-html! context {:webview-panel webview-panel}))
+     (add-subscriptions! context {:webview-panel webview-panel})
+     (reset! repl-output-webview-panel webview-panel)
+     (let [[scroll-left scroll-top] (when state [(.-scrollLeft state) (.-scrollTop state)])]
+       (post-message-to-webview webview-panel {:command/name "scroll-to"
+                                               :x scroll-left
+                                               :y scroll-top}))
+     (post-message-to-webview webview-panel {:command/name "restore-copy-buttons"})
+     (resolve nil))))
+
 (defn register-output-view-webview-serializer!
   [context]
   (let [^js vscode (:vscode/vscode context)]
     (.. vscode -window
         (registerWebviewPanelSerializer
          "calva.output-view"
-         #js {:deserializeWebviewPanel
-              (fn [^js webview-panel ^js state]
-                (js/Promise.
-                 (fn [resolve _reject]
-                   (add-listeners! webview-panel)
-                   (if (and state (.-html state))
-                     (set! (.. webview-panel -webview -html) (.-html state))
-                     (set-webview-html! context {:webview-panel webview-panel}))
-                   (add-subscriptions! context {:webview-panel webview-panel})
-                   (reset! repl-output-webview-panel webview-panel)
-                   (let [[scroll-left scroll-top] (when state [(.-scrollLeft state) (.-scrollTop state)])]
-                     (post-message-to-webview webview-panel {:command/name "scroll-to"
-                                                             :x scroll-left
-                                                             :y scroll-top}))
-                   (post-message-to-webview webview-panel {:command/name "restore-copy-buttons"})
-                   (resolve nil))))}))))
+         #js {:deserializeWebviewPanel (partial deserialize-webview-panel context)}))))
 
 (defn ^:export show-repl-output-webview-panel
   [preserve-focus?]

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -67,11 +67,11 @@
 
 (defn append-evaluated-code
   "Appends evaluated code to the given dom element."
-  [^js dom-element content]
+  [^js dom-element {:keys [output]}]
   (let [div (js/document.createElement "div")
         span (js/document.createElement "span")
         span-text-node (js/document.createTextNode "Evaluated code")
-        {:keys [container-element code-element]} (clojure-code-element content)]
+        {:keys [container-element code-element]} (clojure-code-element output)]
     (.. span -classList (add "border-text"))
     (.. span (appendChild span-text-node))
     (.. div -classList (add "evaluated-code-container"))
@@ -82,8 +82,8 @@
     (.. dom-element (dispatchEvent (output-appended-event div)))))
 
 (defn append-eval-result
-  [^js dom-element content]
-  (let [{:keys [code-element container-element]} (clojure-code-element content)]
+  [^js dom-element {:keys [output]}]
+  (let [{:keys [code-element container-element]} (clojure-code-element output)]
     (.. dom-element (appendChild container-element))
     (.. js/window -hljs (highlightElement code-element))
     (.. dom-element (dispatchEvent (output-appended-event container-element)))))
@@ -100,8 +100,8 @@
 (defn append-stdout
   "Appends stdout content to the given DOM element, unless the last element is already a stdout element,
    in which case it appends the content to that element instead."
-  [^js dom-element content]
-  (let [text-node (js/document.createTextNode (strip-ansi content))]
+  [^js dom-element {:keys [output]}]
+  (let [text-node (js/document.createTextNode (strip-ansi output))]
     (if-let [last-output-element (.. dom-element -lastElementChild)]
       (if (= "stdout" (.. last-output-element -dataset -outputElementType))
         (do
@@ -129,11 +129,11 @@
                    (.. copy-container-node -style (setProperty "--hljs-theme-padding" code-padding)))))))
 
 (defn set-code-theme!
-  [theme]
+  [{:keys [code-theme]}]
   (let [code-theme-link-nodes (js/document.querySelectorAll "[data-code-theme]")]
     (.. code-theme-link-nodes (forEach (fn [^js node]
-                                         (let [code-theme (.. node -dataset -codeTheme)]
-                                           (if (= code-theme theme)
+                                         (let [current-code-theme (.. node -dataset -codeTheme)]
+                                           (if (= current-code-theme code-theme)
                                              (.. node (removeAttribute "disabled"))
                                              (.. node (setAttribute "disabled" "disabled")))))))
     ;; The timeout seems to prevent an issue where the copy buttons lose some of their styles on theme change.
@@ -147,15 +147,14 @@
 (defn handle-message
   [^js output-dom-element ^js message]
   (let [message-data (reader/read-string (.-data message))
-        command-name (:command/name message-data)
-        content (:content message-data)]
+        command-name (:command/name message-data)]
     (case command-name
-      "show-result" (append-eval-result output-dom-element content)
-      "show-evaluated-code" (append-evaluated-code output-dom-element content)
-      "show-stdout" (append-stdout output-dom-element content)
+      "show-result" (append-eval-result output-dom-element message-data)
+      "show-evaluated-code" (append-evaluated-code output-dom-element message-data)
+      "show-stdout" (append-stdout output-dom-element message-data)
       "clear-output-view" (clear-output-view output-dom-element)
-      "set-code-theme" (set-code-theme! content)
-      "scroll-to" (scroll-to content))))
+      "set-code-theme" (set-code-theme! message-data)
+      "scroll-to" (scroll-to message-data))))
 
 (defn handle-output-appended
   [^js _event]

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -35,14 +35,6 @@
   []
   (js/scrollTo 0 js/document.documentElement.scrollHeight))
 
-(comment
-  js/document.documentElement.scrollTop
-  js/document.documentElement.scrollLeft
-  js/document.documentElement.scrollHeight
-
-  (js/scrollTo 0)
-  :rcf)
-
 ;; This can be adjusted if needed to avoid performance issues with too frequent scrolling.
 (def throttled-scroll-to-bottom (throttle-fn scroll-to-bottom 0))
 
@@ -141,7 +133,6 @@
 
 (defn scroll-to
   [{:keys [x y]}]
-  (js/console.log "scrolling to:" x y)
   (js/scrollTo x y))
 
 (defn handle-message
@@ -160,29 +151,21 @@
   [^js _event]
   (throttled-scroll-to-bottom))
 
-(defn set-state
-  []
-  (js/console.log "saving state")
-  (.. vscode (setState #js {:html (.. js/document.documentElement -outerHTML)})))
-
-(def throttled-set-state (throttle-fn set-state 1000))
-
 (defn merge-state
-  [new-state]
-  (let [current-state (.. vscode (getState))]
-    (.. vscode (setState (merge current-state new-state)))))
+  [state]
+  (.. vscode (setState (js/Object.assign (or (.. vscode (getState)) #js {})
+                                         (clj->js state)))))
 
-(comment
-  (.. vscode (setState {:a 1}))
-  (.. vscode (getState))
+(defn save-html
+  []
+  (merge-state {:html (.. js/document.documentElement -outerHTML)}))
 
-  (merge-state {:b 2})
-  :rcf)
+(def throttled-save-html (throttle-fn save-html 1000))
 
 (defn handle-document-mutations
   [_mutation-list, _observer]
   ;; Throttle to avoid performance issues with high volume output.
-  (throttled-set-state))
+  (throttled-save-html))
 
 (defn observe-document-mutations
   []
@@ -192,10 +175,18 @@
                                                :attributes true
                                                :characterData true})))
 
+(defn save-scroll-state
+  []
+  (merge-state {:scrollLeft js/document.documentElement.scrollLeft
+                :scrollTop js/document.documentElement.scrollTop}))
+
+(def throttled-save-scroll-state (throttle-fn save-scroll-state 200))
+
 (defn add-event-listeners
   [^js output-dom-element]
   (.. js/window (addEventListener "message" (partial handle-message output-dom-element)))
-  (.. output-dom-element (addEventListener "output-appended" handle-output-appended)))
+  (.. output-dom-element (addEventListener "output-appended" handle-output-appended))
+  (.. js/document (addEventListener "scroll" throttled-save-scroll-state)))
 
 (defn ^:export main []
   (add-event-listeners output-dom-element)

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -136,7 +136,7 @@
   (js/scrollTo x y))
 
 (defn restore-copy-buttons
-  "Re-initializes copy buttons from CopyButtonPlugin (highlightjs-copy - highlight.js plugin) so they they look
+  "Re-initializes copy buttons from CopyButtonPlugin (highlightjs-copy - highlight.js plugin) so they look
    correct and function correctly after the webview HTML is restored from state."
   []
   (.. js/document (querySelectorAll "pre code")

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -139,6 +139,11 @@
     ;; The timeout seems to prevent an issue where the copy buttons lose some of their styles on theme change.
     (js/setTimeout update-theme-of-copy-buttons 100)))
 
+(defn scroll-to
+  [{:keys [x y]}]
+  (js/console.log "scrolling to:" x y)
+  (js/scrollTo x y))
+
 (defn handle-message
   [^js output-dom-element ^js message]
   (let [message-data (reader/read-string (.-data message))
@@ -149,7 +154,8 @@
       "show-evaluated-code" (append-evaluated-code output-dom-element content)
       "show-stdout" (append-stdout output-dom-element content)
       "clear-output-view" (clear-output-view output-dom-element)
-      "set-code-theme" (set-code-theme! content))))
+      "set-code-theme" (set-code-theme! content)
+      "scroll-to" (scroll-to content))))
 
 (defn handle-output-appended
   [^js _event]
@@ -158,11 +164,21 @@
 (defn set-state
   []
   (js/console.log "saving state")
-  (.. vscode (setState #js {:html (.. js/document.documentElement -outerHTML)
-                            :scrollLeft js/document.documentElement.scrollLeft
-                            :scrollTop js/document.documentElement.scrollTop})))
+  (.. vscode (setState #js {:html (.. js/document.documentElement -outerHTML)})))
 
 (def throttled-set-state (throttle-fn set-state 1000))
+
+(defn merge-state
+  [new-state]
+  (let [current-state (.. vscode (getState))]
+    (.. vscode (setState (merge current-state new-state)))))
+
+(comment
+  (.. vscode (setState {:a 1}))
+  (.. vscode (getState))
+
+  (merge-state {:b 2})
+  :rcf)
 
 (defn handle-document-mutations
   [_mutation-list, _observer]

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -135,6 +135,17 @@
   [{:keys [x y]}]
   (js/scrollTo x y))
 
+(defn restore-copy-buttons
+  "Re-initializes copy buttons from CopyButtonPlugin (highlightjs-copy - highlight.js plugin) so they they look
+   correct and function correctly after the webview HTML is restored from state."
+  []
+  (.. js/document (querySelectorAll "pre code")
+      (forEach (fn [^js element]
+                 (js-delete (.. element -dataset) "highlighted")
+                 (when-let [copy-container (.. element -parentElement (querySelector ".hljs-copy-container"))]
+                   (.. copy-container (remove)))
+                 (.. js/window -hljs (highlightElement element))))))
+
 (defn handle-message
   [^js output-dom-element ^js message]
   (let [message-data (reader/read-string (.-data message))
@@ -145,7 +156,8 @@
       "show-stdout" (append-stdout output-dom-element message-data)
       "clear-output-view" (clear-output-view output-dom-element)
       "set-code-theme" (set-code-theme! message-data)
-      "scroll-to" (scroll-to message-data))))
+      "scroll-to" (scroll-to message-data)
+      "restore-copy-buttons" (restore-copy-buttons))))
 
 (defn handle-output-appended
   [^js _event]

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -7,6 +7,8 @@
 ;; The DOM element where output is written
 (def output-dom-element (js/document.getElementById "output"))
 
+(defonce vscode (js/acquireVsCodeApi))
+
 (defn throttle-fn
   "Returns a throttled version of the function, which will only be called at most once every `wait`
    milliseconds with the arguments passed in the latest call.
@@ -145,6 +147,18 @@
   [^js output-dom-element ^js _event]
   (throttled-scroll-to-bottom output-dom-element))
 
+(defn handle-document-mutations
+  [_mutation-list, _observer]
+  (.. vscode (setState #js {:html (.. js/document.documentElement -outerHTML)})))
+
+(defn observe-document-mutations
+  []
+  (doto (js/MutationObserver. handle-document-mutations)
+    (.observe js/document.documentElement #js {:childList true
+                                               :subtree true
+                                               :attributes true
+                                               :characterData true})))
+
 (defn add-event-listeners
   [^js output-dom-element]
   (.. js/window (addEventListener "message" (partial handle-message output-dom-element)))
@@ -152,4 +166,5 @@
 
 (defn ^:export main []
   (add-event-listeners output-dom-element)
+  (observe-document-mutations)
   (.. js/window -hljs (addPlugin (CopyButtonPlugin. #js {:autohide true}))))

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -32,8 +32,16 @@
 
 (defn scroll-to-bottom
   "Scrolls to the bottom of the the given dom element."
-  [^js dom-element]
-  (.. dom-element (scrollIntoView #js {:behavior "instant" :block "end"})))
+  []
+  (js/scrollTo 0 js/document.documentElement.scrollHeight))
+
+(comment
+  js/document.documentElement.scrollTop
+  js/document.documentElement.scrollLeft
+  js/document.documentElement.scrollHeight
+
+  (js/scrollTo 0)
+  :rcf)
 
 ;; This can be adjusted if needed to avoid performance issues with too frequent scrolling.
 (def throttled-scroll-to-bottom (throttle-fn scroll-to-bottom 0))
@@ -144,12 +152,22 @@
       "set-code-theme" (set-code-theme! content))))
 
 (defn handle-output-appended
-  [^js output-dom-element ^js _event]
-  (throttled-scroll-to-bottom output-dom-element))
+  [^js _event]
+  (throttled-scroll-to-bottom))
+
+(defn set-state
+  []
+  (js/console.log "saving state")
+  (.. vscode (setState #js {:html (.. js/document.documentElement -outerHTML)
+                            :scrollLeft js/document.documentElement.scrollLeft
+                            :scrollTop js/document.documentElement.scrollTop})))
+
+(def throttled-set-state (throttle-fn set-state 1000))
 
 (defn handle-document-mutations
   [_mutation-list, _observer]
-  (.. vscode (setState #js {:html (.. js/document.documentElement -outerHTML)})))
+  ;; Throttle to avoid performance issues with high volume output.
+  (throttled-set-state))
 
 (defn observe-document-mutations
   []
@@ -162,7 +180,7 @@
 (defn add-event-listeners
   [^js output-dom-element]
   (.. js/window (addEventListener "message" (partial handle-message output-dom-element)))
-  (.. output-dom-element (addEventListener "output-appended" (partial handle-output-appended output-dom-element))))
+  (.. output-dom-element (addEventListener "output-appended" handle-output-appended)))
 
 (defn ^:export main []
   (add-event-listeners output-dom-element)

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -160,6 +160,35 @@
         (is (= 1 (count calls)))
         (is (fn? (type (ffirst calls))))))))
 
+(deftest initialize-webview-panel-test
+  (testing "Given a context, a webview panel, and an nil state,"
+    (let [on-did-dispose-spy (spy/spy)
+          stub-webview-panel (clj->js {:onDidDispose (test-util/wrap-spy on-did-dispose-spy)})
+          set-webview-html-spy (spy/spy)
+          add-subscriptions-spy (spy/spy)
+          post-message-to-webview-spy (spy/spy)
+          context {:some "context"}]
+      (with-redefs [sut/set-webview-html! (test-util/wrap-spy set-webview-html-spy)
+                    sut/add-subscriptions! (test-util/wrap-spy add-subscriptions-spy)
+                    sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)]
+        (sut/initialize-webview-panel context stub-webview-panel nil)
+        (testing "should call onDidDispose with expected args"
+          (let [calls (spy/calls on-did-dispose-spy)]
+            (is (= 1 (count calls)))
+            (is (match? [(list fn?)] calls))))
+        (testing "should call set-webview-html! with expected args"
+          (is (spy/called-once-with? set-webview-html-spy context {:webview-panel stub-webview-panel})))
+        (testing "should call add-subscriptions! with expected args"
+          (is (spy/called-once-with? add-subscriptions-spy context {:webview-panel stub-webview-panel})))
+        (testing "should call post-message-to-webview twice with expected args"
+          (is (= 2 (spy/call-count post-message-to-webview-spy)))
+          (is (spy/called-with? post-message-to-webview-spy stub-webview-panel
+                                {:command/name "scroll-to"
+                                 :x nil
+                                 :y nil}))
+          (is (spy/called-with? post-message-to-webview-spy stub-webview-panel
+                                {:command/name "restore-copy-buttons"})))))))
+
 (deftest create-repl-output-webview-panel-test
   (testing "Given a context,"
     (let [on-did-dispose-spy (spy/spy)
@@ -169,9 +198,11 @@
                                                      (test-util/wrap-spy create-webview-panel-spy)}
                                             :ViewColumn {:Beside 1}})}
           set-webview-html-spy (spy/spy)
-          add-subscriptions-spy (spy/spy)]
+          add-subscriptions-spy (spy/spy)
+          initialize-webview-panel-spy (spy/spy)]
       (with-redefs [sut/set-webview-html! (test-util/wrap-spy set-webview-html-spy)
-                    sut/add-subscriptions! (test-util/wrap-spy add-subscriptions-spy)]
+                    sut/add-subscriptions! (test-util/wrap-spy add-subscriptions-spy)
+                    sut/initialize-webview-panel (test-util/wrap-spy initialize-webview-panel-spy)]
         (let [result (sut/create-repl-output-webview-panel context)]
           (testing "should call createWebviewPanel with expacted args"
             (let [calls (spy/calls create-webview-panel-spy)]
@@ -181,14 +212,8 @@
                         {:preserveFocus true, :viewColumn 1}
                         {:enableScripts true, :retainContextWhenHidden true, :enableFindWidget true})]
                      (js->clj calls :keywordize-keys true)))))
-          (testing "should call onDidDispose with expected args"
-            (let [calls (spy/calls on-did-dispose-spy)]
-              (is (= 1 (count calls)))
-              (is (match? [(list fn?)] calls))))
-          (testing "should call set-webview-html! with expected args"
-            (is (spy/called-once-with? set-webview-html-spy context {:webview-panel stub-webview-panel})))
-          (testing "should call add-subscriptions! with expected args"
-            (is (spy/called-once-with? add-subscriptions-spy context {:webview-panel stub-webview-panel})))
+          (testing "should call initialize-webview-panel with expected args"
+            (is (spy/called-once-with? initialize-webview-panel-spy context stub-webview-panel nil)))
           (testing "should return the webview panel"
             (is (= stub-webview-panel result))))))))
 

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -116,28 +116,28 @@
             (sut/set-code-theme! context {:color-theme-kind (:Dark color-theme-kind-enum)
                                           :webview-panel webview-panel})
             (is (spy/called-once-with? post-message-to-webview-spy webview-panel {:command/name "set-code-theme"
-                                                                                  :content "dark"})))))
+                                                                                  :code-theme "dark"})))))
       (testing "when the ColorThemeKind is Light, should set the code theme to light"
         (let [post-message-to-webview-spy (spy/spy)]
           (with-redefs [sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)]
             (sut/set-code-theme! context {:color-theme-kind (:Light color-theme-kind-enum)
                                           :webview-panel webview-panel})
             (is (spy/called-once-with? post-message-to-webview-spy webview-panel {:command/name "set-code-theme"
-                                                                                  :content "light"})))))
+                                                                                  :code-theme "light"})))))
       (testing "when the ColorThemeKind is HighContrast, should set the code theme to high-contrast"
         (let [post-message-to-webview-spy (spy/spy)]
           (with-redefs [sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)]
             (sut/set-code-theme! context {:color-theme-kind (:HighContrast color-theme-kind-enum)
                                           :webview-panel webview-panel})
             (is (spy/called-once-with? post-message-to-webview-spy webview-panel {:command/name "set-code-theme"
-                                                                                  :content "high-contrast"})))))
+                                                                                  :code-theme "high-contrast"})))))
       (testing "when the ColorThemeKind is HighContrastLight, should set the code theme to high-contrast-light"
         (let [post-message-to-webview-spy (spy/spy)]
           (with-redefs [sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)]
             (sut/set-code-theme! context {:color-theme-kind (:HighContrastLight color-theme-kind-enum)
                                           :webview-panel webview-panel})
             (is (spy/called-once-with? post-message-to-webview-spy webview-panel {:command/name "set-code-theme"
-                                                                                  :content "high-contrast-light"})))))
+                                                                                  :code-theme "high-contrast-light"})))))
       (testing "when there is no configured code theme for the ColorThemeKind, should log the expected error"
         (let [log-to-console-spy (spy/spy)
               color-theme-kind 99]
@@ -176,7 +176,7 @@
           (testing "should call createWebviewPanel with expacted args"
             (let [calls (spy/calls create-webview-panel-spy)]
               (is (= 1 (count calls)))
-              (is (= '[("calva:repl-output"
+              (is (= '[("calva.output-view"
                         "REPL Output"
                         {:preserveFocus true, :viewColumn 1}
                         {:enableScripts true, :retainContextWhenHidden true, :enableFindWidget true})]
@@ -259,7 +259,7 @@
           (is (spy/called-once-with? post-message-to-webview-spy
                                      "webview-panel-stub"
                                      {:command/name "show-stdout"
-                                      :content message})))))
+                                      :output message})))))
     (testing "when command does not exist for output category,"
       (let [options (clj->js {:outputCategory "nonexistent-category"})
             message "some-message"
@@ -276,7 +276,7 @@
             (is (spy/called-once-with?
                  log-to-console-spy
                  :error
-                 "Cannot append content to output webview. No outputCategory matches \"nonexistent-category\""))))))))
+                 "Cannot append output to output webview. No outputCategory matches \"nonexistent-category\""))))))))
 
 (deftest stacktrace->message-test
   (testing "Given a stacktrace with no duplicate flags and no classes to ignore, should return the expected message"
@@ -359,7 +359,7 @@
           (is (spy/called-once-with? post-message-to-webview-spy
                                      "webview-panel-stub"
                                      {:command/name "show-stdout"
-                                      :content "some-message"})))))))
+                                      :output "some-message"})))))))
 
 (deftest clear-output-view-test
   (testing "Should call post-message-to-webview with expected args"

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -435,7 +435,8 @@
       (let [calls (spy/calls register-webview-panel-serializer-spy)]
         (is (= 1 (count calls)))
         (is (= "calva.output-view" (ffirst calls)))
-        (is (some? (-> calls first second .-deserializeWebviewPanel type)))))))
+        (let [webview-panel-serializer (-> calls first second)]
+          (is (some? ^js (.-deserializeWebviewPanel webview-panel-serializer))))))))
 
 (deftest deserialize-webview-panel-test
   (testing "Given a context, a webview panel, and a state, should return a promise that resolves after calling

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -371,4 +371,16 @@
                                    "webview-panel-stub"
                                    {:command/name "clear-output-view"}))))))
 
+(deftest register-output-view-webview-serializer!-test
+  (testing "Given a context, should call registerWebviewPanelSerializer with expected args"
+    (let [register-webview-panel-serializer-spy (spy/spy)
+          context {:vscode/vscode (clj->js {:window {:registerWebviewPanelSerializer
+                                                     (test-util/wrap-spy register-webview-panel-serializer-spy)}})}]
+      (sut/register-output-view-webview-serializer! context)
+      (let [calls (spy/calls register-webview-panel-serializer-spy)]
+        (is (= 1 (count calls)))
+        (is (= "calva.output-view" (ffirst calls)))
+        (is (some? (-> calls first second .-deserializeWebviewPanel type)))))))
+
+(deftest deserialize-webview-panel-test)
 #_(run-tests)

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -407,5 +407,17 @@
         (is (= "calva.output-view" (ffirst calls)))
         (is (some? (-> calls first second .-deserializeWebviewPanel type)))))))
 
-(deftest deserialize-webview-panel-test)
+(deftest deserialize-webview-panel-test
+  (testing "Given a context, a webview panel, and a state, should return a promise that resolves after calling
+            initialize-webview-panel with expected args"
+    (let [initialize-webview-panel-spy (spy/spy)
+          context {:some "context"}
+          webview-panel {:some "webview-panel"}
+          state {:some "state"}]
+      (with-redefs [sut/initialize-webview-panel (test-util/wrap-spy initialize-webview-panel-spy)]
+        (let [result (sut/deserialize-webview-panel context webview-panel state)]
+          (.. result
+              (then (fn [_]
+                      (is (spy/called-once-with? initialize-webview-panel-spy context webview-panel state))))))))))
+
 #_(run-tests)

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -187,6 +187,36 @@
                                  :x nil
                                  :y nil}))
           (is (spy/called-with? post-message-to-webview-spy stub-webview-panel
+                                {:command/name "restore-copy-buttons"}))))))
+  (testing "Given a context, a webview panel, and a non-nil state,"
+    (let [on-did-dispose-spy (spy/spy)
+          stub-webview-panel (clj->js {:onDidDispose (test-util/wrap-spy on-did-dispose-spy)
+                                       :webview {}})
+          set-webview-html-spy (spy/spy)
+          add-subscriptions-spy (spy/spy)
+          post-message-to-webview-spy (spy/spy)
+          context {:some "context"}]
+      (with-redefs [sut/set-webview-html! (test-util/wrap-spy set-webview-html-spy)
+                    sut/add-subscriptions! (test-util/wrap-spy add-subscriptions-spy)
+                    sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)]
+        (sut/initialize-webview-panel context stub-webview-panel #js {:html "some-html"
+                                                                      :scrollLeft 77
+                                                                      :scrollTop 88})
+        (testing "should call onDidDispose with expected args"
+          (let [calls (spy/calls on-did-dispose-spy)]
+            (is (= 1 (count calls)))
+            (is (match? [(list fn?)] calls))))
+        (testing "should not call set-webview-html!"
+          (is (spy/not-called? set-webview-html-spy)))
+        (testing "should call add-subscriptions! with expected args"
+          (is (spy/called-once-with? add-subscriptions-spy context {:webview-panel stub-webview-panel})))
+        (testing "should call post-message-to-webview twice with expected args"
+          (is (= 2 (spy/call-count post-message-to-webview-spy)))
+          (is (spy/called-with? post-message-to-webview-spy stub-webview-panel
+                                {:command/name "scroll-to"
+                                 :x 77
+                                 :y 88}))
+          (is (spy/called-with? post-message-to-webview-spy stub-webview-panel
                                 {:command/name "restore-copy-buttons"})))))))
 
 (deftest create-repl-output-webview-panel-test

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,11 +90,6 @@ async function activate(context: vscode.ExtensionContext) {
 
   registerOutputViewWebviewSerializer();
 
-  // vscode.window.registerWebviewPanelSerializer(
-  //   'calva.output-view',
-  //   new CalvaOutputViewSerializer()
-  // );
-
   initializeState();
   state.setExtensionContext(context);
   state.initDepsEdnJackInExecutable();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,6 +79,34 @@ function initializeState() {
   );
 }
 
+class CalvaOutputViewSerializer implements vscode.WebviewPanelSerializer {
+  async deserializeWebviewPanel(webviewPanel: vscode.WebviewPanel, state: any) {
+    console.log('hello from the webview serializer');
+    console.log(`Got state: ${state}`);
+    webviewPanel.webview.html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cat Coding</title>
+</head>
+<body>
+    <img src="https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif" width="300" />
+    <h1 id="lines-of-code-counter">0</h1>
+
+    <script>
+        const counter = document.getElementById('lines-of-code-counter');
+
+        let count = 0;
+        setInterval(() => {
+            counter.textContent = count++;
+        }, 100);
+    </script>
+</body>
+</html>`;
+  }
+}
+
 async function activate(context: vscode.ExtensionContext) {
   console.info('Calva activate START');
 
@@ -86,6 +114,11 @@ async function activate(context: vscode.ExtensionContext) {
   // because requiring the vscode API poses issues with being able to test the cljs lib.
   // We cannot run unit tests on code that imports the vscode API, because it's only available at runtime.
   initializeCljs(vscode, context);
+
+  // vscode.window.registerWebviewPanelSerializer(
+  //   'calva.output-view',
+  //   new CalvaOutputViewSerializer()
+  // );
 
   initializeState();
   state.setExtensionContext(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import {
   setStateValue,
   initializeCljs,
   clearReplOutputView,
+  registerOutputViewWebviewSerializer,
   showReplOutputWebviewPanel,
 } from '../out/cljs-lib/cljs-lib';
 import * as edit from './edit';
@@ -79,34 +80,6 @@ function initializeState() {
   );
 }
 
-class CalvaOutputViewSerializer implements vscode.WebviewPanelSerializer {
-  async deserializeWebviewPanel(webviewPanel: vscode.WebviewPanel, state: any) {
-    console.log('hello from the webview serializer');
-    console.log(`Got state: ${state}`);
-    webviewPanel.webview.html = `<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cat Coding</title>
-</head>
-<body>
-    <img src="https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif" width="300" />
-    <h1 id="lines-of-code-counter">0</h1>
-
-    <script>
-        const counter = document.getElementById('lines-of-code-counter');
-
-        let count = 0;
-        setInterval(() => {
-            counter.textContent = count++;
-        }, 100);
-    </script>
-</body>
-</html>`;
-  }
-}
-
 async function activate(context: vscode.ExtensionContext) {
   console.info('Calva activate START');
 
@@ -114,6 +87,8 @@ async function activate(context: vscode.ExtensionContext) {
   // because requiring the vscode API poses issues with being able to test the cljs lib.
   // We cannot run unit tests on code that imports the vscode API, because it's only available at runtime.
   initializeCljs(vscode, context);
+
+  registerOutputViewWebviewSerializer();
 
   // vscode.window.registerWebviewPanelSerializer(
   //   'calva.output-view',


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- The contents of the output view are reloaded when VS Code is reloaded. (Note: this is different than closing and reopening the output view without closing / reloading VS Code. Contents are not yet preserved in that case.)
- The scroll position is preserved between VS Code reloads
- The `getState` and `setState` API is used, which will also provides a foundation for persisting contents between closing and reopening the output view without reloading VS Code. This work will be done in another PR.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2827

## Todo

- [x] Changed theme should be remembered between closing and reopening
- [x] Scroll to previous scroll position after VS Code is reloaded 
  - Save scrollLeft and scrollHeight on scroll event - maybe throttle
- [x] Make sure copy button is working after a reload of the window + output view - I saw it not changing to "copied" when clicked one time
   - We need to call highlightElement or the function from highlightjs that highlights all elements after the reload of the output view. The highlightjs-copy plugin provides an `"after:highlightElement"` function that highlightjs will call after highlighting an element.
   - **It seems we need to remove the copy buttons before re-highlighting. Just re-highlighting is not working.** This worked when I manually deleted the div with the class `hljs-copy-container` and then ran highlightAll.
- [x] Look into error seen in console after reloading VS Code and the output view reloading
   - `Uncaught TypeError: Cannot read properties of undefined (reading '__vscode_post_message__')`
   - Not sure if this is something we're doing wrong. I don't see anything obvious and things work as they should. I'll leave it for now.
- [x] Make sure existing tests are passing
- [x] Add new tests

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- ~[ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
