### PR TITLE
Flare in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Add option for opening flares in side panel view](https://github.com/BetterThanTomorrow/calva/issues/2873)
+
 ## [2.0.519] - 2025-06-09
 
 - [Support `before` and `after` functions for refresh namespaces commands](https://github.com/BetterThanTomorrow/calva/issues/2862)

--- a/docs/site/flares.md
+++ b/docs/site/flares.md
@@ -41,6 +41,24 @@ To show a webpage, pass a `:url` instead of `:html` in the request:
 The `:key` parameter is optional and can be used to reuse the same WebView panel.
 If omitted, a new WebView panel will be created per request.
 
+## Sidebar vs Panel Display
+
+By default, flares open in a separate WebView panel alongside your code.
+You can also display flares in the Calva sidebar using the `:sidebar-panel?` option:
+
+```clojure
+;; Display in a separate panel (default)
+(tagged-literal 'flare/html {:html "<h1>Hello, Panel!</h1>",
+                             :title "Panel Display"})
+
+;; Display in the Calva sidebar
+(tagged-literal 'flare/html {:html "<h1>Hello, Sidebar!</h1>",
+                             :title "Sidebar Display"
+                             :sidebar-panel? true})
+```
+
+The sidebar Flare view is located in the Calva activity bar section.
+
 ## Try a more interesting example
 
 Let's create an SVG containing circles of varying radii and colors:
@@ -102,6 +120,7 @@ so you can do anything you can do in a browser, there's really no limit.
 | `:reveal` | boolean | true | If true, reveals the panel if it is not visible. |
 | `:column` | integer | vscode.ViewColumn.Beside | See [ViewColumn](https://code.visualstudio.com/api/references/vscode-api#ViewColumn) |
 | `:opts` | map | {:enableScripts true} | See [WebviewOptions](https://code.visualstudio.com/api/references/vscode-api#WebviewOptions) |
+| `:sidebar-panel` | boolean | false | If true, displays the content in the sidebar Flare view instead of a separate panel. |
 
 ### Suggestions welcome
 

--- a/package.json
+++ b/package.json
@@ -3317,12 +3317,14 @@
       "calva": [
         {
           "id": "calva.inspector",
-          "name": "Inspector"
+          "name": "Inspector",
+          "icon": "assets/images/calva-symbol-white.svg"
         },
         {
           "id": "calva.flare",
           "name": "Flare",
-          "type": "webview"
+          "type": "webview",
+          "icon": "assets/images/calva-symbol-white.svg"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -3322,8 +3322,7 @@
         {
           "id": "calva.flare",
           "name": "Flare",
-          "type": "webview",
-          "icon": "$(globe)"
+          "type": "webview"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -3318,6 +3318,12 @@
         {
           "id": "calva.inspector",
           "name": "Inspector"
+        },
+        {
+          "id": "calva.flare",
+          "name": "Flare",
+          "type": "webview",
+          "icon": "$(globe)"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,6 +48,7 @@ import { capitalize } from './utilities';
 import * as overrides from './overrides';
 import * as lsp from './lsp';
 import * as fiddleFiles from './fiddle-files';
+import * as flareHandler from './flare-handler';
 import * as output from './results-output/output';
 import * as inspector from './providers/inspector';
 
@@ -99,6 +100,9 @@ async function activate(context: vscode.ExtensionContext) {
   });
   inspectorDataProvider.treeView = inspectorTreeView;
   vscode.window.registerFileDecorationProvider(new inspector.InspectorItemDecorationProvider());
+
+  // Initialize flare webview provider for sidebar
+  flareHandler.registerFlareWebviewProvider(context);
 
   overrides.activate();
 

--- a/src/flare-handler.ts
+++ b/src/flare-handler.ts
@@ -72,6 +72,11 @@ class CalvaFlareWebviewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'calva.flare';
   private _view?: vscode.WebviewView;
   private _context: vscode.ExtensionContext;
+  private _lastContent?: {
+    html: string;
+    title?: string;
+    key?: string;
+  };
 
   constructor(private readonly context: vscode.ExtensionContext) {
     this._context = context;
@@ -85,15 +90,27 @@ class CalvaFlareWebviewProvider implements vscode.WebviewViewProvider {
     this._view = webviewView;
 
     webviewView.webview.options = {
-      // Allow scripts in the webview
       enableScripts: true,
       localResourceRoots: [this._context.extensionUri],
     };
 
-    webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
+    if (this._lastContent) {
+      webviewView.webview.html = this._lastContent.html;
+      if (this._lastContent.title) {
+        webviewView.title = this._lastContent.title;
+      }
+      if (this._lastContent.key) {
+        (webviewView as CalvaWebView).url = this._lastContent.key;
+        calvaSidebarWebViews[this._lastContent.key] = webviewView as CalvaWebView;
+      }
+    } else {
+      webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
+    }
   }
 
   public updateContent(html: string, title?: string, key?: string) {
+    this._lastContent = { html, title, key };
+
     if (this._view) {
       this._view.webview.html = html;
       if (title) {
@@ -107,8 +124,11 @@ class CalvaFlareWebviewProvider implements vscode.WebviewViewProvider {
   }
 
   public updateUrl(url: string, title?: string, key?: string) {
+    const iframeHtml = urlInIframe(url);
+    this._lastContent = { html: iframeHtml, title, key };
+
     if (this._view) {
-      this._view.webview.html = urlInIframe(url);
+      this._view.webview.html = iframeHtml;
       if (title) {
         this._view.title = title;
       }
@@ -168,7 +188,6 @@ function showWebView({
   'sidebar-panel?'?: boolean;
 }): void {
   if (sidebarPanel) {
-    // Handle sidebar webview
     if (flareWebviewProvider) {
       if (html) {
         flareWebviewProvider.updateContent(html, title, key);
@@ -188,7 +207,6 @@ function showWebView({
     return;
   }
 
-  // Handle regular webview panel (existing logic)
   let panel: CalvaWebPanel;
   if (key) {
     panel = calvaWebPanels[key];

--- a/src/flare-handler.ts
+++ b/src/flare-handler.ts
@@ -29,13 +29,11 @@ export function inspect(edn: string, evaluate: EvaluateFunction): any {
     (edn.startsWith('#flare/') || edn.startsWith('#cursive/'))
   ) {
     try {
-      console.log('Inspecting EDN:', edn);
       // decompose the flare into the tag and the literal
       const match = edn.match(/^#(?:flare|cursive)\/(\w+)\s*(\{.*})\s*$/s);
       if (match) {
         const tag = match[1];
         const flare = parseEdn(match[2]);
-        console.log('Parsed flare:', { tag, flare });
         const handler = actHandlers[tag];
         if (handler) {
           handler(flare, evaluate);
@@ -96,12 +94,6 @@ class CalvaFlareWebviewProvider implements vscode.WebviewViewProvider {
   }
 
   public updateContent(html: string, title?: string, key?: string) {
-    console.log('updateContent called with:', {
-      html: html?.substring(0, 100),
-      title,
-      key,
-      hasView: !!this._view,
-    });
     if (this._view) {
       this._view.webview.html = html;
       if (title) {
@@ -111,9 +103,6 @@ class CalvaFlareWebviewProvider implements vscode.WebviewViewProvider {
         (this._view as CalvaWebView).url = key; // Store key in url field for tracking
         calvaSidebarWebViews[key] = this._view as CalvaWebView;
       }
-      console.log('Content updated successfully');
-    } else {
-      console.log('ERROR: No webview available for content update');
     }
   }
 
@@ -178,24 +167,12 @@ function showWebView({
   opts?: typeof defaultWebviewOptions;
   'sidebar-panel?'?: boolean;
 }): void {
-  // Debug logging
-  console.log('showWebView called with:', {
-    title,
-    key,
-    html: html?.substring(0, 100),
-    url,
-    sidebarPanel,
-  });
-
   if (sidebarPanel) {
-    console.log('Using sidebar panel, flareWebviewProvider:', !!flareWebviewProvider);
     // Handle sidebar webview
     if (flareWebviewProvider) {
       if (html) {
-        console.log('Updating sidebar content with HTML:', html.substring(0, 100));
         flareWebviewProvider.updateContent(html, title, key);
       } else if (url) {
-        console.log('Updating sidebar content with URL:', url);
         flareWebviewProvider.updateUrl(url, title, key);
       }
 
@@ -204,7 +181,6 @@ function showWebView({
         void vscode.commands.executeCommand('calva.flare.focus');
       }
     } else {
-      console.log('ERROR: flareWebviewProvider is null');
       void vscode.window.showErrorMessage(
         'Sidebar flare webview not available. Please restart VS Code.'
       );
@@ -212,7 +188,6 @@ function showWebView({
     return;
   }
 
-  console.log('Using regular panel');
   // Handle regular webview panel (existing logic)
   let panel: CalvaWebPanel;
   if (key) {

--- a/src/flare-handler.ts
+++ b/src/flare-handler.ts
@@ -11,6 +11,7 @@ type WebviewRequest = {
   column?: vscode.ViewColumn;
   opts?: any;
   then?: string;
+  'sidebar-panel?'?: boolean;
 };
 
 type ActRequest = WebviewRequest;
@@ -28,11 +29,13 @@ export function inspect(edn: string, evaluate: EvaluateFunction): any {
     (edn.startsWith('#flare/') || edn.startsWith('#cursive/'))
   ) {
     try {
+      console.log('Inspecting EDN:', edn);
       // decompose the flare into the tag and the literal
       const match = edn.match(/^#(?:flare|cursive)\/(\w+)\s*(\{.*})\s*$/s);
       if (match) {
         const tag = match[1];
         const flare = parseEdn(match[2]);
+        console.log('Parsed flare:', { tag, flare });
         const handler = actHandlers[tag];
         if (handler) {
           handler(flare, evaluate);
@@ -57,9 +60,102 @@ interface CalvaWebPanel extends vscode.WebviewPanel {
   url?: string;
 }
 
+interface CalvaWebView extends vscode.WebviewView {
+  url?: string;
+}
+
 // keep track of open webviews that have a key
 // so that they can be updated in the future
 const calvaWebPanels: Record<string, CalvaWebPanel> = {};
+const calvaSidebarWebViews: Record<string, CalvaWebView> = {};
+
+// WebView provider for sidebar
+class CalvaFlareWebviewProvider implements vscode.WebviewViewProvider {
+  public static readonly viewType = 'calva.flare';
+  private _view?: vscode.WebviewView;
+  private _context: vscode.ExtensionContext;
+
+  constructor(private readonly context: vscode.ExtensionContext) {
+    this._context = context;
+  }
+
+  public resolveWebviewView(
+    webviewView: vscode.WebviewView,
+    context: vscode.WebviewViewResolveContext,
+    _token: vscode.CancellationToken
+  ) {
+    this._view = webviewView;
+
+    webviewView.webview.options = {
+      // Allow scripts in the webview
+      enableScripts: true,
+      localResourceRoots: [this._context.extensionUri],
+    };
+
+    webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
+  }
+
+  public updateContent(html: string, title?: string, key?: string) {
+    console.log('updateContent called with:', {
+      html: html?.substring(0, 100),
+      title,
+      key,
+      hasView: !!this._view,
+    });
+    if (this._view) {
+      this._view.webview.html = html;
+      if (title) {
+        this._view.title = title;
+      }
+      if (key) {
+        (this._view as CalvaWebView).url = key; // Store key in url field for tracking
+        calvaSidebarWebViews[key] = this._view as CalvaWebView;
+      }
+      console.log('Content updated successfully');
+    } else {
+      console.log('ERROR: No webview available for content update');
+    }
+  }
+
+  public updateUrl(url: string, title?: string, key?: string) {
+    if (this._view) {
+      this._view.webview.html = urlInIframe(url);
+      if (title) {
+        this._view.title = title;
+      }
+      if (key) {
+        (this._view as CalvaWebView).url = url;
+        calvaSidebarWebViews[key] = this._view as CalvaWebView;
+      }
+    }
+  }
+
+  private _getHtmlForWebview(webview: vscode.Webview) {
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Calva Flare</title>
+</head>
+<body>
+    <p>Flare content will appear here</p>
+</body>
+</html>`;
+  }
+}
+
+let flareWebviewProvider: CalvaFlareWebviewProvider | null = null;
+
+export function registerFlareWebviewProvider(context: vscode.ExtensionContext) {
+  flareWebviewProvider = new CalvaFlareWebviewProvider(context);
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(
+      CalvaFlareWebviewProvider.viewType,
+      flareWebviewProvider
+    )
+  );
+}
 
 function showWebView({
   title = 'WebView',
@@ -70,6 +166,7 @@ function showWebView({
   reveal = true,
   column = vscode.ViewColumn.Beside,
   opts = defaultWebviewOptions,
+  'sidebar-panel?': sidebarPanel = false,
 }: {
   title?: string;
   key?: string;
@@ -79,7 +176,44 @@ function showWebView({
   reveal?: boolean;
   column?: vscode.ViewColumn;
   opts?: typeof defaultWebviewOptions;
+  'sidebar-panel?'?: boolean;
 }): void {
+  // Debug logging
+  console.log('showWebView called with:', {
+    title,
+    key,
+    html: html?.substring(0, 100),
+    url,
+    sidebarPanel,
+  });
+
+  if (sidebarPanel) {
+    console.log('Using sidebar panel, flareWebviewProvider:', !!flareWebviewProvider);
+    // Handle sidebar webview
+    if (flareWebviewProvider) {
+      if (html) {
+        console.log('Updating sidebar content with HTML:', html.substring(0, 100));
+        flareWebviewProvider.updateContent(html, title, key);
+      } else if (url) {
+        console.log('Updating sidebar content with URL:', url);
+        flareWebviewProvider.updateUrl(url, title, key);
+      }
+
+      if (reveal) {
+        // Focus the Calva view container to show the sidebar
+        void vscode.commands.executeCommand('calva.flare.focus');
+      }
+    } else {
+      console.log('ERROR: flareWebviewProvider is null');
+      void vscode.window.showErrorMessage(
+        'Sidebar flare webview not available. Please restart VS Code.'
+      );
+    }
+    return;
+  }
+
+  console.log('Using regular panel');
+  // Handle regular webview panel (existing logic)
   let panel: CalvaWebPanel;
   if (key) {
     panel = calvaWebPanels[key];


### PR DESCRIPTION
## What has changed?

Adding an option to flares so that we can open them in the VS Code Sidebar.

* Fixes #2873

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
