### PR TITLE
Reload contents of output view when it's closed and reopened 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Reload contents of output view when VS Code window is reloaded](https://github.com/BetterThanTomorrow/calva/issues/2827)
+- [Reload contents of output view when it's closed and reopened (without closing VS Code)](https://github.com/BetterThanTomorrow/calva/issues/2867)
 
 ## [2.0.520] - 2025-06-28
 

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -171,19 +171,21 @@
       "save-state" (save-state message-data))))
 
 (defn initialize-webview-panel
-  [context ^js webview-panel ^js state]
+  [context ^js webview-panel state]
   ;; TODO: Add test for this call
   (.. webview-panel -webview (onDidReceiveMessage handle-message))
   (add-listeners! webview-panel)
   (add-subscriptions! context {:webview-panel webview-panel})
-  (if (and state (.-html state))
-    (set! (.. webview-panel -webview -html) (.-html state))
+  (if (and state (:html state))
+    ;; TODO: Address console warnings and errors when this code is run
+    (set! (.. webview-panel -webview -html) (:html state))
     (set-webview-html! context {:webview-panel webview-panel}))
-  (let [[scroll-left scroll-top] (when state [(.-scrollLeft state) (.-scrollTop state)])]
+  (let [[scroll-left scroll-top] (when state [(:scrollLeft state) (:scrollTop state)])]
     (post-message-to-webview webview-panel {:command/name "scroll-to"
                                             :x scroll-left
                                             :y scroll-top}))
-  (post-message-to-webview webview-panel {:command/name "restore-copy-buttons"}))
+  (post-message-to-webview webview-panel {:command/name "restore-copy-buttons"})
+  webview-panel)
 
 (defn create-repl-output-webview-panel
   [{:keys [vscode/vscode] :as context}]
@@ -202,14 +204,14 @@
                                 ;; panel's context cannot be quickly saved and restored."
                                 :retainContextWhenHidden true
                                 :enableFindWidget true}))]
-    (initialize-webview-panel context webview-panel nil)
+    (initialize-webview-panel context webview-panel @output-view-state)
     (reset! repl-output-webview-panel webview-panel)))
 
 (defn deserialize-webview-panel
   [context ^js webview-panel ^js state]
   (js/Promise.
    (fn [resolve _reject]
-     (initialize-webview-panel context webview-panel state)
+     (initialize-webview-panel context webview-panel (js->clj state :keywordize-keys true))
      (resolve nil))))
 
 (defn register-output-view-webview-serializer!
@@ -229,6 +231,7 @@
                               (reset! repl-output-webview-panel (create-repl-output-webview-panel context)))
         active-code-theme-kind (.. ^js @util/vscode -window -activeColorTheme -kind)]
     (.. webview-panel (reveal nil preserve-focus?))
+    ;; TODO: Test closing the webview panel, then changing the VS Code theme, then reopening the webview panel.
     (set-code-theme! context {:color-theme-kind active-code-theme-kind
                               :webview-panel webview-panel})))
 

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -1,9 +1,16 @@
 (ns calva.repl.webview.core
   (:require
    [calva.util :as util]
+   [cljs.reader :as reader]
    [clojure.string :as str]))
 
 (defonce repl-output-webview-panel (atom nil))
+
+(defonce output-view-state (atom nil))
+
+(defn save-state
+  [{:keys [state]}]
+  (reset! output-view-state state))
 
 (defn dispose-repl-output-webview-panel
   [webview-panel-atom]
@@ -156,8 +163,17 @@
   [^js webview-panel]
   (.. webview-panel (onDidDispose (fn [] (dispose-repl-output-webview-panel repl-output-webview-panel)))))
 
+(defn handle-message
+  [^js message]
+  (let [message-data (reader/read-string message)
+        command-name (:command/name message-data)]
+    (case command-name
+      "save-state" (save-state message-data))))
+
 (defn initialize-webview-panel
   [context ^js webview-panel ^js state]
+  ;; TODO: Add test for this call
+  (.. webview-panel -webview (onDidReceiveMessage handle-message))
   (add-listeners! webview-panel)
   (add-subscriptions! context {:webview-panel webview-panel})
   (if (and state (.-html state))

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -172,7 +172,6 @@
 
 (defn initialize-webview-panel
   [context ^js webview-panel state]
-  ;; TODO: Add test for this call
   (.. webview-panel -webview (onDidReceiveMessage handle-message))
   (add-listeners! webview-panel)
   (add-subscriptions! context {:webview-panel webview-panel})

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -164,7 +164,7 @@
   (.. webview-panel (onDidDispose (fn [] (dispose-repl-output-webview-panel repl-output-webview-panel)))))
 
 (defn handle-message
-  [^js message]
+  [message]
   (let [message-data (reader/read-string message)
         command-name (:command/name message-data)]
     (case command-name

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -230,7 +230,6 @@
                               (reset! repl-output-webview-panel (create-repl-output-webview-panel context)))
         active-code-theme-kind (.. ^js @util/vscode -window -activeColorTheme -kind)]
     (.. webview-panel (reveal nil preserve-focus?))
-    ;; TODO: Test closing the webview panel, then changing the VS Code theme, then reopening the webview panel.
     (set-code-theme! context {:color-theme-kind active-code-theme-kind
                               :webview-panel webview-panel})))
 

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -169,6 +169,11 @@
         new-state (merge current-state state)]
     (.. vscode (setState (clj->js new-state)))
     ;; Send a command to the extension to save the state, so we can restore it when the webview is closed and reopened.
+    ;; TODO: Figure out why we're getting the console error `Cannot read properties of undefined (reading '__vscode_post_message__')`
+    ;; after the webview is closed and reopened.
+    ;; Every time it's closed an reopened, an additional duplicate error is added to the console.
+    ;; Note: I looked into this for a while and I'm not sure if it's worth continuing to investigate.
+    ;; It may actually be an issue with the VS Code API, but in any case, it's not causing a real problem.
     (.. vscode (postMessage (pr-str {:command/name "save-state"
                                      :state new-state})))))
 

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -165,8 +165,12 @@
 
 (defn merge-state
   [state]
-  (.. vscode (setState (js/Object.assign (or (.. vscode (getState)) #js {})
-                                         (clj->js state)))))
+  (let [current-state (js->clj (.. vscode (getState)) :keywordize-keys true)
+        new-state (merge current-state state)]
+    (.. vscode (setState (clj->js new-state)))
+    ;; Send a command to the extension to save the state, so we can restore it when the webview is closed and reopened.
+    (.. vscode (postMessage (pr-str {:command/name "save-state"
+                                     :state new-state})))))
 
 (defn save-html
   []

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -163,7 +163,9 @@
 (deftest initialize-webview-panel-test
   (testing "Given a context, a webview panel, and an nil state,"
     (let [on-did-dispose-spy (spy/spy)
-          stub-webview-panel (clj->js {:onDidDispose (test-util/wrap-spy on-did-dispose-spy)})
+          stub-webview-panel (clj->js {:onDidDispose (test-util/wrap-spy on-did-dispose-spy)
+                                       :webview {;; TODO: Use a spy here and test for a call / no call
+                                                 :onDidReceiveMessage (constantly nil)}})
           set-webview-html-spy (spy/spy)
           add-subscriptions-spy (spy/spy)
           post-message-to-webview-spy (spy/spy)
@@ -191,7 +193,8 @@
   (testing "Given a context, a webview panel, and a non-nil state,"
     (let [on-did-dispose-spy (spy/spy)
           stub-webview-panel (clj->js {:onDidDispose (test-util/wrap-spy on-did-dispose-spy)
-                                       :webview {}})
+                                       :webview {;; TODO: Use a spy here and test for a call / no call
+                                                 :onDidReceiveMessage (constantly nil)}})
           set-webview-html-spy (spy/spy)
           add-subscriptions-spy (spy/spy)
           post-message-to-webview-spy (spy/spy)

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -163,9 +163,9 @@
 (deftest initialize-webview-panel-test
   (testing "Given a context, a webview panel, and an nil state,"
     (let [on-did-dispose-spy (spy/spy)
+          on-did-receive-message-spy (spy/spy)
           stub-webview-panel (clj->js {:onDidDispose (test-util/wrap-spy on-did-dispose-spy)
-                                       :webview {;; TODO: Use a spy here and test for a call / no call
-                                                 :onDidReceiveMessage (constantly nil)}})
+                                       :webview {:onDidReceiveMessage (test-util/wrap-spy on-did-receive-message-spy)}})
           set-webview-html-spy (spy/spy)
           add-subscriptions-spy (spy/spy)
           post-message-to-webview-spy (spy/spy)
@@ -174,9 +174,11 @@
                     sut/add-subscriptions! (test-util/wrap-spy add-subscriptions-spy)
                     sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)]
         (sut/initialize-webview-panel context stub-webview-panel nil)
+        (testing "should call onDidReceiveMessage with expected args"
+          (let [calls (spy/calls on-did-receive-message-spy)]
+            (is (match? [(list fn?)] calls))))
         (testing "should call onDidDispose with expected args"
           (let [calls (spy/calls on-did-dispose-spy)]
-            (is (= 1 (count calls)))
             (is (match? [(list fn?)] calls))))
         (testing "should call set-webview-html! with expected args"
           (is (spy/called-once-with? set-webview-html-spy context {:webview-panel stub-webview-panel})))
@@ -192,9 +194,9 @@
                                 {:command/name "restore-copy-buttons"}))))))
   (testing "Given a context, a webview panel, and a non-nil state,"
     (let [on-did-dispose-spy (spy/spy)
+          on-did-receive-message-spy (spy/spy)
           stub-webview-panel (clj->js {:onDidDispose (test-util/wrap-spy on-did-dispose-spy)
-                                       :webview {;; TODO: Use a spy here and test for a call / no call
-                                                 :onDidReceiveMessage (constantly nil)}})
+                                       :webview {:onDidReceiveMessage (test-util/wrap-spy on-did-receive-message-spy)}})
           set-webview-html-spy (spy/spy)
           add-subscriptions-spy (spy/spy)
           post-message-to-webview-spy (spy/spy)
@@ -205,9 +207,11 @@
         (sut/initialize-webview-panel context stub-webview-panel {:html "some-html"
                                                                   :scrollLeft 77
                                                                   :scrollTop 88})
+        (testing "should call onDidReceiveMessage with expected args"
+          (let [calls (spy/calls on-did-receive-message-spy)]
+            (is (match? [(list fn?)] calls))))
         (testing "should call onDidDispose with expected args"
           (let [calls (spy/calls on-did-dispose-spy)]
-            (is (= 1 (count calls)))
             (is (match? [(list fn?)] calls))))
         (testing "should not call set-webview-html!"
           (is (spy/not-called? set-webview-html-spy)))

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -202,9 +202,9 @@
       (with-redefs [sut/set-webview-html! (test-util/wrap-spy set-webview-html-spy)
                     sut/add-subscriptions! (test-util/wrap-spy add-subscriptions-spy)
                     sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)]
-        (sut/initialize-webview-panel context stub-webview-panel #js {:html "some-html"
-                                                                      :scrollLeft 77
-                                                                      :scrollTop 88})
+        (sut/initialize-webview-panel context stub-webview-panel {:html "some-html"
+                                                                  :scrollLeft 77
+                                                                  :scrollTop 88})
         (testing "should call onDidDispose with expected args"
           (let [calls (spy/calls on-did-dispose-spy)]
             (is (= 1 (count calls)))


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- When the output view is closed and reopened, the contents are reloaded. This is achieved by saving state in the extension memory by passing it from the webview panel using `postMessage` when the HTML document is updated, but with a throttle for performance reasons.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Closes #2867 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- ~[ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
