### PR TITLE
Store webview panel for output view when it's deserialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [After VS Code reload a new separate output view is opened on connect when one is already open](https://github.com/BetterThanTomorrow/calva/issues/2883)
+
 ## [2.0.521] - 2025-07-09
 
 - [Reload contents of output view when VS Code window is reloaded](https://github.com/BetterThanTomorrow/calva/issues/2827)

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -4,7 +4,7 @@
    [cljs.reader :as reader]
    [clojure.string :as str]))
 
-(defonce repl-output-webview-panel (atom nil))
+(defonce output-view-webview-panel (atom nil))
 
 (defonce output-view-state (atom nil))
 
@@ -161,7 +161,7 @@
 
 (defn add-listeners!
   [^js webview-panel]
-  (.. webview-panel (onDidDispose (fn [] (dispose-repl-output-webview-panel repl-output-webview-panel)))))
+  (.. webview-panel (onDidDispose (fn [] (dispose-repl-output-webview-panel output-view-webview-panel)))))
 
 (defn handle-message
   [message]
@@ -204,13 +204,13 @@
                                 :retainContextWhenHidden true
                                 :enableFindWidget true}))]
     (initialize-webview-panel context webview-panel @output-view-state)
-    (reset! repl-output-webview-panel webview-panel)))
+    (reset! output-view-webview-panel webview-panel)))
 
 (defn deserialize-webview-panel
-  [context ^js webview-panel ^js state]
+  [context webview-panel-atom ^js webview-panel ^js state]
   (js/Promise.
    (fn [resolve _reject]
-     (reset! repl-output-webview-panel webview-panel)
+     (reset! webview-panel-atom webview-panel)
      (initialize-webview-panel context webview-panel (js->clj state :keywordize-keys true))
      (resolve nil))))
 
@@ -220,15 +220,15 @@
     (.. vscode -window
         (registerWebviewPanelSerializer
          "calva.output-view"
-         #js {:deserializeWebviewPanel (partial deserialize-webview-panel context)}))))
+         #js {:deserializeWebviewPanel (partial deserialize-webview-panel context output-view-webview-panel)}))))
 
 (defn ^:export show-repl-output-webview-panel
   [preserve-focus?]
   (let [context {:env/is-debug (:is-debug util/env)
                  :vscode/vscode @util/vscode
                  :vscode/context @util/vscode-context}
-        ^js webview-panel (or @repl-output-webview-panel
-                              (reset! repl-output-webview-panel (create-repl-output-webview-panel context)))
+        ^js webview-panel (or @output-view-webview-panel
+                              (reset! output-view-webview-panel (create-repl-output-webview-panel context)))
         active-code-theme-kind (.. ^js @util/vscode -window -activeColorTheme -kind)]
     (.. webview-panel (reveal nil preserve-focus?))
     (set-code-theme! context {:color-theme-kind active-code-theme-kind
@@ -248,7 +248,7 @@
   (let [output-category (.-outputCategory options)
         command-name (get output-category->command-name output-category)]
     (if command-name
-      (post-message-to-webview @repl-output-webview-panel {:command/name command-name
+      (post-message-to-webview @output-view-webview-panel {:command/name command-name
                                                            :output message})
       (util/log-to-console
        :error
@@ -277,11 +277,11 @@
   [^js stacktrace]
   (let [stacktrace (js->clj stacktrace :keywordize-keys true)
         stacktrace-message (stacktrace->message stacktrace)]
-    (post-message-to-webview @repl-output-webview-panel {:command/name "show-stdout"
+    (post-message-to-webview @output-view-webview-panel {:command/name "show-stdout"
                                                          :output stacktrace-message})))
 
 (defn ^:export clear-output-view []
-  (post-message-to-webview @repl-output-webview-panel {:command/name "clear-output-view"}))
+  (post-message-to-webview @output-view-webview-panel {:command/name "clear-output-view"}))
 
 (defn ^:export register-output-view-webview-serializer
   []

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -210,6 +210,7 @@
   [context ^js webview-panel ^js state]
   (js/Promise.
    (fn [resolve _reject]
+     (reset! repl-output-webview-panel webview-panel)
      (initialize-webview-panel context webview-panel (js->clj state :keywordize-keys true))
      (resolve nil))))
 

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -269,14 +269,14 @@
       (with-redefs [util/env {:is-debug false}
                     util/vscode (atom vscode-stub)
                     util/vscode-context (atom vscode-context-stub)
-                    sut/repl-output-webview-panel (atom nil)
+                    sut/output-view-webview-panel (atom nil)
                     sut/create-repl-output-webview-panel (test-util/wrap-spy create-repl-output-webview-panel-spy)
                     sut/set-code-theme! (test-util/wrap-spy set-code-theme!-spy)]
         (sut/show-repl-output-webview-panel true)
         (testing "Should call create-repl-output-webview-panel with expected args"
           (is (spy/called-once-with? create-repl-output-webview-panel-spy expected-context)))
         (testing "Should set repl-output-webview-panel to the result of create-repl-output-webview-panel"
-          (is (= webview-panel-stub @sut/repl-output-webview-panel)))
+          (is (= webview-panel-stub @sut/output-view-webview-panel)))
         (testing "Should call reveal on webview panel with expected args"
           (is (spy/called-once-with? reveal-spy nil true)))
         (testing "Should call set-code-theme! with expected args"
@@ -296,7 +296,7 @@
       (with-redefs [util/env {:is-debug false}
                     util/vscode (atom vscode-stub)
                     util/vscode-context (atom vscode-context-stub)
-                    sut/repl-output-webview-panel (atom webview-panel-stub)
+                    sut/output-view-webview-panel (atom webview-panel-stub)
                     sut/create-repl-output-webview-panel (test-util/wrap-spy create-repl-output-webview-panel-spy)
                     sut/set-code-theme! (test-util/wrap-spy set-code-theme!-spy)]
         (sut/show-repl-output-webview-panel false)
@@ -316,7 +316,7 @@
             post-message-to-webview-spy (spy/spy)]
         (with-redefs [sut/output-category->command-name {"evalOut" "show-stdout"}
                       sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)
-                      sut/repl-output-webview-panel (atom "webview-panel-stub")]
+                      sut/output-view-webview-panel (atom "webview-panel-stub")]
           (sut/append options message)
           (is (spy/called-once-with? post-message-to-webview-spy
                                      "webview-panel-stub"
@@ -329,7 +329,7 @@
             log-to-console-spy (spy/spy)]
         (with-redefs [sut/output-category->command-name {"evalOut" "show-stdout"}
                       sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)
-                      sut/repl-output-webview-panel (atom "webview-panel-stub")
+                      sut/output-view-webview-panel (atom "webview-panel-stub")
                       util/log-to-console (test-util/wrap-spy log-to-console-spy)]
           (sut/append options message)
           (testing "should not call post-message-to-webview"
@@ -413,7 +413,7 @@
           js-stacktrace (clj->js clj-stacktrace)]
       (with-redefs [sut/stacktrace->message (test-util/wrap-spy stacktrace->message-spy)
                     sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)
-                    sut/repl-output-webview-panel (atom "webview-panel-stub")]
+                    sut/output-view-webview-panel (atom "webview-panel-stub")]
         (sut/append-stacktrace js-stacktrace)
         (testing "should call stacktrace->message with clj stacktrace"
           (is (spy/called-once-with? stacktrace->message-spy clj-stacktrace)))
@@ -427,7 +427,7 @@
   (testing "Should call post-message-to-webview with expected args"
     (let [post-message-to-webview-spy (spy/spy)]
       (with-redefs [sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)
-                    sut/repl-output-webview-panel (atom "webview-panel-stub")]
+                    sut/output-view-webview-panel (atom "webview-panel-stub")]
         (sut/clear-output-view)
         (is (spy/called-once-with? post-message-to-webview-spy
                                    "webview-panel-stub"
@@ -447,15 +447,17 @@
 
 (deftest deserialize-webview-panel-test
   (testing "Given a context, a webview panel, and a state, should return a promise that resolves after calling
-            initialize-webview-panel with expected args"
+            initialize-webview-panel with expected args and storing the webview in the webview panel atom"
     (let [initialize-webview-panel-spy (spy/spy)
+          webview-panel-atom (atom nil)
           context {:some "context"}
           webview-panel {:some "webview-panel"}
           state {:some "state"}]
       (with-redefs [sut/initialize-webview-panel (test-util/wrap-spy initialize-webview-panel-spy)]
-        (let [result (sut/deserialize-webview-panel context webview-panel state)]
+        (let [result (sut/deserialize-webview-panel context webview-panel-atom webview-panel state)]
           (.. result
               (then (fn [_]
-                      (is (spy/called-once-with? initialize-webview-panel-spy context webview-panel state))))))))))
+                      (is (spy/called-once-with? initialize-webview-panel-spy context webview-panel state))
+                      (is (= webview-panel @webview-panel-atom))))))))))
 
 #_(run-tests)


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- We now reset the atom that stores the output view webview panel when the panel is deserialized upon the opening of VS Code

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2883 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- ~[ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.~
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
