### PR TITLE
Fix: Output view syntax highlighting breaks when it's dragged into or out of main VS Code window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 
 - Fix: [[doc] Unneeded send-off function call in sample code](https://github.com/BetterThanTomorrow/calva/issues/2888)
 - Fix: [Ctrl+Home shortcut has no title](https://github.com/BetterThanTomorrow/calva/issues/2890)
+- Fix: [Output view syntax highlighting breaks when it's dragged into or out of main VS Code window](https://github.com/BetterThanTomorrow/calva/issues/2895)
 
 ## [2.0.522] - 2025-07-12
 

--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
     "workspaceContains:**/project.clj",
     "workspaceContains:**/shadow-cljs.edn",
     "workspaceContains:**/deps.edn",
-    "onDebugResolve:type",
-    "onWebviewPanel:calva.output-view"
+    "onDebugResolve:type"
   ],
   "main": "./out/extension",
   "capabilities": {

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -189,6 +189,10 @@
                                 ;; See also: https://code.visualstudio.com/api/references/vscode-api#WebviewPanelOptions
                                 ;; "retainContextWhenHidden has a high memory overhead and should only be used if your
                                 ;; panel's context cannot be quickly saved and restored."
+                                ;; Content reloading using setState and getState and message passing between the webview
+                                ;; and the extension was attempted, but it proved to be troublesome, so it was removed.
+                                ;; If someone wants to attempt to add it again, here's the PR for the removal:
+                                ;; https://github.com/BetterThanTomorrow/calva/pull/2896
                                 :retainContextWhenHidden true
                                 :enableFindWidget true}))]
     (initialize-webview-panel context webview-panel)

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -142,14 +142,30 @@
   (.. vscode -window
       (onDidChangeActiveColorTheme
        (fn [e]
+         ;; Ensure syntax highlighting is not broken after the output view is moved into or out of the main
+         ;; VS Code window. See https://github.com/BetterThanTomorrow/calva/issues/2895.
+         ;; This is probably called more frequently than it needs to be, but if that's problematic we can try to
+         ;; figure out how to identify when this event means the output view moved into or out of the main window.
+         ;; This event fires for more cases than just that, such as when it's focused or unfocused.
          (set-code-theme! context {:color-theme-kind (.. e -kind)
                                    :webview-panel webview-panel})))))
+
+(defn create-view-state-change-listener
+  [{:keys [^js vscode/vscode] :as context}
+   {:keys [^js webview-panel]}]
+  (.. webview-panel
+      (onDidChangeViewState
+       (fn [^js _event]
+         (set-code-theme! context
+                          {:color-theme-kind (.. ^js vscode -window -activeColorTheme -kind)
+                           :webview-panel webview-panel})))))
 
 (defn add-subscriptions!
   [{vscode-context :vscode/context
     :as context}
    {:keys [webview-panel]}]
-  (let [subscriptions [(create-color-theme-change-listener context {:webview-panel webview-panel})]]
+  (let [subscriptions [(create-color-theme-change-listener context {:webview-panel webview-panel})
+                       (create-view-state-change-listener context {:webview-panel webview-panel})]]
     (run! (fn [subscription]
             (.. ^js vscode-context -subscriptions (push subscription)))
           subscriptions)))

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -160,6 +160,15 @@
         (is (= 1 (count calls)))
         (is (fn? (type (ffirst calls))))))))
 
+(deftest create-view-state-change-listener-test
+  (testing "Given a context and a webview panel, should call onDidChangeViewState and pass it a function"
+    (let [on-did-change-view-state-spy (spy/spy)
+          webview-panel-stub #js {:onDidChangeViewState (test-util/wrap-spy on-did-change-view-state-spy)}]
+      (sut/create-view-state-change-listener {} {:webview-panel webview-panel-stub})
+      (let [calls (spy/calls on-did-change-view-state-spy)]
+        (is (= 1 (count calls)))
+        (is (fn? (type (ffirst calls))))))))
+
 (deftest initialize-webview-panel-test
   (testing "Given a context, a webview panel, and an nil state,"
     (let [on-did-dispose-spy (spy/spy)


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Removed an unneeded activation event from package.json. It was added for reloading webview content, but that functionality has been removed.
- We now set the code theme when the view state of the output view changes so that the syntax highlighting is not broken when the output view is dragged into or out of the main VS Code window

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2895 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
