### PR TITLE
Cursor in whitespace after line comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- add gnome-linux-keybindings.md for Gnome Linux users to use Gnome editing keybindings
+- Fix: [set calva:cursorInWhitespaceAfterComment if the cursor is in whitespace after a comment's newline](https://github.com/BetterThanTomorrow/calva/issues/2917)
 
 ## [2.0.525] - 2025-08-30
 

--- a/docs/site/customizing.md
+++ b/docs/site/customizing.md
@@ -106,6 +106,7 @@ The following contexts are available with Calva:
 * `calva:cursorInComment`: `true` when the cursor is in, or adjacent to a line comment
 * `calva:cursorBeforeComment`: `true` when the cursor is adjacent before a line comment
 * `calva:cursorAfterComment`: `true` when the cursor is adjacent after a line comment
+* `calva:cursorInWhitespaceAfterComment`: `true` when the cursor is in whitespace after a line comment
 * `calva:cursorAtStartOfLine`: `true` when the cursor is at the start of a line including any leading whitespace
 * `calva:cursorAtEndOfLine`: `true` when the cursor is at the end of a line including any trailing whitespace
 

--- a/docs/site/gnome-linux-keybindings.md
+++ b/docs/site/gnome-linux-keybindings.md
@@ -36,7 +36,7 @@ Add the JSON below to your VS Code keybindings.json file.
     {
         "key": "ctrl+backspace",
         "command": "paredit.killSexpBackward",
-        "when": "calva:keybindingsEnabled && editorTextFocus && !calva:cursorInComment && editorLangId == 'clojure' && paredit:keyMap =~ /original|strict/"
+        "when": "calva:keybindingsEnabled && editorTextFocus && !calva:cursorInWhitespaceAfterComment && !calva:cursorInComment && editorLangId == 'clojure' && paredit:keyMap =~ /original|strict/"
     },
     {
         "key": "ctrl+shift+delete",

--- a/docs/site/when-clauses.md
+++ b/docs/site/when-clauses.md
@@ -17,6 +17,7 @@ description: Calva comes with batteries included and preconfigured, and if you d
 * `calva:cursorInComment`: `true` when the cursor is in, or adjacent to a line comment
 * `calva:cursorBeforeComment`: `true` when the cursor is adjacent before a line comment
 * `calva:cursorAfterComment`: `true` when the cursor is adjacent after a line comment
+* `calva:cursorInWhitespaceAfterComment`: `true` when the cursor is in whitespace after a line comment
 * `calva:cursorAtStartOfLine`: `true` when the cursor is at the start of a line including any leading whitespace
 * `calva:cursorAtEndOfLine`: `true` when the cursor is at the end of a line including any trailing whitespace
 * `calva:projectRoot`: A string with the absolute path to the repl project root, _without trailing slash_

--- a/src/cursor-doc/cursor-context.ts
+++ b/src/cursor-doc/cursor-context.ts
@@ -7,6 +7,7 @@ export const allCursorContexts = [
   'calva:cursorAtEndOfLine',
   'calva:cursorBeforeComment',
   'calva:cursorAfterComment',
+  'calva:cursorInWhitespaceAfterComment',
 ] as const;
 
 export type CursorContext = typeof allCursorContexts[number];
@@ -87,6 +88,22 @@ export function determineContexts(
       if (tokenCursor.getPrevToken().type != 'comment') {
         contexts.push('calva:cursorBeforeComment');
       }
+    }
+  }
+
+  // Is the cursor in the whitespace (after a newline) after a comment?  For example:
+  // (+ 1 1)   ;; my comment
+  //  |
+  // If so, we mark this as whitespace after a comment so keybinding's when clauses can
+  // choose to use non-paredit text editing.  The calva:cursorInComment context ends at
+  // a newline so calva:cursorInWhitespaceAfterComment implicitly starts after a newline
+  // after a comment.
+  if (!contexts.includes('calva:cursorInComment') && tokenCursor.isWhiteSpace()) {
+    const cursor = tokenCursor.clone();
+    cursor.backwardWhitespace(false);
+
+    if (cursor.getPrevToken().type === 'comment') {
+      contexts.push('calva:cursorInWhitespaceAfterComment');
     }
   }
 

--- a/src/extension-test/unit/cursor-doc/cursor-context-test.ts
+++ b/src/extension-test/unit/cursor-doc/cursor-context-test.ts
@@ -359,4 +359,36 @@ describe('Cursor Contexts', () => {
       ).toBe(false);
     });
   });
+  describe('cursorInWhitespaceAfterComment', () => {
+    it('is false in whitespace directly after comment; the parser considers this part of a comment', () => {
+      const contexts = context.determineContexts(docFromTextNotation(';; comment line | '));
+      expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
+    });
+    it('is true after newline after comment', () => {
+      const contexts = context.determineContexts(docFromTextNotation(';; comment line•| '));
+      expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(true);
+    });
+    it('is true in whitespace after newlines after comment', () => {
+      const contexts = context.determineContexts(
+        docFromTextNotation(':foo ;; comment line•• •  | ')
+      );
+      expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(true);
+    });
+    it('is false after a symbol', () => {
+      const contexts = context.determineContexts(docFromTextNotation(':foo | '));
+      expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
+    });
+    it('is false after symbol, newlines, and whitespace', () => {
+      const contexts = context.determineContexts(docFromTextNotation('{:foo :bar}•• •  | '));
+      expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
+    });
+    it('is false inside a comment', () => {
+      const contexts = context.determineContexts(docFromTextNotation(';; comment| line'));
+      expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
+    });
+    it('is false at the beginning of a document', () => {
+      const contexts = context.determineContexts(docFromTextNotation('| '));
+      expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
This is a fix for the case where there wasn't a way to tell if the cursor is after a line comment (on a following line, 
but before any actual code).

Fixes: https://github.com/BetterThanTomorrow/calva/issues/2917

The idea is that the user should be able to use standard editing command keys when removing
a line comment and deleting further (acting on the text before the cursor).  As it stands now, paredit
commands are enabled which deletes the entire comment.  Before this change, there was no way
to detect and stop this behavior.

This was experimental.  It works for me and I haven't actually enabled it for any keybindings, other than
in the keybindings.json for Gnome/Linux markdown file.  I suspect it would be relevant for Windows
and it might also be relevant for MacOS, but I don't have access to those operating systems to test with.

<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
