### PR TITLE
2926-runtimes-node-description

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,653 +4,653 @@ version: 2
 jobs:
   checkout:
     docker:
-      - image: cimg/openjdk:17.0.1-node
+    - image: cimg/openjdk:17.0.1-node
     working_directory: ~/calva
     steps:
-      - attach_workspace:
-          at: /tmp
-      - checkout:
-          path: ~/calva
-      - restore_cache:
-          name: Restore dependencies
-          key: ts-{{ checksum "package.json" }}-cljs-{{ checksum "shadow-cljs.edn" }}-grammar-{{ checksum "src/calva-fmt/atom-language-clojure/package.json" }}
-      - run:
-          name: Install node_modules
-          command: cp package.json /tmp && npm install && cp /tmp/package.json .
-      - run:
-          name: Create build workspace
-          command: mkdir /tmp/build
-      - run:
-          name: Copy build
-          command: cp -r . /tmp/build
-      - save_cache:
-          name: Save dependencies
-          key: ts-{{ checksum "package.json" }}-cljs-{{ checksum "shadow-cljs.edn" }}-grammar-{{ checksum "src/calva-fmt/atom-language-clojure/package.json" }}
-          paths:
-            - ./node_modules
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-            - build
+    - attach_workspace:
+        at: /tmp
+    - checkout:
+        path: ~/calva
+    - restore_cache:
+        name: Restore dependencies
+        key: ts-{{ checksum "package.json" }}-cljs-{{ checksum "shadow-cljs.edn" }}-grammar-{{ checksum "src/calva-fmt/atom-language-clojure/package.json" }}
+    - run:
+        name: Install node_modules
+        command: cp package.json /tmp && npm install && cp /tmp/package.json .
+    - run:
+        name: Create build workspace
+        command: mkdir /tmp/build
+    - run:
+        name: Copy build
+        command: cp -r . /tmp/build
+    - save_cache:
+        name: Save dependencies
+        key: ts-{{ checksum "package.json" }}-cljs-{{ checksum "shadow-cljs.edn" }}-grammar-{{ checksum "src/calva-fmt/atom-language-clojure/package.json" }}
+        paths:
+        - ./node_modules
+    - persist_to_workspace:
+        root: /tmp
+        paths:
+        - build
   build:
     docker:
-      - image: cimg/clojure:1.11-node
+    - image: cimg/clojure:1.12.0-openjdk-21.0-node
     working_directory: ~/calva
     steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Restore build
-          command: rmdir ~/calva && cp -r /tmp/build ~/calva
-      - run:
-          name: Install CLJS dependencies
-          command: npx shadow-cljs classpath
-      - run:
-          name: Create artifacts workspace
-          command: mkdir /tmp/artifacts
-      - run:
-          name: Tamper Calva version if not release versioned
-          command: |
-            VERSION=$(node -p 'require("./package.json").version')
-            TAG_VERSION=NO-TAG
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Restore build
+        command: rmdir ~/calva && cp -r /tmp/build ~/calva
+    - run:
+        name: Install CLJS dependencies
+        command: npx shadow-cljs classpath
+    - run:
+        name: Create artifacts workspace
+        command: mkdir /tmp/artifacts
+    - run:
+        name: Tamper Calva version if not release versioned
+        command: |
+          VERSION=$(node -p 'require("./package.json").version')
+          TAG_VERSION=NO-TAG
 
-            if [[ $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+          if [[ $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            TAG_VERSION=${BASH_REMATCH[1]}
+            echo 'No version tampering because this is a release tag'
+
+          else
+            COMMIT=${CIRCLE_SHA1:0:8}
+
+            if [[ $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-(.*) ]]; then
               TAG_VERSION=${BASH_REMATCH[1]}
-              echo 'No version tampering because this is a release tag'
-
+              TAG_TITLE=${BASH_REMATCH[2]}
+              PRERELEASE=$TAG_TITLE-$COMMIT
             else
-              COMMIT=${CIRCLE_SHA1:0:8}
-
-              if [[ $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-(.*) ]]; then
-                TAG_VERSION=${BASH_REMATCH[1]}
-                TAG_TITLE=${BASH_REMATCH[2]}
-                PRERELEASE=$TAG_TITLE-$COMMIT
-              else
-                BRANCH=${CIRCLE_BRANCH//[^[:alnum:]]/-}
-                PRERELEASE=$BRANCH-$COMMIT
-              fi
-
-              echo "Append prerelease to version: -$PRERELEASE"
-              npx json -I -f package.json \
-                -e 'this.version=this.version.replace(/$/,"-'"$PRERELEASE"'")'
+              BRANCH=${CIRCLE_BRANCH//[^[:alnum:]]/-}
+              PRERELEASE=$BRANCH-$COMMIT
             fi
 
-            if [[ $TAG_VERSION == NO-TAG || $TAG_VERSION == "$VERSION" ]]; then
-              VERSION=$(node -p 'require("./package.json").version')
-              echo "Using version: $VERSION"
+            echo "Append prerelease to version: -$PRERELEASE"
+            npx json -I -f package.json \
+              -e 'this.version=this.version.replace(/$/,"-'"$PRERELEASE"'")'
+          fi
 
-            else
-              echo >&2 'FATAL! Version missmatch between package.json and tag. Aborting.'
-              exit 1
-            fi
-      - run:
-          name: Package vsix
-          command: |
-            if [[ $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-              echo 'Packaging as release'
-              PACKAGE_CMD=(vsce package --githubBranch published)
+          if [[ $TAG_VERSION == NO-TAG || $TAG_VERSION == "$VERSION" ]]; then
+            VERSION=$(node -p 'require("./package.json").version')
+            echo "Using version: $VERSION"
 
-            else
-              echo 'Packaging as pre-release'
-              PACKAGE_CMD=(vsce package --pre-release)
-            fi
+          else
+            echo >&2 'FATAL! Version missmatch between package.json and tag. Aborting.'
+            exit 1
+          fi
+    - run:
+        name: Package vsix
+        command: |
+          if [[ $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo 'Packaging as release'
+            PACKAGE_CMD=(vsce package --githubBranch published)
 
-            npx "${PACKAGE_CMD[@]}"
-      - run:
-          name: Copy vsix
-          command: cp *.vsix /tmp/artifacts/
-      - run:
-          name: Copy build
-          command: cp -r out /tmp/build; cp package.json /tmp/build
-      - save_cache:
-          name: Save dependencies
-          key: ts-{{ checksum "package.json" }}-cljs-{{ checksum "shadow-cljs.edn" }}-grammar-{{ checksum "src/calva-fmt/atom-language-clojure/package.json" }}
-          paths:
-            - ./node_modules
-            - ~/.m2
-      - store_artifacts:
-          path: /tmp/artifacts
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-            - artifacts
-            - build
-            - env
+          else
+            echo 'Packaging as pre-release'
+            PACKAGE_CMD=(vsce package --pre-release)
+          fi
+
+          npx "${PACKAGE_CMD[@]}"
+    - run:
+        name: Copy vsix
+        command: cp *.vsix /tmp/artifacts/
+    - run:
+        name: Copy build
+        command: cp -r out /tmp/build; cp package.json /tmp/build
+    - save_cache:
+        name: Save dependencies
+        key: ts-{{ checksum "package.json" }}-cljs-{{ checksum "shadow-cljs.edn" }}-grammar-{{ checksum "src/calva-fmt/atom-language-clojure/package.json" }}
+        paths:
+        - ./node_modules
+        - ~/.m2
+    - store_artifacts:
+        path: /tmp/artifacts
+    - persist_to_workspace:
+        root: /tmp
+        paths:
+        - artifacts
+        - build
+        - env
   test-grammar:
     working_directory: ~/calva
     environment:
       DISPLAY: :99
     docker:
-      - image: arcanemagus/atom-docker-ci
+    - image: arcanemagus/atom-docker-ci
     steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Restore build
-          command: rmdir ~/calva && cp -r /tmp/build ~/calva
-      - run:
-          name: Start display server for Atom
-          command: /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1024x768x16 +extension RANDR
-          background: true
-      - run:
-          name: Run package tests
-          command: cd src/calva-fmt/atom-language-clojure; ./run-grammar-tests.sh
-      - save_cache:
-          name: Save dependencies
-          key: ts-{{ checksum "package.json" }}-cljs-{{ checksum "shadow-cljs.edn" }}-grammar-{{ checksum "src/calva-fmt/atom-language-clojure/package.json" }}
-          paths:
-            - ~/.atom/packages
-            - ./node_modules
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Restore build
+        command: rmdir ~/calva && cp -r /tmp/build ~/calva
+    - run:
+        name: Start display server for Atom
+        command: /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1024x768x16 +extension RANDR
+        background: true
+    - run:
+        name: Run package tests
+        command: cd src/calva-fmt/atom-language-clojure; ./run-grammar-tests.sh
+    - save_cache:
+        name: Save dependencies
+        key: ts-{{ checksum "package.json" }}-cljs-{{ checksum "shadow-cljs.edn" }}-grammar-{{ checksum "src/calva-fmt/atom-language-clojure/package.json" }}
+        paths:
+        - ~/.atom/packages
+        - ./node_modules
   prettier-check:
     docker:
-      - image: cimg/node:22.16.0
+    - image: cimg/node:22.16.0
     working_directory: ~/calva
     steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Restore build
-          command: rmdir ~/calva && cp -r /tmp/build ~/calva
-      - run:
-          name: Run prettier format check
-          command: npm run prettier-check
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Restore build
+        command: rmdir ~/calva && cp -r /tmp/build ~/calva
+    - run:
+        name: Run prettier format check
+        command: npm run prettier-check
   eslint-check:
     docker:
-      - image: cimg/node:22.16.0
+    - image: cimg/node:22.16.0
     working_directory: ~/calva
     steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Restore build
-          command: rmdir ~/calva && cp -r /tmp/build ~/calva
-      - run:
-          name: Run eslint check
-          command: npm run eslint
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Restore build
+        command: rmdir ~/calva && cp -r /tmp/build ~/calva
+    - run:
+        name: Run eslint check
+        command: npm run eslint
   test-cljslib:
     docker:
-      - image: cimg/node:22.16.0
+    - image: cimg/node:22.16.0
     working_directory: ~/calva
     steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Restore build
-          command: rmdir ~/calva && cp -r /tmp/build ~/calva
-      - run:
-          name: Run CLJS Tests
-          command: npm run calva-lib-test
-      - store_test_results:
-          path: ~/calva/junit
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Restore build
+        command: rmdir ~/calva && cp -r /tmp/build ~/calva
+    - run:
+        name: Run CLJS Tests
+        command: npm run calva-lib-test
+    - store_test_results:
+        path: ~/calva/junit
   test-ts-unit:
     docker:
-      - image: cimg/node:22.16.0
+    - image: cimg/node:22.16.0
     working_directory: ~/calva
     steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Restore build
-          command: rmdir ~/calva && cp -r /tmp/build ~/calva
-      - run:
-          name: Run TS Unit Tests
-          command: npm run unit-test
-      - store_test_results:
-          path: ~/calva/junit
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Restore build
+        command: rmdir ~/calva && cp -r /tmp/build ~/calva
+    - run:
+        name: Run TS Unit Tests
+        command: npm run unit-test
+    - store_test_results:
+        path: ~/calva/junit
   test-integration:
     docker:
-      - image: cimg/clojure:1.11-browsers
+    - image: cimg/clojure:1.11-browsers
     working_directory: ~/calva
     steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Restore build
-          command: rmdir ~/calva && cp -r /tmp/build ~/calva
-      - run:
-          name: Compile Extension Tests
-          command: npm run compile-test
-      - run:
-          name: Apt install missing dependencies
-          command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E88979FB9B30ACF2; sudo apt update && sudo apt install -y libnss3 imagemagick
-      - run:
-          name: Pip install Basilisp (Python)
-          command: sudo add-apt-repository --yes ppa:deadsnakes/ppa; sudo apt-get update; sudo apt-get install python3.12; wget https://bootstrap.pypa.io/get-pip.py; sudo python3.12 get-pip.py; sudo python3.12 -m pip install --upgrade pip setuptools wheel; sudo python3.12 -m pip install pipenv; python3.12 -m pip install basilisp==0.1.0b2;
-      - run:
-          name: Run Extension Tests
-          command: npm run integration-test
-      - store_test_results:
-          path: ~/calva/junit
-      - store_artifacts:
-          path: ~/calva/out/extension-test/integration/screenshots
-          destination: integration-screenshots
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Restore build
+        command: rmdir ~/calva && cp -r /tmp/build ~/calva
+    - run:
+        name: Compile Extension Tests
+        command: npm run compile-test
+    - run:
+        name: Apt install missing dependencies
+        command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E88979FB9B30ACF2; sudo apt update && sudo apt install -y libnss3 imagemagick
+    - run:
+        name: Pip install Basilisp (Python)
+        command: sudo add-apt-repository --yes ppa:deadsnakes/ppa; sudo apt-get update; sudo apt-get install python3.12; wget https://bootstrap.pypa.io/get-pip.py; sudo python3.12 get-pip.py; sudo python3.12 -m pip install --upgrade pip setuptools wheel; sudo python3.12 -m pip install pipenv; python3.12 -m pip install basilisp==0.1.0b2;
+    - run:
+        name: Run Extension Tests
+        command: npm run integration-test
+    - store_test_results:
+        path: ~/calva/junit
+    - store_artifacts:
+        path: ~/calva/out/extension-test/integration/screenshots
+        destination: integration-screenshots
   test-e2e:
     docker:
-      - image: cimg/clojure:1.11-browsers
+    - image: cimg/clojure:1.11-browsers
     working_directory: ~/calva
     steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Restore build
-          command: rmdir ~/calva && cp -r /tmp/build ~/calva
-      - run:
-          name: Apt install missing dependencies
-          command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E88979FB9B30ACF2; sudo apt update && sudo apt install -y libnss3
-      - run:
-          name: Run VSIX E2E Tests
-          command: npm run e2e-test -- --calva-vsix=/tmp/artifacts/calva-$( node -p 'require("./package.json").version' ).vsix --test-workspace=src/extension-test/e2e-test
-      - store_test_results:
-          path: ~/calva/junit
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Restore build
+        command: rmdir ~/calva && cp -r /tmp/build ~/calva
+    - run:
+        name: Apt install missing dependencies
+        command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E88979FB9B30ACF2; sudo apt update && sudo apt install -y libnss3
+    - run:
+        name: Run VSIX E2E Tests
+        command: npm run e2e-test -- --calva-vsix=/tmp/artifacts/calva-$( node -p 'require("./package.json").version' ).vsix --test-workspace=src/extension-test/e2e-test
+    - store_test_results:
+        path: ~/calva/junit
   test-e2e-sub-projects:
     docker:
-      - image: cimg/clojure:1.11-browsers
+    - image: cimg/clojure:1.11-browsers
     working_directory: ~/calva
     steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Restore build
-          command: rmdir ~/calva && cp -r /tmp/build ~/calva
-      - run:
-          name: Apt install missing dependencies
-          command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E88979FB9B30ACF2; sudo apt update && sudo apt install -y libnss3
-      - run:
-          name: Run VSIX E2E Tests for test-data/projects/e2e-sub-projects
-          command: npm run e2e-test -- --calva-vsix=/tmp/artifacts/calva-$( node -p 'require("./package.json").version' ).vsix --test-workspace=test-data/projects/e2e-sub-projects
-      - store_test_results:
-          path: ~/calva/junit
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Restore build
+        command: rmdir ~/calva && cp -r /tmp/build ~/calva
+    - run:
+        name: Apt install missing dependencies
+        command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E88979FB9B30ACF2; sudo apt update && sudo apt install -y libnss3
+    - run:
+        name: Run VSIX E2E Tests for test-data/projects/e2e-sub-projects
+        command: npm run e2e-test -- --calva-vsix=/tmp/artifacts/calva-$( node -p 'require("./package.json").version' ).vsix --test-workspace=test-data/projects/e2e-sub-projects
+    - store_test_results:
+        path: ~/calva/junit
   github-release:
     docker:
-      - image: cibuilds/github:0.10
+    - image: cibuilds/github:0.10
     working_directory: ~/calva
     steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Restore build
-          command: rmdir ~/calva && cp -r /tmp/build ~/calva
-      - run:
-          name: Publish Release on GitHub
-          command: |
-            EXTRA_RELEASE_OPTIONS=()
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Restore build
+        command: rmdir ~/calva && cp -r /tmp/build ~/calva
+    - run:
+        name: Publish Release on GitHub
+        command: |
+          EXTRA_RELEASE_OPTIONS=()
 
-            if [[ $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-              echo "Publishing GitHub Release: $CIRCLE_TAG"
-            else
-              echo "Publishing GitHub Prerelease: $CIRCLE_TAG"
-              EXTRA_RELEASE_OPTIONS=(-prerelease)
-            fi
+          if [[ $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "Publishing GitHub Release: $CIRCLE_TAG"
+          else
+            echo "Publishing GitHub Prerelease: $CIRCLE_TAG"
+            EXTRA_RELEASE_OPTIONS=(-prerelease)
+          fi
 
-            [[ $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+) ]] || exit
-            TAG_VERSION=${BASH_REMATCH[1]}
+          [[ $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+) ]] || exit
+          TAG_VERSION=${BASH_REMATCH[1]}
 
-            BODY=$(awk '
-            /^## \['"$TAG_VERSION"'\]/, started &&
-            /^##/ {
-              started=1;
-              if ($0 !~ /(^#|^\s*$)/) {
-                gsub(/["$]/, "\\\\&");
-                print
-              }
-            }' CHANGELOG.md)
+          BODY=$(awk '
+          /^## \['"$TAG_VERSION"'\]/, started &&
+          /^##/ {
+            started=1;
+            if ($0 !~ /(^#|^\s*$)/) {
+              gsub(/["$]/, "\\\\&");
+              print
+            }
+          }' CHANGELOG.md)
 
-            echo $'Changes: \n'"$BODY"
+          echo $'Changes: \n'"$BODY"
 
-            if [[ $IS_LOCAL == YES ]]; then
-              GHR_CMD='echo'
-            else
-              GHR_CMD=ghr
-            fi
+          if [[ $IS_LOCAL == YES ]]; then
+            GHR_CMD='echo'
+          else
+            GHR_CMD=ghr
+          fi
 
-            $GHR_CMD -t "$GITHUB_TOKEN" \
-              "${EXTRA_RELEASE_OPTIONS[@]}" \
-              -u "$CIRCLE_PROJECT_USERNAME" \
-              -r "$CIRCLE_PROJECT_REPONAME" \
-              -b "$BODY" \
-              -c "$CIRCLE_SHA1" \
-              -delete "$CIRCLE_TAG" \
-              /tmp/artifacts/
+          $GHR_CMD -t "$GITHUB_TOKEN" \
+            "${EXTRA_RELEASE_OPTIONS[@]}" \
+            -u "$CIRCLE_PROJECT_USERNAME" \
+            -r "$CIRCLE_PROJECT_REPONAME" \
+            -b "$BODY" \
+            -c "$CIRCLE_SHA1" \
+            -delete "$CIRCLE_TAG" \
+            /tmp/artifacts/
   marketplace-publish:
     docker:
-      - image: cimg/node:22.16.0
+    - image: cimg/node:22.16.0
     working_directory: ~/calva
     steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Restore build
-          command: rmdir ~/calva && cp -r /tmp/build ~/calva
-      - run:
-          name: Publish to the marketplace
-          command: |
-            VSCE_CMD=(
-              vsce publish --packagePath "/tmp/artifacts/calva-$(
-                node -p 'require("./package.json").version'
-              ).vsix" -p "$PUBLISH_TOKEN"
-            )
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Restore build
+        command: rmdir ~/calva && cp -r /tmp/build ~/calva
+    - run:
+        name: Publish to the marketplace
+        command: |
+          VSCE_CMD=(
+            vsce publish --packagePath "/tmp/artifacts/calva-$(
+              node -p 'require("./package.json").version'
+            ).vsix" -p "$PUBLISH_TOKEN"
+          )
 
-            if [[ $IS_LOCAL == YES ]]; then
-              echo "Dry npx ${VSCE_CMD[*]}"
+          if [[ $IS_LOCAL == YES ]]; then
+            echo "Dry npx ${VSCE_CMD[*]}"
 
-            else
-              npx "${VSCE_CMD[@]}"
-            fi
+          else
+            npx "${VSCE_CMD[@]}"
+          fi
   marketplace-preview-publish:
     docker:
-      - image: cimg/node:22.16.0
+    - image: cimg/node:22.16.0
     working_directory: ~/calva
     steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Restore build
-          command: rmdir ~/calva && cp -r /tmp/build ~/calva
-      - run:
-          name: Publish to the marketplace
-          command: |
-            VSCE_CMD=(
-              vsce publish --pre-release --packagePath "/tmp/artifacts/calva-$(
-                node -p 'require("./package.json").version'
-              ).vsixi" -p "$PUBLISH_TOKEN"
-            )
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Restore build
+        command: rmdir ~/calva && cp -r /tmp/build ~/calva
+    - run:
+        name: Publish to the marketplace
+        command: |
+          VSCE_CMD=(
+            vsce publish --pre-release --packagePath "/tmp/artifacts/calva-$(
+              node -p 'require("./package.json").version'
+            ).vsixi" -p "$PUBLISH_TOKEN"
+          )
 
-            if [[ $IS_LOCAL == YES ]]; then
-              echo "Dry npx ${VSCE_CMD[*]}"
+          if [[ $IS_LOCAL == YES ]]; then
+            echo "Dry npx ${VSCE_CMD[*]}"
 
-            else
-              npx "${VSCE_CMD[@]}"
-            fi
+          else
+            npx "${VSCE_CMD[@]}"
+          fi
   open-vsx-publish:
     docker:
-      - image: cimg/node:22.16.0
+    - image: cimg/node:22.16.0
     working_directory: ~/calva
     steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Restore build
-          command: rmdir ~/calva && cp -r /tmp/build ~/calva
-      - run:
-          name: Publish to Open VSX
-          command: |
-            OVSX_CMD=(
-              ovsx publish "/tmp/artifacts/calva-$(
-                node -p 'require("./package.json").version'
-              ).vsix" --pat "$OVSX_PUBLISH_TOKEN"
-            )
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Restore build
+        command: rmdir ~/calva && cp -r /tmp/build ~/calva
+    - run:
+        name: Publish to Open VSX
+        command: |
+          OVSX_CMD=(
+            ovsx publish "/tmp/artifacts/calva-$(
+              node -p 'require("./package.json").version'
+            ).vsix" --pat "$OVSX_PUBLISH_TOKEN"
+          )
 
-            if [[ $IS_LOCAL == YES ]]; then
-              echo "Dry npx ${OVSX_CMD[*]}"
+          if [[ $IS_LOCAL == YES ]]; then
+            echo "Dry npx ${OVSX_CMD[*]}"
 
-            else
-              npx "${OVSX_CMD[@]}"
-            fi
+          else
+            npx "${OVSX_CMD[@]}"
+          fi
   merge-dev-into-published:
     docker:
-      - image: cimg/node:15.8
+    - image: cimg/node:15.8
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - d1:06:ff:c3:58:59:68:6e:a3:2f:69:1d:e2:94:7c:14
-      - checkout
-      - run:
-          name: Merge dev into published
-          command: |
-            git config --global user.email "$GITHUB_USER_EMAIL"
-            git config --global user.name "$GITHUB_USER_NAME"
-            git checkout published
-            git pull
-            git merge origin/dev --no-ff -m "Merge branch dev into published"
-            git push origin HEAD
+    - add_ssh_keys:
+        fingerprints:
+        - d1:06:ff:c3:58:59:68:6e:a3:2f:69:1d:e2:94:7c:14
+    - checkout
+    - run:
+        name: Merge dev into published
+        command: |
+          git config --global user.email "$GITHUB_USER_EMAIL"
+          git config --global user.name "$GITHUB_USER_NAME"
+          git checkout published
+          git pull
+          git merge origin/dev --no-ff -m "Merge branch dev into published"
+          git push origin HEAD
   merge-published-into-dev:
     docker:
-      - image: cimg/node:15.8
+    - image: cimg/node:15.8
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - d1:06:ff:c3:58:59:68:6e:a3:2f:69:1d:e2:94:7c:14
-      - checkout
-      - run:
-          name: Merge published into dev
-          command: |
-            git config --global user.email "$GITHUB_USER_EMAIL"
-            git config --global user.name "$GITHUB_USER_NAME"
-            git checkout dev
-            git pull
-            git merge origin/published --no-ff -m "Merge branch published into dev [skip ci]"
-            git push origin HEAD
+    - add_ssh_keys:
+        fingerprints:
+        - d1:06:ff:c3:58:59:68:6e:a3:2f:69:1d:e2:94:7c:14
+    - checkout
+    - run:
+        name: Merge published into dev
+        command: |
+          git config --global user.email "$GITHUB_USER_EMAIL"
+          git config --global user.name "$GITHUB_USER_NAME"
+          git checkout dev
+          git pull
+          git merge origin/published --no-ff -m "Merge branch published into dev [skip ci]"
+          git push origin HEAD
   deploy-docs:
     docker:
-      - image: cimg/python:3.8-node
+    - image: cimg/python:3.8-node
     environment:
       MKDOCS_ENV: production
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - d1:06:ff:c3:58:59:68:6e:a3:2f:69:1d:e2:94:7c:14
-      - checkout
-      - run:
-          name: Update system package lists
-          command: sudo apt-get update
-      - run:
-          name: Install mkdocs-materials dependencies
-          command: sudo apt-get install libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
-      - run:
-          name: Install mkdocs and mkdocs-materials
-          command: pip install -r requirements.txt
-      - run:
-          name: Deploy docs
-          command: git checkout published; mkdocs gh-deploy --config-file mkdocs.yml --message "[skip ci]" --clean
+    - add_ssh_keys:
+        fingerprints:
+        - d1:06:ff:c3:58:59:68:6e:a3:2f:69:1d:e2:94:7c:14
+    - checkout
+    - run:
+        name: Update system package lists
+        command: sudo apt-get update
+    - run:
+        name: Install mkdocs-materials dependencies
+        command: sudo apt-get install libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
+    - run:
+        name: Install mkdocs and mkdocs-materials
+        command: pip install -r requirements.txt
+    - run:
+        name: Deploy docs
+        command: git checkout published; mkdocs gh-deploy --config-file mkdocs.yml --message "[skip ci]" --clean
   bump-dev-version:
     docker:
-      - image: cimg/node:15.8
+    - image: cimg/node:15.8
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - d1:06:ff:c3:58:59:68:6e:a3:2f:69:1d:e2:94:7c:14
-      - checkout
-      - run:
-          name: Bump dev version
-          command: |
-            git config --global user.email "$GITHUB_USER_EMAIL"
-            git config --global user.name "$GITHUB_USER_NAME"
-            git checkout dev
-            npm run bump-version
-            git pull
-            git add .
-            git commit -m "Bring on version $(node -p "require('./package').version")!"
-            git push origin HEAD
+    - add_ssh_keys:
+        fingerprints:
+        - d1:06:ff:c3:58:59:68:6e:a3:2f:69:1d:e2:94:7c:14
+    - checkout
+    - run:
+        name: Bump dev version
+        command: |
+          git config --global user.email "$GITHUB_USER_EMAIL"
+          git config --global user.name "$GITHUB_USER_NAME"
+          git checkout dev
+          npm run bump-version
+          git pull
+          git add .
+          git commit -m "Bring on version $(node -p "require('./package').version")!"
+          git push origin HEAD
 workflows:
   version: 2
   calva-io-build:
     jobs:
-      - deploy-docs:
-          filters:
-            branches:
-              only: published
-          context: Calva
-      - merge-published-into-dev:
-          filters:
-            branches:
-              only: published
-          context: Calva
+    - deploy-docs:
+        filters:
+          branches:
+            only: published
+        context: Calva
+    - merge-published-into-dev:
+        filters:
+          branches:
+            only: published
+        context: Calva
   build-test:
     jobs:
-      - checkout:
-          filters:
-            tags:
-              ignore: /^v\d+\.\d+\.\d+-?.*/
-      - prettier-check:
-          requires:
-            - checkout
-      - test-grammar:
-          requires:
-            - checkout
-      - build:
-          requires:
-            - checkout
-      - eslint-check:
-          requires:
-            - build
-      - test-cljslib:
-          requires:
-            - build
-      - test-integration:
-          requires:
-            - build
-      - test-e2e:
-          requires:
-            - build
-      - test-e2e-sub-projects:
-          requires:
-            - build
-      - test-ts-unit:
-          requires:
-            - build
-      - marketplace-preview-publish:
-          requires:
-            - prettier-check
-            - eslint-check
-            - test-grammar
-            - test-cljslib
-            - test-integration
-            - test-e2e
-            - test-e2e-sub-projects
-            - test-ts-unit
-          filters:
-            branches:
-              only: disabled
-          context: Calva
+    - checkout:
+        filters:
+          tags:
+            ignore: /^v\d+\.\d+\.\d+-?.*/
+    - prettier-check:
+        requires:
+        - checkout
+    - test-grammar:
+        requires:
+        - checkout
+    - build:
+        requires:
+        - checkout
+    - eslint-check:
+        requires:
+        - build
+    - test-cljslib:
+        requires:
+        - build
+    - test-integration:
+        requires:
+        - build
+    - test-e2e:
+        requires:
+        - build
+    - test-e2e-sub-projects:
+        requires:
+        - build
+    - test-ts-unit:
+        requires:
+        - build
+    - marketplace-preview-publish:
+        requires:
+        - prettier-check
+        - eslint-check
+        - test-grammar
+        - test-cljslib
+        - test-integration
+        - test-e2e
+        - test-e2e-sub-projects
+        - test-ts-unit
+        filters:
+          branches:
+            only: disabled
+        context: Calva
   release-publish:
     jobs:
-      - checkout:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+-?.*/
-      - build:
-          requires:
-            - checkout
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+-?.*/
-      - prettier-check:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+-?.*/
-      - eslint-check:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+-?.*/
-      - test-grammar:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+-?.*/
-      - test-cljslib:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+-?.*/
-      - test-integration:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+-?.*/
-      - test-e2e:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+-?.*/
-      - test-e2e-sub-projects:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+-?.*/
-      - test-ts-unit:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+-?.*/
-      - github-release:
-          requires:
-            - prettier-check
-            - eslint-check
-            - test-grammar
-            - test-cljslib
-            - test-integration
-            - test-e2e
-            - test-e2e-sub-projects
-            - test-ts-unit
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+-?.*/
-          context: Calva
-      - marketplace-publish:
-          requires:
-            - github-release
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-          context: Calva
-      - open-vsx-publish:
-          requires:
-            - github-release
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-          context: Calva
-      - merge-dev-into-published:
-          requires:
-            - marketplace-publish
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-          context: Calva
-      - bump-dev-version:
-          requires:
-            - merge-dev-into-published
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-          context: Calva
+    - checkout:
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+-?.*/
+    - build:
+        requires:
+        - checkout
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+-?.*/
+    - prettier-check:
+        requires:
+        - build
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+-?.*/
+    - eslint-check:
+        requires:
+        - build
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+-?.*/
+    - test-grammar:
+        requires:
+        - build
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+-?.*/
+    - test-cljslib:
+        requires:
+        - build
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+-?.*/
+    - test-integration:
+        requires:
+        - build
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+-?.*/
+    - test-e2e:
+        requires:
+        - build
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+-?.*/
+    - test-e2e-sub-projects:
+        requires:
+        - build
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+-?.*/
+    - test-ts-unit:
+        requires:
+        - build
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+-?.*/
+    - github-release:
+        requires:
+        - prettier-check
+        - eslint-check
+        - test-grammar
+        - test-cljslib
+        - test-integration
+        - test-e2e
+        - test-e2e-sub-projects
+        - test-ts-unit
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+-?.*/
+        context: Calva
+    - marketplace-publish:
+        requires:
+        - github-release
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+$/
+        context: Calva
+    - open-vsx-publish:
+        requires:
+        - github-release
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+$/
+        context: Calva
+    - merge-dev-into-published:
+        requires:
+        - marketplace-publish
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+$/
+        context: Calva
+    - bump-dev-version:
+        requires:
+        - merge-dev-into-published
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v\d+\.\d+\.\d+$/
+        context: Calva

--- a/.circleci/jobs/build.yaml
+++ b/.circleci/jobs/build.yaml
@@ -1,7 +1,7 @@
 !YS-v0:
 
 docker:
-- image: cimg/clojure:1.12-node
+- image: cimg/clojure:1.12.0-openjdk-21.0-node
 
 working_directory: ~/calva
 

--- a/.circleci/jobs/build.yaml
+++ b/.circleci/jobs/build.yaml
@@ -1,7 +1,7 @@
 !YS-v0:
 
 docker:
-- image: cimg/clojure:1.11-node
+- image: cimg/clojure:1.12-node
 
 working_directory: ~/calva
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [shadow-cljs runtimes for Node get not description at all](https://github.com/BetterThanTomorrow/calva/issues/2926)
+
 ## [2.0.527] - 2025-09-17
 
 - [Add command for selecting shadow-cljs runtime to connect to](https://github.com/BetterThanTomorrow/calva/issues/2923)

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
                        :exclusions [rewrite-clj/rewrite-clj]}
         dev.weavejester/cljfmt {:mvn/version "0.13.1"
                                 :exclusions [rewrite-clj/rewrite-clj]}
-        thheller/shadow-cljs {:mvn/version "2.28.15"}
+        thheller/shadow-cljs {:mvn/version "3.2.0"}
         org.clojars.liverm0r/dartclojure {:mvn/version "0.2.23-SNAPSHOT"}
         vvvvalvalval/supdate {:mvn/version "0.2.3"}
         camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
 {:deps {org.clojure/clojure {:mvn/version "1.12.0"}
+        org.clojure/clojurescript {:mvn/version "1.12.42"}
         rewrite-clj/rewrite-clj {:mvn/version "1.1.49"} ;; Temporary, while waiting for zprint to bump their deps
         zprint/zprint {:mvn/version "1.2.9"
                        :exclusions [rewrite-clj/rewrite-clj]}

--- a/scripts/build-and-test/Dockerfile
+++ b/scripts/build-and-test/Dockerfile
@@ -3,7 +3,7 @@
 ################################################################################
 # Install deps step
 ################################################################################
-FROM cimg/clojure:1.11-node as step-install-deps
+FROM cimg/clojure:1.12.0-openjdk-21.0-node as step-install-deps
 
 USER circleci
 RUN mkdir /home/circleci/calva
@@ -23,7 +23,7 @@ CMD echo "Nothing to do here" # All actions run at image build time
 ################################################################################
 # Build step
 ################################################################################
-FROM cimg/clojure:1.11-node as step-build
+FROM cimg/clojure:1.12.0-openjdk-21.0-node as step-build
 USER circleci
 
 # copy shadow deps

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -14,6 +14,7 @@
                              :cljify calva.js-utils/cljify
                              :prettyPrint calva.pprint.printer/pretty-print-js-bridge
                              :parseEdn calva.parse/parse-edn-js-bridge
+                             :parseEdnWithInst calva.parse/parse-edn-with-inst-js-bridge
                              :parseForms calva.parse/parse-forms-js-bridge
                              :setStateValue calva.state/set-state-value!
                              :getStateValue calva.state/get-state-value

--- a/src/cljs-lib/src/calva/parse.cljs
+++ b/src/cljs-lib/src/calva/parse.cljs
@@ -73,3 +73,15 @@
                   (:require [clojure.java.io :as io])
                   (:import (java.io RandomAccessFile)))
 (defn foo [] (println \"whee\"))"))
+
+(defn parse-edn-with-inst
+  "Parses EDN with support for #inst tags, converting them to JS Date objects.
+   Returns the parsed form."
+  [s]
+  (edn/read-string {:readers {'inst #(js/Date. %)}} s))
+
+(defn parse-edn-with-inst-js [s]
+  (jsify (parse-edn-with-inst s)))
+
+(defn parse-edn-with-inst-js-bridge [s]
+  (parse-edn-with-inst-js s))

--- a/src/shadow-cljs-runtime.ts
+++ b/src/shadow-cljs-runtime.ts
@@ -7,9 +7,10 @@ import * as output from './results-output/output';
 import * as state from './state';
 import status from './status';
 
-interface ShadowRuntimeInfo {
+interface ShadowApiRuntimeInfo {
   'client-id': number;
   'user-agent'?: string;
+  desc?: string;
   type: string;
   lang: string;
   'build-id': string;
@@ -24,14 +25,42 @@ interface ShadowRuntimeInfo {
   };
 }
 
+interface RuntimeInfo {
+  clientId: number;
+  description: string;
+  buildId: string;
+  host: string;
+  workerId: number;
+  since: string;
+}
+
+function normalizeRuntimeInfo(apiInfo: ShadowApiRuntimeInfo): RuntimeInfo {
+  return {
+    clientId: apiInfo['client-id'],
+    description: apiInfo.desc || apiInfo['user-agent'] || 'No description',
+    buildId: apiInfo['build-id'],
+    host: apiInfo.host,
+    workerId: apiInfo['worker-id'],
+    since: apiInfo.since || 'Unknown time',
+  };
+}
+
 interface RuntimeQuickPickItem extends vscode.QuickPickItem {
-  runtimeInfo: ShadowRuntimeInfo;
+  runtimeInfo: RuntimeInfo;
+}
+
+export function getSelectedRuntimeInfo(): RuntimeInfo {
+  return getStateValue('shadow-cljs:getSelectedRuntimeInfo');
+}
+
+export function getSelectedRuntimeId(): number {
+  return getStateValue('shadow-cljs:getSelectedRuntimeId');
 }
 
 /**
  * Get available shadow-cljs runtimes for the current build
  */
-export async function getShadowRuntimes(): Promise<ShadowRuntimeInfo[] | null> {
+export async function getShadowRuntimes(): Promise<RuntimeInfo[] | null> {
   try {
     const cljSession = replSession.getSession('clj');
     if (!cljSession) {
@@ -56,8 +85,8 @@ export async function getShadowRuntimes(): Promise<ShadowRuntimeInfo[] | null> {
 
     // Parse the EDN data structure returned by shadow-cljs
     try {
-      const runtimes: ShadowRuntimeInfo[] = parseEdn(result);
-      return runtimes;
+      const apiRuntimes: ShadowApiRuntimeInfo[] = parseEdn(result);
+      return apiRuntimes.map(normalizeRuntimeInfo);
     } catch (parseError) {
       output.appendLineOtherErr(`Error parsing runtime information: ${parseError}`);
       output.appendLineOtherOut(`Raw result: ${result}`);
@@ -72,19 +101,18 @@ export async function getShadowRuntimes(): Promise<ShadowRuntimeInfo[] | null> {
 /**
  * Format runtime information for display in QuickPick
  */
-function makeRuntimeMenuItem(runtime: ShadowRuntimeInfo): RuntimeQuickPickItem {
+function makeRuntimeMenuItem(runtime: RuntimeInfo): RuntimeQuickPickItem {
   const detailParts = [
-    `build: ${runtime['build-id']}`,
-    `id: ${runtime['client-id']}`,
+    `build: ${runtime.buildId}`,
+    `id: ${runtime.clientId}`,
     `host: ${runtime.host}`,
-    `dom: ${runtime.dom}`,
     `since: ${runtime.since}`,
-    `worker: ${runtime['worker-id']}`,
+    `worker: ${runtime.workerId}`,
   ];
 
   return {
-    label: `Runtime: ${runtime['client-id']}`,
-    description: runtime['user-agent'],
+    label: `Runtime: ${runtime.clientId}`,
+    description: runtime.description,
     detail: detailParts.join(', '),
     runtimeInfo: runtime,
   };
@@ -111,9 +139,9 @@ export async function selectShadowRuntime(): Promise<RuntimeQuickPickItem | null
   const items = runtimes.map(makeRuntimeMenuItem);
 
   // Get currently selected runtime from state to pre-select it in QuickPick
-  const currentRuntimeId = getStateValue('shadowCljs:selectedRuntime');
+  const currentRuntimeId = getSelectedRuntimeId();
   const currentItem = currentRuntimeId
-    ? items.find((item) => item.runtimeInfo['client-id'] === currentRuntimeId)
+    ? items.find((item) => item.runtimeInfo.clientId === currentRuntimeId)
     : undefined;
 
   const selected = await util.quickPickSingle({
@@ -133,7 +161,7 @@ export async function selectShadowRuntime(): Promise<RuntimeQuickPickItem | null
 /**
  * Switch to a specific shadow-cljs runtime
  */
-export async function switchToRuntime(runtimeInfo: ShadowRuntimeInfo): Promise<boolean> {
+export async function switchToRuntime(runtimeInfo: RuntimeInfo): Promise<boolean> {
   try {
     const cljSession = replSession.getSession('clj');
     if (!cljSession) {
@@ -142,15 +170,15 @@ export async function switchToRuntime(runtimeInfo: ShadowRuntimeInfo): Promise<b
     }
 
     const currentBuild = getStateValue('cljsBuild');
-    const clientId = runtimeInfo['client-id'];
+    const clientId = runtimeInfo.clientId;
 
     const selectRuntimeCode = `(shadow.cljs.devtools.api/repl-runtime-select ${currentBuild} ${clientId})`;
 
     await cljSession.eval(selectRuntimeCode, 'user').value;
 
     // Store runtime selection in state
-    cljsLib.setStateValue('shadowCljs:selectedRuntime', clientId);
-    cljsLib.setStateValue('shadowCljs:runtimeInfo', runtimeInfo);
+    cljsLib.setStateValue('shadow-cljs:getSelectedRuntimeId', clientId);
+    cljsLib.setStateValue('shadow-cljs:getSelectedRuntimeInfo', runtimeInfo);
 
     // Update status bar to show the new runtime
     status.update();
@@ -175,11 +203,11 @@ export async function selectShadowCljsRuntimeCommand(): Promise<void> {
 
       if (success) {
         void output.appendLineOtherOut(
-          `Switched to runtime ${selectedRuntime.runtimeInfo['client-id']}: ${selectedRuntime.description}`
+          `Switched to runtime ${selectedRuntime.runtimeInfo.clientId}: ${selectedRuntime.description}`
         );
       } else {
         void vscode.window.showErrorMessage(
-          `Failed to switch runtime (ID: ${selectedRuntime.runtimeInfo['client-id']}). See Calva output for details.`
+          `Failed to switch runtime (ID: ${selectedRuntime.runtimeInfo.clientId}). See Calva output for details.`
         );
       }
     }
@@ -207,11 +235,11 @@ export async function detectInitialRuntime(): Promise<void> {
     }
 
     const runtime = runtimes[0];
-    const clientId = runtime['client-id'];
+    const clientId = runtime.clientId;
 
     // Store the detected runtime
-    cljsLib.setStateValue('shadowCljs:selectedRuntime', clientId);
-    cljsLib.setStateValue('shadowCljs:runtimeInfo', runtime);
+    cljsLib.setStateValue('shadow-cljs:getSelectedRuntimeId', clientId);
+    cljsLib.setStateValue('shadow-cljs:getSelectedRuntimeInfo', runtime);
 
     status.update();
     if (runtimes.length > 1) {
@@ -220,11 +248,11 @@ export async function detectInitialRuntime(): Promise<void> {
       );
     }
     output.appendLineOtherOut(
-      `Connected runtime: ${clientId}, ${runtime['user-agent']}, host: ${runtime.host}, dom: ${runtime.dom}`
+      `Connected runtime: ${clientId}, ${runtime.description}, host: ${runtime.host}`
     );
   } catch (error) {
     output.appendLineOtherOut(`Note: Could not detect initial shadow-cljs runtime: ${error}`);
   }
 }
 
-export type { ShadowRuntimeInfo, RuntimeQuickPickItem };
+export type { ShadowApiRuntimeInfo as ShadowRuntimeInfo, RuntimeQuickPickItem };

--- a/src/shadow-cljs-runtime.ts
+++ b/src/shadow-cljs-runtime.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as replSession from './nrepl/repl-session';
 import { cljsLib } from './utilities';
 import * as util from './utilities';
-import { getStateValue, parseEdn } from '../out/cljs-lib/cljs-lib';
+import { getStateValue, parseEdn, parseEdnWithInst } from '../out/cljs-lib/cljs-lib';
 import * as output from './results-output/output';
 import * as state from './state';
 import status from './status';
@@ -17,7 +17,9 @@ interface ShadowApiRuntimeInfo {
   host: string;
   'worker-id': number;
   dom?: boolean;
-  since?: string;
+  since?: Date;
+  sinceInst?: number;
+  sinceDescription?: string;
   'proc-id'?: string;
   'connection-info'?: {
     remote: boolean;
@@ -31,17 +33,38 @@ interface RuntimeInfo {
   buildId: string;
   host: string;
   workerId: number;
-  since: string;
+  sinceInst: number;
+  sinceDescription: string;
+}
+
+/**
+ * Format a timestamp to a human-readable local time string
+ */
+function formatSinceDescription(since: Date | undefined): string {
+  if (!since) {
+    return 'Unknown time';
+  }
+
+  return since.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+    hour12: false,
+  });
 }
 
 function normalizeRuntimeInfo(apiInfo: ShadowApiRuntimeInfo): RuntimeInfo {
+  const sinceDate = apiInfo.since;
+  const sinceInst = sinceDate ? sinceDate.getTime() : 0;
+  const sinceDescription = formatSinceDescription(sinceDate);
+
   return {
     clientId: apiInfo['client-id'],
     description: apiInfo.desc || apiInfo['user-agent'] || 'No description',
     buildId: apiInfo['build-id'],
     host: apiInfo.host,
     workerId: apiInfo['worker-id'],
-    since: apiInfo.since || 'Unknown time',
+    sinceInst,
+    sinceDescription,
   };
 }
 
@@ -85,7 +108,7 @@ export async function getShadowRuntimes(): Promise<RuntimeInfo[] | null> {
 
     // Parse the EDN data structure returned by shadow-cljs
     try {
-      const apiRuntimes: ShadowApiRuntimeInfo[] = parseEdn(result);
+      const apiRuntimes: ShadowApiRuntimeInfo[] = parseEdnWithInst(result);
       return apiRuntimes.map(normalizeRuntimeInfo);
     } catch (parseError) {
       output.appendLineOtherErr(`Error parsing runtime information: ${parseError}`);
@@ -106,7 +129,7 @@ function makeRuntimeMenuItem(runtime: RuntimeInfo): RuntimeQuickPickItem {
     `build: ${runtime.buildId}`,
     `id: ${runtime.clientId}`,
     `host: ${runtime.host}`,
-    `since: ${runtime.since}`,
+    `since: ${runtime.sinceDescription}`,
     `worker: ${runtime.workerId}`,
   ];
 

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as state from './state';
 import * as util from './utilities';
 import * as config from './config';
+import * as shadowRuntimes from './shadow-cljs-runtime';
 import { getStateValue } from '../out/cljs-lib/cljs-lib';
 import { getSession, getReplSessionTypeFromState } from './nrepl/repl-session';
 
@@ -117,14 +118,12 @@ function update() {
     }
 
     if (replType === 'cljs' && cljsTypeName === 'shadow-cljs') {
-      const selectedRuntime = getStateValue('shadowCljs:selectedRuntime');
-      const runtimeInfo = getStateValue('shadowCljs:runtimeInfo');
+      const selectedRuntime = shadowRuntimes.getSelectedRuntimeId();
+      const runtimeInfo = shadowRuntimes.getSelectedRuntimeInfo();
 
       if (selectedRuntime && runtimeInfo) {
         shadowRuntimeStatus.text = `rt: ${selectedRuntime}`;
-        const userAgent = runtimeInfo['user-agent'] || 'Unknown runtime';
-        const since = runtimeInfo.since || 'Unknown time';
-        shadowRuntimeStatus.tooltip = `Connected to ${userAgent}, ${since}`;
+        shadowRuntimeStatus.tooltip = `Connected to ${runtimeInfo.description}, ${runtimeInfo.since}`;
         shadowRuntimeStatus.command = 'calva.selectShadowCljsRuntime';
       } else {
         shadowRuntimeStatus.text = 'No Runtime';

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -123,7 +123,7 @@ function update() {
 
       if (selectedRuntime && runtimeInfo) {
         shadowRuntimeStatus.text = `rt: ${selectedRuntime}`;
-        shadowRuntimeStatus.tooltip = `Connected to ${runtimeInfo.description}, ${runtimeInfo.since}`;
+        shadowRuntimeStatus.tooltip = `Connected to ${runtimeInfo.description}, ${runtimeInfo.sinceDescription}`;
         shadowRuntimeStatus.command = 'calva.selectShadowCljsRuntime';
       } else {
         shadowRuntimeStatus.text = 'No Runtime';


### PR DESCRIPTION
## What has changed?


* Fixes #2926

Also:

- Normalizing the Shadow API response at the gate
   - Creating a description from either the desc or the user-agent field
- Centralizing the state managamenet to the shadow runtimes module
- Displaying less verbose since times

## My Calva PR Checklist


I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
