### PR TITLE
2929-shadow-cljs-node-browser-repl-builds

### DIFF
--- a/.github/instructions/workspace-memory.instructions.md
+++ b/.github/instructions/workspace-memory.instructions.md
@@ -25,6 +25,12 @@ Remember that the human and the system (the Calva extension under development) a
 ### Joyride Integration
 Joyride gives you access to the extension host and VS Code APIs (sadly not the Development Extension host, though). You can create "tools" you need for your workflow, as Joyride is a bit of a DIY MCP server for VS Code itself.
 
+### Extension Development and Testing Workflow
+The extension uses TypeScript watchers for automatic recompilation during development. Key patterns:
+
+- **Watch tasks handle compilation**: Watchers automatically recompile TypeScript and ClojureScript as files change
+- **Human testing required**: Changes to extension logic TypeScript code require manual testing in the Development Extension Host since automated testing cannot access that environment
+
 ## Issue Workflow
 
 ### Starting Work on an Issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [No `node-repl` and `browser-repl` builds available with **deps.edn + shadow-cljs** project types](https://github.com/BetterThanTomorrow/calva/issues/2929)
+
 ## [2.0.528] - 2025-09-18
 
 - Fix: [shadow-cljs runtimes for Node get not description at all](https://github.com/BetterThanTomorrow/calva/issues/2926)

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -414,10 +414,17 @@ function createCLJSReplType(
         useDefaultBuild = false;
       } else {
         if (typeof initCode === 'object' || initCode.includes('%BUILD%')) {
+          const allBuilds = await figwheelOrShadowBuilds(cljsTypeName);
+          const availableBuilds = startedBuilds
+            ? [
+                ...new Set([
+                  ...startedBuilds,
+                  ...allBuilds.filter((b) => ['node-repl', 'browser-repl'].includes(b)),
+                ]),
+              ]
+            : allBuilds;
           const buildItem = await util.quickPickSingle({
-            values: startedBuilds
-              ? startedBuilds.map((a) => ({ label: a }))
-              : (await figwheelOrShadowBuilds(cljsTypeName)).map((a) => ({ label: a })),
+            values: availableBuilds.map((a) => ({ label: a })),
             placeHolder: 'Select which build to connect to',
             saveAs: `${state.getProjectRootUri().toString()}/${cljsTypeName.replace(
               ' ',

--- a/test-data/.vscode/settings.json
+++ b/test-data/.vscode/settings.json
@@ -85,7 +85,7 @@
       "projectRootPath": ["projects/pirate-lang"],
       "afterCLJReplJackInCode": ["(require 'repl)", "(println 1)", "(println 2)"],
       //"autoSelectForJackIn": true,
-      "autoSelectForConnect": true,
+      // "autoSelectForConnect": true,
       "cljsType": "none",
       "menuSelections": {
         "cljAliases": ["dev", "test"]
@@ -116,7 +116,7 @@
       "projectType": "deps.edn",
       "projectRootPath": ["projects/deps-main-opts"],
       "afterCLJReplJackInCode": "(require 'repl)",
-      "autoSelectForConnect": true,
+      // "autoSelectForConnect": true,
       // "autoSelectForJackIn": true,
       "cljsType": "none",
       "menuSelections": {

--- a/test-data/projects/minimal-figwheel-main/README.md
+++ b/test-data/projects/minimal-figwheel-main/README.md
@@ -1,0 +1,78 @@
+# Minimal Figwheel Main Project
+
+A minimal ClojureScript project using Figwheel Main for development.
+
+## Getting Started
+
+This project uses the latest patterns and dependencies from the figwheel-main repository, configured for Calva development workflow.
+
+### Dependencies
+- Clojure: 1.12.2
+- ClojureScript: 1.12.42
+- Figwheel Main: 0.2.20
+- Rebel Readline: 0.1.4
+
+### Running the Development Build
+
+This project is configured for Calva, which will automatically detect and manage the figwheel-main builds. From VS Code with Calva:
+
+1. Open the project in VS Code
+2. Use **Calva: Start a Project REPL and Connect (aka Jack-In)**
+3. Calva will detect the figwheel-main configuration and present build options
+4. Select the development build to start
+
+Alternatively, from the command line:
+
+```bash
+# Start the development build with REPL
+clojure -M -m figwheel.main -b dev -r
+```
+
+This will:
+1. Start watching your source files for changes
+2. Open a browser window at `http://localhost:9500`
+3. Launch a ClojureScript REPL connected to the browser
+
+### Project Structure
+
+```
+minimal-figwheel-main/
+├── deps.edn              # Project dependencies (no aliases needed for Calva)
+├── dev.cljs.edn          # Development build configuration
+├── src/
+│   └── minimal/
+│       └── core.cljs     # Main ClojureScript source
+└── resources/
+    └── public/
+        └── index.html    # Host HTML page
+```
+
+### Development Workflow
+
+1. Edit `src/minimal/core.cljs`
+2. Save the file
+3. Watch Figwheel automatically reload changes in the browser
+4. Use the REPL to evaluate code interactively
+
+### Build Configuration
+
+The `dev.cljs.edn` file contains minimal build configuration:
+- `:main` specifies the entry point namespace
+- Additional compiler options can be added as needed
+
+### Hot Reloading
+
+Figwheel Main provides:
+- Automatic compilation on file changes
+- Hot code reloading without page refresh
+- CSS reloading (add `:css-dirs` to figwheel-main.edn if needed)
+- Excellent error reporting
+
+### Calva Integration
+
+This project is specifically configured for Calva:
+- No build aliases in deps.edn (Calva manages the build process)
+- Standard figwheel-main project structure
+- Compatible with Calva's jack-in workflow
+
+Enjoy your ClojureScript development with Figwheel Main and Calva!

--- a/test-data/projects/minimal-figwheel-main/deps.edn
+++ b/test-data/projects/minimal-figwheel-main/deps.edn
@@ -1,0 +1,4 @@
+{:deps {org.clojure/clojure {:mvn/version "1.12.2"}
+        org.clojure/clojurescript {:mvn/version "1.12.42"}
+        com.bhauman/figwheel-main {:mvn/version "0.2.20"}}
+ :paths ["src" "target" "resources"]}

--- a/test-data/projects/minimal-figwheel-main/dev-too.cljs.edn
+++ b/test-data/projects/minimal-figwheel-main/dev-too.cljs.edn
@@ -1,0 +1,1 @@
+{:main minimal.core}

--- a/test-data/projects/minimal-figwheel-main/dev.cljs.edn
+++ b/test-data/projects/minimal-figwheel-main/dev.cljs.edn
@@ -1,0 +1,1 @@
+{:main minimal.core}

--- a/test-data/projects/minimal-figwheel-main/resources/public/index.html
+++ b/test-data/projects/minimal-figwheel-main/resources/public/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Minimal Figwheel Main</title>
+  </head>
+  <body>
+    <div id="app">
+      <h1>Welcome to Figwheel Main!</h1>
+      <p>Open the browser console to see output from your ClojureScript code.</p>
+      <p>Edit <code>src/minimal/core.cljs</code> and watch the changes reload automatically!</p>
+    </div>
+    <script src="cljs-out/dev-main.js" type="text/javascript"></script>
+    <script>minimal.core.init();</script>
+  </body>
+</html>

--- a/test-data/projects/minimal-figwheel-main/src/minimal/core.cljs
+++ b/test-data/projects/minimal-figwheel-main/src/minimal/core.cljs
@@ -1,0 +1,19 @@
+;; first notify figwheel that this ns has callbacks defined in it
+(ns ^:figwheel-hooks minimal.core)
+
+(enable-console-print!)
+
+(defn start []
+  (println "Hello World")
+  (-> js/document
+      (.getElementById "app")
+      (.-innerHTML)
+      (set! "Acme App started.")))
+
+(defn ^:export init []
+  (println "Initializing...")
+  (start))
+
+(defn ^:after-load reload []
+  (println "Reloading...")
+  (start))


### PR DESCRIPTION
## What has changed?

Fix: Ensure `node-repl` and `browser-repl` builds are available for all shadow-cljs project types

### Problem
When connecting to shadow-cljs via deps.edn + shadow-cljs project types, the `node-repl` and `browser-repl` build options were missing from the connect menu, unlike pure shadow-cljs projects.

### Root Cause
The connection logic inconsistently filtered available builds based on `startedBuilds`, which excluded these special REPL types for deps.edn + shadow-cljs but included them for pure shadow-cljs projects.

### Solution
Modified the build selection logic in `createCLJSReplType` to always include `node-repl` and `browser-repl` for shadow-cljs connections, ensuring consistent behavior across all project types.


Fixes #2929

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
