### PR TITLE
Show api evaluations in output destinations, just like with manual evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Make API evaluations show in the Calva output destination](https://github.com/BetterThanTomorrow/calva/issues/2942)
+
 ## [2.0.534] - 2025-09-24
 
 - Re-enable shadow-cljs runtimes connection updates...

--- a/src/api/repl-v1.ts
+++ b/src/api/repl-v1.ts
@@ -3,6 +3,7 @@ import * as printer from '../printer';
 import * as replSession from '../nrepl/repl-session';
 import * as resultOutput from '../results-output/output';
 import * as util from '../utilities';
+import { getConfig } from '../config';
 
 type Result = {
   result: string;
@@ -35,31 +36,58 @@ export const evaluateCode = async (
       );
     }
   }
-  const stdout = output
-    ? output.stdout
-    : (m: string) => {
-        resultOutput.appendOtherOut(m);
-      };
-  const stderr = output
-    ? output.stderr
-    : (m: string) => {
-        resultOutput.appendOtherErr(m);
-      };
+  // Always send to Calva destinations AND call custom handlers if provided
+  const stdout = (m: string) => {
+    resultOutput.appendEvalOut(m);
+
+    if (output?.stdout) {
+      output.stdout(m);
+    }
+  };
+
+  const stderr = (m: string) => {
+    resultOutput.appendEvalErr(m, {
+      ns: ns,
+      replSessionType: sessionKeyToUse,
+    });
+
+    if (output?.stderr) {
+      output.stderr(m);
+    }
+  };
   const evaluation = session.eval(code, ns, {
     stdout: stdout,
     stderr: stderr,
     pprintOptions: printer.disabledPrettyPrinter,
     ...nReplEvalOptions,
   });
+  // Honor the evaluationSendCodeToOutputWindow setting like manual evaluations do
+  if (getConfig().evaluationSendCodeToOutputWindow) {
+    if (resultOutput.getDestinationConfiguration().evalResults !== 'repl-window') {
+      resultOutput.appendClojureEval(code, {
+        ns,
+        replSessionType: sessionKeyToUse,
+        outputCategory: 'evaluatedCode',
+      });
+    }
+  }
+
   let result: Result;
   try {
+    const evaluationResult = await evaluation.value;
     result = {
-      result: await evaluation.value,
+      result: evaluationResult,
       ns: evaluation.ns,
       output: evaluation.outPut,
       errorOutput: evaluation.errorOutput,
       sessionKey: sessionKeyToUse,
     };
+
+    // Always display results in Calva destination
+    resultOutput.appendClojureEval(evaluationResult, {
+      ns: evaluation.ns,
+      replSessionType: sessionKeyToUse,
+    });
   } catch (evalError) {
     let stacktrace;
     try {
@@ -76,6 +104,11 @@ export const evaluateCode = async (
         error: `${evalError}`,
         stacktrace,
       };
+
+      resultOutput.appendClojureEval('nil', {
+        ns: evaluation.ns,
+        replSessionType: sessionKeyToUse,
+      });
     }
   }
   return result;


### PR DESCRIPTION
I asked Copilot to test the change for me and it immediately started to do fancy ANSI terminal code stuff. 😂

<img width="1076" height="836" alt="image" src="https://github.com/user-attachments/assets/c4beb67d-23ce-48f3-a7d7-0b6dfce5ce27" />

* Fixes #2942


## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
