### PR TITLE
Only normalize `\n`, not `\r`, in terminal output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Terminal output destination normalizes `\r` to `\r\n`, breaking TUI output using `\r` for cursor return only](https://github.com/BetterThanTomorrow/calva/issues/2945)
+
 ## [2.0.535] - 2025-09-28
 
 - [Make API evaluations show in the Calva output destination](https://github.com/BetterThanTomorrow/calva/issues/2942)

--- a/docs/site/output.md
+++ b/docs/site/output.md
@@ -33,6 +33,7 @@ The table below lists the features of the different output destinations.
 | Syntax highlighting | ✅ | ✅ | ✅ | ✅ |
 | Syntax highlighting matches editor | ✅ | ❌ ** | ❌ | ❌ |
 | Supports input | ✅ | ❌ | ❌ | ❌ |
+| TUI applications (progress bars, cursor positioning) | ❌ | ❌ | ❌ | ✅ |
 | Handles high volume output well | ❌ | ✅ | ✅ | ✅ |
 | Handles large data structures well | ❌ | ✅ | ✅ | ✅ |
 | Command for clearing output | ❌ | ✅ | ✅ | ✅ |

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -125,7 +125,7 @@ See also the Calva Inspector: https://calva.io/inspector
     );
   }
   write(message: string) {
-    this.writeEmitter.fire(message.replace(/\r(?!\n)|(?<!\r)\n/g, '\r\n'));
+    this.writeEmitter.fire(message.replace(/\r?\n/g, '\r\n'));
   }
   close(): void {
     outputPTY = undefined;


### PR DESCRIPTION
* Fixes #2945


## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
          * (Shouldn't change a real use case anywhere, afaict, but who knows...)
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
