### PR TITLE
doc: Add version of cider-nrepl and cider that fix behavior of unset breakpoints when loading file

### DIFF
--- a/docs/site/debugger.md
+++ b/docs/site/debugger.md
@@ -138,7 +138,10 @@ Here the breakpoint is exactly in front of a form that contains as its last expr
 
 ### Loading the File and "Eval On Save"
 
-When you load a file, any breakpoints that were previously set in functions will be unset. If you have the "Eval On Save" setting enabled, your file is also loaded with each save, therefore saving the file will remove breakpoints previously set.
+When you load a file, any breakpoints that were previously set in functions will be unset if you are using `nREPL` versions older than 1.5.0 or `cider-nrepl` versions older than 0.58.0. Starting with `nREPL` 1.5.0 together with `cider-nrepl` 0.58.0, breakpoints persist when the file is reloaded. If you have the "Eval On Save" setting enabled, saving the file will reload it; this only removes breakpoints when you're on older versions of these dependencies.
+
+!!! Note
+    If you want to know how to configure the versions of the dependencies that Calva Jack-in injects, see [Customizing Calva - Jack-in Dependency Versions](customizing-jack-in-and-connect.md#jack-in-dependency-versions).
 
 ## Clashes with Emacs/CIDER debugger
 
@@ -167,7 +170,7 @@ It's likely that your breakpoint is in a place that cider-nrepl does not see as 
   (+ 1 #break 1)) ;; This breakpoint will not be hit
 ```
 
-Another possible issue is that you're loading the file again after setting breakpoints, which unsets them. See [Loading the File and "Eval On Save"](#loading-the-file-and-eval-on-save) under Caveats.
+Another possible issue is that you're loading the file again after setting breakpoints, which unsets them when you're using `nREPL` versions older than 1.5.0 or `cider-nrepl` versions older than 0.58.0. See [Loading the File and "Eval On Save"](#loading-the-file-and-eval-on-save) under Caveats for more details and how newer versions preserve breakpoints.
 
 ### My breakpoint in a test isn't being hit
 

--- a/docs/site/jack-in-guide.md
+++ b/docs/site/jack-in-guide.md
@@ -12,7 +12,7 @@ search:
 Like with [CIDER Jack-in](https://metaredux.com/posts/2019/11/02/hard-cider-understanding-the-jack-in-process.html), Calva's let-me-help-you-start-your-project-and-connect feature might seem a bit mysterious. It really is helpful, but also really isn't mysterious. Here are a few things about it that is good to know about.
 
 !!! Note
-    If you came here to find out how to configure the versions of the dependencies that Calva Jack-in injects, see [Customizing Calva - Jack-in Dependency Versions](customizing.md#jack-in-dependency-versions).
+    If you came here to find out how to configure the versions of the dependencies that Calva Jack-in injects, see [Customizing Calva - Jack-in Dependency Versions](customizing-jack-in-and-connect.md#jack-in-dependency-versions).
 
 ## What it Solves
 


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Update debugger documentation to include that newer versions of `cider-nrepl` and `cider` fixed the behavior of unset breakpoints when load-file

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [ ] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.): Only documentation
- [ ] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.): documentation only PR
- [ ] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
