### PR TITLE
feat: uses latest version of depencies for jack-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- Bump default `nREPL`, `cider-nrepl`, and `cider/piggieback` Jack-in dependency to `1.5.1`, `0.58.0`, and `0.6.1`
-- [Get latest version of libs to inject in jack-in if no specific version was set by the user](https://github.com/BetterThanTomorrow/calva/issues/2959)
+- [Use latest version of libs for Jack-in, if no specific version was set by the user](https://github.com/BetterThanTomorrow/calva/issues/2959)
+
+  Previous default versions:
+  - `nrepl`: 1.3.1
+  - `cider-nrepl`: 0.55.4
+  - `cider/piggieback`: 0.6.0
 
 ## [2.0.538] - 2025-10-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Bump default `nREPL`, `cider-nrepl`, and `cider/piggieback` Jack-in dependency to `1.5.1`, `0.58.0`, and `0.6.1`
+- [Get latest version of libs to inject in jack-in if no specific version was set by the user](https://github.com/BetterThanTomorrow/calva/issues/2959)
+
 ## [2.0.538] - 2025-10-19
 
 - Fix: [Semantic tokens fail on some input with ignored forms](https://github.com/BetterThanTomorrow/calva/issues/2956)

--- a/docs/site/customizing-jack-in-and-connect.md
+++ b/docs/site/customizing-jack-in-and-connect.md
@@ -171,6 +171,9 @@ It may be helpful to view the messages sent between nREPL and Calva when trouble
 
 The versions used are configurable via the VS Code settings `calva.jackInDependencyVersions`.
 
+!!! Note "Latest versions by default"
+    By default, Calva resolves the latest available versions of `nrepl`, `cider-nrepl`, and `cider/piggieback` when Jacking in. If the latest version cannot be determined, Calva falls back to the default versions pinned in Calva's `package.json`. If you specify versions in `calva.jackInDependencyVersions`, those versions take precedence and will be used. You can specify just one; any unspecified dependencies still use the latest-or-fallback behavior.
+
 !!! Note "Java 1.8 compatible versions"
     The default dependency versions are not compatible with Java 1.8. If your project needs that version of Java you can use these settings in your Workspace `.vscode/settings.json`:
 

--- a/package.json
+++ b/package.json
@@ -490,10 +490,10 @@
                 "description": "Piggieback is used to create nREPL sessions in ClojureScript projects (not with shadow-cljs though, which provides its own middleware for this."
               }
             },
-            "default": {
-              "nrepl": "1.3.1",
-              "cider-nrepl": "0.55.4",
-              "cider/piggieback": "0.6.0"
+            "default": {  
+              "nrepl": "1.5.1",
+              "cider-nrepl": "0.58.0",
+              "cider/piggieback": "0.6.1"
             }
           },
           "calva.clojureLspVersion": {

--- a/package.json
+++ b/package.json
@@ -475,7 +475,7 @@
           },
           "calva.jackInDependencyVersions": {
             "type": "object",
-            "description": "Versions of the dependencies injected by Calva Jack-in",
+            "description": "Versions of the dependencies injected by Calva Jack-in. Calva caches the latest releases on first startup and uses them unless you override them here. If fetching fails, the built-in defaults below are used.",
             "properties": {
               "nrepl": {
                 "type": "string",

--- a/package.json
+++ b/package.json
@@ -475,7 +475,7 @@
           },
           "calva.jackInDependencyVersions": {
             "type": "object",
-            "description": "Versions of the dependencies injected by Calva Jack-in. Calva caches the latest releases on first startup and uses them unless you override them here. If fetching fails, the built-in defaults below are used.",
+            "description": "By default Calva Jack-in will inject the latest `nrepl`, etcetera versions when starting the repl. Override this default behaviour by declaring which versions to use here.",
             "properties": {
               "nrepl": {
                 "type": "string",

--- a/package.json
+++ b/package.json
@@ -490,7 +490,7 @@
                 "description": "Piggieback is used to create nREPL sessions in ClojureScript projects (not with shadow-cljs though, which provides its own middleware for this."
               }
             },
-            "default": {  
+            "default": {
               "nrepl": "1.5.1",
               "cider-nrepl": "0.58.0",
               "cider/piggieback": "0.6.1"

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ import { isDefined } from './utilities';
 import * as converters from './converters';
 import * as nreplUtil from './nrepl/util';
 import * as output from './results-output/output';
+import { getEffectiveJackInDependencyVersions } from './nrepl/jack-in-dependency-versions';
 
 const REPL_FILE_EXT = 'calva-repl';
 const FIDDLE_FILE_EXT = 'fiddle';
@@ -203,9 +204,7 @@ function getConfig() {
     testOnSave: configOptions.get('testOnSave'),
     showDocstringInParameterHelp: configOptions.get<boolean>('showDocstringInParameterHelp'),
     jackInEnv: configOptions.get('jackInEnv'),
-    jackInDependencyVersions: configOptions.get<{
-      JackInDependency: string;
-    }>('jackInDependencyVersions'),
+    jackInDependencyVersions: getEffectiveJackInDependencyVersions(),
     clojureLspVersion: configOptions.get<string>('clojureLspVersion'),
     clojureLspPath: configOptions.get<string>('clojureLspPath'),
     openBrowserWhenFigwheelStarted: configOptions.get<boolean>('openBrowserWhenFigwheelStarted'),

--- a/src/extension-test/integration/suite/jack-in-dependency-versions-test.ts
+++ b/src/extension-test/integration/suite/jack-in-dependency-versions-test.ts
@@ -5,6 +5,7 @@ import * as state from '../../../state';
 import {
   getEffectiveJackInDependencyVersions,
   JackInDependencyKey,
+  refreshJackInDependencyVersions,
 } from '../../../nrepl/jack-in-dependency-versions';
 
 const SUITE = 'Jack-in dependency versions';
@@ -15,10 +16,12 @@ type Versions = Partial<Record<JackInDependencyKey, string>>;
 let prevWorkspaceValue: Versions | undefined;
 let prevStoredValue: Versions | undefined;
 
-suite.only(SUITE, () => {
+suite(SUITE, () => {
   before(async () => {
     const ext = vscode.extensions.getExtension('betterthantomorrow.calva');
     await ext?.activate();
+
+    await refreshJackInDependencyVersions();
 
     const inspected = vscode.workspace
       .getConfiguration('calva')

--- a/src/extension-test/integration/suite/jack-in-dependency-versions-test.ts
+++ b/src/extension-test/integration/suite/jack-in-dependency-versions-test.ts
@@ -1,0 +1,160 @@
+import * as assert from 'assert';
+import { before, after, suite, test } from 'mocha';
+import * as vscode from 'vscode';
+import * as state from '../../../state';
+import {
+  getEffectiveJackInDependencyVersions,
+  JackInDependencyKey,
+} from '../../../nrepl/jack-in-dependency-versions';
+
+const SUITE = 'Jack-in dependency versions';
+const GLOBAL_STATE_KEY = 'calva.jackIn.latestDependencyVersions';
+
+type Versions = Partial<Record<JackInDependencyKey, string>>;
+
+let prevWorkspaceValue: Versions | undefined;
+let prevStoredValue: Versions | undefined;
+
+suite.only(SUITE, () => {
+  before(async () => {
+    const ext = vscode.extensions.getExtension('betterthantomorrow.calva');
+    await ext?.activate();
+
+    const inspected = vscode.workspace
+      .getConfiguration('calva')
+      .inspect<Versions>('jackInDependencyVersions');
+    prevWorkspaceValue = inspected?.workspaceValue;
+
+    prevStoredValue = state.extensionContext?.globalState.get<Versions>(GLOBAL_STATE_KEY);
+  });
+
+  after(async () => {
+    await vscode.workspace
+      .getConfiguration('calva')
+      .update('jackInDependencyVersions', prevWorkspaceValue, vscode.ConfigurationTarget.Workspace);
+
+    await state.extensionContext?.globalState.update(GLOBAL_STATE_KEY, prevStoredValue);
+  });
+
+  test('happy path: uses configured versions when set at workspace level', async () => {
+    const configured: Record<JackInDependencyKey, string> = {
+      nrepl: 'TEST-NREPL-1',
+      'cider-nrepl': 'TEST-CIDER-NREPL-2',
+      'cider/piggieback': 'TEST-PIGGIEBACK-3',
+    };
+
+    await vscode.workspace
+      .getConfiguration('calva')
+      .update('jackInDependencyVersions', configured, vscode.ConfigurationTarget.Workspace);
+
+    const effective = getEffectiveJackInDependencyVersions();
+
+    assert.deepStrictEqual(
+      effective,
+      configured,
+      `Expected configured versions to be used. Got ${JSON.stringify(effective)}`
+    );
+  });
+
+  test('partial configuration: missing keys fall back while set keys are respected', async () => {
+    // Clear stored values to avoid influencing this test
+    await state.extensionContext?.globalState.update(GLOBAL_STATE_KEY, {});
+
+    const inspectedDefaults = vscode.workspace
+      .getConfiguration('calva')
+      .inspect<Record<JackInDependencyKey, string>>('jackInDependencyVersions');
+    const defaults = (inspectedDefaults?.defaultValue ?? {}) as Record<JackInDependencyKey, string>;
+
+    const configured: Versions = {
+      nrepl: 'PARTIAL-NREPL-1',
+    };
+
+    await vscode.workspace
+      .getConfiguration('calva')
+      .update('jackInDependencyVersions', configured, vscode.ConfigurationTarget.Workspace);
+
+    const effective = getEffectiveJackInDependencyVersions();
+
+    assert.strictEqual(effective.nrepl, 'PARTIAL-NREPL-1', 'nrepl should use configured value');
+    assert.strictEqual(
+      effective['cider-nrepl'],
+      defaults['cider-nrepl'],
+      'cider-nrepl should fall back to default'
+    );
+    assert.strictEqual(
+      effective['cider/piggieback'],
+      defaults['cider/piggieback'],
+      'cider/piggieback should fall back to default'
+    );
+  });
+
+  test('precedence: stored values are used when nothing is configured', async () => {
+    const stored: Record<JackInDependencyKey, string> = {
+      nrepl: 'STORED-NREPL-1',
+      'cider-nrepl': 'STORED-CIDER-2',
+      'cider/piggieback': 'STORED-PIGGIE-3',
+    };
+    await state.extensionContext?.globalState.update(GLOBAL_STATE_KEY, stored);
+
+    await vscode.workspace
+      .getConfiguration('calva')
+      .update('jackInDependencyVersions', undefined, vscode.ConfigurationTarget.Workspace);
+
+    const effective = getEffectiveJackInDependencyVersions();
+    assert.deepStrictEqual(
+      effective,
+      stored,
+      'When nothing is configured, stored values should be used'
+    );
+  });
+
+  test('precedence: configured overrides stored', async () => {
+    const stored: Record<JackInDependencyKey, string> = {
+      nrepl: 'STORED-NREPL-1',
+      'cider-nrepl': 'STORED-CIDER-2',
+      'cider/piggieback': 'STORED-PIGGIE-3',
+    };
+    await state.extensionContext?.globalState.update(GLOBAL_STATE_KEY, stored);
+
+    const configured: Versions = {
+      nrepl: 'CONFIG-NREPL-1',
+      'cider/piggieback': 'CONFIG-PIGGIE-3',
+    };
+    await vscode.workspace
+      .getConfiguration('calva')
+      .update('jackInDependencyVersions', configured, vscode.ConfigurationTarget.Workspace);
+
+    const effective = getEffectiveJackInDependencyVersions();
+    assert.strictEqual(effective.nrepl, 'CONFIG-NREPL-1', 'configured should override stored');
+    assert.strictEqual(
+      effective['cider/piggieback'],
+      'CONFIG-PIGGIE-3',
+      'configured should override stored'
+    );
+    assert.strictEqual(
+      effective['cider-nrepl'],
+      'STORED-CIDER-2',
+      'stored should be used when not configured'
+    );
+  });
+
+  test('precedence: default is used when neither configured nor stored', async () => {
+    const inspectedDefaults = vscode.workspace
+      .getConfiguration('calva')
+      .inspect<Record<JackInDependencyKey, string>>('jackInDependencyVersions');
+    const defaults = (inspectedDefaults?.defaultValue ?? {}) as Record<JackInDependencyKey, string>;
+
+    await state.extensionContext?.globalState.update(GLOBAL_STATE_KEY, {});
+    await vscode.workspace
+      .getConfiguration('calva')
+      .update('jackInDependencyVersions', undefined, vscode.ConfigurationTarget.Workspace);
+
+    const effective = getEffectiveJackInDependencyVersions();
+
+    assert.deepStrictEqual(
+      effective,
+      defaults,
+      'effective should equal defaults when nothing is configured or stored'
+    );
+  });
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,7 @@ import * as converters from './converters';
 import * as joyride from './joyride';
 import * as api from './api/index';
 import * as depsClj from './nrepl/deps-clj';
+import { refreshJackInDependencyVersions } from './nrepl/jack-in-dependency-versions';
 import * as clojureDocs from './clojuredocs';
 import { capitalize } from './utilities';
 import * as overrides from './overrides';
@@ -186,7 +187,11 @@ async function activate(context: vscode.ExtensionContext) {
     );
   }
 
-  void depsClj.downloadDepsClj(context.extensionPath);
+  void depsClj
+    .downloadDepsClj(context.extensionPath)
+    .finally(() => {
+      void refreshJackInDependencyVersions();
+    });
 
   if (cljKondoExtension) {
     void vscode.window.showWarningMessage(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -187,11 +187,9 @@ async function activate(context: vscode.ExtensionContext) {
     );
   }
 
-  void depsClj
-    .downloadDepsClj(context.extensionPath)
-    .finally(() => {
-      void refreshJackInDependencyVersions();
-    });
+  void depsClj.downloadDepsClj(context.extensionPath).finally(() => {
+    void refreshJackInDependencyVersions();
+  });
 
   if (cljKondoExtension) {
     void vscode.window.showWarningMessage(

--- a/src/greet.ts
+++ b/src/greet.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
 import * as config from './config';
-import { getEffectiveJackInDependencyVersions } from './nrepl/jack-in-dependency-versions';
+import { getJackInVersionsDetail } from './nrepl/jack-in-dependency-versions';
 
 export function activationGreetings(chan: vscode.OutputChannel) {
   const conf = config.getConfig();
-  const jackInDependencyVersions = getEffectiveJackInDependencyVersions();
+  const detail = getJackInVersionsDetail();
   const clojureLspVersion = conf.clojureLspVersion;
   const clojureLspPath = conf.clojureLspPath;
 
@@ -26,10 +26,26 @@ export function activationGreetings(chan: vscode.OutputChannel) {
   chan.appendLine(
     'Calva is utilizing cider-nrepl and clojure-lsp to create this VS Code experience.'
   );
-  chan.appendLine('  nREPL dependencies configured:');
-  for (const dep in jackInDependencyVersions) {
-    chan.appendLine(`    ${dep}: ${jackInDependencyVersions[dep]}`);
-  }
+
+  chan.appendLine('  Latest available nREPL dependency versions known by Calva:');
+  Object.keys(detail.effective).forEach((dep) => {
+    const latest = detail.storedLatest[dep] ?? 'unknown';
+    chan.appendLine(`    ${dep}: ${latest}`);
+  });
+  chan.appendLine('');
+
+  chan.appendLine('  nREPL dependency versions:');
+  Object.keys(detail.effective).forEach((dep) => {
+    const source = detail.sources[dep];
+    const sourceLabel =
+      source === 'configured'
+        ? 'user configured override'
+        : source === 'stored'
+        ? 'latest known by Calva'
+        : 'Calva defaults fallback';
+    chan.appendLine(`    ${dep}: effective ${detail.effective[dep]} (${sourceLabel})`);
+  });
+
   if (clojureLspPath) {
     chan.appendLine(`  clojure-lsp path configured: ${clojureLspPath}`);
   } else {

--- a/src/greet.ts
+++ b/src/greet.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
 import * as config from './config';
+import { getEffectiveJackInDependencyVersions } from './nrepl/jack-in-dependency-versions';
 
 export function activationGreetings(chan: vscode.OutputChannel) {
   const conf = config.getConfig();
-  const jackInDependencyVersions = conf.jackInDependencyVersions;
+  const jackInDependencyVersions = getEffectiveJackInDependencyVersions();
   const clojureLspVersion = conf.clojureLspVersion;
   const clojureLspPath = conf.clojureLspPath;
 

--- a/src/nrepl/jack-in-dependency-versions.ts
+++ b/src/nrepl/jack-in-dependency-versions.ts
@@ -171,10 +171,7 @@ export function getJackInVersionsDetail(): JackInVersionsDetail {
   const configured = getConfiguredJackInDependencyVersions();
   const defaults = getDefaultJackInDependencyVersions();
 
-  const effective: Record<JackInDependencyKey, string> = {} as Record<
-    JackInDependencyKey,
-    string
-  >;
+  const effective: Record<JackInDependencyKey, string> = {} as Record<JackInDependencyKey, string>;
   const sources: Record<JackInDependencyKey, VersionSource> = {} as Record<
     JackInDependencyKey,
     VersionSource
@@ -216,7 +213,10 @@ export async function refreshJackInDependencyVersions(): Promise<void> {
 
   const stored = getStoredJackInDependencyVersions();
   if (isFullyPopulated(stored)) {
-    console.info('[Calva] Jack-in dependency versions already populated in global storage:', stored);
+    console.info(
+      '[Calva] Jack-in dependency versions already populated in global storage:',
+      stored
+    );
     return;
   }
 

--- a/src/nrepl/jack-in-dependency-versions.ts
+++ b/src/nrepl/jack-in-dependency-versions.ts
@@ -15,9 +15,7 @@ const JACK_IN_DEPENDENCY_LIBRARIES: Record<JackInDependencyKey, string> = {
   'cider/piggieback': 'cider/piggieback',
 };
 
-const JACK_IN_DEPENDENCY_KEYS = Object.keys(
-  JACK_IN_DEPENDENCY_LIBRARIES
-) as JackInDependencyKey[];
+const JACK_IN_DEPENDENCY_KEYS = Object.keys(JACK_IN_DEPENDENCY_LIBRARIES) as JackInDependencyKey[];
 
 const GLOBAL_STATE_KEY = 'calva.jackIn.latestDependencyVersions';
 
@@ -149,7 +147,9 @@ function getDefaultJackInDependencyVersions(): JackInDependencyVersions {
   return inspected?.defaultValue;
 }
 
-function isFullyPopulated(versions: JackInDependencyVersions): versions is Record<JackInDependencyKey, string> {
+function isFullyPopulated(
+  versions: JackInDependencyVersions
+): versions is Record<JackInDependencyKey, string> {
   return JACK_IN_DEPENDENCY_KEYS.every((key) => {
     const value = versions[key];
     return typeof value === 'string' && value.trim().length > 0;
@@ -216,10 +216,9 @@ export async function refreshJackInDependencyVersions(): Promise<void> {
     if (Object.keys(fetched).length > 0) {
       await storeJackInDependencyVersions(fetched);
     }
-  })()
-    .finally(() => {
-      refreshPromise = null;
-    });
+  })().finally(() => {
+    refreshPromise = null;
+  });
 
   refreshPromise = promise;
   return promise;

--- a/src/nrepl/jack-in-dependency-versions.ts
+++ b/src/nrepl/jack-in-dependency-versions.ts
@@ -156,26 +156,52 @@ function isFullyPopulated(
   });
 }
 
-export function getEffectiveJackInDependencyVersions(): Record<JackInDependencyKey, string> {
+export type VersionSource = 'configured' | 'stored' | 'default';
+
+export type JackInVersionsDetail = {
+  effective: Record<JackInDependencyKey, string>;
+  sources: Record<JackInDependencyKey, VersionSource>;
+  storedLatest: JackInDependencyVersions;
+  configured: JackInDependencyVersions;
+  defaults: JackInDependencyVersions;
+};
+
+export function getJackInVersionsDetail(): JackInVersionsDetail {
   const stored = getStoredJackInDependencyVersions();
   const configured = getConfiguredJackInDependencyVersions();
   const defaults = getDefaultJackInDependencyVersions();
 
-  return JACK_IN_DEPENDENCY_KEYS.reduce((acc, key) => {
+  const effective: Record<JackInDependencyKey, string> = {} as Record<
+    JackInDependencyKey,
+    string
+  >;
+  const sources: Record<JackInDependencyKey, VersionSource> = {} as Record<
+    JackInDependencyKey,
+    VersionSource
+  >;
+
+  for (const key of JACK_IN_DEPENDENCY_KEYS) {
     const configuredValue = configured[key];
     const storedValue = stored[key];
     const defaultValue = defaults[key] ?? '';
 
-    const chosen =
-      typeof configuredValue === 'string' && configuredValue.trim().length > 0
-        ? configuredValue
-        : typeof storedValue === 'string' && storedValue.trim().length > 0
-        ? storedValue
-        : defaultValue;
+    if (typeof configuredValue === 'string' && configuredValue.trim().length > 0) {
+      effective[key] = configuredValue;
+      sources[key] = 'configured';
+    } else if (typeof storedValue === 'string' && storedValue.trim().length > 0) {
+      effective[key] = storedValue;
+      sources[key] = 'stored';
+    } else {
+      effective[key] = defaultValue;
+      sources[key] = 'default';
+    }
+  }
 
-    acc[key] = chosen;
-    return acc;
-  }, {} as Record<JackInDependencyKey, string>);
+  return { effective, sources, storedLatest: stored, configured, defaults };
+}
+
+export function getEffectiveJackInDependencyVersions(): Record<JackInDependencyKey, string> {
+  return getJackInVersionsDetail().effective;
 }
 
 export async function refreshJackInDependencyVersions(): Promise<void> {
@@ -190,6 +216,7 @@ export async function refreshJackInDependencyVersions(): Promise<void> {
 
   const stored = getStoredJackInDependencyVersions();
   if (isFullyPopulated(stored)) {
+    console.info('[Calva] Jack-in dependency versions already populated in global storage:', stored);
     return;
   }
 
@@ -197,6 +224,8 @@ export async function refreshJackInDependencyVersions(): Promise<void> {
     const value = stored[key];
     return !(typeof value === 'string' && value.trim().length > 0);
   });
+
+  console.info('[Calva] Refreshing jack-in dependency versions. Missing keys:', missingKeys);
 
   const promise = (async () => {
     const fetched: JackInDependencyVersions = {};
@@ -206,6 +235,7 @@ export async function refreshJackInDependencyVersions(): Promise<void> {
       try {
         const version = await fetchLatestVersion(lib);
         fetched[key] = version;
+        console.info(`[Calva] Latest version for ${lib} resolved to ${version}`);
       } catch (error) {
         console.warn(
           `[Calva] Failed to fetch latest version for ${lib}: ${(error as Error).message}`
@@ -215,6 +245,9 @@ export async function refreshJackInDependencyVersions(): Promise<void> {
 
     if (Object.keys(fetched).length > 0) {
       await storeJackInDependencyVersions(fetched);
+      console.info('[Calva] Updated latest jack-in versions in global storage:', fetched);
+    } else {
+      console.info('[Calva] No new jack-in versions fetched.');
     }
   })().finally(() => {
     refreshPromise = null;

--- a/src/nrepl/jack-in-dependency-versions.ts
+++ b/src/nrepl/jack-in-dependency-versions.ts
@@ -19,12 +19,6 @@ const JACK_IN_DEPENDENCY_KEYS = Object.keys(
   JACK_IN_DEPENDENCY_LIBRARIES
 ) as JackInDependencyKey[];
 
-const JACK_IN_DEPENDENCY_DEFAULTS: Record<JackInDependencyKey, string> = {
-  'nrepl': '1.3.1',
-  'cider-nrepl': '0.55.4',
-  'cider/piggieback': '0.6.0',
-};
-
 const GLOBAL_STATE_KEY = 'calva.jackIn.latestDependencyVersions';
 
 let refreshPromise: Promise<void> | null = null;
@@ -149,6 +143,12 @@ function getConfiguredJackInDependencyVersions(): JackInDependencyVersions {
   return sources.reduce((acc, value) => ({ ...acc, ...value }), {} as JackInDependencyVersions);
 }
 
+function getDefaultJackInDependencyVersions(): JackInDependencyVersions {
+  const config = vscode.workspace.getConfiguration('calva');
+  const inspected = config.inspect<JackInDependencyVersions>('jackInDependencyVersions');
+  return inspected?.defaultValue;
+}
+
 function isFullyPopulated(versions: JackInDependencyVersions): versions is Record<JackInDependencyKey, string> {
   return JACK_IN_DEPENDENCY_KEYS.every((key) => {
     const value = versions[key];
@@ -159,11 +159,12 @@ function isFullyPopulated(versions: JackInDependencyVersions): versions is Recor
 export function getEffectiveJackInDependencyVersions(): Record<JackInDependencyKey, string> {
   const stored = getStoredJackInDependencyVersions();
   const configured = getConfiguredJackInDependencyVersions();
+  const defaults = getDefaultJackInDependencyVersions();
 
   return JACK_IN_DEPENDENCY_KEYS.reduce((acc, key) => {
     const configuredValue = configured[key];
     const storedValue = stored[key];
-    const defaultValue = JACK_IN_DEPENDENCY_DEFAULTS[key];
+    const defaultValue = defaults[key] ?? '';
 
     const chosen =
       typeof configuredValue === 'string' && configuredValue.trim().length > 0

--- a/src/nrepl/jack-in-dependency-versions.ts
+++ b/src/nrepl/jack-in-dependency-versions.ts
@@ -1,0 +1,225 @@
+import * as state from '../state';
+import * as vscode from 'vscode';
+import * as child from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import { parseEdn } from '../../out/cljs-lib/cljs-lib';
+
+export type JackInDependencyKey = 'nrepl' | 'cider-nrepl' | 'cider/piggieback';
+
+export type JackInDependencyVersions = Partial<Record<JackInDependencyKey, string>>;
+
+const JACK_IN_DEPENDENCY_LIBRARIES: Record<JackInDependencyKey, string> = {
+  nrepl: 'nrepl/nrepl',
+  'cider-nrepl': 'cider/cider-nrepl',
+  'cider/piggieback': 'cider/piggieback',
+};
+
+const JACK_IN_DEPENDENCY_KEYS = Object.keys(
+  JACK_IN_DEPENDENCY_LIBRARIES
+) as JackInDependencyKey[];
+
+const JACK_IN_DEPENDENCY_DEFAULTS: Record<JackInDependencyKey, string> = {
+  'nrepl': '1.3.1',
+  'cider-nrepl': '0.55.4',
+  'cider/piggieback': '0.6.0',
+};
+
+const GLOBAL_STATE_KEY = 'calva.jackIn.latestDependencyVersions';
+
+let refreshPromise: Promise<void> | null = null;
+
+function execFileAsync(command: string, args: string[]) {
+  return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+    child.execFile(
+      command,
+      args,
+      { encoding: 'utf8', timeout: 30000, maxBuffer: 1024 * 1024, windowsHide: true },
+      (error, stdout, stderr) => {
+        if (error) {
+          const execError = error as NodeJS.ErrnoException & {
+            stdout?: string;
+            stderr?: string;
+          };
+          execError.stdout = stdout;
+          execError.stderr = stderr;
+          reject(execError);
+          return;
+        }
+        resolve({ stdout, stderr });
+      }
+    );
+  });
+}
+
+function parseFindVersionsOutput(output: string): string | undefined {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      try {
+        return parseEdn(line);
+      } catch (error) {
+        console.warn('[Calva] Failed to parse find-versions output line', line, error);
+        return undefined;
+      }
+    })
+    .map((data) => (data ? data['mvn/version'] : undefined))
+    .find((version) => typeof version === 'string');
+}
+
+function getDepsCljJarPath(): string | undefined {
+  const context = state.extensionContext;
+  if (!context) {
+    return undefined;
+  }
+  const jarPath = path.join(context.extensionPath, 'deps.clj.jar');
+  return fs.existsSync(jarPath) ? jarPath : undefined;
+}
+
+async function fetchLatestVersion(library: string): Promise<string> {
+  const args = ['-X:deps', 'find-versions', ':lib', library, ':n', '1'];
+  const errors: string[] = [];
+
+  try {
+    const { stdout } = await execFileAsync('clojure', args);
+    const version = parseFindVersionsOutput(stdout);
+    if (version) {
+      return version;
+    }
+    errors.push(`clojure output missing version for ${library}`);
+  } catch (error) {
+    errors.push(`clojure failed: ${(error as Error).message}`);
+  }
+
+  const depsCljJarPath = getDepsCljJarPath();
+  if (depsCljJarPath) {
+    try {
+      const { stdout } = await execFileAsync('java', ['-jar', depsCljJarPath, ...args]);
+      const version = parseFindVersionsOutput(stdout);
+      if (version) {
+        return version;
+      }
+      errors.push(`deps.clj output missing version for ${library}`);
+    } catch (error) {
+      errors.push(`deps.clj failed: ${(error as Error).message}`);
+    }
+  } else {
+    errors.push('deps.clj.jar not available');
+  }
+
+  throw new Error(errors.join(' | '));
+}
+
+function getStoredJackInDependencyVersions(): JackInDependencyVersions {
+  const context = state.extensionContext;
+  if (!context) {
+    return {};
+  }
+  const stored = context.globalState.get<JackInDependencyVersions>(GLOBAL_STATE_KEY, {});
+  return { ...stored };
+}
+
+async function storeJackInDependencyVersions(versions: JackInDependencyVersions) {
+  const context = state.extensionContext;
+  if (!context) {
+    return;
+  }
+  const current = getStoredJackInDependencyVersions();
+  const merged: JackInDependencyVersions = { ...current, ...versions };
+  await context.globalState.update(GLOBAL_STATE_KEY, merged);
+}
+
+function getConfiguredJackInDependencyVersions(): JackInDependencyVersions {
+  const config = vscode.workspace.getConfiguration('calva');
+  const inspected = config.inspect<JackInDependencyVersions>('jackInDependencyVersions');
+  if (!inspected) {
+    return {};
+  }
+  const sources = [
+    inspected.globalValue,
+    inspected.globalLanguageValue,
+    inspected.workspaceValue,
+    inspected.workspaceLanguageValue,
+    inspected.workspaceFolderValue,
+    inspected.workspaceFolderLanguageValue,
+  ].filter((value): value is JackInDependencyVersions => Boolean(value));
+
+  return sources.reduce((acc, value) => ({ ...acc, ...value }), {} as JackInDependencyVersions);
+}
+
+function isFullyPopulated(versions: JackInDependencyVersions): versions is Record<JackInDependencyKey, string> {
+  return JACK_IN_DEPENDENCY_KEYS.every((key) => {
+    const value = versions[key];
+    return typeof value === 'string' && value.trim().length > 0;
+  });
+}
+
+export function getEffectiveJackInDependencyVersions(): Record<JackInDependencyKey, string> {
+  const stored = getStoredJackInDependencyVersions();
+  const configured = getConfiguredJackInDependencyVersions();
+
+  return JACK_IN_DEPENDENCY_KEYS.reduce((acc, key) => {
+    const configuredValue = configured[key];
+    const storedValue = stored[key];
+    const defaultValue = JACK_IN_DEPENDENCY_DEFAULTS[key];
+
+    const chosen =
+      typeof configuredValue === 'string' && configuredValue.trim().length > 0
+        ? configuredValue
+        : typeof storedValue === 'string' && storedValue.trim().length > 0
+        ? storedValue
+        : defaultValue;
+
+    acc[key] = chosen;
+    return acc;
+  }, {} as Record<JackInDependencyKey, string>);
+}
+
+export async function refreshJackInDependencyVersions(): Promise<void> {
+  const context = state.extensionContext;
+  if (!context) {
+    return;
+  }
+
+  if (refreshPromise !== null) {
+    return refreshPromise;
+  }
+
+  const stored = getStoredJackInDependencyVersions();
+  if (isFullyPopulated(stored)) {
+    return;
+  }
+
+  const missingKeys = JACK_IN_DEPENDENCY_KEYS.filter((key) => {
+    const value = stored[key];
+    return !(typeof value === 'string' && value.trim().length > 0);
+  });
+
+  const promise = (async () => {
+    const fetched: JackInDependencyVersions = {};
+
+    for (const key of missingKeys) {
+      const lib = JACK_IN_DEPENDENCY_LIBRARIES[key];
+      try {
+        const version = await fetchLatestVersion(lib);
+        fetched[key] = version;
+      } catch (error) {
+        console.warn(
+          `[Calva] Failed to fetch latest version for ${lib}: ${(error as Error).message}`
+        );
+      }
+    }
+
+    if (Object.keys(fetched).length > 0) {
+      await storeJackInDependencyVersions(fetched);
+    }
+  })()
+    .finally(() => {
+      refreshPromise = null;
+    });
+
+  refreshPromise = promise;
+  return promise;
+}

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -6,6 +6,10 @@ import * as utilities from '../utilities';
 import * as pprint from '../printer';
 import { getConfig } from '../config';
 import { keywordize, unKeywordize } from '../util/string';
+import {
+  getEffectiveJackInDependencyVersions,
+  type JackInDependencyKey,
+} from './jack-in-dependency-versions';
 import { CljsTypes, ReplConnectSequence } from './connectSequence';
 import { getStateValue, parseForms, parseEdn } from '../../out/cljs-lib/cljs-lib';
 import * as joyride from '../joyride';
@@ -236,9 +240,11 @@ export enum JackInDependency {
   'cider/piggieback' = 'cider/piggieback',
 }
 
-const NREPL_VERSION = () => getConfig().jackInDependencyVersions['nrepl'],
-  CIDER_NREPL_VERSION = () => getConfig().jackInDependencyVersions['cider-nrepl'],
-  PIGGIEBACK_VERSION = () => getConfig().jackInDependencyVersions['cider/piggieback'];
+const jackInVersionFor = (key: JackInDependencyKey) => getEffectiveJackInDependencyVersions()[key];
+
+const NREPL_VERSION = () => jackInVersionFor('nrepl'),
+  CIDER_NREPL_VERSION = () => jackInVersionFor('cider-nrepl'),
+  PIGGIEBACK_VERSION = () => jackInVersionFor('cider/piggieback');
 
 const cliDependencies = () => {
   return {


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Jack-in now auto-fetches the latest `nREPL`, `cider-nrepl`, and `piggieback` versions on first startup (via clojure/deps; falls back to deps.clj), caches them in global state, and falls back to built-in defaults if fetching fails.
  - The fall back to deps.clj is because Calva already have deps.clj.jar, but can be removed. I added because I thought that was a nice quickwin here.
- User overrides remain the highest priority; effective resolution is: overrides → cached latest → built-in defaults.
- New module `src/nrepl/jack-in-dependency-versions.ts` implements fetching, EDN parsing, persistence, and a single-flight refresh to avoid duplicate requests.
- Added `jackInVersionFor` helper in `project-types` and removed direct dependency on raw config for version lookup.
- Activation now triggers a background refresh of missing versions after `deps.clj` is downloaded; this is non-blocking for startup.
- Built-in default versions (used only if needed): nrepl 1.3.1, cider-nrepl 0.55.4, piggieback 0.6.0. (can be defined to be the latest before merge this PR)
- Backwards compatible: existing pinned versions and workflows continue to work unchanged.
<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2959 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
