### PR TITLE
Fixed nRepl unknown-session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Bump default deps.clj to `v1.12.4.1582`
+- [Fixed nRepl unknown-session](https://github.com/BetterThanTomorrow/calva/issues/2974)
 
 ## [2.0.541] - 2025-12-08
 

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -171,7 +171,7 @@ export class NReplClient {
               log(msg, Direction.ClientToServer);
               client.encoder.write(msg);
             }
-          } else if (data['id'] === cloneId) {
+          } else if (data['id'] === cloneId && data['new-session']) {
             client.session = new NReplSession(data['new-session'], client);
             const msg = {
               op: 'describe',


### PR DESCRIPTION
## What has changed?

Modified the clone response handler to check for the `new-session` field before processing it as a clone response. This ensures only actual clone responses update the session, preventing `out` messages from corrupting session state.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2974

## My Calva PR Checklist
I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
~- [ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
