### PR TITLE
Add pair selecting support for cond forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Grow Selection Could Consider 'Form Pairs' in :let Bindings](https://github.com/BetterThanTomorrow/calva/issues/2988)
+- Enhancement: Grow selection now considers test/expr pairs in `cond` forms.
 
 ## [2.0.545] - 2026-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - [Grow Selection Could Consider 'Form Pairs' in :let Bindings](https://github.com/BetterThanTomorrow/calva/issues/2988)
-- Enhancement: Grow selection now considers test/expr pairs in `cond` forms.
+- Enhancement: [Grow selection now considers test/expr pairs in `cond` forms](https://github.com/BetterThanTomorrow/calva/issues/2991)=======
 
 ## [2.0.545] - 2026-01-17
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1253,7 +1253,7 @@ export function growSelection(doc: EditableDocument, selections = doc.selections
       // if there's not, do nothing, we will not be expanding this cursor
       return [start, end];
     } else {
-      // check if we need to handle binding pairs
+      // check if we need to handle pairs (binding forms, conditional forms, maps, etc.)
       if (isInPairsList(startC, bindingForms)) {
         // Use the selection start to determine the pair
         const pairRange = currentSexpsRange(doc, startC, start, true);
@@ -1511,6 +1511,28 @@ function isPrecededByLetKeyword(cursor: LispTokenCursor): boolean {
     precedingToken = testCursor.getPrevToken();
   }
   return !!precedingToken && String(precedingToken.raw) === ':let';
+
+}
+
+export const conditionalForms = ['cond'];
+
+/**
+ * Returns the offset (number of initial forms that are not part of pairs)
+ * for conditional forms.
+ * - cond: pairs start after function name (offset 1 for 'cond' itself)
+ */
+function getConditionalFormPairOffset(cursor: LispTokenCursor): number {
+  const probeCursor = cursor.clone();
+  if (probeCursor.backwardList()) {
+    const opening = probeCursor.getPrevToken().raw;
+    if (opening.endsWith('(')) {
+      const fn = probeCursor.getFunctionName();
+      if (fn === 'cond') {
+        return 1;
+      }
+    }
+  }
+  return 0;
 }
 
 export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boolean {
@@ -1533,6 +1555,13 @@ export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boo
       }
       const fn = probeCursor.getFunctionName();
       if (fn && pairForms.includes(fn)) {
+        return true;
+      }
+    }
+    if (opening.endsWith('(')) {
+      // Check if this is a conditional form like (cond test expr test expr ...)
+      const fn = probeCursor.getFunctionName();
+      if (fn && conditionalForms.includes(fn)) {
         return true;
       }
     }
@@ -1560,14 +1589,24 @@ export function currentSexpsRange(
       const indexOfCurrentSingle = ranges.findIndex(
         (r) => r[0] === currentSingleRange[0] && r[1] === currentSingleRange[1]
       );
-      if (indexOfCurrentSingle % 2 == 0) {
-        const pairCursor = doc.getTokenCursor(currentSingleRange[1]);
-        pairCursor.forwardSexp();
-        return [currentSingleRange[0], pairCursor.offsetStart];
-      } else {
-        const pairCursor = doc.getTokenCursor(currentSingleRange[0]);
-        pairCursor.backwardSexp();
-        return [pairCursor.offsetStart, currentSingleRange[1]];
+
+      // Get the offset for conditional forms (e.g., cond has 1 initial non-pair form)
+      const pairOffset = getConditionalFormPairOffset(listCursor);
+
+      // Adjust the index to account for non-pair forms at the start
+      const adjustedIndex = indexOfCurrentSingle - pairOffset;
+
+      // Only treat as pairs if we're past the offset
+      if (adjustedIndex >= 0) {
+        if (adjustedIndex % 2 == 0) {
+          const pairCursor = doc.getTokenCursor(currentSingleRange[1]);
+          pairCursor.forwardSexp();
+          return [currentSingleRange[0], pairCursor.offsetStart];
+        } else {
+          const pairCursor = doc.getTokenCursor(currentSingleRange[0]);
+          pairCursor.backwardSexp();
+          return [pairCursor.offsetStart, currentSingleRange[1]];
+        }
       }
     }
   }

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1511,7 +1511,6 @@ function isPrecededByLetKeyword(cursor: LispTokenCursor): boolean {
     precedingToken = testCursor.getPrevToken();
   }
   return !!precedingToken && String(precedingToken.raw) === ':let';
-
 }
 
 const conditionalForms = ['cond'];

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1514,7 +1514,7 @@ function isPrecededByLetKeyword(cursor: LispTokenCursor): boolean {
 
 }
 
-export const conditionalForms = ['cond'];
+const conditionalForms = ['cond'];
 
 /**
  * Returns the offset (number of initial forms that are not part of pairs)

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1388,6 +1388,39 @@ describe('paredit', () => {
       paredit.growSelection(g);
       expect(g.selectionsStack).toEqual([[gSelection], [hSelection]]);
     });
+
+     it('grows selection to test/expr pairs in cond (expr selected first)', () => {
+       const a = docFromTextNotation('(cond true |:yes| false :no)');
+       const aSelection = a.selections[0];
+       const b = docFromTextNotation('(cond |true :yes| false :no)');
+       const bSelection = b.selections[0];
+       paredit.growSelection(a);
+       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+     });
+     it('grows selection to test/expr pairs in cond (test selected first)', () => {
+       const a = docFromTextNotation('(cond |true| :yes false :no)');
+       const aSelection = a.selections[0];
+       const b = docFromTextNotation('(cond |true :yes| false :no)');
+       const bSelection = b.selections[0];
+       paredit.growSelection(a);
+       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+     });
+     it('grows selection to test/expr pairs in cond (second pair)', () => {
+       const a = docFromTextNotation('(cond (pos? x) :positive |(neg? x)| :negative :else :zero)');
+       const aSelection = a.selections[0];
+       const b = docFromTextNotation('(cond (pos? x) :positive |(neg? x) :negative| :else :zero)');
+       const bSelection = b.selections[0];
+       paredit.growSelection(a);
+       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+     });
+     it('grows selection to test/expr pairs in cond with comment between', () => {
+       const a = docFromTextNotation('(cond true ;; comment\n |:yes| false :no)');
+       const aSelection = a.selections[0];
+       const b = docFromTextNotation('(cond |true ;; comment\n :yes| false :no)');
+       const bSelection = b.selections[0];
+       paredit.growSelection(a);
+       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+     });
   });
 
   describe('dragSexpr', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1371,7 +1371,7 @@ describe('paredit', () => {
       paredit.growSelection(a);
       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
-    
+
     it('grows selection to binding pairs in :let with diverse interspersed comments', () => {
       // Comment inside the vector between pairs
       const e = docFromTextNotation('(for [x xs :let [a b ; comment\n c |d|]])');
@@ -1390,46 +1390,53 @@ describe('paredit', () => {
       expect(g.selectionsStack).toEqual([[gSelection], [hSelection]]);
     });
 
-     it('grows selection to test/expr pairs in cond (expr selected first)', () => {
-       const a = docFromTextNotation('(cond true |:yes| false :no)');
-       const aSelection = a.selections[0];
-       const b = docFromTextNotation('(cond |true :yes| false :no)');
-       const bSelection = b.selections[0];
-       paredit.growSelection(a);
-       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-     });
-     it('grows selection to test/expr pairs in cond (test selected first)', () => {
-       const a = docFromTextNotation('(cond |true| :yes false :no)');
-       const aSelection = a.selections[0];
-       const b = docFromTextNotation('(cond |true :yes| false :no)');
-       const bSelection = b.selections[0];
-       paredit.growSelection(a);
-       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-     });
-     it('grows selection to test/expr pairs in cond (second pair)', () => {
-       const a = docFromTextNotation('(cond (pos? x) :positive |(neg? x)| :negative :else :zero)');
-       const aSelection = a.selections[0];
-       const b = docFromTextNotation('(cond (pos? x) :positive |(neg? x) :negative| :else :zero)');
-       const bSelection = b.selections[0];
-       paredit.growSelection(a);
-       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-     });
-     it('grows selection to test/expr pairs in cond with comment between', () => {
-       const a = docFromTextNotation('(cond true ;; comment\n |:yes| false :no)');
-       const aSelection = a.selections[0];
-       const b = docFromTextNotation('(cond |true ;; comment\n :yes| false :no)');
-       const bSelection = b.selections[0];
-       paredit.growSelection(a);
-       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-     });
-     it('grows selection to test/expr pairs in cond with comment between', () => {
-      const a = docFromTextNotation('(cond true ;; comment\n |:yes| false :no)');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(cond |true ;; comment\n :yes| false :no)');
-      const bSelection = b.selections[0];
-      paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
+    it('cond pairs'),
+      () => {
+        it('grows selection to test/expr pairs in cond (expr selected first)', () => {
+          const a = docFromTextNotation('(cond true |:yes| false :no)');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(cond |true :yes| false :no)');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('grows selection to test/expr pairs in cond (test selected first)', () => {
+          const a = docFromTextNotation('(cond |true| :yes false :no)');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(cond |true :yes| false :no)');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('grows selection to test/expr pairs in cond (second pair)', () => {
+          const a = docFromTextNotation(
+            '(cond (pos? x) :positive |(neg? x)| :negative :else :zero)'
+          );
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation(
+            '(cond (pos? x) :positive |(neg? x) :negative| :else :zero)'
+          );
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('grows selection to test/expr pairs in cond with comment between', () => {
+          const a = docFromTextNotation('(cond true ;; comment\n |:yes| false :no)');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(cond |true ;; comment\n :yes| false :no)');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('grows selection to test/expr pairs in cond with comment between', () => {
+          const a = docFromTextNotation('(cond true ;; comment\n |:yes| false :no)');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(cond |true ;; comment\n :yes| false :no)');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+      };
   });
 
   describe('dragSexpr', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1371,6 +1371,7 @@ describe('paredit', () => {
       paredit.growSelection(a);
       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
+    
     it('grows selection to binding pairs in :let with diverse interspersed comments', () => {
       // Comment inside the vector between pairs
       const e = docFromTextNotation('(for [x xs :let [a b ; comment\n c |d|]])');
@@ -1421,6 +1422,14 @@ describe('paredit', () => {
        paredit.growSelection(a);
        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
      });
+     it('grows selection to test/expr pairs in cond with comment between', () => {
+      const a = docFromTextNotation('(cond true ;; comment\n |:yes| false :no)');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(cond |true ;; comment\n :yes| false :no)');
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
   });
 
   describe('dragSexpr', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1390,7 +1390,7 @@ describe('paredit', () => {
       expect(g.selectionsStack).toEqual([[gSelection], [hSelection]]);
     });
 
-    it('cond pairs'),
+    describe('cond pairs'),
       () => {
         it('grows selection to test/expr pairs in cond (expr selected first)', () => {
           const a = docFromTextNotation('(cond true |:yes| false :no)');

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1390,53 +1390,40 @@ describe('paredit', () => {
       expect(g.selectionsStack).toEqual([[gSelection], [hSelection]]);
     });
 
-    describe('cond pairs'),
-      () => {
-        it('grows selection to test/expr pairs in cond (expr selected first)', () => {
-          const a = docFromTextNotation('(cond true |:yes| false :no)');
-          const aSelection = a.selections[0];
-          const b = docFromTextNotation('(cond |true :yes| false :no)');
-          const bSelection = b.selections[0];
-          paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-        });
-        it('grows selection to test/expr pairs in cond (test selected first)', () => {
-          const a = docFromTextNotation('(cond |true| :yes false :no)');
-          const aSelection = a.selections[0];
-          const b = docFromTextNotation('(cond |true :yes| false :no)');
-          const bSelection = b.selections[0];
-          paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-        });
-        it('grows selection to test/expr pairs in cond (second pair)', () => {
-          const a = docFromTextNotation(
-            '(cond (pos? x) :positive |(neg? x)| :negative :else :zero)'
-          );
-          const aSelection = a.selections[0];
-          const b = docFromTextNotation(
-            '(cond (pos? x) :positive |(neg? x) :negative| :else :zero)'
-          );
-          const bSelection = b.selections[0];
-          paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-        });
-        it('grows selection to test/expr pairs in cond with comment between', () => {
-          const a = docFromTextNotation('(cond true ;; comment\n |:yes| false :no)');
-          const aSelection = a.selections[0];
-          const b = docFromTextNotation('(cond |true ;; comment\n :yes| false :no)');
-          const bSelection = b.selections[0];
-          paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-        });
-        it('grows selection to test/expr pairs in cond with comment between', () => {
-          const a = docFromTextNotation('(cond true ;; comment\n |:yes| false :no)');
-          const aSelection = a.selections[0];
-          const b = docFromTextNotation('(cond |true ;; comment\n :yes| false :no)');
-          const bSelection = b.selections[0];
-          paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-        });
-      };
+    describe('cond pairs', () => {
+      it('grows selection to test/expr pairs in cond (expr selected first)', () => {
+        const a = docFromTextNotation('(cond true |:yes| false :no)');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(cond |true :yes| false :no)');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('grows selection to test/expr pairs in cond (test selected first)', () => {
+        const a = docFromTextNotation('(cond |true| :yes false :no)');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(cond |true :yes| false :no)');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('grows selection to test/expr pairs in cond (second pair)', () => {
+        const a = docFromTextNotation('(cond (pos? x) :positive |(neg? x)| :negative :else :zero)');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(cond (pos? x) :positive |(neg? x) :negative| :else :zero)');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('grows selection to test/expr pairs in cond with comment between', () => {
+        const a = docFromTextNotation('(cond true ;; comment\n |:yes| false :no)');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(cond |true ;; comment\n :yes| false :no)');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+    });
   });
 
   describe('dragSexpr', () => {

--- a/test-data/test-files/paredit_sandbox.clj
+++ b/test-data/test-files/paredit_sandbox.clj
@@ -110,6 +110,14 @@ string. "
 (#|())
 
 
+;; cond pair
+
+(cond
+  (= 1 2) 1
+  (= 2 2) 2
+  :else 23)
+
+
 (comment
   (a b (c
         d) e)


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

This PR adds pair selecting behavior for `cond` forms

### Implementation

- Added `conditionalForms` constant to identify forms that have test/expr pairs
- Added `getConditionalFormPairOffset()` function to handle offset requirements
- Modified `isInPairsList()` to detect `cond` forms in lists
- Updated `currentSexpsRange()` to use `pairOffset` when calculating pair indices
- Added comprehensive tests for `cond` form pair selection

### Status

Currently implemented:
- `cond` - fully working with tests
- `case` and `condp` should be included with other issue/PR because  they can be different (defaults, result-expr or result-fn, etc.)

### Why This Approach

Rather than hardcoding offset values directly in the pairing logic, we:
1. Created a separate `getConditionalFormPairOffset()` function that determines the offset dynamically based on the form type. This makes  easier to add more conditional forms in the future
2. This keeps the main `currentSexpsRange()` logic clean and maintainable

### Alternative Considered

Could have created separate functions for each form type, but this would duplicate logic. The offset approach is more maintainable.

Fixes #2991

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go.)

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
