### PR TITLE
Add pair selecting support for cond-> and cond->> forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Enhancement: [Grow selection now considers test/expr pairs in `cond->` and `cond->>` forms](https://github.com/BetterThanTomorrow/calva/issues/2991)
+
 ## [2.0.545] - 2026-01-17
 
 - Fix: [Jack-in sometimes fails from quoting issues](https://github.com/BetterThanTomorrow/calva/issues/2549)

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1497,7 +1497,7 @@ export const bindingForms = [
   'with-redefs',
 ];
 
-const conditionalForms = ['cond->', 'cond->>'];
+const conditionalForms = ['cond', 'cond->', 'cond->>'];
 
 /**
  * Returns the offset (number of initial forms that are not part of pairs)
@@ -1510,6 +1510,9 @@ function getConditionalFormPairOffset(cursor: LispTokenCursor): number {
     const opening = probeCursor.getPrevToken().raw;
     if (opening.endsWith('(')) {
       const fn = probeCursor.getFunctionName();
+      if (fn === 'cond') {
+        return 1;
+      }
       if (fn === 'cond->' || fn === 'cond->>') {
         return 2;
       }
@@ -1532,27 +1535,6 @@ function isPrecededByLetKeyword(cursor: LispTokenCursor): boolean {
     precedingToken = testCursor.getPrevToken();
   }
   return !!precedingToken && String(precedingToken.raw) === ':let';
-}
-
-const conditionalForms = ['cond'];
-
-/**
- * Returns the offset (number of initial forms that are not part of pairs)
- * for conditional forms.
- * - cond: pairs start after function name (offset 1 for 'cond' itself)
- */
-function getConditionalFormPairOffset(cursor: LispTokenCursor): number {
-  const probeCursor = cursor.clone();
-  if (probeCursor.backwardList()) {
-    const opening = probeCursor.getPrevToken().raw;
-    if (opening.endsWith('(')) {
-      const fn = probeCursor.getFunctionName();
-      if (fn === 'cond') {
-        return 1;
-      }
-    }
-  }
-  return 0;
 }
 
 export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boolean {

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1497,11 +1497,28 @@ export const bindingForms = [
   'with-redefs',
 ];
 
+function isPrecededByLetKeyword(cursor: LispTokenCursor): boolean {
+  const testCursor = cursor.clone();
+  // helper: move one token left from current position and skip whitespace
+  function stepLeftAndSkipWs() {
+    testCursor.previous();
+    testCursor.backwardWhitespace();
+  }
+  stepLeftAndSkipWs();
+  let precedingToken = testCursor.getPrevToken();
+  while (precedingToken && precedingToken.type === 'comment') {
+    stepLeftAndSkipWs();
+    precedingToken = testCursor.getPrevToken();
+  }
+  return !!precedingToken && String(precedingToken.raw) === ':let';
+}
+
 const conditionalForms = ['cond', 'cond->', 'cond->>'];
 
 /**
  * Returns the offset (number of initial forms that are not part of pairs)
  * for conditional forms.
+ * - cond: pairs start after function name (offset 1 for 'cond' itself)
  * - cond->/cond->>: pairs start after function name and initial form (offset 2)
  */
 function getConditionalFormPairOffset(cursor: LispTokenCursor): number {
@@ -1519,22 +1536,6 @@ function getConditionalFormPairOffset(cursor: LispTokenCursor): number {
     }
   }
   return 0;
-}
-
-function isPrecededByLetKeyword(cursor: LispTokenCursor): boolean {
-  const testCursor = cursor.clone();
-  // helper: move one token left from current position and skip whitespace
-  function stepLeftAndSkipWs() {
-    testCursor.previous();
-    testCursor.backwardWhitespace();
-  }
-  stepLeftAndSkipWs();
-  let precedingToken = testCursor.getPrevToken();
-  while (precedingToken && precedingToken.type === 'comment') {
-    stepLeftAndSkipWs();
-    precedingToken = testCursor.getPrevToken();
-  }
-  return !!precedingToken && String(precedingToken.raw) === ':let';
 }
 
 export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boolean {

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1253,20 +1253,26 @@ export function growSelection(doc: EditableDocument, selections = doc.selections
       // if there's not, do nothing, we will not be expanding this cursor
       return [start, end];
     } else {
+      // check if we need to handle pairs (binding forms, conditional forms, maps, etc.)
+      if (isInPairsList(startC, bindingForms)) {
+        // Use the selection start to determine the pair
+        const pairRange = currentSexpsRange(doc, startC, start, true);
+        // Only expand to pair if current selection is smaller than the pair
+        // (i.e., we have a single form selected, not already a pair or larger)
+        const currentSelectionLength = end - start;
+        const pairLength = pairRange[1] - pairRange[0];
+        if (currentSelectionLength < pairLength) {
+          return pairRange;
+        }
+        // else, current selection is >= pair size, next section should handle whole list
+      }
+
       // check if there's a list containing the current form
       if (startC.getPrevToken().type == 'open' && endC.getToken().type == 'close') {
         startC.backwardList();
         startC.backwardUpList();
         endC.forwardList();
         return [startC.offsetStart, endC.offsetEnd];
-        // check if we need to handle binding pairs
-      } else if (isInPairsList(startC, bindingForms)) {
-        const pairRange = currentSexpsRange(doc, startC, start, true);
-        // if pair not already selected, expand to pair
-        if (!_.isEqual(pairRange, [start, end])) {
-          return pairRange;
-        }
-        // else, if pair already selected, next section should handle whole list
       }
 
       // expand to whole list contents, if appropriate
@@ -1491,6 +1497,27 @@ export const bindingForms = [
   'with-redefs',
 ];
 
+const conditionalForms = ['cond->', 'cond->>'];
+
+/**
+ * Returns the offset (number of initial forms that are not part of pairs)
+ * for conditional forms.
+ * - cond->/cond->>: pairs start after function name and initial form (offset 2)
+ */
+function getConditionalFormPairOffset(cursor: LispTokenCursor): number {
+  const probeCursor = cursor.clone();
+  if (probeCursor.backwardList()) {
+    const opening = probeCursor.getPrevToken().raw;
+    if (opening.endsWith('(')) {
+      const fn = probeCursor.getFunctionName();
+      if (fn === 'cond->' || fn === 'cond->>') {
+        return 2;
+      }
+    }
+  }
+  return 0;
+}
+
 export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boolean {
   const probeCursor = cursor.clone();
   if (probeCursor.backwardList()) {
@@ -1506,6 +1533,13 @@ export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boo
       }
       const fn = probeCursor.getFunctionName();
       if (fn && pairForms.includes(fn)) {
+        return true;
+      }
+    }
+    if (opening.endsWith('(')) {
+      // Check if this is a conditional form like (cond test expr test expr ...)
+      const fn = probeCursor.getFunctionName();
+      if (fn && conditionalForms.includes(fn)) {
         return true;
       }
     }
@@ -1526,19 +1560,31 @@ export function currentSexpsRange(
 ): [number, number] {
   const currentSingleRange = cursor.rangeForCurrentForm(offset);
   if (usePairs) {
-    const ranges = cursor.rangesForSexpsInList();
+    // Create a fresh cursor at the offset position to ensure correct list context
+    const listCursor = doc.getTokenCursor(offset);
+    const ranges = listCursor.rangesForSexpsInList();
     if (ranges.length > 1) {
       const indexOfCurrentSingle = ranges.findIndex(
         (r) => r[0] === currentSingleRange[0] && r[1] === currentSingleRange[1]
       );
-      if (indexOfCurrentSingle % 2 == 0) {
-        const pairCursor = doc.getTokenCursor(currentSingleRange[1]);
-        pairCursor.forwardSexp();
-        return [currentSingleRange[0], pairCursor.offsetStart];
-      } else {
-        const pairCursor = doc.getTokenCursor(currentSingleRange[0]);
-        pairCursor.backwardSexp();
-        return [pairCursor.offsetStart, currentSingleRange[1]];
+
+      // Get the offset for conditional forms (e.g., cond has 1 initial non-pair form)
+      const pairOffset = getConditionalFormPairOffset(listCursor);
+
+      // Adjust the index to account for non-pair forms at the start
+      const adjustedIndex = indexOfCurrentSingle - pairOffset;
+
+      // Only treat as pairs if we're past the offset
+      if (adjustedIndex >= 0) {
+        if (adjustedIndex % 2 == 0) {
+          const pairCursor = doc.getTokenCursor(currentSingleRange[1]);
+          pairCursor.forwardSexp();
+          return [currentSingleRange[0], pairCursor.offsetStart];
+        } else {
+          const pairCursor = doc.getTokenCursor(currentSingleRange[0]);
+          pairCursor.backwardSexp();
+          return [pairCursor.offsetStart, currentSingleRange[1]];
+        }
       }
     }
   }

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1327,6 +1327,38 @@ describe('paredit', () => {
       paredit.growSelection(a);
       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
+    it('grows selection to test/expr pairs in cond-> (expr selected first)', () => {
+      const a = docFromTextNotation('(cond-> x (> 0 x) |inc| (even? x) (* 2 x))');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
+    it('grows selection to test/expr pairs in cond-> (test selected first)', () => {
+      const a = docFromTextNotation('(cond-> x |(> 0 x)| inc (even? x) (* 2 x))');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
+    it('grows selection to test/expr pairs in cond->> (expr selected first)', () => {
+      const a = docFromTextNotation('(cond->> x (> 0 x) |inc| (even? x) (* 2 x))');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
+    it('grows selection to test/expr pairs in cond->> (test selected first)', () => {
+      const a = docFromTextNotation('(cond->> x |(> 0 x)| inc (even? x) (* 2 x))');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
   });
 
   describe('dragSexpr', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1388,38 +1388,40 @@ describe('paredit', () => {
       paredit.growSelection(g);
       expect(g.selectionsStack).toEqual([[gSelection], [hSelection]]);
     });
-    it('grows selection to test/expr pairs in cond-> (expr selected first)', () => {
-      const a = docFromTextNotation('(cond-> x (> 0 x) |inc| (even? x) (* 2 x))');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
-      const bSelection = b.selections[0];
-      paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
-    it('grows selection to test/expr pairs in cond-> (test selected first)', () => {
-      const a = docFromTextNotation('(cond-> x |(> 0 x)| inc (even? x) (* 2 x))');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
-      const bSelection = b.selections[0];
-      paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
-    it('grows selection to test/expr pairs in cond->> (expr selected first)', () => {
-      const a = docFromTextNotation('(cond->> x (> 0 x) |inc| (even? x) (* 2 x))');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
-      const bSelection = b.selections[0];
-      paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
-    it('grows selection to test/expr pairs in cond->> (test selected first)', () => {
-      const a = docFromTextNotation('(cond->> x |(> 0 x)| inc (even? x) (* 2 x))');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
-      const bSelection = b.selections[0];
-      paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
+    it('cond-> and cond->> pairs'), () => {
+      it('grows selection to test/expr pairs in cond-> (expr selected first)', () => {
+        const a = docFromTextNotation('(cond-> x (> 0 x) |inc| (even? x) (* 2 x))');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('grows selection to test/expr pairs in cond-> (test selected first)', () => {
+        const a = docFromTextNotation('(cond-> x |(> 0 x)| inc (even? x) (* 2 x))');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('grows selection to test/expr pairs in cond->> (expr selected first)', () => {
+        const a = docFromTextNotation('(cond->> x (> 0 x) |inc| (even? x) (* 2 x))');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('grows selection to test/expr pairs in cond->> (test selected first)', () => {
+        const a = docFromTextNotation('(cond->> x |(> 0 x)| inc (even? x) (* 2 x))');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+    }
   });
 
   describe('dragSexpr', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1388,40 +1388,42 @@ describe('paredit', () => {
       paredit.growSelection(g);
       expect(g.selectionsStack).toEqual([[gSelection], [hSelection]]);
     });
-    it('cond-> and cond->> pairs'), () => {
-      it('grows selection to test/expr pairs in cond-> (expr selected first)', () => {
-        const a = docFromTextNotation('(cond-> x (> 0 x) |inc| (even? x) (* 2 x))');
-        const aSelection = a.selections[0];
-        const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
-        const bSelection = b.selections[0];
-        paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-      });
-      it('grows selection to test/expr pairs in cond-> (test selected first)', () => {
-        const a = docFromTextNotation('(cond-> x |(> 0 x)| inc (even? x) (* 2 x))');
-        const aSelection = a.selections[0];
-        const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
-        const bSelection = b.selections[0];
-        paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-      });
-      it('grows selection to test/expr pairs in cond->> (expr selected first)', () => {
-        const a = docFromTextNotation('(cond->> x (> 0 x) |inc| (even? x) (* 2 x))');
-        const aSelection = a.selections[0];
-        const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
-        const bSelection = b.selections[0];
-        paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-      });
-      it('grows selection to test/expr pairs in cond->> (test selected first)', () => {
-        const a = docFromTextNotation('(cond->> x |(> 0 x)| inc (even? x) (* 2 x))');
-        const aSelection = a.selections[0];
-        const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
-        const bSelection = b.selections[0];
-        paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-      });
-    }
+
+    it('cond-> and cond->> pairs'),
+      () => {
+        it('grows selection to test/expr pairs in cond-> (expr selected first)', () => {
+          const a = docFromTextNotation('(cond-> x (> 0 x) |inc| (even? x) (* 2 x))');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('grows selection to test/expr pairs in cond-> (test selected first)', () => {
+          const a = docFromTextNotation('(cond-> x |(> 0 x)| inc (even? x) (* 2 x))');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('grows selection to test/expr pairs in cond->> (expr selected first)', () => {
+          const a = docFromTextNotation('(cond->> x (> 0 x) |inc| (even? x) (* 2 x))');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('grows selection to test/expr pairs in cond->> (test selected first)', () => {
+          const a = docFromTextNotation('(cond->> x |(> 0 x)| inc (even? x) (* 2 x))');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+      };
   });
 
   describe('dragSexpr', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1389,41 +1389,40 @@ describe('paredit', () => {
       expect(g.selectionsStack).toEqual([[gSelection], [hSelection]]);
     });
 
-    it('cond-> and cond->> pairs'),
-      () => {
-        it('grows selection to test/expr pairs in cond-> (expr selected first)', () => {
-          const a = docFromTextNotation('(cond-> x (> 0 x) |inc| (even? x) (* 2 x))');
-          const aSelection = a.selections[0];
-          const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
-          const bSelection = b.selections[0];
-          paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-        });
-        it('grows selection to test/expr pairs in cond-> (test selected first)', () => {
-          const a = docFromTextNotation('(cond-> x |(> 0 x)| inc (even? x) (* 2 x))');
-          const aSelection = a.selections[0];
-          const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
-          const bSelection = b.selections[0];
-          paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-        });
-        it('grows selection to test/expr pairs in cond->> (expr selected first)', () => {
-          const a = docFromTextNotation('(cond->> x (> 0 x) |inc| (even? x) (* 2 x))');
-          const aSelection = a.selections[0];
-          const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
-          const bSelection = b.selections[0];
-          paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-        });
-        it('grows selection to test/expr pairs in cond->> (test selected first)', () => {
-          const a = docFromTextNotation('(cond->> x |(> 0 x)| inc (even? x) (* 2 x))');
-          const aSelection = a.selections[0];
-          const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
-          const bSelection = b.selections[0];
-          paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-        });
-      };
+    describe('cond-> and cond->> pairs', () => {
+      it('grows selection to test/expr pairs in cond-> (expr selected first)', () => {
+        const a = docFromTextNotation('(cond-> x (> 0 x) |inc| (even? x) (* 2 x))');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('grows selection to test/expr pairs in cond-> (test selected first)', () => {
+        const a = docFromTextNotation('(cond-> x |(> 0 x)| inc (even? x) (* 2 x))');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('grows selection to test/expr pairs in cond->> (expr selected first)', () => {
+        const a = docFromTextNotation('(cond->> x (> 0 x) |inc| (even? x) (* 2 x))');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('grows selection to test/expr pairs in cond->> (test selected first)', () => {
+        const a = docFromTextNotation('(cond->> x |(> 0 x)| inc (even? x) (* 2 x))');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+    });
   });
 
   describe('dragSexpr', () => {

--- a/test-data/test-files/paredit_sandbox.clj
+++ b/test-data/test-files/paredit_sandbox.clj
@@ -109,6 +109,23 @@ string. "
 ; Should not delete `#`
 (#|())
 
+;; Pair selecting
+
+(cond
+  (= 1 1)  (println "one is one")
+  (= 2 2)  (println "two is two"))
+
+(cond->> []
+ true  (cons 1)
+ false (cons 2)
+ true  (cons 3))
+
+(cond-> {}
+  true  (assoc :a 1)
+  false (assoc :b 2)
+  true  (assoc :c 3))
+
+
 
 (comment
   (a b (c


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

This PR adds support for growing selection to consider test/expr pairs in `cond->` and `cond->>` threading forms, similar to how it works for `cond` and binding forms like `let`.

- Updated `src/cursor-doc/paredit.ts` to include `cond->` and `cond->>` in conditional forms with correct offset handling.
- Added unit tests in `src/extension-test/unit/cursor-doc/paredit-test.ts` for pair selecting in threading forms.
- Updated `CHANGELOG.md` with an enhancement entry linking to issue #2991.
- Added test data in `test-data/test-files/paredit_sandbox.clj` for the new forms.

Fixes #2994

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ --></content>
<parameter name="filePath">