### PR TITLE
Add support for growing selection in case forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Enhancement: [Grow selection now considers value/result pairs in `case` forms](https://github.com/BetterThanTomorrow/calva/issues/2993)
+
 ## [2.0.545] - 2026-01-17
 
 - Fix: [Jack-in sometimes fails from quoting issues](https://github.com/BetterThanTomorrow/calva/issues/2549)

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1253,20 +1253,26 @@ export function growSelection(doc: EditableDocument, selections = doc.selections
       // if there's not, do nothing, we will not be expanding this cursor
       return [start, end];
     } else {
+      // check if we need to handle pairs (binding forms, conditional forms, maps, etc.)
+      if (isInPairsList(startC, bindingForms)) {
+        // Use the selection start to determine the pair
+        const pairRange = currentSexpsRange(doc, startC, start, true);
+        // Only expand to pair if current selection is smaller than the pair
+        // (i.e., we have a single form selected, not already a pair or larger)
+        const currentSelectionLength = end - start;
+        const pairLength = pairRange[1] - pairRange[0];
+        if (currentSelectionLength < pairLength) {
+          return pairRange;
+        }
+        // else, current selection is >= pair size, next section should handle whole list
+      }
+
       // check if there's a list containing the current form
       if (startC.getPrevToken().type == 'open' && endC.getToken().type == 'close') {
         startC.backwardList();
         startC.backwardUpList();
         endC.forwardList();
         return [startC.offsetStart, endC.offsetEnd];
-        // check if we need to handle binding pairs
-      } else if (isInPairsList(startC, bindingForms)) {
-        const pairRange = currentSexpsRange(doc, startC, start, true);
-        // if pair not already selected, expand to pair
-        if (!_.isEqual(pairRange, [start, end])) {
-          return pairRange;
-        }
-        // else, if pair already selected, next section should handle whole list
       }
 
       // expand to whole list contents, if appropriate
@@ -1491,6 +1497,27 @@ export const bindingForms = [
   'with-redefs',
 ];
 
+const conditionalForms = ['case'];
+
+/**
+ * Returns the offset (number of initial forms that are not part of pairs)
+ * for conditional forms.
+ * - case: pairs start after function name and initial form (offset 2)
+ */
+function getConditionalFormPairOffset(cursor: LispTokenCursor): number {
+  const probeCursor = cursor.clone();
+  if (probeCursor.backwardList()) {
+    const opening = probeCursor.getPrevToken().raw;
+    if (opening.endsWith('(')) {
+      const fn = probeCursor.getFunctionName();
+      if (fn === 'case') {
+        return 2;
+      }
+    }
+  }
+  return 0;
+}
+
 export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boolean {
   const probeCursor = cursor.clone();
   if (probeCursor.backwardList()) {
@@ -1506,6 +1533,13 @@ export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boo
       }
       const fn = probeCursor.getFunctionName();
       if (fn && pairForms.includes(fn)) {
+        return true;
+      }
+    }
+    if (opening.endsWith('(')) {
+      // Check if this is a conditional form like (cond test expr test expr ...)
+      const fn = probeCursor.getFunctionName();
+      if (fn && conditionalForms.includes(fn)) {
         return true;
       }
     }
@@ -1526,19 +1560,40 @@ export function currentSexpsRange(
 ): [number, number] {
   const currentSingleRange = cursor.rangeForCurrentForm(offset);
   if (usePairs) {
-    const ranges = cursor.rangesForSexpsInList();
+    // Create a fresh cursor at the offset position to ensure correct list context
+    const listCursor = doc.getTokenCursor(offset);
+    const ranges = listCursor.rangesForSexpsInList();
     if (ranges.length > 1) {
       const indexOfCurrentSingle = ranges.findIndex(
         (r) => r[0] === currentSingleRange[0] && r[1] === currentSingleRange[1]
       );
-      if (indexOfCurrentSingle % 2 == 0) {
-        const pairCursor = doc.getTokenCursor(currentSingleRange[1]);
-        pairCursor.forwardSexp();
-        return [currentSingleRange[0], pairCursor.offsetStart];
-      } else {
-        const pairCursor = doc.getTokenCursor(currentSingleRange[0]);
-        pairCursor.backwardSexp();
-        return [pairCursor.offsetStart, currentSingleRange[1]];
+
+      // Get the offset for conditional forms (e.g., cond has 1 initial non-pair form)
+      const pairOffset = getConditionalFormPairOffset(listCursor);
+
+      // Adjust the index to account for non-pair forms at the start
+      const adjustedIndex = indexOfCurrentSingle - pairOffset;
+
+      // Only treat as pairs if we're past the offset
+      if (adjustedIndex >= 0) {
+        // For forms like `case`, if there's an odd number of pairable elements,
+        // the last element is the default and should NOT be treated as part of a pair
+        const pairableElementsCount = ranges.length - pairOffset;
+        const isOddElementCount = pairableElementsCount % 2 === 1;
+        const isLastElement = adjustedIndex === pairableElementsCount - 1;
+        const isConditionalDefault = isOddElementCount && isLastElement;
+        if (isConditionalDefault) {
+          return currentSingleRange;
+        }
+        if (adjustedIndex % 2 == 0) {
+          const pairCursor = doc.getTokenCursor(currentSingleRange[1]);
+          pairCursor.forwardSexp();
+          return [currentSingleRange[0], pairCursor.offsetStart];
+        } else {
+          const pairCursor = doc.getTokenCursor(currentSingleRange[0]);
+          pairCursor.backwardSexp();
+          return [pairCursor.offsetStart, currentSingleRange[1]];
+        }
       }
     }
   }

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1389,49 +1389,48 @@ describe('paredit', () => {
       expect(g.selectionsStack).toEqual([[gSelection], [hSelection]]);
     });
 
-    it('pair selection with case'),
-      () => {
-        it('grows selection to value/result pairs in case (result selected first)', () => {
-          const a = docFromTextNotation('(case x "x" |"one"| "y" "two" "default")');
-          const aSelection = a.selections[0];
-          const b = docFromTextNotation('(case x |"x" "one"| "y" "two" "default")');
-          const bSelection = b.selections[0];
-          paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-        });
-        it('grows selection to value/result pairs in case (value selected first)', () => {
-          const a = docFromTextNotation('(case x |"x"| "one" "y" "two" "default")');
-          const aSelection = a.selections[0];
-          const b = docFromTextNotation('(case x |"x" "one"| "y" "two" "default")');
-          const bSelection = b.selections[0];
-          paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-        });
-        it('grows selection to value/result pairs in case with list value', () => {
-          const a = docFromTextNotation('(case x (2 3) |"two or three"| 4 "four" "default")');
-          const aSelection = a.selections[0];
-          const b = docFromTextNotation('(case x |(2 3) "two or three"| 4 "four" "default")');
-          const bSelection = b.selections[0];
-          paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-        });
-        it('does not treat default as pair when growing selection in case', () => {
-          const a = docFromTextNotation('(case x 1 "one" 2 "two" |"default"|)');
-          const aSelection = a.selections[0];
-          const b = docFromTextNotation('(|case x 1 "one" 2 "two" "default"|)');
-          const bSelection = b.selections[0];
-          paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-        });
-        it('grows selection from case keyword to list contents', () => {
-          const a = docFromTextNotation('(|case| x 1 "one" 2 "two" "default")');
-          const aSelection = a.selections[0];
-          const b = docFromTextNotation('(|case x 1 "one" 2 "two" "default"|)');
-          const bSelection = b.selections[0];
-          paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-        });
-      };
+    describe('pair selection with case', () => {
+      it('grows selection to value/result pairs in case (result selected first)', () => {
+        const a = docFromTextNotation('(case x "x" |"one"| "y" "two" "default")');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(case x |"x" "one"| "y" "two" "default")');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('grows selection to value/result pairs in case (value selected first)', () => {
+        const a = docFromTextNotation('(case x |"x"| "one" "y" "two" "default")');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(case x |"x" "one"| "y" "two" "default")');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('grows selection to value/result pairs in case with list value', () => {
+        const a = docFromTextNotation('(case x (2 3) |"two or three"| 4 "four" "default")');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(case x |(2 3) "two or three"| 4 "four" "default")');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('does not treat default as pair when growing selection in case', () => {
+        const a = docFromTextNotation('(case x 1 "one" 2 "two" |"default"|)');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(|case x 1 "one" 2 "two" "default"|)');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('grows selection from case keyword to list contents', () => {
+        const a = docFromTextNotation('(|case| x 1 "one" 2 "two" "default")');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(|case x 1 "one" 2 "two" "default"|)');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+    });
   });
 
   describe('dragSexpr', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1327,6 +1327,38 @@ describe('paredit', () => {
       paredit.growSelection(a);
       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
+    it('grows selection to value/result pairs in case (result selected first)', () => {
+      const a = docFromTextNotation('(case x 1 |"one"| 2 "two" "default")');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(case x |01 "one"|0 2 "two" "default")');
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
+    it('grows selection to value/result pairs in case with list value', () => {
+      const a = docFromTextNotation('(case x (2 3) |"two or three"| 4 "four" "default")');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(case x |(2 3) "two or three"| 4 "four" "default")');
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
+    it('does not treat default as pair when growing selection in case', () => {
+      const a = docFromTextNotation('(case x 1 "one" 2 "two" |"default"|)');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(|case x 1 "one" 2 "two" "default"|)');
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
+    it('grows selection from case keyword to list contents', () => {
+      const a = docFromTextNotation('(|case| x 1 "one" 2 "two" "default")');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(|case x 1 "one" 2 "two" "default"|)');
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
   });
 
   describe('dragSexpr', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1389,46 +1389,49 @@ describe('paredit', () => {
       expect(g.selectionsStack).toEqual([[gSelection], [hSelection]]);
     });
 
-    it('grows selection to value/result pairs in case (result selected first)', () => {
-      const a = docFromTextNotation('(case x "x" |"one"| "y" "two" "default")');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(case x |"x" "one"| "y" "two" "default")');
-      const bSelection = b.selections[0];
-      paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
-    it('grows selection to value/result pairs in case (value selected first)', () => {
-      const a = docFromTextNotation('(case x |"x"| "one" "y" "two" "default")');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(case x |"x" "one"| "y" "two" "default")');
-      const bSelection = b.selections[0];
-      paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
-    it('grows selection to value/result pairs in case with list value', () => {
-      const a = docFromTextNotation('(case x (2 3) |"two or three"| 4 "four" "default")');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(case x |(2 3) "two or three"| 4 "four" "default")');
-      const bSelection = b.selections[0];
-      paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
-    it('does not treat default as pair when growing selection in case', () => {
-      const a = docFromTextNotation('(case x 1 "one" 2 "two" |"default"|)');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(|case x 1 "one" 2 "two" "default"|)');
-      const bSelection = b.selections[0];
-      paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
-    it('grows selection from case keyword to list contents', () => {
-      const a = docFromTextNotation('(|case| x 1 "one" 2 "two" "default")');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(|case x 1 "one" 2 "two" "default"|)');
-      const bSelection = b.selections[0];
-      paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
+    it('pair selection with case'),
+      () => {
+        it('grows selection to value/result pairs in case (result selected first)', () => {
+          const a = docFromTextNotation('(case x "x" |"one"| "y" "two" "default")');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(case x |"x" "one"| "y" "two" "default")');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('grows selection to value/result pairs in case (value selected first)', () => {
+          const a = docFromTextNotation('(case x |"x"| "one" "y" "two" "default")');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(case x |"x" "one"| "y" "two" "default")');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('grows selection to value/result pairs in case with list value', () => {
+          const a = docFromTextNotation('(case x (2 3) |"two or three"| 4 "four" "default")');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(case x |(2 3) "two or three"| 4 "four" "default")');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('does not treat default as pair when growing selection in case', () => {
+          const a = docFromTextNotation('(case x 1 "one" 2 "two" |"default"|)');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(|case x 1 "one" 2 "two" "default"|)');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('grows selection from case keyword to list contents', () => {
+          const a = docFromTextNotation('(|case| x 1 "one" 2 "two" "default")');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(|case x 1 "one" 2 "two" "default"|)');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+      };
   });
 
   describe('dragSexpr', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1328,9 +1328,17 @@ describe('paredit', () => {
       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('grows selection to value/result pairs in case (result selected first)', () => {
-      const a = docFromTextNotation('(case x 1 |"one"| 2 "two" "default")');
+      const a = docFromTextNotation('(case x "x" |"one"| "y" "two" "default")');
       const aSelection = a.selections[0];
-      const b = docFromTextNotation('(case x |01 "one"|0 2 "two" "default")');
+      const b = docFromTextNotation('(case x |"x" "one"| "y" "two" "default")');
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
+    it('grows selection to value/result pairs in case (value selected first)', () => {
+      const a = docFromTextNotation('(case x |"x"| "one" "y" "two" "default")');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(case x |"x" "one"| "y" "two" "default")');
       const bSelection = b.selections[0];
       paredit.growSelection(a);
       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);

--- a/test-data/test-files/paredit_sandbox.clj
+++ b/test-data/test-files/paredit_sandbox.clj
@@ -109,6 +109,37 @@ string. "
 ; Should not delete `#`
 (#|())
 
+;; Pair selecting
+
+(cond
+  (= 1 1)  (println "one is one")
+  (= 2 2)  (println "two is two"))
+
+(cond->> []
+ true  (cons 1)
+ false (cons 2)
+ true  (cons 3))
+
+(cond-> {}
+  true  (assoc :a 1)
+  false (assoc :b 2)
+  true  (assoc :c 3))
+
+(case 1
+  1 "one"
+  2 "two"
+  3 "three"
+  "other")
+
+(condp = 2
+  1 "one"
+  2 "two"
+  3 "three"
+  "other")
+
+(condp some [1 2 3 4]
+  #{0 6 7} :>> inc
+  #{5 9}   :>> dec)
 
 (comment
   (a b (c


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

This PR adds support for growing selection to consider value/result pairs in `case` forms, similar to how it works for `cond` and binding forms like `let`.

- Updated `src/cursor-doc/paredit.ts` to include `case` in conditional forms with correct offset handling (pairs start after function name and initial form).
- Added unit tests in `src/extension-test/unit/cursor-doc/paredit-test.ts` for pair selecting in `case` forms.
- Updated `CHANGELOG.md` with an enhancement entry linking to issue #2993.
- Added test data in `test-data/test-files/paredit_sandbox.clj` for the new forms.

Fixes #2993

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ --></content>
<parameter name="filePath">