### PR TITLE
Fix # deletion 2766

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Improve backspace and deleteForward functions for reader macro hash deletion](https://github.com/BetterThanTomorrow/calva/issues/2766)
+
 ## [2.0.545] - 2026-01-17
 
 - Fix: [Jack-in sometimes fails from quoting issues](https://github.com/BetterThanTomorrow/calva/issues/2549)

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -14,6 +14,8 @@ import _ = require('lodash');
 import { isEqual, last, property } from 'lodash';
 import { TextEditorEdit } from 'vscode';
 
+const OPEN_DELIMITERS_REGEX = /[([{"]/;
+
 // NB: doc.model.edit returns a Thenable, so that the vscode Editor can compose commands.
 // But don't put such chains in this module because that won't work in the repl-console.
 // In the repl-console, compose commands just by performing them in succession, making sure
@@ -1110,7 +1112,9 @@ export function backspace(
     const isInsideReader =
       start > cursor.offsetStart &&
       nextToken.raw.startsWith('#') &&
-      start <= cursor.offsetStart + (nextToken.raw.match(/[([{"]/)?.index ?? nextToken.raw.length);
+      start <=
+        cursor.offsetStart +
+          (nextToken.raw.match(OPEN_DELIMITERS_REGEX)?.index ?? nextToken.raw.length);
     const prevToken =
       (start > cursor.offsetStart && !['open', 'close'].includes(nextToken.type)) || isInsideReader
         ? nextToken // we are “in” a token
@@ -1144,7 +1148,8 @@ export function backspace(
       const isAtReaderPrefix =
         (isInsideReader &&
           start <=
-            cursor.offsetStart + (nextToken.raw.match(/[([{"]/)?.index ?? nextToken.raw.length)) ||
+            cursor.offsetStart +
+              (nextToken.raw.match(OPEN_DELIMITERS_REGEX)?.index ?? nextToken.raw.length)) ||
         (!isInsideReader && prevToken.raw.startsWith('#') && start === cursor.offsetStart);
 
       // Special check: if we're inside a reader macro token like #( or #{,

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1103,8 +1103,15 @@ export function backspace(
     const cursor = doc.getTokenCursor(start);
     const isTopLevel = doc.getTokenCursor(end).atTopLevel();
     const nextToken = cursor.getToken();
+    const JUMP_TOKEN_TYPES = new Set(['open', 'close', 'ignore', 'reader', 'junk']);
+
+    const isInsideReader =
+      start > cursor.offsetStart &&
+      JUMP_TOKEN_TYPES.has(nextToken.type) &&
+      nextToken.raw.startsWith('#') &&
+      start <= cursor.offsetStart + (nextToken.raw.match(/[([{"]/)?.index ?? nextToken.raw.length);
     const prevToken =
-      start > cursor.offsetStart && !['open', 'close'].includes(nextToken.type)
+      (start > cursor.offsetStart && !JUMP_TOKEN_TYPES.has(nextToken.type)) || isInsideReader
         ? nextToken // we are “in” a token
         : cursor.getPrevToken(); // we are “between” tokens
     if (prevToken.type == 'prompt') {
@@ -1133,8 +1140,57 @@ export function backspace(
       // we are at the beginning of a line, and not inside a string
       return backspaceOnWhitespaceEdit(builder, doc, cursor, config);
     } else {
-      if (['open', 'close'].includes(prevToken.type) && cursor.docIsBalanced()) {
-        doc.selections = [new ModelEditSelection(start - prevToken.raw.length)];
+      const isAtReaderPrefix =
+        (isInsideReader &&
+          start <=
+            cursor.offsetStart + (nextToken.raw.match(/[([{"]/)?.index ?? nextToken.raw.length)) ||
+        (!isInsideReader && prevToken.raw.startsWith('#') && start === cursor.offsetStart);
+
+      // Special check: if we're inside a reader macro token like #( or #{,
+      // we should not allow deletion only if it's empty (like #())
+      // Non empty forms like #(prn "hello") can have their # deleted when
+      //  cursor is inside the token
+      let shouldJumpOverReaderMacro = false;
+      if (prevToken.raw.startsWith('#') && prevToken.raw.match(/^#[({]/)) {
+        if (isInsideReader) {
+          // We're inside the #( token (between # and ()
+          // When it is empty, jump; if not, allow deletion
+          const nextCursor = doc.getTokenCursor(cursor.offsetStart);
+          nextCursor.next();
+          const tokenAfterOpen = nextCursor.getToken();
+          shouldJumpOverReaderMacro = tokenAfterOpen.type === 'close';
+        } else {
+          // We're AFTER the #( token - always jump
+          shouldJumpOverReaderMacro = true;
+        }
+      }
+
+      // Check if we're deleting whitespace after an invalid # (junk)
+      // In this case, delete both the whitespace and the junk #
+      if (prevToken.type === 'ws' && prevToken.raw.length === 1) {
+        const prevPrevCursor = doc.getTokenCursor(cursor.offsetStart - 1);
+        const prevPrevToken = prevPrevCursor.getPrevToken();
+        if (prevPrevToken.type === 'junk' && prevPrevToken.raw === '#') {
+          // Delete both the whitespace and the junk #
+          return doc.model.editNow([new ModelEdit('deleteRange', [start - 2, 2])], {
+            builder: builder,
+            skipFormat: true,
+          });
+        }
+      }
+
+      if (
+        JUMP_TOKEN_TYPES.has(prevToken.type) &&
+        cursor.docIsBalanced() &&
+        (!isAtReaderPrefix || shouldJumpOverReaderMacro)
+      ) {
+        // When jumping over a token, if we're inside a reader macro, jump to
+        // its start. Otherwise, jump to the start of the previous token
+        const jumpPosition =
+          isInsideReader && shouldJumpOverReaderMacro
+            ? cursor.offsetStart
+            : start - prevToken.raw.length;
+        doc.selections = [new ModelEditSelection(jumpPosition)];
         return;
       } else {
         const [left, right] = [Math.max(start - 1, 0), start];
@@ -1177,9 +1233,27 @@ export function deleteForward(
         }
       );
     } else {
-      if (['open', 'close'].includes(nextToken.type) && cursor.docIsBalanced()) {
-        doc.selections = [new ModelEditSelection(p + 1)];
-        return;
+      // Check if we're at an invalid reader prefix (junk #) or at the start of a reader macro
+      const isAtInvalidReaderPrefix = nextToken.type === 'junk' && nextToken.raw === '#';
+      const isAtReaderMacroStart =
+        nextToken.type === 'open' && nextToken.raw.match(/^#[({]/) && start === cursor.offsetStart;
+
+      if (
+        (['open', 'close'].includes(nextToken.type) &&
+          cursor.docIsBalanced() &&
+          !isAtReaderMacroStart) ||
+        isAtInvalidReaderPrefix
+      ) {
+        if (isAtInvalidReaderPrefix) {
+          // Delete the invalid # prefix
+          return doc.model.editNow([new ModelEdit('deleteRange', [start, 1])], {
+            builder: builder,
+            skipFormat: true,
+          });
+        } else {
+          doc.selections = [new ModelEditSelection(p + 1)];
+          return;
+        }
       } else {
         return doc.model.editNow([new ModelEdit('deleteRange', [start, 1])], {
           builder: builder,

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1103,7 +1103,6 @@ export function backspace(
     const cursor = doc.getTokenCursor(start);
     const isTopLevel = doc.getTokenCursor(end).atTopLevel();
     const nextToken = cursor.getToken();
-    const JUMP_TOKEN_TYPES = new Set(['open', 'close', 'ignore', 'reader', 'junk']);
 
     // Detect if cursor is inside the '#' prefix of a reader macro token (like #( or #{)
     // before the opening delimiter. Example: in "#(prn)" at position 1, we're inside the reader.
@@ -1113,7 +1112,7 @@ export function backspace(
       nextToken.raw.startsWith('#') &&
       start <= cursor.offsetStart + (nextToken.raw.match(/[([{"]/)?.index ?? nextToken.raw.length);
     const prevToken =
-      (start > cursor.offsetStart && !JUMP_TOKEN_TYPES.has(nextToken.type)) || isInsideReader
+      (start > cursor.offsetStart && !['open', 'close'].includes(nextToken.type)) || isInsideReader
         ? nextToken // we are “in” a token
         : cursor.getPrevToken(); // we are “between” tokens
     if (prevToken.type == 'prompt') {
@@ -1181,8 +1180,9 @@ export function backspace(
         }
       }
 
+      const JUMP_TOKEN_TYPES = ['open', 'close', 'ignore', 'reader', 'junk'];
       if (
-        JUMP_TOKEN_TYPES.has(prevToken.type) &&
+        JUMP_TOKEN_TYPES.includes(prevToken.type) &&
         cursor.docIsBalanced() &&
         (!isAtReaderPrefix || shouldJumpOverReaderMacro)
       ) {

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1105,9 +1105,11 @@ export function backspace(
     const nextToken = cursor.getToken();
     const JUMP_TOKEN_TYPES = new Set(['open', 'close', 'ignore', 'reader', 'junk']);
 
+    // Detect if cursor is inside the '#' prefix of a reader macro token (like #( or #{)
+    // before the opening delimiter. Example: in "#(prn)" at position 1, we're inside the reader.
+    // At position 2, we're no longer inside the reader prefix.
     const isInsideReader =
       start > cursor.offsetStart &&
-      JUMP_TOKEN_TYPES.has(nextToken.type) &&
       nextToken.raw.startsWith('#') &&
       start <= cursor.offsetStart + (nextToken.raw.match(/[([{"]/)?.index ?? nextToken.raw.length);
     const prevToken =

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -2106,6 +2106,50 @@ describe('paredit', () => {
         paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
+      describe('Hash character deletion with non-empty reader macros', () => {
+        it('Deletes # inside non-empty anonymous function', () => {
+          const a = docFromTextNotation('[#|(prn "hello")]');
+          const b = docFromTextNotation('[|(prn "hello")]');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes # and space together after invalid # with space', () => {
+          const a = docFromTextNotation('[# |(prn "hello")]');
+          const b = docFromTextNotation('[|(prn "hello")]');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes # inside non-empty set', () => {
+          const a = docFromTextNotation('[#|{:foo :bar}]');
+          const b = docFromTextNotation('[|{:foo :bar}]');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Does not delete # inside empty anonymous function', () => {
+          const a = docFromTextNotation('(#|())');
+          const b = docFromTextNotation('(|#())');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Does not delete # inside empty set', () => {
+          const a = docFromTextNotation('(#|{})');
+          const b = docFromTextNotation('(|#{})');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Jumps over # when cursor is after opening paren', () => {
+          const a = docFromTextNotation('#(|foo)');
+          const b = docFromTextNotation('|#(foo)');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Jumps over # when cursor is after opening brace', () => {
+          const a = docFromTextNotation('#{|:foo}');
+          const b = docFromTextNotation('|#{:foo}');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+      });
     });
 
     describe('Kill character forwards (delete)', () => {
@@ -2187,6 +2231,40 @@ describe('paredit', () => {
         const b = docFromTextNotation('{::foo |• ::bar :foo}');
         paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      // https://github.com/BetterThanTomorrow/calva/issues/2766
+      describe('Hash character deletion with reader macros', () => {
+        it('Deletes # before non-empty anonymous function', () => {
+          const a = docFromTextNotation('[|#(prn "hello")]');
+          const b = docFromTextNotation('[|(prn "hello")]');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes # before non-empty set', () => {
+          const a = docFromTextNotation('[|#{:foo :bar}]');
+          const b = docFromTextNotation('[|{:foo :bar}]');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes # with invalid syntax before vector', () => {
+          const a = docFromTextNotation('[|#[:foo]]');
+          const b = docFromTextNotation('[|[:foo]]');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes # before empty anonymous function', () => {
+          const a = docFromTextNotation('[|#()]');
+          const b = docFromTextNotation('[|()]');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes # before empty set', () => {
+          const a = docFromTextNotation('[|#{}]');
+          const b = docFromTextNotation('[|{}]');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
       });
     });
 

--- a/test-data/test-files/paredit_sandbox.clj
+++ b/test-data/test-files/paredit_sandbox.clj
@@ -109,6 +109,24 @@ string. "
 ; Should not delete `#`
 (#|())
 
+;Should delete entire #() form with backspace and delete
+#()
+
+; Should not delete #  
+#{|21 2}
+
+; Should delete #
+#|{21}
+
+;; Backspace should delete the #
+[|#(prn "hello")]
+|#(prn "hello"|)
+
+;; Delete should delete space and #
+[# |(prn "hello")]
+
+; Delete should move before # without deleting it
+(#(|inc 2))
 
 (comment
   (a b (c


### PR DESCRIPTION
# Improve backspace and deleteForward functions for reader macro hash deletion

<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on a documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- **Enhanced backspace function** in `src/cursor-doc/paredit.ts`: Added comprehensive logic to handle deletion behavior when interacting with reader macro tokens (`#(`, `#{`), distinguishing between empty and non-empty forms, and properly managing cursor positioning.

- **Enhanced deleteForward function** in `src/cursor-doc/paredit.ts`: Added detection for invalid reader prefixes (junk `#` tokens) and reader macro start positions, allowing proper deletion of `#` characters in appropriate contexts.

- **Added comprehensive test suite**: Implemented 12 new tests covering all hash character deletion scenarios for both backspace and delete-forward operations, ensuring robust behavior across different reader macro contexts.

The implementation correctly handles:
- Empty reader macros (`#()`, `#{}`) - jumps over `#` instead of deleting
- Non-empty reader macros (`#(prn "hello")`, `#{:foo :bar}`) - allows `#` deletion
- Invalid reader syntax (`#[...]`, junk `#` tokens) - allows `#` deletion
- Proper cursor positioning and token boundary detection

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2766

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the change might have some side effects and tested those as well.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->