### PR TITLE
Test/drag sexp pairs triples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,11 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- [Grow Selection now considers form pairs in `:let` Bindings](https://github.com/BetterThanTomorrow/calva/issues/2988)
-- [Grow selection now considers test/expr pairs in `cond` forms](https://github.com/BetterThanTomorrow/calva/issues/2991)
-- [Grow selection now considers test/expr pairs in `cond->` and `cond->>` forms](https://github.com/BetterThanTomorrow/calva/issues/2991)
-- [Grow selection now considers value/result pairs in `case` forms](https://github.com/BetterThanTomorrow/calva/issues/2993)
-- [Grow selection now considers test/result pairs and `:>>` function triples in `condp` forms](https://github.com/BetterThanTomorrow/calva/issues/2995)
-- Drag Sexp commands now correctly move pairs/triples in `cond`, `cond->`, `cond->>`, `case`, `condp`, and `:let` bindings
+- [Consider form pairs in `:let` bindings when growing the selection and when dragging forms](https://github.com/BetterThanTomorrow/calva/issues/2988)
+- [Consider test/expr pairs in `cond` forms when growing the selection and when dragging forms](https://github.com/BetterThanTomorrow/calva/issues/2991)
+- [Consider test/expr pairs in `cond->` and `cond->>` forms when growing the selection and when dragging forms](https://github.com/BetterThanTomorrow/calva/issues/2991)
+- [Consider value/result pairs in `case` forms when growing the selection and when dragging forms](https://github.com/BetterThanTomorrow/calva/issues/2993)
+- [Consider test/result pairs and `:>>` function triples in `condp` forms when growing the selection and when dragging forms](https://github.com/BetterThanTomorrow/calva/issues/2995)
 - [Improve backspace and deleteForward functions for reader macro hash deletion](https://github.com/BetterThanTomorrow/calva/issues/2766)
 
 ## [2.0.545] - 2026-01-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes to Calva.
 - [Grow selection now considers test/expr pairs in `cond->` and `cond->>` forms](https://github.com/BetterThanTomorrow/calva/issues/2991)
 - [Grow selection now considers value/result pairs in `case` forms](https://github.com/BetterThanTomorrow/calva/issues/2993)
 - [Grow selection now considers test/result pairs and `:>>` function triples in `condp` forms](https://github.com/BetterThanTomorrow/calva/issues/2995)
+- Drag Sexp commands now correctly move pairs/triples in `cond`, `cond->`, `cond->>`, `case`, `condp`, and `:let` bindings
 - [Improve backspace and deleteForward functions for reader macro hash deletion](https://github.com/BetterThanTomorrow/calva/issues/2766)
 
 ## [2.0.545] - 2026-01-17

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1902,6 +1902,36 @@ describe('paredit', () => {
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
+
+    describe('condp forms', () => {
+      it('drags test/result pair forward in condp', async () => {
+        const a = docFromTextNotation('(condp = x |01 "one" 2 "two" "default")');
+        const b = docFromTextNotation('(condp = x 2 "two" |01 "one" "default")');
+        await paredit.dragSexprForward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('drags test/result pair backward in condp', async () => {
+        const a = docFromTextNotation('(condp = x 1 "one" |02 "two" "default")');
+        const b = docFromTextNotation('(condp = x |02 "two" 1 "one" "default")');
+        await paredit.dragSexprBackward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('drags triple (:>> form) forward in condp', async () => {
+        const a = docFromTextNotation('(condp some [1 2] |#{1} :>> inc #{2} :>> dec)');
+        const b = docFromTextNotation('(condp some [1 2] #{2} :>> dec |#{1} :>> inc)');
+        await paredit.dragSexprForward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('drags triple (:>> form) backward in condp', async () => {
+        const a = docFromTextNotation('(condp some [1 2] #{1} :>> inc |#{2} :>> dec)');
+        const b = docFromTextNotation('(condp some [1 2] |#{2} :>> dec #{1} :>> inc)');
+        await paredit.dragSexprBackward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+    });
   });
   describe('edits', () => {
     describe('Close lists', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1862,6 +1862,22 @@ describe('paredit', () => {
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
+
+    describe('cond-> and cond->> forms', () => {
+      it('drags test/expr pair forward in cond->', async () => {
+        const a = docFromTextNotation('(cond-> x |:a (inc) :b (dec))');
+        const b = docFromTextNotation('(cond-> x :b (dec) |:a (inc))');
+        await paredit.dragSexprForward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('drags test/expr pair backward in cond->>', async () => {
+        const a = docFromTextNotation('(cond->> x :a (inc) |:b (dec))');
+        const b = docFromTextNotation('(cond->> x |:b (dec) :a (inc))');
+        await paredit.dragSexprBackward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+    });
   });
   describe('edits', () => {
     describe('Close lists', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1839,6 +1839,30 @@ describe('paredit', () => {
       });
     });
   });
+  describe('Drag Sexp with pairs/triples', () => {
+    describe('cond forms', () => {
+      it('drags test/expr pair forward in cond', async () => {
+        const a = docFromTextNotation('(cond |:a 1 :b 2)');
+        const b = docFromTextNotation('(cond :b 2 |:a 1)');
+        await paredit.dragSexprForward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('drags test/expr pair backward in cond', async () => {
+        const a = docFromTextNotation('(cond :a 1 |:b 2)');
+        const b = docFromTextNotation('(cond |:b 2 :a 1)');
+        await paredit.dragSexprBackward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('drags test/expr pair forward in cond when cursor on expr', async () => {
+        const a = docFromTextNotation('(cond :a |01 :b 2)');
+        const b = docFromTextNotation('(cond :b 2 :a |01)');
+        await paredit.dragSexprForward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+    });
+  });
   describe('edits', () => {
     describe('Close lists', () => {
       it('Advances cursor if at end of list of the same type', async () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1878,6 +1878,30 @@ describe('paredit', () => {
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
+
+    describe('case forms', () => {
+      it('drags value/result pair forward in case', async () => {
+        const a = docFromTextNotation('(case x |01 "one" 2 "two" "default")');
+        const b = docFromTextNotation('(case x 2 "two" |01 "one" "default")');
+        await paredit.dragSexprForward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('drags value/result pair backward in case', async () => {
+        const a = docFromTextNotation('(case x 1 "one" |02 "two" "default")');
+        const b = docFromTextNotation('(case x |02 "two" 1 "one" "default")');
+        await paredit.dragSexprBackward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('does not drag default value as pair in case', async () => {
+        const a = docFromTextNotation('(case x 1 "one" |"default")');
+        // Default is a single form, not a pair, so it should drag alone
+        const b = docFromTextNotation('(case x |"default" 1 "one")');
+        await paredit.dragSexprBackward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+    });
   });
   describe('edits', () => {
     describe('Close lists', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1932,6 +1932,22 @@ describe('paredit', () => {
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
+
+    describe(':let bindings in for/doseq', () => {
+      it('drags binding pair forward in :let within for', async () => {
+        const a = docFromTextNotation('(for [x xs :let [|a 1 b 2]] [a b])');
+        const b = docFromTextNotation('(for [x xs :let [b 2 |a 1]] [a b])');
+        await paredit.dragSexprForward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('drags binding pair backward in :let within doseq', async () => {
+        const a = docFromTextNotation('(doseq [x xs :let [a 1 |b 2]] (println a b))');
+        const b = docFromTextNotation('(doseq [x xs :let [|b 2 a 1]] (println a b))');
+        await paredit.dragSexprBackward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+    });
   });
   describe('edits', () => {
     describe('Close lists', () => {


### PR DESCRIPTION
  ## What has changed?

  Added tests for Drag Sexp commands (`dragSexprForward`, `dragSexprBackward`) to verify they correctly move pairs/triples in various Clojure forms:

  - **cond forms**: test/expr pairs
  - **cond-> and cond->> forms**: test/expr pairs (with initial form offset)
  - **case forms**: value/result pairs (with default value handling)
  - **condp forms**: test/result pairs and `:>>` function triples
  - **:let bindings in for/doseq**: binding pairs within `:let` vectors

  These tests verify that the pair logic (via `isInPairsList` and `currentSexpsRange`) works correctly for drag operations, complementing the existing Grow Selection tests for these forms.

  Fixes # (no issue)

  ## My Calva PR Checklist

  I have:

  - [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
  - [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
  - [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
  - [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
  - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
  - [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever~ (tests only, no platform-specific behavior)
  - [x] Added to or updated docs in this branch~ (tests only, no user-facing changes)
  - [x] Tests
    - [x] Tested the particular change
    - [x] Figured if the change might have some side effects and tested those as well.
  - [x] Formatted all JavaScript and TypeScript code that was changed.
  - [x] Confirmed that there are no linter warnings or errors.
