### PR TITLE
3008 assoc pair forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Consider form pairs in `assoc` when growing the selection and when dragging forms](https://github.com/BetterThanTomorrow/calva/issues/3008)
+
 ## [2.0.546] - 2026-01-30
 
 - [Consider form pairs in `:let` bindings when growing the selection and when dragging forms](https://github.com/BetterThanTomorrow/calva/issues/2988)

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1594,17 +1594,18 @@ function isPrecededByLetKeyword(cursor: LispTokenCursor): boolean {
   return !!precedingToken && String(precedingToken.raw) === ':let';
 }
 
-const conditionalForms = ['cond', 'cond->', 'cond->>', 'case', 'condp'];
+const flatPairForms = ['cond', 'cond->', 'cond->>', 'case', 'condp', 'assoc'];
 
 /**
  * Returns the offset (number of initial forms that are not part of pairs)
- * for conditional forms.
+ * for flat pair forms (forms where pairs appear directly in the list).
  * - cond: pairs start after function name (offset 1 for 'cond' itself)
  * - cond->/cond->>: pairs start after function name and initial form (offset 2)
  * - case: pairs start after function name and initial form (offset 2)
  * - condp: pairs start after function name, predicate, and initial form (offset 3)
+ * - assoc: pairs start after function name and map (offset 2)
  */
-function getConditionalFormPairOffset(cursor: LispTokenCursor): number {
+function getFlatPairFormOffset(cursor: LispTokenCursor): number {
   const probeCursor = cursor.clone();
   if (probeCursor.backwardList()) {
     const opening = probeCursor.getPrevToken().raw;
@@ -1613,7 +1614,7 @@ function getConditionalFormPairOffset(cursor: LispTokenCursor): number {
       if (fn === 'cond') {
         return 1;
       }
-      if (fn === 'cond->' || fn === 'cond->>' || fn === 'case') {
+      if (fn === 'cond->' || fn === 'cond->>' || fn === 'case' || fn === 'assoc') {
         return 2;
       }
       if (fn === 'condp') {
@@ -1648,9 +1649,9 @@ export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boo
       }
     }
     if (opening.endsWith('(')) {
-      // Check if this is a conditional form like (cond test expr test expr ...)
+      // Check if this is a flat pair form like (cond test expr ...) or (assoc m k v ...)
       const fn = probeCursor.getFunctionName();
-      if (fn && conditionalForms.includes(fn)) {
+      if (fn && flatPairForms.includes(fn)) {
         return true;
       }
     }
@@ -1845,8 +1846,8 @@ export function currentSexpsRange(
         (r) => r[0] === currentSingleRange[0] && r[1] === currentSingleRange[1]
       );
 
-      // Get the offset for conditional forms (e.g., cond has 1 initial non-pair form)
-      const pairOffset = getConditionalFormPairOffset(listCursor);
+      // Get the offset for flat pair forms (e.g., cond has 1, assoc has 2 initial non-pair forms)
+      const pairOffset = getFlatPairFormOffset(listCursor);
 
       // Adjust the index to account for non-pair forms at the start
       const adjustedIndex = indexOfCurrentSingle - pairOffset;

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1502,6 +1502,41 @@ describe('paredit', () => {
         expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
     });
+
+    describe('assoc pairs', () => {
+      it('grows selection to key/value pairs in assoc (value selected first)', () => {
+        const a = docFromTextNotation('(assoc m :a |"one"| :b "two")');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(assoc m |:a "one"| :b "two")');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('grows selection to key/value pairs in assoc (key selected first)', () => {
+        const a = docFromTextNotation('(assoc m |:a| "one" :b "two")');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(assoc m |:a "one"| :b "two")');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('grows selection to key/value pairs in assoc (second pair)', () => {
+        const a = docFromTextNotation('(assoc m :a "one" |:b| "two")');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(assoc m :a "one" |:b "two"|)');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+      it('does not treat map argument as part of pair', () => {
+        const a = docFromTextNotation('(assoc |m| :a "one" :b "two")');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(|assoc m :a "one" :b "two"|)');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+    });
   });
 
   describe('condp pair/triple selection tests', () => {
@@ -1945,6 +1980,37 @@ describe('paredit', () => {
         const a = docFromTextNotation('(doseq [x xs :let [a 1 |b 2]] (println a b))');
         const b = docFromTextNotation('(doseq [x xs :let [|b 2 a 1]] (println a b))');
         await paredit.dragSexprBackward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+    });
+
+    describe('assoc forms', () => {
+      it('drags key/value pair forward in assoc', async () => {
+        const a = docFromTextNotation('(assoc m |:a "one" :b "two")');
+        const b = docFromTextNotation('(assoc m :b "two" |:a "one")');
+        await paredit.dragSexprForward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('drags key/value pair backward in assoc', async () => {
+        const a = docFromTextNotation('(assoc m :a "one" |:b "two")');
+        const b = docFromTextNotation('(assoc m |:b "two" :a "one")');
+        await paredit.dragSexprBackward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('drags key/value pair forward in assoc when cursor on value', async () => {
+        const a = docFromTextNotation('(assoc m :a |"one" :b "two")');
+        const b = docFromTextNotation('(assoc m :b "two" :a |"one")');
+        await paredit.dragSexprForward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('drags map argument past pair when dragging forward in assoc', async () => {
+        const a = docFromTextNotation('(assoc |m :a "one" :b "two")');
+        // Map drags past the first key-value pair to maintain pair structure
+        const b = docFromTextNotation('(assoc :a "one" |m :b "two")');
+        await paredit.dragSexprForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });

--- a/test-data/test-files/paredit_sandbox.clj
+++ b/test-data/test-files/paredit_sandbox.clj
@@ -160,6 +160,8 @@ string. "
   #{0 6 7} :>> inc
   #{5 9}   :>> dec)
 
+(assoc {} :a 1 :b 2)
+
 (comment
   (a b (c
         d) e)


### PR DESCRIPTION
## What has changed?

Added support for treating `assoc` form pairs in paredit operations (grow selection and drag sexp).

The `assoc` form has the structure `(assoc map key value key value ...)` where key-value pairs start after the map argument (offset 2). This brings feature parity with other pair-aware forms like `cond`, `case`, and `condp`.

**Changes:**
- Renamed `conditionalForms` → `flatPairForms` to reflect broader applicability
- Renamed `getConditionalFormPairOffset` → `getFlatPairFormOffset` to reflect broader applicability
- Added `assoc` offset handling (offset 2: skip function name and map argument)

**Example behavior:**
- Grow selection: `(assoc m |:a| "one")` → `(assoc m |:a "one"|)`
- Drag forward: `(assoc m |:a "one" :b "two")` → `(assoc m :b "two" |:a "one"|)`

Fixes #3008

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch.
- [x] Made sure I have changed the PR base branch, so that it is not `published`.
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses.
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking issue #3008.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and tested it.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change (8 new tests added)
  - [x] Figured if the change might have some side effects and tested those as well (all 387 paredit tests pass).
- [x] Formatted all JavaScript and TypeScript code that was changed.
- [x] Confirmed that there are no linter warnings or errors.
