### PR TITLE
3010 threading pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes to Calva.
 - Fix: Slurp Forward no longer adds leading space when slurping into empty forms. [#1440](https://github.com/BetterThanTomorrow/calva/issues/1440) & [#2085](https://github.com/BetterThanTomorrow/calva/issues/2085)
 - Fix: Slurp Backward no longer adds trailing space when slurping into empty forms
 - [Consider form pairs in `assoc` when growing the selection and when dragging forms](https://github.com/BetterThanTomorrow/calva/issues/3008)
+- [Add threading macro support for flat pair forms](https://github.com/BetterThanTomorrow/calva/issues/3009)
 
 ## [2.0.546] - 2026-01-30
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1689,6 +1689,36 @@ function isPrecededByKeywordPairForm(
 
 const flatPairForms = ['cond', 'cond->', 'cond->>', 'case', 'condp', 'assoc'];
 
+const threadingMacros = {
+  firstArg: ['->', 'some->'],
+  lastArg: ['->>', 'some->>'],
+};
+
+/**
+ * Detects if cursor's form is the direct child of a threading macro.
+ * Returns:
+ * - 'firstArg' if form is direct child of -> style macro (threads to first position, offset -1)
+ * - 'lastArg' if form is direct child of ->> style macro (threads to last position)
+ * - null if not direct child of threading macro
+ */
+function getDirectThreadingMacroStyle(cursor: LispTokenCursor): 'firstArg' | 'lastArg' | null {
+  const probeCursor = cursor.clone();
+  // Only check immediate parent - go up one level
+  if (probeCursor.backwardList()) {
+    probeCursor.backwardUpList();
+    const fn = probeCursor.getFunctionName();
+    if (fn) {
+      if (threadingMacros.firstArg.includes(fn)) {
+        return 'firstArg';
+      }
+      if (threadingMacros.lastArg.includes(fn)) {
+        return 'lastArg';
+      }
+    }
+  }
+  return null;
+}
+
 /**
  * Returns the offset (number of initial forms that are not part of pairs)
  * for flat pair forms (forms where pairs appear directly in the list).
@@ -1697,6 +1727,11 @@ const flatPairForms = ['cond', 'cond->', 'cond->>', 'case', 'condp', 'assoc'];
  * - case: pairs start after function name and initial form (offset 2)
  * - condp: pairs start after function name, predicate, and initial form (offset 3)
  * - assoc: pairs start after function name and map (offset 2)
+ *
+ * Note: When inside threading macros (-> or ->>), the offset is adjusted:
+ * - Inside ->: offset is reduced by 1 (first argument is threaded from outside)
+ * - Inside ->>: offset adjustment depends on position (may have trailing unpaired elements)
+ *               this is handled in getPairElementGroupRange: builds pairs
  */
 function getFlatPairFormOffset(cursor: LispTokenCursor): number {
   const probeCursor = cursor.clone();
@@ -1704,15 +1739,28 @@ function getFlatPairFormOffset(cursor: LispTokenCursor): number {
     const opening = probeCursor.getPrevToken().raw;
     if (opening.endsWith('(')) {
       const fn = probeCursor.getFunctionName();
+      let offset = 0;
+
       if (fn === 'cond') {
-        return 1;
+        offset = 1;
+      } else if (fn === 'cond->' || fn === 'cond->>' || fn === 'case' || fn === 'assoc') {
+        offset = 2;
+      } else if (fn === 'condp') {
+        offset = 3;
+      } else {
+        return 0;
       }
-      if (fn === 'cond->' || fn === 'cond->>' || fn === 'case' || fn === 'assoc') {
-        return 2;
+
+      // All flat pair forms are threading-aware: when inside a -> threading macro,
+      // the first argument is threaded from outside and not visible in the form,
+      // so reduce the offset by 1.
+      const threadingStyle = getDirectThreadingMacroStyle(cursor);
+      if (threadingStyle === 'firstArg') {
+        return Math.max(0, offset - 1);
       }
-      if (fn === 'condp') {
-        return 3;
-      }
+      // we don't care of threadingStyle === 'lastArg' because
+      // it is handled in getPairElementGroupRange
+      return offset;
     }
   }
   return 0;

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -2014,6 +2014,65 @@ describe('paredit', () => {
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });
+
+    describe('threading macros with pairs', () => {
+      describe('assoc in -> macro', () => {
+        it('grows selection to key/value pairs in assoc inside ->', () => {
+          const a = docFromTextNotation('(-> m (assoc |:a| "one" :b "two"))');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(-> m (assoc |:a "one"| :b "two"))');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+
+        it('drags key/value pair forward in assoc inside ->', async () => {
+          const a = docFromTextNotation('(-> m (assoc |:a "one" :b "two"))');
+          const b = docFromTextNotation('(-> m (assoc :b "two" |:a "one"))');
+          await paredit.dragSexprForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+      });
+
+      describe('cond-> inside -> macro (nested threading)', () => {
+        it('grows selection to pair inside cond-> which is itself inside ->', () => {
+          const a = docFromTextNotation('(-> {} (cond-> |true| (assoc :a "one")))');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(-> {} (cond-> |true (assoc :a "one")|))');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+
+        it('drags pair forward in cond-> which is inside ->', async () => {
+          const a = docFromTextNotation(
+            '(-> {} (cond-> |true (assoc :a "one") false (assoc :b "two")))'
+          );
+          const b = docFromTextNotation(
+            '(-> {} (cond-> false (assoc :b "two") |true (assoc :a "one")))'
+          );
+          await paredit.dragSexprForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+      });
+
+      describe('case inside -> macro', () => {
+        it('grows selection to value/result pair inside case>', () => {
+          const a = docFromTextNotation('(-> x (case |"x"| "one" 2 "two" "default"))');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(-> x (case |"x" "one"| 2 "two" "default"))');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('drags value/result pair backward in case inside ->', async () => {
+          const a = docFromTextNotation('(-> x (case |"x" "one" 2 "two" "default"))');
+          const b = docFromTextNotation('(-> x (case 2 "two" |"x" "one" "default"))');
+          await paredit.dragSexprForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+      });
+    });
   });
   describe('edits', () => {
     describe('Close lists', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -2072,6 +2072,47 @@ describe('paredit', () => {
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
       });
+
+      describe('assoc in ->> macro', () => {
+        it('grows selection to key/value pairs with trailing unpaired key in assoc inside ->>', () => {
+          const a = docFromTextNotation('(->> "two" (assoc {} |:one| "one" :two))');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(->> "two" (assoc {} |:one "one"| :two))');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('grows selection to entire form because :two is trailing unpaired key', () => {
+          const a = docFromTextNotation('(->> "two" (assoc {} :one "one" |:two|))');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(->> "two" (|assoc {} :one "one" :two|))');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('drags key/value pair forward with trailing unpaired key in assoc inside ->>', async () => {
+          const a = docFromTextNotation('(->> "three" (assoc {} |:one "one" :two "two" :three))');
+          const b = docFromTextNotation('(->> "three" (assoc {} :two "two" |:one "one" :three))');
+          await paredit.dragSexprForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+      });
+      describe('case inside ->> macro', () => {
+        it('grows selection to value/result pair inside case inside ->>', () => {
+          const a = docFromTextNotation('(->> "default" (case "x" :four "four" :five |"five"|))');
+          const aSelection = a.selections[0];
+          const b = docFromTextNotation('(->> "default" (case "x" :four "four" |:five "five"|))');
+          const bSelection = b.selections[0];
+          paredit.growSelection(a);
+          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        });
+        it('drags value/result pair backward in case inside ->>', async () => {
+          const a = docFromTextNotation('(->> "default" (case "x" |:four "four" :five "five"))');
+          const b = docFromTextNotation('(->> "default" (case "x" :five "five" |:four "four"))');
+          await paredit.dragSexprForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+      });
     });
   });
   describe('edits', () => {

--- a/test-data/test-files/paredit_sandbox.clj
+++ b/test-data/test-files/paredit_sandbox.clj
@@ -135,14 +135,45 @@ string. "
   (= 2 2)  (println "two is two"))
 
 (cond->> []
- true  (cons 1)
- false (cons 2)
- true  (cons 3))
+  true  (cons 1)
+  false (cons 2)
+  true  (cons 3))
 
 (cond-> {}
   true  (assoc :a 1)
   false (assoc :b 2)
   true  (assoc :c 3))
+
+(assoc {} :a 1 :b 2 :c 3)
+
+;; threaded 
+(-> {}
+    (cond-> 
+     |true (assoc :a "one")))
+;; should select the true
+(-> {}
+    (cond->
+     |true| (assoc :a "one")|))
+;; with the true selected should select the pair
+(-> {}
+    (cond->
+     |true (assoc :a "one")|))
+
+(-> "one"
+    (case 
+     "two" "second"
+      "three" "third"
+      "one" "first"))
+
+(->> true (assoc {} :success?))
+
+(->> "two" (assoc {} :one "one" :two))
+
+(->> "default"
+     (case 1
+       :zero "zero"
+       2 "two"
+       3 "three"))
 
 (case 1
   1 "one"


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- `flatPairForms` are award of being in a `->` threading macro.  This reduces the offset by 1 and doesn't break pairs calculation.
- Introduced unit tests  
- Includes #3009 changes to avoid conflicts but I can delete them if you prefer, the diff is not too large

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3010 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
