### PR TITLE
Feature/3007 pair consolidation

### DIFF
--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1568,30 +1568,89 @@ export async function transpose(
   }
 }
 
-export const bindingForms = [
-  'let',
-  'for',
-  'loop',
-  'binding',
-  'with-local-vars',
-  'doseq',
-  'with-redefs',
+interface VectorPairForm {
+  type: 'function';
+  name: string;
+}
+
+interface KeywordPairForm {
+  type: 'keyword';
+  keyword: string;
+  validParents?: string[];
+}
+
+type VectorBindingConfig = VectorPairForm | KeywordPairForm;
+
+const defaultVectorPairForms: VectorBindingConfig[] = [
+  // Function-based binding forms
+  { type: 'function', name: 'let' },
+  { type: 'function', name: 'for' },
+  { type: 'function', name: 'loop' },
+  { type: 'function', name: 'binding' },
+  { type: 'function', name: 'with-local-vars' },
+  { type: 'function', name: 'doseq' },
+  { type: 'function', name: 'with-redefs' },
+
+  // Keyword-based modifiers
+  { type: 'keyword', keyword: ':let', validParents: ['for', 'doseq', 'dotimes'] },
 ];
 
-function isPrecededByLetKeyword(cursor: LispTokenCursor): boolean {
+// Backward compatibility
+export const bindingForms = defaultVectorPairForms
+  .filter((f): f is VectorPairForm => f.type === 'function')
+  .map((f) => f.name);
+
+/**
+ * Checks if a vector is preceded by a keyword pair form (like `:let`).
+ * Returns the matching KeywordPairForm if found and valid, otherwise null.
+ */
+function isPrecededByKeywordPairForm(
+  cursor: LispTokenCursor,
+  keywordForms: KeywordPairForm[]
+): KeywordPairForm | null {
   const testCursor = cursor.clone();
-  // helper: move one token left from current position and skip whitespace
+
   function stepLeftAndSkipWs() {
     testCursor.previous();
     testCursor.backwardWhitespace();
   }
+
   stepLeftAndSkipWs();
   let precedingToken = testCursor.getPrevToken();
   while (precedingToken && precedingToken.type === 'comment') {
     stepLeftAndSkipWs();
     precedingToken = testCursor.getPrevToken();
   }
-  return !!precedingToken && String(precedingToken.raw) === ':let';
+
+  if (!precedingToken) {
+    return null;
+  }
+
+  const matchingForm = keywordForms.find((f) => f.keyword === precedingToken.raw);
+  if (!matchingForm) {
+    return null;
+  }
+
+  // Validate parent if specified - search up through lists until we find a function call
+  if (matchingForm.validParents?.length) {
+    const parentCursor = cursor.clone();
+    while (parentCursor.backwardUpList()) {
+      parentCursor.backwardList();
+      const opening = parentCursor.getPrevToken().raw;
+      if (opening.endsWith('(')) {
+        // Found a function call, check if it's a valid parent
+        const parentFn = parentCursor.getFunctionName();
+        if (parentFn && matchingForm.validParents.includes(parentFn)) {
+          return matchingForm;
+        }
+        return null; // Found a function call but not a valid parent
+      }
+      // Not a function call (e.g., a vector), continue searching up
+    }
+    return null; // No valid parent function found
+  }
+
+  return matchingForm;
 }
 
 const conditionalForms = ['cond', 'cond->', 'cond->>', 'case', 'condp'];
@@ -1624,7 +1683,11 @@ function getConditionalFormPairOffset(cursor: LispTokenCursor): number {
   return 0;
 }
 
-export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boolean {
+export function isInPairsList(
+  cursor: LispTokenCursor,
+  pairForms: string[],
+  vectorConfigs: VectorBindingConfig[] = defaultVectorPairForms
+): boolean {
   const probeCursor = cursor.clone();
   if (probeCursor.backwardList()) {
     const opening = probeCursor.getPrevToken().raw;
@@ -1632,7 +1695,9 @@ export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boo
       return true;
     }
     if (opening.endsWith('[')) {
-      if (isPrecededByLetKeyword(probeCursor)) {
+      // Check keyword modifiers first (like :let)
+      const keywordForms = vectorConfigs.filter((f): f is KeywordPairForm => f.type === 'keyword');
+      if (isPrecededByKeywordPairForm(probeCursor, keywordForms)) {
         return true;
       }
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -2000,9 +2000,8 @@ export function currentSexpsRange(
       const flatForms = groupedDefaultPairForms.flat;
       const flatForm = getFlatPairForm(listCursor, flatForms);
       const threadingStyle = getDirectThreadingMacroStyle(cursor);
-
-      const pairOffset =
-        threadingStyle === 'firstArg' ? Math.max(0, flatForm.offset - 1) : flatForm.offset || 0;
+      const formOffset = flatForm?.offset || 0;
+      const pairOffset = threadingStyle === 'firstArg' ? Math.max(0, formOffset - 1) : formOffset;
 
       // Adjust the index to account for non-pair forms at the start
       const adjustedIndex = indexOfCurrentSingle - pairOffset;

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1568,8 +1568,8 @@ export async function transpose(
   }
 }
 
-interface VectorPairForm {
-  type: 'function';
+interface VectorBindingForm {
+  type: 'vector-binding';
   name: string;
 }
 
@@ -1579,25 +1579,39 @@ interface KeywordPairForm {
   validParents?: string[];
 }
 
-type VectorBindingConfig = VectorPairForm | KeywordPairForm;
+interface FlatPairForm {
+  type: 'flat';
+  name: string;
+  offset: number;
+  tripleMarker?: string;
+}
 
-const defaultVectorPairForms: VectorBindingConfig[] = [
-  // Function-based binding forms
-  { type: 'function', name: 'let' },
-  { type: 'function', name: 'for' },
-  { type: 'function', name: 'loop' },
-  { type: 'function', name: 'binding' },
-  { type: 'function', name: 'with-local-vars' },
-  { type: 'function', name: 'doseq' },
-  { type: 'function', name: 'with-redefs' },
+type PairFormConfig = VectorBindingForm | KeywordPairForm | FlatPairForm;
+
+const defaultPairForms: PairFormConfig[] = [
+  // Vector Binding forms
+  { type: 'vector-binding', name: 'let' },
+  { type: 'vector-binding', name: 'for' },
+  { type: 'vector-binding', name: 'loop' },
+  { type: 'vector-binding', name: 'binding' },
+  { type: 'vector-binding', name: 'with-local-vars' },
+  { type: 'vector-binding', name: 'doseq' },
+  { type: 'vector-binding', name: 'with-redefs' },
 
   // Keyword-based modifiers
   { type: 'keyword', keyword: ':let', validParents: ['for', 'doseq', 'dotimes'] },
+
+  // flat
+  { type: 'flat', name: 'cond', offset: 1 },
+  { type: 'flat', name: 'cond->', offset: 2 },
+  { type: 'flat', name: 'cond->>', offset: 2 },
+  { type: 'flat', name: 'case', offset: 2 },
+  { type: 'flat', name: 'condp', offset: 3, tripleMarker: ':>>' },
 ];
 
 // Backward compatibility
-export const bindingForms = defaultVectorPairForms
-  .filter((f): f is VectorPairForm => f.type === 'function')
+export const bindingForms = defaultPairForms
+  .filter((f): f is VectorBindingForm => f.type === 'vector-binding')
   .map((f) => f.name);
 
 /**
@@ -1653,40 +1667,28 @@ function isPrecededByKeywordPairForm(
   return matchingForm;
 }
 
-const conditionalForms = ['cond', 'cond->', 'cond->>', 'case', 'condp'];
-
 /**
- * Returns the offset (number of initial forms that are not part of pairs)
- * for conditional forms.
- * - cond: pairs start after function name (offset 1 for 'cond' itself)
- * - cond->/cond->>: pairs start after function name and initial form (offset 2)
- * - case: pairs start after function name and initial form (offset 2)
- * - condp: pairs start after function name, predicate, and initial form (offset 3)
+ * Gets the offset for a flat pair form (e.g., cond, case, condp).
+ * Returns the matching FlatPairForm if found, otherwise null.
  */
-function getConditionalFormPairOffset(cursor: LispTokenCursor): number {
+function getFlatPairForm(cursor: LispTokenCursor, flatForms: FlatPairForm[]): FlatPairForm | null {
   const probeCursor = cursor.clone();
   if (probeCursor.backwardList()) {
     const opening = probeCursor.getPrevToken().raw;
     if (opening.endsWith('(')) {
       const fn = probeCursor.getFunctionName();
-      if (fn === 'cond') {
-        return 1;
-      }
-      if (fn === 'cond->' || fn === 'cond->>' || fn === 'case') {
-        return 2;
-      }
-      if (fn === 'condp') {
-        return 3;
+      if (fn) {
+        return flatForms.find((f) => f.name === fn) ?? null;
       }
     }
   }
-  return 0;
+  return null;
 }
 
 export function isInPairsList(
   cursor: LispTokenCursor,
   pairForms: string[],
-  vectorConfigs: VectorBindingConfig[] = defaultVectorPairForms
+  vectorConfigs: PairFormConfig[] = defaultPairForms
 ): boolean {
   const probeCursor = cursor.clone();
   if (probeCursor.backwardList()) {
@@ -1713,9 +1715,9 @@ export function isInPairsList(
       }
     }
     if (opening.endsWith('(')) {
-      // Check if this is a conditional form like (cond test expr test expr ...)
-      const fn = probeCursor.getFunctionName();
-      if (fn && conditionalForms.includes(fn)) {
+      // Check if this is a flat pair form like (cond test expr test expr ...)
+      const flatForms = vectorConfigs.filter((f): f is FlatPairForm => f.type === 'flat');
+      if (getFlatPairForm(probeCursor, flatForms)) {
         return true;
       }
     }
@@ -1725,14 +1727,15 @@ export function isInPairsList(
 }
 
 /**
- * Checks if the current index is part of a condp triple (test :>> function).
+ * Checks if the current index is part of a triple (test marker function).
  * Returns the range of the triple if found, otherwise null.
  */
-function getCondpTripleRange(
+function getTripleRange(
   doc: EditableDocument,
   ranges: [number, number][],
   currentIndex: number,
-  pairOffset: number
+  pairOffset: number,
+  tripleMarker: string
 ): [number, number] | null {
   const adjustedIndex = currentIndex - pairOffset;
   if (adjustedIndex < 0) {
@@ -1743,22 +1746,22 @@ function getCondpTripleRange(
   const getText = (idx: number) =>
     idx >= 0 && idx < ranges.length ? doc.model.getText(ranges[idx][0], ranges[idx][1]) : '';
 
-  // If current is :>>, return test + :>> + fn
+  // If current is the marker, return test + marker + fn
   if (
-    getText(currentIndex) === ':>>' &&
+    getText(currentIndex) === tripleMarker &&
     currentIndex > pairOffset &&
     currentIndex < ranges.length - 1
   ) {
     return [ranges[currentIndex - 1][0], ranges[currentIndex + 1][1]];
   }
 
-  // If previous is :>>, return test + :>> + fn
-  if (getText(currentIndex - 1) === ':>>' && currentIndex > pairOffset + 1) {
+  // If previous is the marker, return test + marker + fn
+  if (getText(currentIndex - 1) === tripleMarker && currentIndex > pairOffset + 1) {
     return [ranges[currentIndex - 2][0], ranges[currentIndex][1]];
   }
 
-  // If next is :>>, return test + :>> + fn
-  if (getText(currentIndex + 1) === ':>>' && currentIndex < ranges.length - 2) {
+  // If next is the marker, return test + marker + fn
+  if (getText(currentIndex + 1) === tripleMarker && currentIndex < ranges.length - 2) {
     return [ranges[currentIndex][0], ranges[currentIndex + 2][1]];
   }
 
@@ -1766,23 +1769,24 @@ function getCondpTripleRange(
 }
 
 /**
- * Builds condp element groups (pairs and :>> triples) and returns the range
+ * Builds element groups (pairs and triples with a marker) and returns the range
  * containing the current selection, or currentSingleRange as a fallback.
  */
-function getCondpElementGroupRange(
+function getTripleOrPairGroupRange(
   doc: EditableDocument,
   ranges: [number, number][],
   indexOfCurrentSingle: number,
   pairOffset: number,
-  currentSingleRange: [number, number]
+  currentSingleRange: [number, number],
+  tripleMarker: string
 ): [number, number] {
   const adjustedIndex = indexOfCurrentSingle - pairOffset;
   if (adjustedIndex < 0) {
     return currentSingleRange;
   }
 
-  // Check for :>> triple first
-  const tripleRange = getCondpTripleRange(doc, ranges, indexOfCurrentSingle, pairOffset);
+  // Check for triple first
+  const tripleRange = getTripleRange(doc, ranges, indexOfCurrentSingle, pairOffset, tripleMarker);
   if (tripleRange) {
     return tripleRange;
   }
@@ -1795,15 +1799,15 @@ function getCondpElementGroupRange(
     return currentSingleRange;
   }
 
-  // Handle regular pairs and :>> triples by grouping elements
+  // Handle regular pairs and triples by grouping elements
   const elementGroups: { start: number; end: number; groupStart: number }[] = [];
   let i = pairOffset;
 
   while (i < ranges.length) {
-    // Check if next element is :>>
+    // Check if next element is the triple marker
     if (i + 1 < ranges.length) {
       const nextText = doc.model.getText(ranges[i + 1][0], ranges[i + 1][1]);
-      if (nextText === ':>>') {
+      if (nextText === tripleMarker) {
         if (i + 2 < ranges.length) {
           elementGroups.push({
             start: ranges[i][0],
@@ -1910,27 +1914,26 @@ export function currentSexpsRange(
         (r) => r[0] === currentSingleRange[0] && r[1] === currentSingleRange[1]
       );
 
-      // Get the offset for conditional forms (e.g., cond has 1 initial non-pair form)
-      const pairOffset = getConditionalFormPairOffset(listCursor);
+      // Get the flat pair form config (e.g., cond has offset 1, condp has offset 3 and tripleMarker)
+      const flatForms = defaultPairForms.filter((f): f is FlatPairForm => f.type === 'flat');
+      const flatForm = getFlatPairForm(listCursor, flatForms);
+      const pairOffset = flatForm?.offset ?? 0;
 
       // Adjust the index to account for non-pair forms at the start
       const adjustedIndex = indexOfCurrentSingle - pairOffset;
 
       // Only treat as pairs if we're past the offset
       if (adjustedIndex >= 0) {
-        // Check if we're in a condp form
-        const probeCursor = listCursor.clone();
-        if (probeCursor.backwardList()) {
-          const fn = probeCursor.getFunctionName();
-          if (fn === 'condp') {
-            return getCondpElementGroupRange(
-              doc,
-              ranges,
-              indexOfCurrentSingle,
-              pairOffset,
-              currentSingleRange
-            );
-          }
+        // Check if this flat form has a triple marker (like condp with :>>)
+        if (flatForm?.tripleMarker) {
+          return getTripleOrPairGroupRange(
+            doc,
+            ranges,
+            indexOfCurrentSingle,
+            pairOffset,
+            currentSingleRange,
+            flatForm.tripleMarker
+          );
         }
         return getPairElementGroupRange(ranges, pairOffset, currentSingleRange);
       }

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1588,6 +1588,12 @@ interface FlatPairForm {
 
 type PairFormConfig = VectorBindingForm | KeywordPairForm | FlatPairForm;
 
+type GroupedPairForms = {
+  'vector-binding': VectorBindingForm[];
+  keyword: KeywordPairForm[];
+  flat: FlatPairForm[];
+};
+
 const defaultPairForms: PairFormConfig[] = [
   // Vector Binding forms
   { type: 'vector-binding', name: 'let' },
@@ -1609,10 +1615,25 @@ const defaultPairForms: PairFormConfig[] = [
   { type: 'flat', name: 'condp', offset: 3, tripleMarker: ':>>' },
 ];
 
-// Backward compatibility
-export const bindingForms = defaultPairForms
-  .filter((f): f is VectorBindingForm => f.type === 'vector-binding')
-  .map((f) => f.name);
+const groupedDefaultPairForms = defaultPairForms.reduce<GroupedPairForms>(
+  (acc, form) => {
+    switch (form.type) {
+      case 'vector-binding':
+        acc['vector-binding'].push(form);
+        break;
+      case 'keyword':
+        acc.keyword.push(form);
+        break;
+      case 'flat':
+        acc.flat.push(form);
+        break;
+    }
+    return acc;
+  },
+  { 'vector-binding': [], keyword: [], flat: [] }
+);
+
+export const bindingForms = groupedDefaultPairForms['vector-binding'].map((f) => f.name);
 
 /**
  * Checks if a vector is preceded by a keyword pair form (like `:let`).
@@ -1685,11 +1706,7 @@ function getFlatPairForm(cursor: LispTokenCursor, flatForms: FlatPairForm[]): Fl
   return null;
 }
 
-export function isInPairsList(
-  cursor: LispTokenCursor,
-  pairForms: string[],
-  vectorConfigs: PairFormConfig[] = defaultPairForms
-): boolean {
+export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boolean {
   const probeCursor = cursor.clone();
   if (probeCursor.backwardList()) {
     const opening = probeCursor.getPrevToken().raw;
@@ -1698,7 +1715,7 @@ export function isInPairsList(
     }
     if (opening.endsWith('[')) {
       // Check keyword modifiers first (like :let)
-      const keywordForms = vectorConfigs.filter((f): f is KeywordPairForm => f.type === 'keyword');
+      const keywordForms = groupedDefaultPairForms.keyword;
       if (isPrecededByKeywordPairForm(probeCursor, keywordForms)) {
         return true;
       }
@@ -1716,7 +1733,7 @@ export function isInPairsList(
     }
     if (opening.endsWith('(')) {
       // Check if this is a flat pair form like (cond test expr test expr ...)
-      const flatForms = vectorConfigs.filter((f): f is FlatPairForm => f.type === 'flat');
+      const flatForms = groupedDefaultPairForms.flat;
       if (getFlatPairForm(probeCursor, flatForms)) {
         return true;
       }
@@ -1915,7 +1932,7 @@ export function currentSexpsRange(
       );
 
       // Get the flat pair form config (e.g., cond has offset 1, condp has offset 3 and tripleMarker)
-      const flatForms = defaultPairForms.filter((f): f is FlatPairForm => f.type === 'flat');
+      const flatForms = groupedDefaultPairForms.flat;
       const flatForm = getFlatPairForm(listCursor, flatForms);
       const pairOffset = flatForm?.offset ?? 0;
 


### PR DESCRIPTION
## What has changed?

This is the first step toward making pair form handling fully configurable. It provides the internal infrastructure by consolidating and generalizing the handling of pair forms (like `let` bindings, `cond` pairs, and keyword-based modifiers) within the Paredit logic. It replaces several disparate, hardcoded lists and specialized functions with a unified configuration-driven approach.

This work is part of the first step for #3007 (but does not fix it yet).

Key changes:
- **Unified Configuration:** Introduced `PairFormConfig` which supports three main styles:
    - `VectorBindingForm`: For forms like `let`, `loop`, `doseq`, etc., where pairs are in a vector.
    - `KeywordPairForm`: For keyword-based modifiers like `:let` within `for` or `doseq`.
    - `FlatPairForm`: For forms like `cond`, `case`, and `condp` where pairs are interleaved in the list itself.
- **Enhanced Parent Validation:** `isPrecededByKeywordPairForm` now supports validating the parent function, ensuring `:let` is only treated as a pair form when inside appropriate contexts (e.g., `for`, `doseq`, `dotimes`).
- **Generalized Triple Handling:** Logic for handling triples (like `test :>> expression` in `condp`) has been generalized to support configurable markers and offsets, facilitating easier addition of similar patterns in the future.
- **Refactoring for Maintainability:** Replaced hardcoded `bindingForms` and `conditionalForms` arrays with `defaultPairForms`, reducing code duplication and making the system more extensible.

This is part of an effort to make Calva's structural editing more robust and easier to configure for different Clojure dialects or user preferences.

Relates to #3007 (Step 1)

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch.
- [x] Made sure I have changed the PR base branch, so that it is not `published`.
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses.
    - [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed.
- [x] Confirmed that there are no linter warnings or errors.
