### PR TITLE
2981 load file promise completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [The 'calva.loadFile' command returns a Promise that is only completed on the first execution.](https://github.com/BetterThanTomorrow/calva/issues/2981)
+
 ## [2.0.546] - 2026-01-30
 
 - [Consider form pairs in `:let` bindings when growing the selection and when dragging forms](https://github.com/BetterThanTomorrow/calva/issues/2988)

--- a/src/extension-test/integration/runTests.ts
+++ b/src/extension-test/integration/runTests.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as fs from 'fs';
 import { glob } from 'glob';
 
 import { runTests } from '@vscode/test-electron';
@@ -8,6 +9,8 @@ async function main() {
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
     const extensionDevelopmentPath = path.resolve(__dirname, ...['..', '..', '..']);
+    const vscodeTestPath = path.resolve(extensionDevelopmentPath, '.vscode-test');
+    fs.rmSync(vscodeTestPath, { recursive: true, force: true });
 
     // The path to the extension test runner script
     // Passed to --extensionTestsPath

--- a/src/extension-test/integration/suite/load-file-test.ts
+++ b/src/extension-test/integration/suite/load-file-test.ts
@@ -80,6 +80,7 @@ suite('Load File Command Test', () => {
       });
       await jackInHarness.waitForNextClient();
       testUtil.log(suite, 'Waiting for jack-in to complete (terminal output mode)...');
+      // Unfortunately, awaiting jack-in does not work with terminal output mode.
       await testUtil.sleep(5000);
     } else {
       await jackInHarness.jackInWithConnectSequence(testFilePath, connectSequence);

--- a/src/extension-test/integration/suite/load-file-test.ts
+++ b/src/extension-test/integration/suite/load-file-test.ts
@@ -1,0 +1,121 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as path from 'path';
+import { before, after, beforeEach, afterEach } from 'mocha';
+import { getDocument } from '../../../doc-mirror';
+import * as jackIn from '../../../nrepl/jack-in';
+import {
+  ReplConnectSequence,
+  ProjectTypes,
+  CljsTypes,
+} from '../../../nrepl/connect-sequence-types';
+import * as outputWindow from '../../../repl-window/repl-window-doc';
+import * as testUtil from './util';
+
+suite('Load File Command Test', () => {
+  const suite = 'Load File Command Test';
+  const jackInHarness = new testUtil.JackInHarness(suite);
+  let originalDestinations: any;
+
+  const testFile = 'test.clj';
+  const testFilePath = path.join(testUtil.testDataDir, testFile);
+  const connectSequence: ReplConnectSequence = {
+    projectType: ProjectTypes['deps.edn'],
+    name: 'deps.edn',
+    cljsType: CljsTypes.none,
+    projectRootPath: [path.join(testUtil.testDataDir, '..')],
+    menuSelections: { cljAliases: [] },
+  };
+
+  before(async () => {
+    testUtil.showMessage(suite, 'suite starting!');
+    await testUtil.ensureOutputDir(testUtil.testDataDir);
+    const config = vscode.workspace.getConfiguration('calva');
+    originalDestinations = config.inspect('outputDestinations')?.globalValue;
+  });
+
+  after(async () => {
+    testUtil.log(suite, 'Suite cleanup: killing all jack-in processes');
+    await jackIn.calvaJackout({ force: true });
+    await testUtil.sleep(500);
+    testUtil.showMessage(suite, 'suite done!');
+  });
+
+  beforeEach(async function () {
+    this.timeout(60_000);
+    await outputWindow.clearReplWindowDoc();
+    jackInHarness.reset();
+    await jackInHarness.disconnectAllClients();
+  });
+
+  afterEach(async () => {
+    const config = vscode.workspace.getConfiguration('calva');
+    await config.update(
+      'outputDestinations',
+      originalDestinations,
+      vscode.ConfigurationTarget.Global
+    );
+  });
+
+  async function setOutputDestinations(destination: string) {
+    const config = vscode.workspace.getConfiguration('calva');
+    await config.update(
+      'outputDestinations',
+      {
+        evalResults: destination,
+        evalOutput: destination,
+        otherOutput: destination,
+      },
+      vscode.ConfigurationTarget.Global
+    );
+  }
+
+  async function performJackIn(destination: 'terminal' | 'repl-window') {
+    await setOutputDestinations(destination);
+    if (destination === 'terminal') {
+      await testUtil.openFile(testFilePath);
+      await vscode.commands.executeCommand('calva.jackIn', {
+        connectSequence,
+        disableAutoSelect: true,
+      });
+      await jackInHarness.waitForNextClient();
+      testUtil.log(suite, 'Waiting for jack-in to complete (terminal output mode)...');
+      await testUtil.sleep(5000);
+    } else {
+      await jackInHarness.jackInWithConnectSequence(testFilePath, connectSequence);
+    }
+  }
+
+  async function getReplWindowText() {
+    const replWindowDoc = await outputWindow.openReplWindowDoc();
+    return getDocument(replWindowDoc).document.getText();
+  }
+
+  test('execute calva.loadFile with repl-window output and verify results', async function () {
+    await performJackIn('repl-window');
+    await testUtil.openFile(testFilePath);
+    await vscode.commands.executeCommand('calva.loadFile');
+    let text = await getReplWindowText();
+    assert.ok(text.includes('; bar'), 'Output should contain evaluation result from first load');
+    await testUtil.openFile(testFilePath);
+    await vscode.commands.executeCommand('calva.loadFile');
+    text = await getReplWindowText();
+    const occurrences = (text.match(/; bar/g) || []).length;
+    assert.ok(
+      occurrences >= 2,
+      `Expected "; bar" to appear at least twice, but found ${occurrences} times.`
+    );
+  });
+
+  test('execute calva.loadFile twice with terminal output', async function () {
+    await performJackIn('terminal');
+    await testUtil.openFile(testFilePath);
+    await vscode.commands.executeCommand('calva.loadFile');
+    await testUtil.openFile(testFilePath);
+    const loadFilePromise = vscode.commands.executeCommand('calva.loadFile');
+    const timeoutPromise = new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('calva.loadFile hung on second execution')), 5000)
+    );
+    await Promise.race([loadFilePromise, timeoutPromise]);
+  });
+});

--- a/src/repl-window/repl-window-doc.ts
+++ b/src/repl-window/repl-window-doc.ts
@@ -612,8 +612,7 @@ export function appendPrompt(onAppended?: OnAppendedCallback) {
   const prompt = getPrompt();
   if (!lastAppended.trimEnd().endsWith(prompt.trimEnd())) {
     appendLine(getPrompt(), onAppended);
-  }
-  else if (onAppended) {
+  } else if (onAppended) {
     // Resolve promise though no append is actually needed
     onAppended(undefined);
   }

--- a/src/repl-window/repl-window-doc.ts
+++ b/src/repl-window/repl-window-doc.ts
@@ -613,6 +613,10 @@ export function appendPrompt(onAppended?: OnAppendedCallback) {
   if (!lastAppended.trimEnd().endsWith(prompt.trimEnd())) {
     appendLine(getPrompt(), onAppended);
   }
+  else if (onAppended) {
+    // Resolve promise though no append is actually needed
+    onAppended(undefined);
+  }
 }
 
 export function forceAppendPrompt(onAppended?: OnAppendedCallback) {


### PR DESCRIPTION
… new load-file-test.ts integration test

+ improved integration test run isolation by removing `.vscode-test` at the start of each run.

<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- The `appendPrompt` function in repl-window-doc.ts now resolves the given promise (`onAppended`) even when no prompt needs to be appended. 

As alternative solution I considered turning `appendPrompt` into an `async` function itself. I seemed to get quite far with this refactoring that affected more code than I identified initially. Unfortunately, I must have overlooked some consequences, because even if I got the new integration test to pass this way, other integration tests started to fail with timeouts. :-) Now realizing that I understood even less of the expected async/sync behavior and the interaction between those integration tests I decided to put more emphasis on having a better isolated integrationtest first.

I have also considered (and tried) renaming the (now rather misleadingly named) `onAppended` parameter to `onAppendDone` (+ renaming the specific type accordingly), but that also required me to make rather extensive changes to the code base that I could not yet fully oversee and therefore chickened out of. I do still think such a rename might make sense and would not necessarily break things. So, if desirable for this PR, I can certainly give that another go now that I am experiencing more control over the integration tests.

(Another possible direction that I have not tried in the end, might be to wrap the call to `appendPrompt` from `loadFileCommand` in evaluate.ts in another `if` statement over `replWindow.isReplWindowDoc(doc)`, but that would also require some code duplication/refactoring to require `doc` again.)

- I introduced a new integration test `load-file-test.ts` to prove the problem and verify the solution. 

I can imagine there is some overlap with jack-in-and-connect-test.ts, but having a dedicated test file was of course easier to work with. In a way this kind of test may also belong to the sphere of 'end-to-end' tests. So, please let me know if it would be preferable to merge or rearrange things after all.

- Modified src/extension-test/integration/runTests.ts to always start by removing any existing '.vscode-test' directory, because I found during development of my integration test that I was really bitten again and again by the configuration not being returned to its expected original state. By now, I believe that the integration test itself does a good job of resetting the configuration, so that this explicit removal may no longer be strictly necessary, but I still think it is useful to guarantee in this manner that the integration tests always start from a clean configuration state.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2981 'The 'calva.loadFile' command returns a Promise that is only completed on the first execution.'

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [~] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [~] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
