### PR TITLE
Prefix deletion consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Pair selection and drag with threaded `cond->`](https://github.com/BetterThanTomorrow/calva/issues/3018)
+- Fix: [Inconsistent deletion of structural prefixes with empty forms](https://github.com/BetterThanTomorrow/calva/issues/3021)
+
 ## [2.0.547] - 2026-02-02
 
 - Fix: [The 'calva.loadFile' command returns a Promise that is only completed on the first execution.](https://github.com/BetterThanTomorrow/calva/issues/2981)

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1415,76 +1415,166 @@ function deleteCharacter(
   });
 }
 
+interface ForwardDeletionContext {
+  isAtInvalidReaderPrefix: boolean;
+  isAtReaderMacroStart: boolean;
+  isAtQuotePrefix: boolean;
+  shouldDeletePrefix: boolean;
+}
+
 export function deleteForward(
   doc: EditableDocument,
   builder?: TextEditorEdit,
   start: number = doc.selections[0].anchor,
   end: number = doc.selections[0].active
 ) {
-  if (start != end) {
-    const [left, right] = [Math.min(start, end), Math.max(start, end)];
-    return doc.model.editNow([new ModelEdit('deleteRange', [start, end - start])], {
-      builder: builder,
-    });
-  } else {
-    // Note: skipFormat, lest formatter unexpectedly move the point (eg skipping past commas)
-    const cursor = doc.getTokenCursor(start);
-    const prevToken = cursor.getPrevToken();
-    const nextToken = cursor.getToken();
-    const p = start;
-    if (doc.model.getText(p, p + 2, true) == '\\"') {
-      return doc.model.editNow([new ModelEdit('deleteRange', [p, 2])], {
-        builder: builder,
-        skipFormat: true,
-      });
-    } else if (prevToken.type === 'open' && nextToken.type === 'close') {
-      return doc.model.editNow(
-        [new ModelEdit('deleteRange', [p - prevToken.raw.length, prevToken.raw.length + 1])],
-        {
-          builder: builder,
-        }
-      );
-    } else {
-      // Check if we're at an invalid reader prefix (junk #) or at the start of a simple reader macro
-      const isAtInvalidReaderPrefix = nextToken.type === 'junk' && nextToken.raw === '#';
-      // Only match simple reader macros like #(, #{, #[ (exactly 2 characters)
-      // Don't match namespaced maps like #:same{ which are longer
-      const isAtReaderMacroStart =
-        nextToken.type === 'open' &&
-        isSimpleReaderPrefix(nextToken) &&
-        start === cursor.offsetStart;
-
-      // Check if we're at a quote prefix for an empty form like '()
-      // Option B: Delete the quote prefix, leaving the empty form
-      const isAtQuotePrefix = isQuotePrefix(nextToken) && start === cursor.offsetStart;
-
-      // For quote prefixes or reader macro prefixes, we should delete them
-      const shouldDeletePrefix = isAtReaderMacroStart || isAtQuotePrefix;
-
-      if (
-        (['open', 'close'].includes(nextToken.type) &&
-          cursor.docIsBalanced() &&
-          !shouldDeletePrefix) ||
-        isAtInvalidReaderPrefix
-      ) {
-        if (isAtInvalidReaderPrefix) {
-          // Delete the invalid # prefix
-          return doc.model.editNow([new ModelEdit('deleteRange', [start, 1])], {
-            builder: builder,
-            skipFormat: true,
-          });
-        } else {
-          doc.selections = [new ModelEditSelection(p + 1)];
-          return;
-        }
-      } else {
-        return doc.model.editNow([new ModelEdit('deleteRange', [start, 1])], {
-          builder: builder,
-          skipFormat: true,
-        });
-      }
-    }
+  if (start !== end) {
+    handleRangeDeleteForward(doc, builder, start, end);
+    return;
   }
+
+  handleSingleCursorDeleteForward(doc, builder, start);
+}
+
+function handleRangeDeleteForward(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  start: number,
+  end: number
+): void {
+  doc.model.editNow([new ModelEdit('deleteRange', [start, end - start])], {
+    builder,
+  });
+}
+
+function handleSingleCursorDeleteForward(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  start: number
+): void {
+  const cursor = doc.getTokenCursor(start);
+  const prevToken = cursor.getPrevToken();
+  const nextToken = cursor.getToken();
+
+  if (shouldDeleteForwardQuotedQuote(doc, start)) {
+    deleteForwardQuotedQuote(doc, builder, start);
+    return;
+  }
+
+  if (shouldDeleteEmptyList(prevToken, nextToken)) {
+    deleteForwardEmptyList(doc, builder, start, prevToken);
+    return;
+  }
+
+  handleStructuralDeleteForward(doc, builder, cursor, start, nextToken);
+}
+
+function shouldDeleteForwardQuotedQuote(doc: EditableDocument, start: number): boolean {
+  return doc.model.getText(start, start + QUOTED_QUOTE_LENGTH, true) === '\\"';
+}
+
+function deleteForwardQuotedQuote(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  start: number
+): void {
+  doc.model.editNow([new ModelEdit('deleteRange', [start, QUOTED_QUOTE_LENGTH])], {
+    builder,
+    skipFormat: true,
+  });
+}
+
+function deleteForwardEmptyList(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  start: number,
+  prevToken: Token
+): void {
+  doc.model.editNow(
+    [new ModelEdit('deleteRange', [start - prevToken.raw.length, prevToken.raw.length + 1])],
+    { builder }
+  );
+}
+
+function handleStructuralDeleteForward(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  cursor: LispTokenCursor,
+  start: number,
+  nextToken: Token
+): void {
+  const context = analyzeForwardDeletionContext(cursor, start, nextToken);
+
+  if (shouldJumpForward(cursor, nextToken, context)) {
+    if (context.isAtInvalidReaderPrefix) {
+      deleteInvalidReaderPrefix(doc, builder, start);
+    } else {
+      performForwardJump(doc, start);
+    }
+  } else {
+    deleteForwardCharacter(doc, builder, start);
+  }
+}
+
+function analyzeForwardDeletionContext(
+  cursor: LispTokenCursor,
+  start: number,
+  nextToken: Token
+): ForwardDeletionContext {
+  const isAtInvalidReaderPrefix = nextToken.type === 'junk' && nextToken.raw === '#';
+
+  const isAtReaderMacroStart =
+    nextToken.type === 'open' && isSimpleReaderPrefix(nextToken) && start === cursor.offsetStart;
+
+  const isAtQuotePrefix = isQuotePrefix(nextToken) && start === cursor.offsetStart;
+
+  const shouldDeletePrefix = isAtReaderMacroStart || isAtQuotePrefix;
+
+  return {
+    isAtInvalidReaderPrefix,
+    isAtReaderMacroStart,
+    isAtQuotePrefix,
+    shouldDeletePrefix,
+  };
+}
+
+function shouldJumpForward(
+  cursor: LispTokenCursor,
+  nextToken: Token,
+  context: ForwardDeletionContext
+): boolean {
+  const isStructuralBoundary =
+    ['open', 'close'].includes(nextToken.type) &&
+    cursor.docIsBalanced() &&
+    !context.shouldDeletePrefix;
+
+  return isStructuralBoundary || context.isAtInvalidReaderPrefix;
+}
+
+function deleteInvalidReaderPrefix(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  start: number
+): void {
+  doc.model.editNow([new ModelEdit('deleteRange', [start, 1])], {
+    builder,
+    skipFormat: true,
+  });
+}
+
+function performForwardJump(doc: EditableDocument, start: number): void {
+  doc.selections = [new ModelEditSelection(start + 1)];
+}
+
+function deleteForwardCharacter(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  start: number
+): void {
+  doc.model.editNow([new ModelEdit('deleteRange', [start, 1])], {
+    builder,
+    skipFormat: true,
+  });
 }
 
 export async function stringQuote(

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1133,6 +1133,23 @@ function backspaceOnWhitespaceEdit(
   );
 }
 
+const JUMP_TOKEN_TYPES = ['open', 'close', 'ignore'] as const;
+const SIMPLE_READER_LENGTH = 2;
+const QUOTED_QUOTE_LENGTH = 2;
+const JUNK_HASH_LENGTH = 2;
+
+interface ReaderMacroContext {
+  isInsideReader: boolean;
+  isAtReaderPrefix: boolean;
+  isInComplexReaderToken: boolean;
+  shouldConsiderForJump: boolean;
+}
+
+interface PrefixDeletionContext {
+  shouldDeletePrefix: boolean;
+  isAtQuotePrefix: boolean;
+}
+
 export function backspace(
   doc: EditableDocument,
   builder?: TextEditorEdit,
@@ -1140,134 +1157,262 @@ export function backspace(
   start: number = doc.selections[0].anchor,
   end: number = doc.selections[0].active
 ): void {
-  if (start != end) {
-    const [left, right] = [Math.min(start, end), Math.max(start, end)];
-    return doc.model.editNow([new ModelEdit('deleteRange', [left, right - left])], {
-      builder: builder,
-      skipFormat: true,
-    });
-  } else {
-    const cursor = doc.getTokenCursor(start);
-    const isTopLevel = doc.getTokenCursor(end).atTopLevel();
-    const nextToken = cursor.getToken();
-
-    // Detect if cursor is inside the '#' prefix of a reader macro token (like #( or #{)
-    // before the opening delimiter. Example: in "#(prn)" at position 1, we're inside the reader.
-    // At position 2, we're no longer inside the reader prefix.
-    const isInsideReader =
-      start > cursor.offsetStart &&
-      nextToken.raw.startsWith('#') &&
-      start <=
-        cursor.offsetStart +
-          (nextToken.raw.match(OPEN_DELIMITERS_REGEX)?.index ?? nextToken.raw.length);
-    const prevToken =
-      (start > cursor.offsetStart && !['open', 'close'].includes(nextToken.type)) || isInsideReader
-        ? nextToken // we are “in” a token
-        : cursor.getPrevToken(); // we are “between” tokens
-    if (prevToken.type == 'prompt') {
-      return;
-    } else if (nextToken.type == 'prompt') {
-      return;
-    } else if (doc.model.getText(start - 2, start, true) == '\\"') {
-      // delete quoted double quote
-      return doc.model.editNow([new ModelEdit('deleteRange', [start - 2, 2])], {
-        builder: builder,
-        skipFormat: true,
-      });
-    } else if (prevToken.type === 'open' && nextToken.type === 'close') {
-      // delete empty list
-      return doc.model.editNow(
-        [new ModelEdit('deleteRange', [start - prevToken.raw.length, prevToken.raw.length + 1])],
-        {
-          builder: builder,
-        }
-      );
-    } else if (
-      !isTopLevel &&
-      !cursor.withinString() &&
-      onlyWhitespaceLeftOfCursor(doc.selections[0].anchor, cursor)
-    ) {
-      // we are at the beginning of a line, and not inside a string
-      return backspaceOnWhitespaceEdit(builder, doc, cursor, config);
-    } else {
-      // isAtReaderPrefix should only be true for simple reader macros like #(, #{
-      // Not for complex forms like namespaced maps: #:same{:a 1 :b 2}
-      const isAtReaderPrefix =
-        (isInsideReader &&
-          start <=
-            cursor.offsetStart +
-              (nextToken.raw.match(OPEN_DELIMITERS_REGEX)?.index ?? nextToken.raw.length) &&
-          nextToken.raw.length === 2) || // Only 2-char reader macros like #( #{
-        (!isInsideReader && isSimpleReaderPrefix(prevToken) && start === cursor.offsetStart);
-
-      // Check if we're at a quote prefix for an empty form like '()
-      // In this case, we want to delete the quote prefix
-      const isAtQuotePrefix =
-        isQuotePrefix(prevToken) && start === cursor.offsetStart + 1 && nextToken.type === 'close';
-
-      // Special check: if we're inside a simple reader macro token like #( or #{ or #[
-      // Always delete the prefix (both # and '), leaving the empty form
-      // But we need to be careful: #:same{ is a namespaced map (longer than 2 chars),
-      // not a simple reader prefix
-      let shouldDeletePrefix = false;
-      if (isAtQuotePrefix) {
-        // Delete the quote prefix from empty forms like '()
-        shouldDeletePrefix = true;
-      } else if (isSimpleReaderPrefix(prevToken)) {
-        // Only match simple reader prefixes like #(, #{, #[ (exactly 2 characters)
-        if (isInsideReader) {
-          // We're inside the #( or #{ or #[ token (between # and the opening delimiter)
-          // Always allow deletion to remove the # prefix
-          shouldDeletePrefix = true;
-        }
-      }
-
-      // Check if we're deleting whitespace after an invalid # (junk)
-      // In this case, delete both the whitespace and the junk #
-      if (prevToken.type === 'ws' && prevToken.raw.length === 1) {
-        const prevPrevCursor = doc.getTokenCursor(cursor.offsetStart - 1);
-        const prevPrevToken = prevPrevCursor.getPrevToken();
-        if (prevPrevToken.type === 'junk' && prevPrevToken.raw === '#') {
-          // Delete both the whitespace and the junk #
-          return doc.model.editNow([new ModelEdit('deleteRange', [start - 2, 2])], {
-            builder: builder,
-            skipFormat: true,
-          });
-        }
-      }
-
-      const JUMP_TOKEN_TYPES = ['open', 'close', 'ignore'];
-      // For 'reader' tokens, only jump if they are simple 2-char prefixes like #( or #{
-      // For complex reader tags like #:same or #inst, allow deletion
-      const shouldConsiderReaderForJump = isSimpleReaderPrefix(prevToken);
-
-      // When we're inside a complex reader token like #:same{, we should delete normally (not jump)
-      // Only jump for structural boundaries or simple 2-char readers
-      const isInComplexReaderToken =
-        isInsideReader && prevToken.raw.length > 2 && prevToken.raw.startsWith('#');
-
-      const shouldJump =
-        (JUMP_TOKEN_TYPES.includes(prevToken.type) || shouldConsiderReaderForJump) &&
-        cursor.docIsBalanced() &&
-        !shouldDeletePrefix &&
-        (!isAtReaderPrefix || !shouldDeletePrefix) &&
-        !isInComplexReaderToken; // Don't jump inside complex reader tokens like #:same{
-
-      if (shouldJump) {
-        // When jumping over a token, if we're inside a reader macro, jump to
-        // its start. Otherwise, jump to the start of the previous token
-        const jumpPosition = isInsideReader ? cursor.offsetStart : start - prevToken.raw.length;
-        doc.selections = [new ModelEditSelection(jumpPosition)];
-        return;
-      } else {
-        const [left, right] = [Math.max(start - 1, 0), start];
-        return doc.model.editNow([new ModelEdit('deleteRange', [left, right - left])], {
-          builder: builder,
-          skipFormat: true,
-        });
-      }
-    }
+  if (start !== end) {
+    handleRangeBackspace(doc, builder, start, end);
+    return;
   }
+  handleSingleCursorBackspace(doc, builder, config, start, end);
+}
+
+function handleRangeBackspace(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  start: number,
+  end: number
+): void {
+  const [left, right] = [Math.min(start, end), Math.max(start, end)];
+  doc.model.editNow([new ModelEdit('deleteRange', [left, right - left])], {
+    builder,
+    skipFormat: true,
+  });
+}
+
+function handleSingleCursorBackspace(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  config: FormatterConfig | undefined,
+  start: number,
+  end: number
+): void {
+  const cursor = doc.getTokenCursor(start);
+  const isTopLevel = doc.getTokenCursor(end).atTopLevel();
+  const nextToken = cursor.getToken();
+  const prevToken = getPreviousToken(cursor, start, nextToken);
+
+  if (prevToken.type === 'prompt' || nextToken.type === 'prompt') {
+    return;
+  }
+
+  if (shouldDeleteQuotedQuote(doc, start)) {
+    deleteQuotedQuote(doc, builder, start);
+    return;
+  }
+
+  if (shouldDeleteEmptyList(prevToken, nextToken)) {
+    deleteEmptyList(doc, builder, start, prevToken);
+    return;
+  }
+
+  if (shouldBackspaceOnWhitespace(isTopLevel, cursor, doc)) {
+    backspaceOnWhitespaceEdit(builder, doc, cursor, config);
+    return;
+  }
+
+  handleStructuralBackspace(doc, builder, cursor, start, nextToken, prevToken);
+}
+
+function getPreviousToken(cursor: LispTokenCursor, start: number, nextToken: Token): Token {
+  const isInsideReader = detectInsideReader(cursor, start, nextToken);
+  const isInToken = start > cursor.offsetStart && !['open', 'close'].includes(nextToken.type);
+
+  return isInToken || isInsideReader ? nextToken : cursor.getPrevToken();
+}
+
+function detectInsideReader(cursor: LispTokenCursor, start: number, nextToken: Token): boolean {
+  if (start <= cursor.offsetStart || !nextToken.raw.startsWith('#')) {
+    return false;
+  }
+
+  const delimiterIndex = nextToken.raw.match(OPEN_DELIMITERS_REGEX)?.index ?? nextToken.raw.length;
+  return start <= cursor.offsetStart + delimiterIndex;
+}
+
+function shouldDeleteQuotedQuote(doc: EditableDocument, start: number): boolean {
+  return doc.model.getText(start - QUOTED_QUOTE_LENGTH, start, true) === '\\"';
+}
+
+function deleteQuotedQuote(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  start: number
+): void {
+  doc.model.editNow(
+    [new ModelEdit('deleteRange', [start - QUOTED_QUOTE_LENGTH, QUOTED_QUOTE_LENGTH])],
+    {
+      builder,
+      skipFormat: true,
+    }
+  );
+}
+
+function shouldDeleteEmptyList(prevToken: Token, nextToken: Token): boolean {
+  return prevToken.type === 'open' && nextToken.type === 'close';
+}
+
+function deleteEmptyList(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  start: number,
+  prevToken: Token
+): void {
+  doc.model.editNow(
+    [new ModelEdit('deleteRange', [start - prevToken.raw.length, prevToken.raw.length + 1])],
+    { builder }
+  );
+}
+
+function shouldBackspaceOnWhitespace(
+  isTopLevel: boolean,
+  cursor: LispTokenCursor,
+  doc: EditableDocument
+): boolean {
+  return (
+    !isTopLevel &&
+    !cursor.withinString() &&
+    onlyWhitespaceLeftOfCursor(doc.selections[0].anchor, cursor)
+  );
+}
+
+function handleStructuralBackspace(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  cursor: LispTokenCursor,
+  start: number,
+  nextToken: Token,
+  prevToken: Token
+): void {
+  const readerContext = analyzeReaderMacroContext(cursor, start, nextToken, prevToken);
+  const prefixContext = analyzePrefixDeletionContext(
+    cursor,
+    start,
+    nextToken,
+    prevToken,
+    readerContext
+  );
+
+  if (shouldDeleteJunkHashWithWhitespace(doc, cursor, start, prevToken)) {
+    deleteJunkHashWithWhitespace(doc, builder, start);
+    return;
+  }
+
+  const shouldJump = determineShouldJump(prevToken, cursor, prefixContext, readerContext);
+
+  if (shouldJump) {
+    performJump(doc, cursor, start, prevToken, readerContext.isInsideReader);
+  } else {
+    deleteCharacter(doc, builder, start);
+  }
+}
+
+function analyzeReaderMacroContext(
+  cursor: LispTokenCursor,
+  start: number,
+  nextToken: Token,
+  prevToken: Token
+): ReaderMacroContext {
+  const isInsideReader = detectInsideReader(cursor, start, nextToken);
+  const delimiterIndex = nextToken.raw.match(OPEN_DELIMITERS_REGEX)?.index ?? nextToken.raw.length;
+
+  const isAtReaderPrefix =
+    (isInsideReader &&
+      start <= cursor.offsetStart + delimiterIndex &&
+      nextToken.raw.length === SIMPLE_READER_LENGTH) ||
+    (!isInsideReader && isSimpleReaderPrefix(prevToken) && start === cursor.offsetStart);
+
+  const isInComplexReaderToken =
+    isInsideReader && prevToken.raw.length > SIMPLE_READER_LENGTH && prevToken.raw.startsWith('#');
+
+  const shouldConsiderForJump = isSimpleReaderPrefix(prevToken);
+
+  return {
+    isInsideReader,
+    isAtReaderPrefix,
+    isInComplexReaderToken,
+    shouldConsiderForJump,
+  };
+}
+
+function analyzePrefixDeletionContext(
+  cursor: LispTokenCursor,
+  start: number,
+  nextToken: Token,
+  prevToken: Token,
+  readerContext: ReaderMacroContext
+): PrefixDeletionContext {
+  const isAtQuotePrefix =
+    isQuotePrefix(prevToken) && start === cursor.offsetStart + 1 && nextToken.type === 'close';
+
+  const shouldDeletePrefix =
+    isAtQuotePrefix || (isSimpleReaderPrefix(prevToken) && readerContext.isInsideReader);
+
+  return { shouldDeletePrefix, isAtQuotePrefix };
+}
+
+function shouldDeleteJunkHashWithWhitespace(
+  doc: EditableDocument,
+  cursor: LispTokenCursor,
+  start: number,
+  prevToken: Token
+): boolean {
+  if (prevToken.type !== 'ws' || prevToken.raw.length !== 1) {
+    return false;
+  }
+
+  const prevPrevCursor = doc.getTokenCursor(cursor.offsetStart - 1);
+  const prevPrevToken = prevPrevCursor.getPrevToken();
+  return prevPrevToken.type === 'junk' && prevPrevToken.raw === '#';
+}
+
+function deleteJunkHashWithWhitespace(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  start: number
+): void {
+  doc.model.editNow([new ModelEdit('deleteRange', [start - JUNK_HASH_LENGTH, JUNK_HASH_LENGTH])], {
+    builder,
+    skipFormat: true,
+  });
+}
+
+function determineShouldJump(
+  prevToken: Token,
+  cursor: LispTokenCursor,
+  prefixContext: PrefixDeletionContext,
+  readerContext: ReaderMacroContext
+): boolean {
+  const isJumpableTokenType =
+    JUMP_TOKEN_TYPES.includes(prevToken.type as typeof JUMP_TOKEN_TYPES[number]) ||
+    readerContext.shouldConsiderForJump;
+
+  return (
+    isJumpableTokenType &&
+    cursor.docIsBalanced() &&
+    !prefixContext.shouldDeletePrefix &&
+    !readerContext.isInComplexReaderToken
+  );
+}
+
+function performJump(
+  doc: EditableDocument,
+  cursor: LispTokenCursor,
+  start: number,
+  prevToken: Token,
+  isInsideReader: boolean
+): void {
+  const jumpPosition = isInsideReader ? cursor.offsetStart : start - prevToken.raw.length;
+  doc.selections = [new ModelEditSelection(jumpPosition)];
+}
+
+function deleteCharacter(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  start: number
+): void {
+  const left = Math.max(start - 1, 0);
+  doc.model.editNow([new ModelEdit('deleteRange', [left, start - left])], {
+    builder,
+    skipFormat: true,
+  });
 }
 
 export function deleteForward(

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -13,8 +13,19 @@ import { backspaceOnWhitespace } from './backspace-on-whitespace';
 import _ = require('lodash');
 import { isEqual, last, property } from 'lodash';
 import { TextEditorEdit } from 'vscode';
+import { Token } from './lexer';
 
 const OPEN_DELIMITERS_REGEX = /[([{"]/;
+
+function isQuotePrefix(token: Token): boolean {
+  return token.type === 'open' && token.raw.startsWith("'");
+}
+
+function isSimpleReaderPrefix(token: Token): boolean {
+  return token.raw.length === 2 && token.raw.startsWith('#') && token.raw.match(/^#[[({]/)
+    ? true
+    : false;
+}
 
 // NB: doc.model.edit returns a Thenable, so that the vscode Editor can compose commands.
 // But don't put such chains in this module because that won't work in the repl-console.
@@ -1179,29 +1190,35 @@ export function backspace(
       // we are at the beginning of a line, and not inside a string
       return backspaceOnWhitespaceEdit(builder, doc, cursor, config);
     } else {
+      // isAtReaderPrefix should only be true for simple reader macros like #(, #{
+      // Not for complex forms like namespaced maps: #:same{:a 1 :b 2}
       const isAtReaderPrefix =
         (isInsideReader &&
           start <=
             cursor.offsetStart +
-              (nextToken.raw.match(OPEN_DELIMITERS_REGEX)?.index ?? nextToken.raw.length)) ||
-        (!isInsideReader && prevToken.raw.startsWith('#') && start === cursor.offsetStart);
+              (nextToken.raw.match(OPEN_DELIMITERS_REGEX)?.index ?? nextToken.raw.length) &&
+          nextToken.raw.length === 2) || // Only 2-char reader macros like #( #{
+        (!isInsideReader && isSimpleReaderPrefix(prevToken) && start === cursor.offsetStart);
 
-      // Special check: if we're inside a reader macro token like #( or #{,
-      // we should not allow deletion only if it's empty (like #())
-      // Non empty forms like #(prn "hello") can have their # deleted when
-      //  cursor is inside the token
-      let shouldJumpOverReaderMacro = false;
-      if (prevToken.raw.startsWith('#') && prevToken.raw.match(/^#[({]/)) {
+      // Check if we're at a quote prefix for an empty form like '()
+      // In this case, we want to delete the quote prefix
+      const isAtQuotePrefix =
+        isQuotePrefix(prevToken) && start === cursor.offsetStart + 1 && nextToken.type === 'close';
+
+      // Special check: if we're inside a simple reader macro token like #( or #{ or #[
+      // Always delete the prefix (both # and '), leaving the empty form
+      // But we need to be careful: #:same{ is a namespaced map (longer than 2 chars),
+      // not a simple reader prefix
+      let shouldDeletePrefix = false;
+      if (isAtQuotePrefix) {
+        // Delete the quote prefix from empty forms like '()
+        shouldDeletePrefix = true;
+      } else if (isSimpleReaderPrefix(prevToken)) {
+        // Only match simple reader prefixes like #(, #{, #[ (exactly 2 characters)
         if (isInsideReader) {
-          // We're inside the #( token (between # and ()
-          // When it is empty, jump; if not, allow deletion
-          const nextCursor = doc.getTokenCursor(cursor.offsetStart);
-          nextCursor.next();
-          const tokenAfterOpen = nextCursor.getToken();
-          shouldJumpOverReaderMacro = tokenAfterOpen.type === 'close';
-        } else {
-          // We're AFTER the #( token - always jump
-          shouldJumpOverReaderMacro = true;
+          // We're inside the #( or #{ or #[ token (between # and the opening delimiter)
+          // Always allow deletion to remove the # prefix
+          shouldDeletePrefix = true;
         }
       }
 
@@ -1219,18 +1236,27 @@ export function backspace(
         }
       }
 
-      const JUMP_TOKEN_TYPES = ['open', 'close', 'ignore', 'reader', 'junk'];
-      if (
-        JUMP_TOKEN_TYPES.includes(prevToken.type) &&
+      const JUMP_TOKEN_TYPES = ['open', 'close', 'ignore'];
+      // For 'reader' tokens, only jump if they are simple 2-char prefixes like #( or #{
+      // For complex reader tags like #:same or #inst, allow deletion
+      const shouldConsiderReaderForJump = isSimpleReaderPrefix(prevToken);
+
+      // When we're inside a complex reader token like #:same{, we should delete normally (not jump)
+      // Only jump for structural boundaries or simple 2-char readers
+      const isInComplexReaderToken =
+        isInsideReader && prevToken.raw.length > 2 && prevToken.raw.startsWith('#');
+
+      const shouldJump =
+        (JUMP_TOKEN_TYPES.includes(prevToken.type) || shouldConsiderReaderForJump) &&
         cursor.docIsBalanced() &&
-        (!isAtReaderPrefix || shouldJumpOverReaderMacro)
-      ) {
+        !shouldDeletePrefix &&
+        (!isAtReaderPrefix || !shouldDeletePrefix) &&
+        !isInComplexReaderToken; // Don't jump inside complex reader tokens like #:same{
+
+      if (shouldJump) {
         // When jumping over a token, if we're inside a reader macro, jump to
         // its start. Otherwise, jump to the start of the previous token
-        const jumpPosition =
-          isInsideReader && shouldJumpOverReaderMacro
-            ? cursor.offsetStart
-            : start - prevToken.raw.length;
+        const jumpPosition = isInsideReader ? cursor.offsetStart : start - prevToken.raw.length;
         doc.selections = [new ModelEditSelection(jumpPosition)];
         return;
       } else {

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1300,15 +1300,26 @@ export function deleteForward(
         }
       );
     } else {
-      // Check if we're at an invalid reader prefix (junk #) or at the start of a reader macro
+      // Check if we're at an invalid reader prefix (junk #) or at the start of a simple reader macro
       const isAtInvalidReaderPrefix = nextToken.type === 'junk' && nextToken.raw === '#';
+      // Only match simple reader macros like #(, #{, #[ (exactly 2 characters)
+      // Don't match namespaced maps like #:same{ which are longer
       const isAtReaderMacroStart =
-        nextToken.type === 'open' && nextToken.raw.match(/^#[({]/) && start === cursor.offsetStart;
+        nextToken.type === 'open' &&
+        isSimpleReaderPrefix(nextToken) &&
+        start === cursor.offsetStart;
+
+      // Check if we're at a quote prefix for an empty form like '()
+      // Option B: Delete the quote prefix, leaving the empty form
+      const isAtQuotePrefix = isQuotePrefix(nextToken) && start === cursor.offsetStart;
+
+      // For quote prefixes or reader macro prefixes, we should delete them
+      const shouldDeletePrefix = isAtReaderMacroStart || isAtQuotePrefix;
 
       if (
         (['open', 'close'].includes(nextToken.type) &&
           cursor.docIsBalanced() &&
-          !isAtReaderMacroStart) ||
+          !shouldDeletePrefix) ||
         isAtInvalidReaderPrefix
       ) {
         if (isAtInvalidReaderPrefix) {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -2713,9 +2713,9 @@ describe('paredit', () => {
       });
 
       // https://github.com/BetterThanTomorrow/calva/issues/2327
-      it('Does not delete hash character to the left of a list, inside a list', () => {
+      it('Deletes hash character to the left of a list, inside a list', () => {
         const a = docFromTextNotation('(#|())');
-        const b = docFromTextNotation('(|#())');
+        const b = docFromTextNotation('(|())');
         paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
@@ -2744,15 +2744,15 @@ describe('paredit', () => {
           paredit.backspace(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('Does not delete # inside empty anonymous function', () => {
+        it('Deletes # inside empty anonymous function', () => {
           const a = docFromTextNotation('(#|())');
-          const b = docFromTextNotation('(|#())');
+          const b = docFromTextNotation('(|())');
           paredit.backspace(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
-        it('Does not delete # inside empty set', () => {
+        it('Deletes # inside empty set', () => {
           const a = docFromTextNotation('(#|{})');
-          const b = docFromTextNotation('(|#{})');
+          const b = docFromTextNotation('(|{})');
           paredit.backspace(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
@@ -2765,6 +2765,32 @@ describe('paredit', () => {
         it('Jumps over # when cursor is after opening brace', () => {
           const a = docFromTextNotation('#{|:foo}');
           const b = docFromTextNotation('|#{:foo}');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+      });
+      describe('Quote prefix deletion with empty forms', () => {
+        it("Deletes ' before empty list", () => {
+          const a = docFromTextNotation("'|()");
+          const b = docFromTextNotation('|()');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it("Deletes ' before empty vector", () => {
+          const a = docFromTextNotation("'|[]");
+          const b = docFromTextNotation('|[]');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it("Deletes ' before empty map", () => {
+          const a = docFromTextNotation("'|{}");
+          const b = docFromTextNotation('|{}');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it("Deletes ' before non-empty list", () => {
+          const a = docFromTextNotation("'|(foo)");
+          const b = docFromTextNotation('|(foo)');
           paredit.backspace(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -2911,6 +2911,32 @@ describe('paredit', () => {
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
       });
+      describe('Quote prefix deletion with empty forms', () => {
+        it("Deletes ' before empty list", () => {
+          const a = docFromTextNotation("|'()");
+          const b = docFromTextNotation('|()');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it("Deletes ' before empty vector", () => {
+          const a = docFromTextNotation("|'[]");
+          const b = docFromTextNotation('|[]');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it("Deletes ' before empty map", () => {
+          const a = docFromTextNotation("|'{}");
+          const b = docFromTextNotation('|{}');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it("Deletes ' before non-empty list", () => {
+          const a = docFromTextNotation("|'(foo)");
+          const b = docFromTextNotation('|(foo)');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+      });
     });
 
     describe('killRange', () => {

--- a/test-data/test-files/paredit_sandbox.clj
+++ b/test-data/test-files/paredit_sandbox.clj
@@ -112,20 +112,34 @@ string. "
 ;Should delete entire #() form with backspace and delete
 #()
 
-; Should not delete #  
+; Should not delete # (delete backspace)
 #{|21 2}
 
-; Should delete #
+; Should delete # (delete backspace)
 #|{21}
 
-;; Backspace should delete the #
+;; Delete forward should delete the #
 [|#(prn "hello")]
 |#(prn "hello"|)
 
-;; Delete should delete space and #
-[# |(prn "hello")]
+;; Delete backspace should delete the #
+(|#(prn "hello"))
 
-; Delete should move before # without deleting it
+; Delete backspace should delete the prefix ' or #
+'|(1 2 3)
+#|{1 2 3}
+'|()
+#|{}
+'|('(1 2 3) '(4 5 6))
+
+; Delete forward should delete the prefix ' or #
+('(1 2 3))
+(|#(1 2 3))
+|'()
+|#{}
+|'('(1 2 3) '(4 5 6))
+
+; Delete backspace should move before # without deleting it
 (#(|inc 2))
 
 ;; Pair selecting


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Makes deletion of structural prefixes with empty form consistent between `#` and `'`
- Refactored `backspace` and  `deleteForward` splitting them into smaller functions

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3021 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
