### PR TITLE
Fix: delete quote prefix that is right after quoted list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes to Calva.
 - Fix: [Inconsistent deletion of structural prefixes with empty forms](https://github.com/BetterThanTomorrow/calva/issues/3021)
 - Fix: [Slurp backward with previous commented expr](https://github.com/BetterThanTomorrow/calva/issues/3025)
 - Fix: [Pair selection and drag with threaded `cond->`](https://github.com/BetterThanTomorrow/calva/issues/3018)
+- Fix: [Delete operations with Single Quote (`'`) right after list opening `'(` e.g. `'('(1 2 3))`](https://github.com/BetterThanTomorrow/calva/issues/3020)
 
 ## [2.0.547] - 2026-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Error when slurping forward before commented s-expressions `(|) #_(dosomething)`](https://github.com/BetterThanTomorrow/calva/issues/2387)
-- Fix: [Inconsistent deletion of structural prefixes with empty forms](https://github.com/BetterThanTomorrow/calva/issues/3021)
 - Fix: [Slurp backward with previous commented expr](https://github.com/BetterThanTomorrow/calva/issues/3025)
-- Fix: [Pair selection and drag with threaded `cond->`](https://github.com/BetterThanTomorrow/calva/issues/3018)
+- Fix: [Inconsistent deletion of structural prefixes with empty forms](https://github.com/BetterThanTomorrow/calva/issues/3021)
 - Fix: [Delete operations with Single Quote (`'`) right after list opening `'(` e.g. `'('(1 2 3))`](https://github.com/BetterThanTomorrow/calva/issues/3020)
+- Fix: [Pair selection and drag with threaded `cond->`](https://github.com/BetterThanTomorrow/calva/issues/3018)
 
 ## [2.0.547] - 2026-02-02
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1287,13 +1287,7 @@ function handleStructuralBackspace(
   prevToken: Token
 ): void {
   const readerContext = analyzeReaderMacroContext(cursor, start, nextToken, prevToken);
-  const prefixContext = analyzePrefixDeletionContext(
-    cursor,
-    start,
-    nextToken,
-    prevToken,
-    readerContext
-  );
+  const prefixContext = analyzePrefixDeletionContext(cursor, start, prevToken, readerContext);
 
   if (shouldDeleteJunkHashWithWhitespace(doc, cursor, start, prevToken)) {
     deleteJunkHashWithWhitespace(doc, builder, start);
@@ -1340,7 +1334,6 @@ function analyzeReaderMacroContext(
 function analyzePrefixDeletionContext(
   cursor: LispTokenCursor,
   start: number,
-  nextToken: Token,
   prevToken: Token,
   readerContext: ReaderMacroContext
 ): PrefixDeletionContext {

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1344,8 +1344,9 @@ function analyzePrefixDeletionContext(
   prevToken: Token,
   readerContext: ReaderMacroContext
 ): PrefixDeletionContext {
-  const isAtQuotePrefix =
-    isQuotePrefix(prevToken) && start === cursor.offsetStart + 1 && nextToken.type === 'close';
+  // Check if we're right after a quote prefix (for backspace)
+  // Allow deletion of quote when cursor is between ' and (, like: '|(
+  const isAtQuotePrefix = isQuotePrefix(prevToken) && start === cursor.offsetStart + 1;
 
   const shouldDeletePrefix =
     isAtQuotePrefix || (isSimpleReaderPrefix(prevToken) && readerContext.isInsideReader);

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -2653,6 +2653,25 @@ describe('paredit', () => {
         paredit.backspace(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
+      it('Deletes quote prefix from quoted list with content', () => {
+        // https://github.com/BetterThanTomorrow/calva/issues/3020
+        const a = docFromTextNotation("'('|(1 2 3) '(4 5 6) '(7 8 9))");
+        const b = docFromTextNotation("'(|(1 2 3) '(4 5 6) '(7 8 9))");
+        paredit.backspace(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('Deletes quote prefix from nested quoted list', () => {
+        const a = docFromTextNotation("(foo '|(bar baz))");
+        const b = docFromTextNotation('(foo |(bar baz))');
+        paredit.backspace(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('Deletes quote prefix from quoted vector', () => {
+        const a = docFromTextNotation("'|[1 2 3]");
+        const b = docFromTextNotation('|[1 2 3]');
+        paredit.backspace(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
       it('Moves cursor past entire open paren, including prefix characters', () => {
         const a = docFromTextNotation('#(|foo)');
         const b = docFromTextNotation('|#(foo)');
@@ -2900,6 +2919,28 @@ describe('paredit', () => {
         const b = docFromTextNotation('{::foo |• ::bar :foo}');
         paredit.deleteForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      // https://github.com/BetterThanTomorrow/calva/issues/3020
+      describe('Quote prefix deletion', () => {
+        it('Deletes quote prefix from quoted list with content', () => {
+          const a = docFromTextNotation("'(|'(1 2 3) '(4 5 6) '(7 8 9))");
+          const b = docFromTextNotation("'(|(1 2 3) '(4 5 6) '(7 8 9))");
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes quote prefix from nested quoted list', () => {
+          const a = docFromTextNotation("(foo |'(bar baz))");
+          const b = docFromTextNotation('(foo |(bar baz))');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes quote prefix from quoted vector', () => {
+          const a = docFromTextNotation("|'[1 2 3]");
+          const b = docFromTextNotation('|[1 2 3]');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
       });
 
       // https://github.com/BetterThanTomorrow/calva/issues/2766

--- a/test-data/test-files/paredit_sandbox.clj
+++ b/test-data/test-files/paredit_sandbox.clj
@@ -131,6 +131,7 @@ string. "
 '|()
 #|{}
 '|('(1 2 3) '(4 5 6))
+'('|(1 2 3) '(4 5 6))
 
 ; Delete forward should delete the prefix ' or #
 ('(1 2 3))
@@ -138,6 +139,7 @@ string. "
 |'()
 |#{}
 |'('(1 2 3) '(4 5 6))
+'(|'(1 2 3) '(4 5 6))
 
 ; Delete backspace should move before # without deleting it
 (#(|inc 2))


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Fixed the issue where nested `'` could not be delete when there was after a opening list form: `'('(1 2 3))`
- Add unit tests 
- Add examples in sandbox
- Includes #3022  changes but this will be squashed if it gets approved and diff will be much smaller

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3020 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
