### PR TITLE
Slurping s-expressions forward with commented expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Error when slurping forward before commented s-expressions `(|) #_(dosomething)`](https://github.com/BetterThanTomorrow/calva/issues/2387)
 - Fix: [Pair selection and drag with threaded `cond->`](https://github.com/BetterThanTomorrow/calva/issues/3018)
 ## [2.0.547] - 2026-02-02
 

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -258,12 +258,18 @@ export class LispTokenCursor extends TokenCursor {
           this.next();
           break;
         case 'ignore':
+          // Always include the ignored form as part of this sexp
+          this.next();
+          this.forwardSexp(skipComments, skipMetadata, skipIgnoredForms);
           if (skipIgnoredForms) {
-            this.next();
-            this.forwardSexp(skipComments, skipMetadata, skipIgnoredForms);
+            // Continue to next sexp when skipping ignored forms
             break;
           }
-        // eslint-disable-next-line no-fallthrough
+          // Stop here: the ignored form is the sexp we found
+          if (stack.length <= 0) {
+            return true;
+          }
+          break;
         case 'id':
         case 'lit':
         case 'kw':

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -2360,6 +2360,18 @@ describe('paredit', () => {
           await paredit.forwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
+        it('slurps form after empty list with ignore marker following', async () => {
+          const a = docFromTextNotation('(|) #_(dosomething)');
+          const b = docFromTextNotation('(|#_(dosomething))');
+          await paredit.forwardSlurpSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('slurps form after empty list with ignore marker following but does not slurp next sexp', async () => {
+          const a = docFromTextNotation('(|) #_(dosomething) something');
+          const b = docFromTextNotation('(|#_(dosomething)) something');
+          await paredit.forwardSlurpSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
       });
 
       describe('Slurping backwards', () => {

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -121,7 +121,7 @@ describe('Token Cursor', () => {
     });
     it('Does not skip ignored forms if skipIgnoredForms is false', () => {
       const a = docFromTextNotation('(a| #_1 #_2 3)');
-      const b = docFromTextNotation('(a #_|a #_2 3)');
+      const b = docFromTextNotation('(a #_1| #_2 3)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp(true, true);
       expect(cursor.offsetStart).toBe(b.selections[0].anchor);

--- a/test-data/test-files/paredit_sandbox.clj
+++ b/test-data/test-files/paredit_sandbox.clj
@@ -298,4 +298,4 @@ _
 ; slurp sexp forward command
 (|) #_(dosomething) ""
 ; should result in
-(|#_(dosomething) "")
+(|#_(dosomething)) ""

--- a/test-data/test-files/paredit_sandbox.clj
+++ b/test-data/test-files/paredit_sandbox.clj
@@ -294,3 +294,8 @@ foo [|]
 ;; Expected: ([|"nested"])
 ([|]) "nested" ;;->> ([|] "nested")->>([|] "nested")->>[(|"nested")] 
 _
+
+; slurp sexp forward command
+(|) #_(dosomething) ""
+; should result in
+(|#_(dosomething) "")


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Fixex the issue where slurping s-expressions forward with commented expressions (using `#_` markers) was causing errors and destructuring the code
- Slurp forward now takes into account entire commented form and not only the `#_` marker
- Modified `forwardSexp()` in `token-cursor.ts` to properly handle ignore marke
- Added test cases
- Modified an incoherent test. It was passing because only cursor offset was checked but forms were not coherent between them
- 
<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2387

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
