### PR TITLE
Error slurp backward commented expresssions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Slurp backward with previous commented expr](https://github.com/BetterThanTomorrow/calva/issues/3025)
 - Fix: [Pair selection and drag with threaded `cond->`](https://github.com/BetterThanTomorrow/calva/issues/3018)
+
 ## [2.0.547] - 2026-02-02
 
 - Fix: [The 'calva.loadFile' command returns a Promise that is only completed on the first execution.](https://github.com/BetterThanTomorrow/calva/issues/2981)

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -960,6 +960,11 @@ function backwardSlurpSexpEdits(doc: EditableDocument, start: number): ModelEdit
   // Navigate to previous sexp
   cursor.previous();
   cursor.backwardSexp(true, true);
+
+  // Check if there's an ignore marker (#_) before the sexp we just found
+  // This ensures that slurping includes the ignore marker as part of the slurped form
+  cursor.backwardThroughAnyIgnore();
+
   const prevSexpStart = cursor.offsetStart;
 
   // Skip whitespace to check if there's a previous sexp to slurp

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -258,12 +258,18 @@ export class LispTokenCursor extends TokenCursor {
           this.next();
           break;
         case 'ignore':
+          // Always include the ignored form as part of this sexp
+          this.next();
+          this.forwardSexp(skipComments, skipMetadata, skipIgnoredForms);
           if (skipIgnoredForms) {
-            this.next();
-            this.forwardSexp(skipComments, skipMetadata, skipIgnoredForms);
+            // When skipping, continue to the next non-ignored sexp
             break;
           }
-        // eslint-disable-next-line no-fallthrough
+          // When not skipping, stop here: the ignored form is the sexp we found
+          if (stack.length <= 0) {
+            return true;
+          }
+          break;
         case 'id':
         case 'lit':
         case 'kw':
@@ -409,6 +415,21 @@ export class LispTokenCursor extends TokenCursor {
       }
     }
     return hasReader;
+  }
+
+  /**
+   * Moves this cursor past the previous non-ws token, if it is an `ignore` token.
+   * Otherwise, this cursor is left unaffected.
+   */
+  backwardThroughAnyIgnore() {
+    const cursor = this.clone();
+    cursor.backwardWhitespace();
+    if (cursor.getPrevToken().type === 'ignore') {
+      cursor.previous();
+      this.set(cursor);
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -262,10 +262,10 @@ export class LispTokenCursor extends TokenCursor {
           this.next();
           this.forwardSexp(skipComments, skipMetadata, skipIgnoredForms);
           if (skipIgnoredForms) {
-            // When skipping, continue to the next non-ignored sexp
+            // Continue to next sexp when skipping ignored forms
             break;
           }
-          // When not skipping, stop here: the ignored form is the sexp we found
+          // Stop here: the ignored form is the sexp we found
           if (stack.length <= 0) {
             return true;
           }

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -2423,6 +2423,18 @@ describe('paredit', () => {
           await paredit.backwardSlurpSexp(a);
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
+        it('slurps form before empty list with ignore marker preceding', async () => {
+          const a = docFromTextNotation('#_(dosomething) (|)');
+          const b = docFromTextNotation('(#_(dosomething)|)');
+          await paredit.backwardSlurpSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('slurps form before empty list with ignore marker preceding but does not slurp previous sexp', async () => {
+          const a = docFromTextNotation('something #_(dosomething) (|)');
+          const b = docFromTextNotation('something (#_(dosomething)|)');
+          await paredit.backwardSlurpSexp(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
       });
     });
 

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -121,7 +121,7 @@ describe('Token Cursor', () => {
     });
     it('Does not skip ignored forms if skipIgnoredForms is false', () => {
       const a = docFromTextNotation('(a| #_1 #_2 3)');
-      const b = docFromTextNotation('(a #_|a #_2 3)');
+      const b = docFromTextNotation('(a #_1| #_2 3)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp(true, true);
       expect(cursor.offsetStart).toBe(b.selections[0].anchor);


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

When attempting to perform a "slurp backward" operation with a previous ignored/commented expression (using `#_` ), the operation would produce incorrect results and throw and error.

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

 - The `forwardSexp` method in `toker-cursor` was treating `#_` as a single token instead of treating `#_(form)` as a unified s-expression. 
Now `forwardSexp` always moves past the complete ignored form `#_(form)` as a single unit:
```typescript
case 'ignore':
  // Always include the ignored form as part of this sexp
  this.next();                                              // Move past #_
  this.forwardSexp(skipComments, skipMetadata, skipIgnoredForms);  // Move past (form)
  if (skipIgnoredForms) {
    // When skipping, continue to the next non-ignored sexp
    break;
  }
  // When not skipping, stop here: the ignored form is the sexp we found
  if (stack.length <= 0) {
    return true;
  }
  break;
```
-  `backwardSexp` would position the cursor at the form being ignored rather than at the `#_` marker itself when slurping.
- After calling `backwardSexp` to find the previous form, we now check if it's preceded by an `#_` ignore marker
- 


<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3025 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
