### PR TITLE
Pair detection in regular vectors inside let body 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Pair selection and drag with threaded `cond->`](https://github.com/BetterThanTomorrow/calva/issues/3018)
-- Fix: [Drag sexp backwards command causes unexpected outcome in specific situation](https://github.com/BetterThanTomorrow/calva/issues/2735)
+- Fix: [Drag sexp backwards command causes unexpected outcome in non-binding vector inside `let`](https://github.com/BetterThanTomorrow/calva/issues/2735)
 
 ## [2.0.547] - 2026-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Pair selection and drag with threaded `cond->`](https://github.com/BetterThanTomorrow/calva/issues/3018)
+- Fix: [Drag sexp backwards command causes unexpected outcome in specific situation](https://github.com/BetterThanTomorrow/calva/issues/2735)
+
 ## [2.0.547] - 2026-02-02
 
 - Fix: [The 'calva.loadFile' command returns a Promise that is only completed on the first execution.](https://github.com/BetterThanTomorrow/calva/issues/2981)

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1775,6 +1775,10 @@ export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boo
   const probeCursor = cursor.clone();
   if (probeCursor.backwardList()) {
     const opening = probeCursor.getPrevToken().raw;
+    // Save the vector's opening bracket position (not the first element)
+    const openingToken = probeCursor.getPrevToken();
+    const vectorOpeningPos = probeCursor.offsetStart - openingToken.raw.length;
+
     if (opening.endsWith('{') && !opening.endsWith('#{')) {
       return true;
     }
@@ -1786,6 +1790,7 @@ export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boo
       }
 
       // Otherwise, check if this is a binding form like (let [...] ...)
+      // and that this vector is the first argument (the bindings vector)
       probeCursor.backwardUpList();
       probeCursor.backwardList();
       if (!probeCursor.getPrevToken().raw.endsWith('(')) {
@@ -1793,7 +1798,23 @@ export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boo
       }
       const fn = probeCursor.getFunctionName();
       if (fn && pairForms.includes(fn)) {
-        return true;
+        // Verify this is the bindings vector (first argument), not a vector in the body
+        // Navigate to find the first argument in the binding form
+        const searchCursor = probeCursor.clone();
+        searchCursor.downList(); // Enter the list: (let ...
+        searchCursor.forwardSexp(); // Skip function name
+        searchCursor.forwardWhitespace();
+
+        // Get the position of what should be the bindings vector's opening bracket
+        const firstArgOpeningPos =
+          searchCursor.getToken().type === 'open'
+            ? searchCursor.offsetStart
+            : searchCursor.offsetStart - searchCursor.getToken().raw.length;
+
+        // If our vector's opening bracket is at the position of the first argument, it's the bindings vector
+        if (vectorOpeningPos === firstArgOpeningPos) {
+          return true;
+        }
       }
     }
     if (opening.endsWith('(')) {

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1805,14 +1805,8 @@ export function isInPairsList(cursor: LispTokenCursor, pairForms: string[]): boo
         searchCursor.forwardSexp(); // Skip function name
         searchCursor.forwardWhitespace();
 
-        // Get the position of what should be the bindings vector's opening bracket
-        const firstArgOpeningPos =
-          searchCursor.getToken().type === 'open'
-            ? searchCursor.offsetStart
-            : searchCursor.offsetStart - searchCursor.getToken().raw.length;
-
         // If our vector's opening bracket is at the position of the first argument, it's the bindings vector
-        if (vectorOpeningPos === firstArgOpeningPos) {
+        if (vectorOpeningPos === searchCursor.offsetStart) {
           return true;
         }
       }

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1390,6 +1390,19 @@ describe('paredit', () => {
       expect(g.selectionsStack).toEqual([[gSelection], [hSelection]]);
     });
 
+    it('does not treat regular vectors in let body as pair forms', () => {
+      const a = docFromTextNotation(
+        '(let [[root left right] tree] [root |(mirror-tree left)| (mirror-tree right)])'
+      );
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation(
+        '(let [[root left right] tree] [|root (mirror-tree left) (mirror-tree right)|])'
+      );
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
+
     describe('cond pairs', () => {
       it('grows selection to test/expr pairs in cond (expr selected first)', () => {
         const a = docFromTextNotation('(cond true |:yes| false :no)');
@@ -1980,6 +1993,32 @@ describe('paredit', () => {
         const a = docFromTextNotation('(doseq [x xs :let [a 1 |b 2]] (println a b))');
         const b = docFromTextNotation('(doseq [x xs :let [|b 2 a 1]] (println a b))');
         await paredit.dragSexprBackward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+    });
+
+    describe('regular vectors in let body', () => {
+      it('does not treat regular vector in let body as pairs when dragging backward', async () => {
+        // https://github.com/BetterThanTomorrow/calva/issues/2735
+        // Regular vectors in let body should not have pair semantics
+        const a = docFromTextNotation(
+          '(let [[root left right] tree] [root (mirror-tree left) |(mirror-tree right)])'
+        );
+        const b = docFromTextNotation(
+          '(let [[root left right] tree] [root |(mirror-tree right) (mirror-tree left)])'
+        );
+        await paredit.dragSexprBackward(a);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+
+      it('does NOT treat regular vector in let body as pairs when dragging forward', async () => {
+        const a = docFromTextNotation(
+          '(let [[root left right] tree] [root |(mirror-tree left) (mirror-tree right)])'
+        );
+        const b = docFromTextNotation(
+          '(let [[root left right] tree] [root (mirror-tree right) |(mirror-tree left)])'
+        );
+        await paredit.dragSexprForward(a);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
     });


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- does not treat regular vectors in let body as pair forms  
- this fixes grow selection and drag in vectors that are in let body  

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2735

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
