### PR TITLE
Threading Macros alias resolution and New Promesa pairs defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changes to Calva.
 - Add support for additional Promesa forms as Default Pair Forms and Default Threading Macros:
   - **New pair forms:** `promesa.core/plet`, `promesa.core/loop`, `promesa.core/doseq`, `promesa.core/with-redefs`
   - **New threading macros:** `promesa.core/->`, `promesa.core/->>`
-- **Threading macros now support alias resolution** - Configure `calva.paredit.aliasMap` (e.g., `"p": "promesa.core"`) and use short forms like `p/->` in your code
+- [**Threading macros now support alias resolution** - Configure `calva.paredit.aliasMap` (e.g., `"p": "promesa.core"`) and use short forms like `p/->` in your code](https://github.com/BetterThanTomorrow/calva/issues/3033)
 
 ## [2.0.548] - 2026-02-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Add support for additional Promesa forms as Default Pair Forms and Default Threading Macros:
+  - **New pair forms:** `promesa.core/plet`, `promesa.core/loop`, `promesa.core/doseq`, `promesa.core/with-redefs`
+  - **New threading macros:** `promesa.core/->`, `promesa.core/->>`
+
 ## [2.0.548] - 2026-02-04
 
 - Fix: [Error when slurping forward before commented s-expressions `(|) #_(dosomething)`](https://github.com/BetterThanTomorrow/calva/issues/2387)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes to Calva.
 - Add support for additional Promesa forms as Default Pair Forms and Default Threading Macros:
   - **New pair forms:** `promesa.core/plet`, `promesa.core/loop`, `promesa.core/doseq`, `promesa.core/with-redefs`
   - **New threading macros:** `promesa.core/->`, `promesa.core/->>`
+- **Threading macros now support alias resolution** - Configure `calva.paredit.aliasMap` (e.g., `"p": "promesa.core"`) and use short forms like `p/->` in your code
 
 ## [2.0.548] - 2026-02-04
 

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -397,8 +397,8 @@ When using library-specific forms like `promesa.core/let`, you typically use ali
 ### The Problem
 
 ```clojure
-;; Forms are configured as fully qualified names by default
-;; For example: promesa.core/let, promesa.core/plet, promesa.core/->, etc.
+;; You configure this:
+{:customPairForms [{:type "vector-binding" :name "promesa.core/let"}]}
 
 ;; But you typically write code with aliases:
 (p/let [x (fetch-data)   ; Calva needs to know p/let = promesa.core/let

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -397,7 +397,7 @@ When using library-specific forms like `promesa.core/let`, you typically use ali
 ### The Problem
 
 ```clojure
-;; Promesa forms are configured as fully qualified names by default
+;; Forms are configured as fully qualified names by default
 ;; For example: promesa.core/let, promesa.core/plet, promesa.core/->, etc.
 
 ;; But you typically write code with aliases:

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -210,7 +210,8 @@ Calva recognizes three categories of pair forms by default:
 **Binding forms** (vector-binding): Forms with a binding vector like `[name value ...]`
 
 - `let`, `for`, `loop`, `binding`, `with-local-vars`, `doseq`, `with-redefs`
-- `promesa.core/let`, `reagent.core/with-let`
+- `promesa.core/let`, `promesa.core/plet`, `promesa.core/loop`, `promesa.core/doseq`, `promesa.core/with-redefs`
+- `reagent.core/with-let`
 
 **Keyword modifiers** (keyword): Forms like `:let` that appear within other forms
 
@@ -234,6 +235,10 @@ Calva recognizes three categories of pair forms by default:
   { "type": "vector-binding", "name": "doseq" },
   { "type": "vector-binding", "name": "with-redefs" },
   { "type": "vector-binding", "name": "promesa.core/let" },
+  { "type": "vector-binding", "name": "promesa.core/plet" },
+  { "type": "vector-binding", "name": "promesa.core/loop" },
+  { "type": "vector-binding", "name": "promesa.core/doseq" },
+  { "type": "vector-binding", "name": "promesa.core/with-redefs" },
   { "type": "vector-binding", "name": "reagent.core/with-let" },
 
   { "type": "keyword", "keyword": ":let", "validParents": ["for", "doseq", "dotimes"] },
@@ -327,15 +332,15 @@ Threading macros affect how Calva calculates pair offsets in forms. For example,
 ### Default Threading Macros
 
 **Thread-first** (threads into first argument position):
-- `->`, `some->`, `cond->`
+- `->`, `some->`, `cond->`, `promesa.core/->`
 
 **Thread-last** (threads into last argument position):
-- `->>`, `some->>`, `cond->>`
+- `->>`, `some->>`, `cond->>`, `promesa.core/->>`
 
 ```json
 {
-  "firstArg": ["->", "some->", "cond->"],
-  "lastArg": ["->>", "some->>", "cond->>"]
+  "firstArg": ["->", "some->", "cond->", "promesa.core/->"],
+  "lastArg": ["->>", "some->>", "cond->>", "promesa.core/->>"]
 }
 ```
 
@@ -392,13 +397,17 @@ When using library-specific forms like `promesa.core/let`, you typically use ali
 ### The Problem
 
 ```clojure
-;; You configure this:
-{:customPairForms [{:type "vector-binding" :name "promesa.core/let"}]}
+;; Promesa forms are configured as fully qualified names by default
+;; For example: promesa.core/let, promesa.core/plet, promesa.core/->, etc.
 
-;; But you write this:
-(p/let [x (fetch-data)   ; Calva doesn't know p/let = promesa.core/let
+;; But you typically write code with aliases:
+(p/let [x (fetch-data)   ; Calva needs to know p/let = promesa.core/let
         y (process x)]
   (println y))
+
+(p/plet [a (async-op-1)  ; Calva needs to know p/plet = promesa.core/plet
+         b (async-op-2)]
+  (combine a b))
 ```
 
 ### The Solution: Configure Alias Mappings

--- a/src/cursor-doc/paredit-config.ts
+++ b/src/cursor-doc/paredit-config.ts
@@ -60,6 +60,10 @@ const defaultPairForms: PairFormConfig[] = [
   { type: 'vector-binding', name: 'doseq' },
   { type: 'vector-binding', name: 'with-redefs' },
   { type: 'vector-binding', name: 'promesa.core/let' },
+  { type: 'vector-binding', name: 'promesa.core/plet' },
+  { type: 'vector-binding', name: 'promesa.core/loop' },
+  { type: 'vector-binding', name: 'promesa.core/doseq' },
+  { type: 'vector-binding', name: 'promesa.core/with-redefs' },
   { type: 'vector-binding', name: 'reagent.core/with-let' },
 
   // Keyword-based modifiers
@@ -99,8 +103,8 @@ export const defaultBindingForms = defaultGroupedDefaultPairForms['vector-bindin
 );
 
 export const defaultThreadingMacros: ThreadingMacrosConfig = {
-  firstArg: ['->', 'some->', 'cond->'],
-  lastArg: ['->>', 'some->>', 'cond->>'],
+  firstArg: ['->', 'some->', 'cond->', 'promesa.core/->'],
+  lastArg: ['->>', 'some->>', 'cond->>', 'promesa.core/->>'],
 };
 
 // ============================================================================

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1887,7 +1887,7 @@ export async function transpose(
 }
 
 /**
- * Detects if cursor's form is the direct child of a threading macro.
+ * Checks if a form is directly inside a threading macro.
  * Returns:
  * - 'firstArg' if form is direct child of -> style macro (threads to first position, offset -1)
  * - 'lastArg' if form is direct child of ->> style macro (threads to last position)
@@ -1900,18 +1900,26 @@ function getDirectThreadingMacroStyle(
   config?: PareditConfig
 ): 'firstArg' | 'lastArg' | null {
   const threadingMacros = config?.threadingMacros ?? defaultThreadingMacros;
+  const aliasMap = config?.aliasMap ?? {};
   const probeCursor = cursor.clone();
   // Only check immediate parent - go up one level
   if (probeCursor.backwardList()) {
     probeCursor.backwardUpList();
     const fn = probeCursor.getFunctionName();
     if (fn) {
-      if (threadingMacros.firstArg.includes(fn)) {
-        return 'firstArg';
-      }
-      if (threadingMacros.lastArg.includes(fn)) {
-        return 'lastArg';
-      }
+      // Resolve aliased function name (e.g., p/-> => promesa.core/->)
+      const resolvedFn = resolveAliasedSymbol(fn, aliasMap);
+
+      const getStyle = (name: string): 'firstArg' | 'lastArg' | null => {
+        if (threadingMacros.firstArg.includes(name)) {
+          return 'firstArg';
+        }
+        if (threadingMacros.lastArg.includes(name)) {
+          return 'lastArg';
+        }
+        return null;
+      };
+      return getStyle(resolvedFn) || getStyle(fn);
     }
   }
   return null;

--- a/src/extension-test/unit/cursor-doc/paredit-config-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-config-test.ts
@@ -356,5 +356,95 @@ describe('paredit-config', () => {
         expect(getText(a)).toBe(getText(b));
       });
     });
+
+    describe('Aliased threading macros', () => {
+      it('applies offset reduction for aliased thread-first macro', () => {
+        const a = docFromTextNotation('(m/-> {} (assoc :a 1| :b 2))');
+        const b = docFromTextNotation('(m/-> {} (assoc |:a 1| :b 2))');
+        const customThreading = {
+          firstArg: ['my.lib/thread-through'],
+        };
+        const config = pareditConfig.createPareditConfig([], customThreading, {
+          m: 'my.lib',
+        });
+        paredit.growSelection(a, a.selections, config);
+        expect(getText(a)).toBe(getText(b));
+      });
+
+      it('works with default promesa thread-first using alias', () => {
+        const a = docFromTextNotation('(p/-> {} (|assoc :a 1 :b 2))');
+        const b = docFromTextNotation('(p/-> {} (|assoc :a 1| :b 2))');
+        const config = pareditConfig.createPareditConfig([], {}, { p: 'promesa.core' });
+        paredit.growSelection(a, a.selections, config);
+        expect(getText(a)).toBe(getText(b));
+      });
+
+      it('works with multiple aliased threading macros', () => {
+        const a = docFromTextNotation('(p/-> x (m/thread-through (assoc |:a 1 :b 2)))');
+        const b = docFromTextNotation('(p/-> x (m/thread-through (assoc |:a 1| :b 2)))');
+        const customThreading = {
+          firstArg: ['my.lib/thread-through'],
+        };
+        const config = pareditConfig.createPareditConfig([], customThreading, {
+          p: 'promesa.core',
+          m: 'my.lib',
+        });
+        paredit.growSelection(a, a.selections, config);
+        expect(getText(a)).toBe(getText(b));
+      });
+
+      it('works with aliased threading macro containing aliased pair form', () => {
+        const a = docFromTextNotation('(p/-> x (m/match |1 :one 2 :two))');
+        const b = docFromTextNotation('(p/-> x (m/match |1 :one| 2 :two))');
+        const customForms: pareditConfig.PairFormConfig[] = [
+          { type: 'flat', name: 'my.ns/match', offset: 1 },
+        ];
+        const config = pareditConfig.createPareditConfig(
+          customForms,
+          {},
+          {
+            p: 'promesa.core',
+            m: 'my.ns',
+          }
+        );
+        paredit.growSelection(a, a.selections, config);
+        expect(getText(a)).toBe(getText(b));
+      });
+
+      it('dragSexprForward works inside aliased threading macro', async () => {
+        const a = docFromTextNotation('(m/-> {} (assoc |:a 1 :b 2))');
+        const b = docFromTextNotation('(m/-> {} (assoc :b 2 |:a 1))');
+        const config = pareditConfig.createPareditConfig(
+          [],
+          { firstArg: ['my-ns/->'] },
+          {
+            m: 'my-ns',
+          }
+        );
+        await paredit.dragSexprForward(a, a.selections[0].anchor, a.selections[0].active, config);
+        expect(getText(a)).toBe(getText(b));
+      });
+
+      it('dragSexprBackward works inside aliased threading macro', async () => {
+        const a = docFromTextNotation('(m/-> {} (assoc :a 1 |:b 2))');
+        const b = docFromTextNotation('(m/-> {} (assoc |:b 2 :a 1))');
+        const customThreading: Partial<pareditConfig.ThreadingMacrosConfig> = {
+          firstArg: ['my-ns/->'],
+        };
+        const config = pareditConfig.createPareditConfig([], customThreading, {
+          m: 'my-ns',
+        });
+        await paredit.dragSexprBackward(a, a.selections[0].anchor, a.selections[0].active, config);
+        expect(getText(a)).toBe(getText(b));
+      });
+
+      it('works with default promesa thread-last using alias', () => {
+        const a = docFromTextNotation('(p/->> x (assoc {} :a 1 :b|))');
+        const b = docFromTextNotation('(p/->> x (|assoc {} :a 1 :b|))');
+        const config = pareditConfig.createPareditConfig([], {}, { p: 'promesa.core' });
+        paredit.growSelection(a, a.selections, config);
+        expect(getText(a)).toBe(getText(b));
+      });
+    });
   });
 });

--- a/test-data/test-files/paredit_sandbox.clj
+++ b/test-data/test-files/paredit_sandbox.clj
@@ -337,3 +337,7 @@ _
 (|) #_(dosomething) ""
 ; should result in
 (|#_(dosomething)) ""
+
+; aliased threading macros
+(p/-> {} (assoc :a 1 :b 2))
+(pr/-> {} (assoc :a 1 :b 2))


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Threading macros now support alias resolution
- Added new defult pairs from `promesa.core`
- I can't think of any pair in js-interop, do you know any @PEZ ?
- Added tests for aliased theaded macros 

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3033


## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
