### PR TITLE
Fix text garbling when hitting a key before indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- Properly implements format-on-type provider to return TextEdit[] instead of performing edits directly
+- [Fix text garbling when hitting a key before indentation](https://github.com/BetterThanTomorrow/calva/issues/3035). 
+Properly implements format-on-type provider to return TextEdit[] 
+instead of performing edits directly.
 
 ## [2.0.548] - 2026-02-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Properly implements format-on-type provider to return TextEdit[] instead of performing edits directly
+
 ## [2.0.548] - 2026-02-04
 
 - Fix: [Error when slurping forward before commented s-expressions `(|) #_(dosomething)`](https://github.com/BetterThanTomorrow/calva/issues/2387)

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -353,8 +353,9 @@ export async function formatPosition(
 }
 
 // Debounce format-as-you-type and toss it aside if User seems still to be working
+// Increased from 250ms to 400ms to reduce cursor jumping issues
 let scheduledFormatCircumstances = undefined;
-const scheduledFormatDelayMs = 250;
+const scheduledFormatDelayMs = 400;
 
 function formatPositionCallback(extraConfig: CljFmtConfig) {
   if (

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -18,6 +18,41 @@ import * as state from '../../state';
 import * as healer from './healer';
 import { nsRangeFromText } from '../../util/ns-form';
 
+/**
+ * Calculates the indent edit needed for a position without performing it.
+ * Returns a TextEdit array suitable for returning from a formatting provider.
+ * Allows VS Code to handle cursor positioning.
+ */
+export async function calculateIndentEdit(
+  position: vscode.Position,
+  document: vscode.TextDocument
+): Promise<vscode.TextEdit[]> {
+  const indent = getIndent(
+    getDocument(document).model.lineInputModel,
+    getDocumentOffset(document, position),
+    await config.getConfig(document)
+  );
+  const currentIndent = document.lineAt(position.line).firstNonWhitespaceCharacterIndex;
+  const delta = currentIndent - indent;
+  const pos = new vscode.Position(position.line, 0);
+
+  if (delta > 0) {
+    // Need to remove whitespace
+    return [vscode.TextEdit.delete(new vscode.Range(pos, new vscode.Position(pos.line, delta)))];
+  } else if (delta < 0) {
+    // Need to add whitespace
+    const str = ' '.repeat(-delta);
+    return [vscode.TextEdit.insert(pos, str)];
+  }
+
+  // No change needed
+  return [];
+}
+
+/**
+ * @deprecated This function performs edits directly and causes cursor jumping (issue #2071).
+ * Use calculateIndentEdit() instead for new code.
+ */
 export async function indentPosition(position: vscode.Position, document: vscode.TextDocument) {
   const editor = util.getActiveTextEditor();
   const pos = new vscode.Position(position.line, 0);

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -23,14 +23,14 @@ import { nsRangeFromText } from '../../util/ns-form';
  * Returns a TextEdit array suitable for returning from a formatting provider.
  * Allows VS Code to handle cursor positioning.
  */
-export async function calculateIndentEdit(
+export function calculateIndentEdit(
   position: vscode.Position,
   document: vscode.TextDocument
-): Promise<vscode.TextEdit[]> {
+): vscode.TextEdit[] {
   const indent = getIndent(
     getDocument(document).model.lineInputModel,
     getDocumentOffset(document, position),
-    await config.getConfig(document)
+    config.getConfigNow(document)
   );
   const currentIndent = document.lineAt(position.line).firstNonWhitespaceCharacterIndex;
   const delta = currentIndent - indent;

--- a/src/calva-fmt/src/providers/ontype_formatter.ts
+++ b/src/calva-fmt/src/providers/ontype_formatter.ts
@@ -30,7 +30,7 @@ export class FormatOnTypeEditProvider implements vscode.OnTypeFormattingEditProv
       if (vscode.workspace.getConfiguration('calva.fmt').get('newIndentEngine')) {
         // Use calculateIndentEdit function that returns TextEdit[]
         // WIth this VS Code handles cursor positioning
-        return await formatter.calculateIndentEdit(position, document);
+        return formatter.calculateIndentEdit(position, document);
       } else {
         // Fall back to legacy behavior for old indent engine
         // This still has the cursor jumping issue but maintains compatibility

--- a/src/calva-fmt/src/providers/ontype_formatter.ts
+++ b/src/calva-fmt/src/providers/ontype_formatter.ts
@@ -4,10 +4,6 @@ import * as util from '../../../utilities';
 import * as formatterConfig from '../../../formatter-config';
 import * as whenContexts from '../../../when-contexts';
 
-// TODO: Make this provider return a proper edit instead of performing it.
-// Errors like that of https://github.com/BetterThanTomorrow/calva/issues/2071
-// probably happens because of this.
-
 function isNewLineInComment(ch: string): boolean {
   return (
     ch === '\n' &&
@@ -22,26 +18,33 @@ function isNewLineInComment(ch: string): boolean {
 export class FormatOnTypeEditProvider implements vscode.OnTypeFormattingEditProvider {
   async provideOnTypeFormattingEdits(
     document: vscode.TextDocument,
-    _position: vscode.Position,
+    position: vscode.Position,
     ch: string,
     _options
   ): Promise<vscode.TextEdit[] | undefined> {
     if (isNewLineInComment(ch) || [')', ']', '}'].includes(ch)) {
       return undefined;
     }
-    const editor = util.getActiveTextEditor();
-    const pos = editor.selections[0].active;
+
     if (formatterConfig.formatOnTypeEnabled()) {
       if (vscode.workspace.getConfiguration('calva.fmt').get('newIndentEngine')) {
-        await formatter.indentPosition(pos, document);
+        // Use calculateIndentEdit function that returns TextEdit[]
+        // WIth this VS Code handles cursor positioning
+        return await formatter.calculateIndentEdit(position, document);
       } else {
+        // Fall back to legacy behavior for old indent engine
+        // This still has the cursor jumping issue but maintains compatibility
+        const editor = util.getActiveTextEditor();
+        const pos = editor.selections[0].active;
         try {
           await formatter.formatPosition(editor, true);
         } catch (e) {
           await formatter.indentPosition(pos, document);
         }
+        return undefined;
       }
     }
+
     return undefined;
   }
 }


### PR DESCRIPTION

<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- New calculateIndentEdit() Function: calculates indent changes and returns vscode.TextEdit[] instead of performing edits directly
- Refactored FormatOnTypeEditProvider Provider to:
	- Return `TextEdit[]` from `provideOnTypeFormattingEdits()` (when using new indent engine)
	- Remove the TODO comment about issue #2071
	- Maintain backward compatibility with old indent engine

Now follows VS Code's proper API pattern instead of performing edits directly

- Deprecated old function `indentPosition()` with documentation
- Increased debounce delay from 250ms to 400ms. his gives users more time to type before formatting triggers, reducing the chance of timing conflicts.
<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Related to, could fix: 
 - [Cursor moves back to start of indented line when typing inside
   parens on a new
   line](https://github.com/BetterThanTomorrow/calva/issues/2071)
 - [https://clojurians.slack.com/archives/CBE668G4R/p1770129911880149](https://clojurians.slack.com/archives/CBE668G4R/p1770129911880149)



## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
