### PR TITLE
Possible fix for no indenting on quick type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- [Fix text garbling when hitting a key before indentation](https://github.com/BetterThanTomorrow/calva/issues/3035). 
-Properly implements format-on-type provider to return TextEdit[] 
-instead of performing edits directly.
+- Fix: [Text garbling when hitting a key before indentation](https://github.com/BetterThanTomorrow/calva/issues/3035).
+- Fix: [No indentation if key is pressed before auto-indent completes](https://github.com/BetterThanTomorrow/calva/issues/3036)
 
 ## [2.0.548] - 2026-02-04
 

--- a/package.json
+++ b/package.json
@@ -2993,6 +2993,11 @@
         "when": "calva:keybindingsEnabled && editorLangId == clojure && editorTextFocus && !editorReadOnly && !suggestWidgetVisible && !hasOtherSuggestions"
       },
       {
+        "key": "enter",
+        "command": "calva-fmt.insertLineWithIndent",
+        "when": "editorTextFocus && editorLangId == clojure && !calva:outputWindowActive"
+      },
+      {
         "command": "calva.openFiddleForSourceFile",
         "key": "ctrl+alt+c f",
         "when": "calva:keybindingsEnabled && !calva:activeEditorIsFiddle"

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -20,47 +20,46 @@ import { nsRangeFromText } from '../../util/ns-form';
 /**
  * Command handler for Enter key that inserts newline + indent atomically.
  * Falls back to default Enter behavior if format-on-type or new indent engine is disabled.
+ *
+ * Uses synchronous TextEditorCommand to prevent keystroke ordering issues.
  */
-export async function insertLineWithIndent(): Promise<void> {
-  console.log('insertLineWithIndent called');
-  const editor = vscode.window.activeTextEditor;
-  if (!editor) {
-    return;
-  }
-
+export function insertLineWithIndent(
+  textEditor: vscode.TextEditor,
+  builder: vscode.TextEditorEdit
+): void {
   // Check if we should use atomic indent (format-on-type + new indent engine)
   const formatOnType = config.formatOnTypeEnabled();
   const newIndentEngine = vscode.workspace.getConfiguration('calva.fmt').get('newIndentEngine');
 
   if (!formatOnType || !newIndentEngine) {
     // Fall back to default Enter behavior
-    await vscode.commands.executeCommand('default:type', { text: '\n' });
+    // Note: We can't execute commands from a TextEditorCommand handler
+    // So we just insert a plain newline
+    for (const selection of textEditor.selections) {
+      builder.replace(selection, '\n');
+    }
     return;
   }
 
-  const document = editor.document;
+  const document = textEditor.document;
 
   // Handle multiple cursors
-  await editor.edit((editBuilder) => {
-    for (const selection of editor.selections) {
-      const position = selection.active;
+  for (const selection of textEditor.selections) {
+    const position = selection.active;
 
-      // Calculate indent for the new line
-      // We need to simulate where the cursor would be after the newline
+    // Calculate indent for the new line
+    const indent = getIndent(
+      getDocument(document).model.lineInputModel,
+      getDocumentOffset(document, position),
+      config.getConfigNow(document)
+    );
 
-      const indent = getIndent(
-        getDocument(document).model.lineInputModel,
-        getDocumentOffset(document, position),
-        config.getConfigNow(document)
-      );
+    const indentString = ' '.repeat(indent);
+    const newText = '\n' + indentString;
 
-      const indentString = ' '.repeat(indent);
-      const newText = '\n' + indentString;
-
-      // Replace selection (or insert at cursor) with newline + indent
-      editBuilder.replace(selection, newText);
-    }
-  });
+    // Replace selection (or insert at cursor) with newline + indent
+    builder.replace(selection, newText);
+  }
 }
 
 /**

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -10,13 +10,58 @@ import {
 import { formatTextAtRange, formatText, jsify } from '../../../out/cljs-lib/cljs-lib';
 import * as util from '../../utilities';
 import * as respacer from './respacer';
-import * as cursorDocUtils from '../../cursor-doc/utilities';
 import { isUndefined, cloneDeep } from 'lodash';
 import { LispTokenCursor } from '../../cursor-doc/token-cursor';
 import { formatIndexes } from './format-index';
 import * as state from '../../state';
 import * as healer from './healer';
 import { nsRangeFromText } from '../../util/ns-form';
+
+/**
+ * Command handler for Enter key that inserts newline + indent atomically.
+ * Falls back to default Enter behavior if format-on-type or new indent engine is disabled.
+ */
+export async function insertLineWithIndent(): Promise<void> {
+  console.log('insertLineWithIndent called');
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    return;
+  }
+
+  // Check if we should use atomic indent (format-on-type + new indent engine)
+  const formatOnType = config.formatOnTypeEnabled();
+  const newIndentEngine = vscode.workspace.getConfiguration('calva.fmt').get('newIndentEngine');
+
+  if (!formatOnType || !newIndentEngine) {
+    // Fall back to default Enter behavior
+    await vscode.commands.executeCommand('default:type', { text: '\n' });
+    return;
+  }
+
+  const document = editor.document;
+
+  // Handle multiple cursors
+  await editor.edit((editBuilder) => {
+    for (const selection of editor.selections) {
+      const position = selection.active;
+
+      // Calculate indent for the new line
+      // We need to simulate where the cursor would be after the newline
+
+      const indent = getIndent(
+        getDocument(document).model.lineInputModel,
+        getDocumentOffset(document, position),
+        config.getConfigNow(document)
+      );
+
+      const indentString = ' '.repeat(indent);
+      const newText = '\n' + indentString;
+
+      // Replace selection (or insert at cursor) with newline + indent
+      editBuilder.replace(selection, newText);
+    }
+  });
+}
 
 /**
  * Calculates the indent edit needed for a position without performing it.

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -18,8 +18,9 @@ import * as config from '../formatter-config';
 import * as mainConfig from '../config';
 import * as textNotation from '../extension-test/unit/common/text-notation';
 import * as calvaState from '../state';
-import { createPareditConfig, defaultBindingForms } from '../cursor-doc/paredit-config';
+import { createPareditConfig } from '../cursor-doc/paredit-config';
 import type { PareditConfig } from '../cursor-doc/paredit-config';
+import { insertLineWithIndent } from '../calva-fmt/src/format';
 
 const onPareditKeyMapChangedEmitter = new EventEmitter<string>();
 
@@ -656,6 +657,9 @@ export function activate(context: ExtensionContext) {
           });
         });
     })
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('calva-fmt.insertLineWithIndent', insertLineWithIndent)
   );
 }
 

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -659,7 +659,10 @@ export function activate(context: ExtensionContext) {
     })
   );
   context.subscriptions.push(
-    vscode.commands.registerCommand('calva-fmt.insertLineWithIndent', insertLineWithIndent)
+    vscode.commands.registerTextEditorCommand(
+      'calva-fmt.insertLineWithIndent',
+      insertLineWithIndent
+    )
   );
 }
 


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Indent is done by a command:
· Created the command handler `insertLineWithIndent`
· Registered the command in `extensions.ts` `activate()`
· Keybinding added to `package.json`

- The command itself will check `formatOnTypeEnabled()` and `newIndentEngine` settings, and fall back to default Enter behavior if disabled.
- The provider remains unchanged. It will still handle `\r` and `\n` for edge cases where the keybinding doesn't fire (e.g. paste with newlines).


<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3036

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
