### PR TITLE
Unable delete after ctrl backspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Unable to delete expressions after pressing CTRL+backspace](https://github.com/BetterThanTomorrow/calva/issues/2973)
+
 ## [2.0.549] - 2026-02-06
 
 - [Fix text garbling when hitting a key before indentation](https://github.com/BetterThanTomorrow/calva/issues/3035)

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -120,6 +120,24 @@ export class DocumentModel implements EditableModel {
     }
   }
 
+  /**
+   * Rebuilds the model from the VS Code document when version tracking is out of sync.
+   * This is a recovery mechanism
+   * Under normal operation, processChanges keeps the model in sync.
+   */
+  resync(document: vscode.TextDocument): void {
+    const text = document.getText().replace(/\r\n/g, '\n');
+    const newModel = new LineInputModel(this.lineEndingLength);
+    newModel.insertString(0, text);
+    newModel.flushChanges();
+    newModel.dirtyLines = [];
+    newModel.insertedLines.clear();
+    newModel.deletedLines.clear();
+    this.lineInputModel = newModel;
+    this.documentVersion = document.version;
+    this.staleDocumentVersion = undefined;
+  }
+
   private editNowTextOnly(
     modelEdits: ModelEdit<ModelEditFunction>[],
     options: ModelEditOptions

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -561,8 +561,10 @@ function wrapPareditCommandNow<C extends PareditCommandNow>(command: C) {
         command.handlerNow(mDoc, builder);
       } else {
         console.warn(
-          'paredit is skipping ' + command.command + ' because TextDocumentChangeEvent is overdue'
+          'paredit: model is stale (' + staleMessage + '), resyncing before ' + command.command
         );
+        model.resync(textEditor.document);
+        command.handlerNow(mDoc, builder);
       }
     } catch (e) {
       console.error(e.message);


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- `wrapPareditCommandNow` was blocking commands when the internal document model's version tracking doesn't match VS Code's document version.
- Added a method (`resync`) that rebuilds the model from the VS Code document's current state. 
- Instead of skipping the command with a warn log, we resync the model and then execute normally.
- Resync only runs when staleness is detected. For normal editing, the fast path (no staleness) is unchanged.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2973 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
