### PR TITLE
Jack in deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Jack-in dependencies not finding latest versions](https://github.com/BetterThanTomorrow/calva/issues/2979)
+
 ## [2.0.549] - 2026-02-06
 
 - [Fix text garbling when hitting a key before indentation](https://github.com/BetterThanTomorrow/calva/issues/3035)

--- a/src/nrepl/jack-in-dependency-versions.ts
+++ b/src/nrepl/jack-in-dependency-versions.ts
@@ -147,15 +147,6 @@ function getDefaultJackInDependencyVersions(): JackInDependencyVersions {
   return inspected?.defaultValue;
 }
 
-function isFullyPopulated(
-  versions: JackInDependencyVersions
-): versions is Record<JackInDependencyKey, string> {
-  return JACK_IN_DEPENDENCY_KEYS.every((key) => {
-    const value = versions[key];
-    return typeof value === 'string' && value.trim().length > 0;
-  });
-}
-
 export type VersionSource = 'configured' | 'stored' | 'default';
 
 export type JackInVersionsDetail = {
@@ -229,26 +220,12 @@ export async function refreshJackInDependencyVersions(): Promise<void> {
     return refreshPromise;
   }
 
-  const stored = getStoredJackInDependencyVersions();
-  if (isFullyPopulated(stored)) {
-    console.info(
-      '[Calva] Jack-in dependency versions already populated in global storage:',
-      stored
-    );
-    return;
-  }
-
-  const missingKeys = JACK_IN_DEPENDENCY_KEYS.filter((key) => {
-    const value = stored[key];
-    return !(typeof value === 'string' && value.trim().length > 0);
-  });
-
-  console.info('[Calva] Refreshing jack-in dependency versions. Missing keys:', missingKeys);
+  console.info('[Calva] Refreshing jack-in dependency versions');
 
   const promise = (async () => {
     const fetched: JackInDependencyVersions = {};
 
-    for (const key of missingKeys) {
+    for (const key of JACK_IN_DEPENDENCY_KEYS) {
       const lib = JACK_IN_DEPENDENCY_LIBRARIES[key];
       try {
         const version = await fetchLatestVersion(lib);


### PR DESCRIPTION
## What has changed?

Fixed the jack-in dependency version refresh mechanism to always fetch the latest versions from Clojars, instead of returning early once all three dependencies are cached.

Previously, once `nrepl`, `cider-nrepl`, and `cider/piggieback` were all cached in VS Code's globalState, the `refreshJackInDependencyVersions()` function would return early without checking for updates. This meant users would permanently see stale versions.

The fix:
- Removed the `isFullyPopulated` early return check
- Changed the fetch loop to always iterate over all dependency keys instead of just missing ones
- Removed the now unused `isFullyPopulated`
- Changed  logging to reflect continuous refresh behavior

Fixes #2979

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch.
- [x] Made sure I have changed the PR base branch, so that it is not `published`.
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
  - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
  - The fix is in a fire-and-forget background function; no platform-specific behavior changes.
- [x] Added to or updated docs in this branch, if appropriate
  - No documentation changes needed; this is a bug fix to internal behavior.
- [x] Tests
  - [x] Tested the particular change
    - Ran `npm run compile` successfully
    - Ran `npm run eslint` on the modified file — no errors
    - Verified no other references to the removed `isFullyPopulated` function exist in the codebase
  - [x] Figured if the change might have some side effects and tested those as well.
    - Integration tests for version resolution logic remain unaffected (they test `getEffectiveJackInDependencyVersions`, not the refresh mechanism)
- [x] Formatted all JavaScript and TypeScript code that was changed. (no manual changes needed; minimal diff)
- [x] Confirmed that there are no linter warnings or errors (ran `npm run eslint`).
