### PR TITLE
Fix backspace discard comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Backspace does not delete discard comment (`#_`) token](https://github.com/BetterThanTomorrow/calva/issues/3040)
 - Fix: [Jack-in dependencies not finding latest versions](https://github.com/BetterThanTomorrow/calva/issues/2979)
 
 ## [2.0.549] - 2026-02-06

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1303,6 +1303,11 @@ function handleStructuralBackspace(
     return;
   }
 
+  if (prevToken.type === 'ignore') {
+    deleteIgnoreMarker(doc, builder, start, prevToken);
+    return;
+  }
+
   const shouldJump = determineShouldJump(prevToken, cursor, prefixContext, readerContext);
 
   if (shouldJump) {
@@ -1418,6 +1423,18 @@ function deleteCharacter(
 ): void {
   const left = Math.max(start - 1, 0);
   doc.model.editNow([new ModelEdit('deleteRange', [left, start - left])], {
+    builder,
+    skipFormat: true,
+  });
+}
+
+function deleteIgnoreMarker(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  start: number,
+  token: Token
+): void {
+  doc.model.editNow([new ModelEdit('deleteRange', [start - token.raw.length, token.raw.length])], {
     builder,
     skipFormat: true,
   });

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -2912,6 +2912,56 @@ describe('paredit', () => {
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
       });
+      describe('Discard comment (#_) deletion', () => {
+        it('Deletes #_ when cursor is right after it', () => {
+          const a = docFromTextNotation('#_|foo');
+          const b = docFromTextNotation('|foo');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes #_ when cursor is between #_ and a vector', () => {
+          const a = docFromTextNotation('#_|[a b]');
+          const b = docFromTextNotation('|[a b]');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes #_ when cursor is between #_ and a map', () => {
+          const a = docFromTextNotation('#_|{:a 1}');
+          const b = docFromTextNotation('|{:a 1}');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes #_ when cursor is between #_ and a paren list', () => {
+          const a = docFromTextNotation('#_|(foo bar)');
+          const b = docFromTextNotation('|(foo bar)');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes #_ inside another form', () => {
+          const a = docFromTextNotation('(a #_|b c)');
+          const b = docFromTextNotation('(a |b c)');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes #_ before a nested list inside a form', () => {
+          const a = docFromTextNotation('(a #_|[1 2] c)');
+          const b = docFromTextNotation('(a |[1 2] c)');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes standalone #_ with nothing after it', () => {
+          const a = docFromTextNotation('#_|');
+          const b = docFromTextNotation('|');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes standalone #_ with nothing after it inside a form', () => {
+          const a = docFromTextNotation('(a #_|)');
+          const b = docFromTextNotation('(a |)');
+          paredit.backspace(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+      });
     });
 
     describe('Kill character forwards (delete)', () => {


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests
-->

## What has changed?

Fixed backspace behavior when deleting Clojure discard comments (`#_`). Previously, backspace would jump over the `#_` token instead of deleting it. Now backspace correctly deletes the entire `#_` token (both characters) when the cursor is positioned immediately after it.

The issue occurred because the `#_` token is tokenized as an `'ignore'` type, which was in the `JUMP_TOKEN_TYPES` list alongside structural delimiters like `()[]{}`. The paredit logic treated it as something to navigate around rather than delete. This fix adds explicit handling to delete the full `#_` token instead of jumping.

Fixes #3040

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch.
- [x] Made sure the PR base branch is not `published`.
- [x] Made sure there is an issue registered with a clear problem statement (#3040).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue.
- [x] Tested on Linux (development machine).
- [x] Tests
  - [x] Tested the particular change (8 new test cases for backspace with discard comments)
  - [x] Figured if the change might have side effects - tested that existing paredit tests still pass (452 tests passing)
- [x] Formatted all JavaScript and TypeScript code that was changed.
- [x] Confirmed no linter warnings or errors.
