### PR TITLE
3041 fix forward delete discard comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Forward delete only deletes first character of discard comment (`#_`)](https://github.com/BetterThanTomorrow/calva/issues/3041)
 - Fix: [Jack-in dependencies not finding latest versions](https://github.com/BetterThanTomorrow/calva/issues/2979)
 
 ## [2.0.549] - 2026-02-06

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1474,6 +1474,11 @@ function handleSingleCursorDeleteForward(
     return;
   }
 
+  if (nextToken.type === 'ignore' && start === cursor.offsetStart) {
+    deleteForwardIgnoreMarker(doc, builder, start, nextToken);
+    return;
+  }
+
   handleStructuralDeleteForward(doc, builder, cursor, start, nextToken);
 }
 
@@ -1580,6 +1585,18 @@ function deleteForwardCharacter(
   start: number
 ): void {
   doc.model.editNow([new ModelEdit('deleteRange', [start, 1])], {
+    builder,
+    skipFormat: true,
+  });
+}
+
+function deleteForwardIgnoreMarker(
+  doc: EditableDocument,
+  builder: TextEditorEdit | undefined,
+  start: number,
+  token: Token
+): void {
+  doc.model.editNow([new ModelEdit('deleteRange', [start, token.raw.length])], {
     builder,
     skipFormat: true,
   });

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -3076,6 +3076,56 @@ describe('paredit', () => {
           expect(textAndSelection(a)).toEqual(textAndSelection(b));
         });
       });
+      describe('Discard comment (#_) deletion', () => {
+        it('Deletes #_ when cursor is right before it', () => {
+          const a = docFromTextNotation('|#_foo');
+          const b = docFromTextNotation('|foo');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes #_ when cursor is before #_ and a list', () => {
+          const a = docFromTextNotation('|#_[a b]');
+          const b = docFromTextNotation('|[a b]');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes #_ when cursor is before #_ and a map', () => {
+          const a = docFromTextNotation('|#_{:a 1}');
+          const b = docFromTextNotation('|{:a 1}');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes #_ when cursor is before #_ and a paren list', () => {
+          const a = docFromTextNotation('|#_(foo bar)');
+          const b = docFromTextNotation('|(foo bar)');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes #_ inside another form', () => {
+          const a = docFromTextNotation('(a |#_b c)');
+          const b = docFromTextNotation('(a |b c)');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes #_ before a nested list inside a form', () => {
+          const a = docFromTextNotation('(a |#_[1 2] c)');
+          const b = docFromTextNotation('(a |[1 2] c)');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes standalone #_ with nothing after it', () => {
+          const a = docFromTextNotation('|#_');
+          const b = docFromTextNotation('|');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+        it('Deletes standalone #_ with nothing after it inside a form', () => {
+          const a = docFromTextNotation('(a |#_)');
+          const b = docFromTextNotation('(a |)');
+          paredit.deleteForward(a);
+          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        });
+      });
     });
 
     describe('killRange', () => {


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests
-->

## What has changed?

Fixed forward delete behavior when deleting Clojure discard comments (`#_`). Previously, forward delete would only delete the `#` character, leaving the `_` behind. This required two delete keypresses to remove the entire `#_` token. Now forward delete correctly deletes the entire `#_` token in a single operation.

The issue occurred because the forward delete logic was deleting characters one at a time without recognizing that `#_` is a single semantic token. This fix adds explicit handling to recognize and delete the full `#_` token when the cursor is positioned before it.

Fixes #3041

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch.
- [x] Made sure the PR base branch is not `published`.
- [x] Made sure there is an issue registered with a clear problem statement (#3041).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue.
- [x] Tested on Linux (development machine).
- [x] Tests
  - [x] Tested the particular change (8 new test cases for forward delete with discard comments)
  - [x] Figured if the change might have side effects - tested that existing paredit tests still pass (452 tests passing)
- [x] Formatted all JavaScript and TypeScript code that was changed.
- [x] Confirmed no linter warnings or errors.
