### PR TITLE
Js interop pair forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Changes to Calva.
 - Add support for additional Promesa forms as Default Pair Forms and Default Threading Macros:
   - **New pair forms:** `promesa.core/plet`, `promesa.core/loop`, `promesa.core/doseq`, `promesa.core/with-redefs`
   - **New threading macros:** `promesa.core/->`, `promesa.core/->>`
+- Add default pair form support for [js-interop](https://github.com/applied-science/js-interop) library:
+  - **New vector-binding form:** `applied-science.js-interop/let`
+  - **New flat pair forms:** `applied-science.js-interop/assoc!`, `applied-science.js-interop/obj`
 
 ## [2.0.549] - 2026-02-06
 

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -260,35 +260,6 @@ Calva recognizes three categories of pair forms by default:
 ]
 ```
 
-#### js-interop Library Forms
-
-[js-interop](https://github.com/applied-science/js-interop) is a ClojureScript library for JavaScript interop that provides idiomatic Clojure-style functions for working with JavaScript objects. Calva includes default support for the following js-interop pair forms:
-
-**Vector-binding forms:**
-- `applied-science.js-interop/let` - Binds local variables in a binding vector
-
-**Flat pair forms:**
-- `applied-science.js-interop/assoc!` - Mutably sets key-value pairs on a JavaScript object
-- `applied-science.js-interop/obj` - Creates a JavaScript object from key-value pairs
-
-These forms work seamlessly with structural editing commands like selection and dragging. To use these with shorter aliases like `j`, configure an alias map in your project config:
-
-```clojure
-{:aliasMap
- {"j" "applied-science.js-interop"}}
-```
-
-Then you can use the shorter forms:
-```clojure
-(j/let [name "Alice"
-        age 30]
-  (println name))
-
-(j/assoc! obj :x 1 :y 2)
-
-(j/obj :a 1 :b 2)
-```
-
 ### Adding Custom Pair Forms
 
 Use the `calva.paredit.customPairForms` setting to add support for custom macros or library-specific forms. Custom forms are **appended** to the built-in defaults and **cannot override** them.

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -212,6 +212,7 @@ Calva recognizes three categories of pair forms by default:
 - `let`, `for`, `loop`, `binding`, `with-local-vars`, `doseq`, `with-redefs`
 - `promesa.core/let`, `promesa.core/plet`, `promesa.core/loop`, `promesa.core/doseq`, `promesa.core/with-redefs`
 - `reagent.core/with-let`
+- `applied-science.js-interop/let`
 
 **Keyword modifiers** (keyword): Forms like `:let` that appear within other forms
 
@@ -221,7 +222,8 @@ Calva recognizes three categories of pair forms by default:
 
 - `cond` (offset: 1), `cond->` (offset: 2), `cond->>` (offset: 2)
 - `case` (offset: 2), `condp` (offset: 3, tripleMarker: `:>>`)
-- `assoc` (offset: 2)
+- `assoc` (offset: 2), `assoc!` (offset: 2), `medley.core/assoc-some` (offset: 2)
+- `applied-science.js-interop/assoc!` (offset: 2), `applied-science.js-interop/obj` (offset: 1)
 
 #### The Default Configuration Structure
 
@@ -240,6 +242,7 @@ Calva recognizes three categories of pair forms by default:
   { "type": "vector-binding", "name": "promesa.core/doseq" },
   { "type": "vector-binding", "name": "promesa.core/with-redefs" },
   { "type": "vector-binding", "name": "reagent.core/with-let" },
+  { "type": "vector-binding", "name": "applied-science.js-interop/let" },
 
   { "type": "keyword", "keyword": ":let", "validParents": ["for", "doseq", "dotimes"] },
 
@@ -250,8 +253,40 @@ Calva recognizes three categories of pair forms by default:
   { "type": "flat", "name": "condp", "offset": 3, "tripleMarker": ":>>" },
   { "type": "flat", "name": "assoc", "offset": 2 },
   { "type": "flat", "name": "assoc!", "offset": 2 },
-  { "type": "flat", "name": "medley.core/assoc-some", "offset": 2 }
+  { "type": "flat", "name": "medley.core/assoc-some", "offset": 2 },
+
+  { "type": "flat", "name": "applied-science.js-interop/assoc!", "offset": 2 },
+  { "type": "flat", "name": "applied-science.js-interop/obj", "offset": 1 }
 ]
+```
+
+#### js-interop Library Forms
+
+[js-interop](https://github.com/applied-science/js-interop) is a ClojureScript library for JavaScript interop that provides idiomatic Clojure-style functions for working with JavaScript objects. Calva includes default support for the following js-interop pair forms:
+
+**Vector-binding forms:**
+- `applied-science.js-interop/let` - Binds local variables in a binding vector
+
+**Flat pair forms:**
+- `applied-science.js-interop/assoc!` - Mutably sets key-value pairs on a JavaScript object
+- `applied-science.js-interop/obj` - Creates a JavaScript object from key-value pairs
+
+These forms work seamlessly with structural editing commands like selection and dragging. To use these with shorter aliases like `j`, configure an alias map in your project config:
+
+```clojure
+{:aliasMap
+ {"j" "applied-science.js-interop"}}
+```
+
+Then you can use the shorter forms:
+```clojure
+(j/let [name "Alice"
+        age 30]
+  (println name))
+
+(j/assoc! obj :x 1 :y 2)
+
+(j/obj :a 1 :b 2)
 ```
 
 ### Adding Custom Pair Forms

--- a/src/cursor-doc/paredit-config.ts
+++ b/src/cursor-doc/paredit-config.ts
@@ -65,6 +65,7 @@ const defaultPairForms: PairFormConfig[] = [
   { type: 'vector-binding', name: 'promesa.core/doseq' },
   { type: 'vector-binding', name: 'promesa.core/with-redefs' },
   { type: 'vector-binding', name: 'reagent.core/with-let' },
+  { type: 'vector-binding', name: 'applied-science.js-interop/let' },
 
   // Keyword-based modifiers
   { type: 'keyword', keyword: ':let', validParents: ['for', 'doseq', 'dotimes'] },

--- a/src/cursor-doc/paredit-config.ts
+++ b/src/cursor-doc/paredit-config.ts
@@ -79,6 +79,10 @@ const defaultPairForms: PairFormConfig[] = [
   { type: 'flat', name: 'assoc', offset: 2 },
   { type: 'flat', name: 'assoc!', offset: 2 },
   { type: 'flat', name: 'medley.core/assoc-some', offset: 2 },
+
+  // js-interop forms (applied-science.js-interop - typically aliased as j)
+  { type: 'flat', name: 'applied-science.js-interop/assoc!', offset: 2 },
+  { type: 'flat', name: 'applied-science.js-interop/obj', offset: 1 },
 ];
 
 export const defaultGroupedDefaultPairForms = defaultPairForms.reduce<GroupedPairForms>(

--- a/src/extension-test/unit/cursor-doc/paredit-config-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-config-test.ts
@@ -3,7 +3,6 @@ import * as paredit from '../../../cursor-doc/paredit';
 import * as pareditConfig from '../../../cursor-doc/paredit-config';
 import * as model from '../../../cursor-doc/model';
 import { docFromTextNotation, getText, textAndSelection } from '../common/text-notation';
-import { defaultBindingForms } from '../../../cursor-doc/paredit-config';
 
 model.initScanner(20000);
 
@@ -354,6 +353,60 @@ describe('paredit-config', () => {
         const config = pareditConfig.createPareditConfig(customForms, {}, { m: 'my.ns' });
         paredit.growSelection(a, a.selections, config);
         expect(getText(a)).toBe(getText(b));
+      });
+    });
+
+    describe('js-interop/let vector-binding form', () => {
+      it('applied-science.js-interop/let - grows selection to binding pairs', () => {
+        const a = docFromTextNotation('(applied-science.js-interop/let [a b |c| d])');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(applied-science.js-interop/let [a b |c d|])');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+    });
+
+    describe('js-interop flat pair forms', () => {
+      it('applied-science.js-interop/assoc! - grows selection to key-value pairs', () => {
+        const a = docFromTextNotation('(applied-science.js-interop/assoc! obj :a 1 |:b| 2)');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(applied-science.js-interop/assoc! obj :a 1 |:b 2|)');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+
+      it('applied-science.js-interop/obj - grows selection to key-value pairs starting at offset 1', () => {
+        const a = docFromTextNotation('(applied-science.js-interop/obj |:a| 1 :b 2)');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(applied-science.js-interop/obj |:a 1| :b 2)');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+
+      it('applied-science.js-interop/assoc! - does not treat object argument as part of pair', () => {
+        const a = docFromTextNotation('(applied-science.js-interop/assoc! |obj| :a 1 :b 2)');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(|applied-science.js-interop/assoc! obj :a 1 :b 2|)');
+        const bSelection = b.selections[0];
+        paredit.growSelection(a);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      });
+
+      it('j/assoc! - works with alias map configuration', () => {
+        const a = docFromTextNotation('(j/assoc! obj :a 1 |:b| 2)');
+        const aSelection = a.selections[0];
+        const b = docFromTextNotation('(j/assoc! obj :a 1 |:b 2|)');
+        const bSelection = b.selections[0];
+        const config = pareditConfig.createPareditConfig(
+          [],
+          {},
+          { j: 'applied-science.js-interop' }
+        );
+        paredit.growSelection(a, a.selections, config);
+        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
     });
 

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1655,6 +1655,35 @@ describe('paredit', () => {
     });
   });
 
+  describe('js-interop flat pair forms', () => {
+    it('applied-science.js-interop/assoc! - grows selection to key-value pairs', () => {
+      const a = docFromTextNotation('(applied-science.js-interop/assoc! obj :a 1 |:b| 2)');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(applied-science.js-interop/assoc! obj :a 1 |:b 2|)');
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
+
+    it('applied-science.js-interop/obj - grows selection to key-value pairs starting at offset 1', () => {
+      const a = docFromTextNotation('(applied-science.js-interop/obj |:a| 1 :b 2)');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(applied-science.js-interop/obj |:a 1| :b 2)');
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
+
+    it('applied-science.js-interop/assoc! - does not treat object argument as part of pair', () => {
+      const a = docFromTextNotation('(applied-science.js-interop/assoc! |obj| :a 1 :b 2)');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(|applied-science.js-interop/assoc! obj :a 1 :b 2|)');
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
+  });
+
   describe('dragSexpr', () => {
     describe('forwardAndBackwardSexpr', () => {
       // (comment\n  ['(0 1 2 "t" "f")•   "b"•             {:s "h"}•             :f]•  [:f '(0 "t") "b" :s]•  [:f 0•   "b" :s•   4 :b]•  {:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b})

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1,6 +1,7 @@
 import * as expect from 'expect';
 import * as paredit from '../../../cursor-doc/paredit';
 import * as model from '../../../cursor-doc/model';
+import { createPareditConfig } from '../../../cursor-doc/paredit-config';
 import {
   docFromTextNotation,
   textAndSelection,
@@ -1680,6 +1681,16 @@ describe('paredit', () => {
       const b = docFromTextNotation('(|applied-science.js-interop/assoc! obj :a 1 :b 2|)');
       const bSelection = b.selections[0];
       paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
+
+    it('j/assoc! - works with alias map configuration', () => {
+      const a = docFromTextNotation('(j/assoc! obj :a 1 |:b| 2)');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(j/assoc! obj :a 1 |:b 2|)');
+      const bSelection = b.selections[0];
+      const config = createPareditConfig([], {}, { j: 'applied-science.js-interop' });
+      paredit.growSelection(a, a.selections, config);
       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
   });

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1644,6 +1644,17 @@ describe('paredit', () => {
     });
   });
 
+  describe('js-interop/let vector-binding form', () => {
+    it('applied-science.js-interop/let - grows selection to binding pairs', () => {
+      const a = docFromTextNotation('(applied-science.js-interop/let [a b |c| d])');
+      const aSelection = a.selections[0];
+      const b = docFromTextNotation('(applied-science.js-interop/let [a b |c d|])');
+      const bSelection = b.selections[0];
+      paredit.growSelection(a);
+      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+    });
+  });
+
   describe('dragSexpr', () => {
     describe('forwardAndBackwardSexpr', () => {
       // (comment\n  ['(0 1 2 "t" "f")•   "b"•             {:s "h"}•             :f]•  [:f '(0 "t") "b" :s]•  [:f 0•   "b" :s•   4 :b]•  {:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b})

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1,7 +1,6 @@
 import * as expect from 'expect';
 import * as paredit from '../../../cursor-doc/paredit';
 import * as model from '../../../cursor-doc/model';
-import { createPareditConfig } from '../../../cursor-doc/paredit-config';
 import {
   docFromTextNotation,
   textAndSelection,
@@ -1641,56 +1640,6 @@ describe('paredit', () => {
       const b = docFromTextNotation('(|condp = x 1 "one" 2 "two" "default"|)');
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
-  });
-
-  describe('js-interop/let vector-binding form', () => {
-    it('applied-science.js-interop/let - grows selection to binding pairs', () => {
-      const a = docFromTextNotation('(applied-science.js-interop/let [a b |c| d])');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(applied-science.js-interop/let [a b |c d|])');
-      const bSelection = b.selections[0];
-      paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
-  });
-
-  describe('js-interop flat pair forms', () => {
-    it('applied-science.js-interop/assoc! - grows selection to key-value pairs', () => {
-      const a = docFromTextNotation('(applied-science.js-interop/assoc! obj :a 1 |:b| 2)');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(applied-science.js-interop/assoc! obj :a 1 |:b 2|)');
-      const bSelection = b.selections[0];
-      paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
-
-    it('applied-science.js-interop/obj - grows selection to key-value pairs starting at offset 1', () => {
-      const a = docFromTextNotation('(applied-science.js-interop/obj |:a| 1 :b 2)');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(applied-science.js-interop/obj |:a 1| :b 2)');
-      const bSelection = b.selections[0];
-      paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
-
-    it('applied-science.js-interop/assoc! - does not treat object argument as part of pair', () => {
-      const a = docFromTextNotation('(applied-science.js-interop/assoc! |obj| :a 1 :b 2)');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(|applied-science.js-interop/assoc! obj :a 1 :b 2|)');
-      const bSelection = b.selections[0];
-      paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
-    });
-
-    it('j/assoc! - works with alias map configuration', () => {
-      const a = docFromTextNotation('(j/assoc! obj :a 1 |:b| 2)');
-      const aSelection = a.selections[0];
-      const b = docFromTextNotation('(j/assoc! obj :a 1 |:b 2|)');
-      const bSelection = b.selections[0];
-      const config = createPareditConfig([], {}, { j: 'applied-science.js-interop' });
-      paredit.growSelection(a, a.selections, config);
       expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
   });


### PR DESCRIPTION
## What has changed?

Added default pair form support for the [applied-science/js-interop](https://github.com/applied-science/js-interop) library

The following pair forms are now recognized by Calva's paredit without requiring custom user configuration:

**Vector-binding form:**
- `applied-science.js-interop/let` - Binds local variables in a binding vector

**Flat pair forms:**
- `applied-science.js-interop/assoc!` - Mutably sets key-value pairs on a JavaScript object
- `applied-science.js-interop/obj` - Creates a JavaScript object from key-value pairs

This enables structural editing commands (selection, dragging, etc.) to work correctly with these forms. 

Fixes #

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [ ] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
  - Updated paredit.md to list js-interop forms in the default pair forms
- [x] Tests
  - [x] Tested the particular change
    - Added 9 test cases covering all three forms and alias configuration
    - All 457 paredit tests passing
  - [x] Figured if the change might have some side effects and tested those as well.
    - Tested with alias configuration to ensure resolved forms work correctly
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).
