### PR TITLE
async appendPrompt (and related) as better solution for #2981

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+-[async `appendPrompt` considered a better solution for #2981 than having to call `onAppended` when nothing needs to be appended](https://github.com/BetterThanTomorrow/calva/pull/3052)
 -[Improve dependency-version reporting to highlight prereleases alongside latest stable](https://github.com/BetterThanTomorrow/calva/issues/3049)
 
 ## [2.0.551] - 2026-02-13

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -226,7 +226,7 @@ async function connectToHost(
         {}
       );
     }
-    output.replWindowAppendPrompt();
+    void output.replWindowAppendPrompt();
 
     const afterMainReplCode =
       connectSequence.afterPrimaryReplConnectedCode ?? connectSequence.afterCLJReplJackInCode;
@@ -237,7 +237,7 @@ async function connectToHost(
     if (!connectSequence.cljsType || connectSequence.cljsType === 'none') {
       output.maybePrintLegacyREPLWindowOutputMessage();
     }
-    output.replWindowAppendPrompt();
+    void output.replWindowAppendPrompt();
 
     clojureDocs.probeAndSetSession(mainSession, mainKey);
 
@@ -425,7 +425,7 @@ async function setUpCljsRepl(
       {}
     );
     output.maybePrintLegacyREPLWindowOutputMessage();
-    output.replWindowAppendPrompt();
+    void output.replWindowAppendPrompt();
   }
   replSession.updateReplSessionType();
 }

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -84,7 +84,7 @@ async function evaluateCodeInContext(
   options: any
 ) {
   const result = await evaluateSnippet(editor, code, context, options);
-  output.replWindowAppendPrompt();
+  void output.replWindowAppendPrompt();
   return result;
 }
 

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -364,7 +364,7 @@ async function evaluateSelection(document = {}, options) {
         { ...options, ns, nsForm, line, column, filePath, session },
         codeSelection
       );
-      output.replWindowAppendPrompt();
+      void output.replWindowAppendPrompt();
     }
   } else {
     void vscode.window.showErrorMessage('Not connected to a REPL');
@@ -606,9 +606,7 @@ async function loadDocument(
 async function loadFileCommand() {
   if (util.getConnectedState()) {
     await loadDocument({}, getConfig().prettyPrintingOptions, true);
-    return new Promise((resolve) => {
-      output.replWindowAppendPrompt(resolve);
-    });
+    await output.replWindowAppendPrompt();
   } else {
     offerToConnect();
   }
@@ -795,7 +793,7 @@ async function evaluateInOutputWindow(code: string, sessionType: string, ns: str
     if (replWindow.getNs() !== ns) {
       replWindow.setSession(session, ns);
       if (options.evaluationSendCodeToOutputWindow !== false) {
-        output.replWindowAppendPrompt();
+        void output.replWindowAppendPrompt();
       }
     }
 

--- a/src/extension-test/integration/suite/repl-history-test.ts
+++ b/src/extension-test/integration/suite/repl-history-test.ts
@@ -36,8 +36,8 @@ async function focusReplWindow(): Promise<vscode.TextEditor> {
 async function appendPromptForSession(sessionKey: string, editor: vscode.TextEditor) {
   setSessionKey(sessionKey);
   const beforeLength = editor.document.getText().length;
-  outputWindow.appendPrompt();
-  await testUtil.waitForCondition(() => editor.document.getText().length > beforeLength);
+  await outputWindow.appendPrompt();
+  assert.ok(editor.document.getText().length > beforeLength);
 }
 
 async function typeAtPrompt(editor: vscode.TextEditor, text: string) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -505,7 +505,7 @@ async function activate(context: vscode.ExtensionContext) {
         if (evalOnSave) {
           if (!outputWindow.isReplWindowDoc(document)) {
             await eval.loadDocument(document, config.getConfig().prettyPrintingOptions, false);
-            output.replWindowAppendPrompt();
+            void output.replWindowAppendPrompt();
           }
         }
 

--- a/src/fiddle-files.ts
+++ b/src/fiddle-files.ts
@@ -151,9 +151,7 @@ export async function evaluateFiddleForSourceFile() {
     await eval.evaluateInOutputWindow(code, sessionKey, ns, {
       nsForm,
     });
-    return new Promise((resolve) => {
-      output.replWindowAppendPrompt(resolve);
-    });
+    await output.replWindowAppendPrompt();
   } catch (e) {
     openFiddleForSourceFile();
   }

--- a/src/joyride.ts
+++ b/src/joyride.ts
@@ -67,7 +67,7 @@ export async function joyrideJackIn(projectDir: string) {
         utilities.setLaunchingState(null);
         await connector.connect(connectSequences.joyrideBuiltIns[0], true, 'localhost', `${port}`);
         output.appendLineOtherOut('Jack-in done.');
-        output.replWindowAppendPrompt();
+        void output.replWindowAppendPrompt();
       })
       .catch((e: Error) => {
         console.error('Joyride REPL start failed: ', e);

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -303,7 +303,7 @@ async function executeJackInTask(
                 }
                 refreshJackedInState();
                 output.appendLineOtherOut('Jack-in done.');
-                output.replWindowAppendPrompt();
+                void output.replWindowAppendPrompt();
                 if (cb) {
                   cb();
                 }

--- a/src/repl-sessions-menu.ts
+++ b/src/repl-sessions-menu.ts
@@ -391,7 +391,7 @@ export function setReplWindowSession(sessionKey: string): boolean {
     return false;
   }
   outputWindow.setSession(session, undefined, sessionKey);
-  output.replWindowForceAppendPrompt();
+  void output.replWindowForceAppendPrompt();
   status.update();
   return true;
 }

--- a/src/repl-window/repl-window-doc.ts
+++ b/src/repl-window/repl-window-doc.ts
@@ -619,6 +619,7 @@ export async function appendPrompt() {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function forceAppendPrompt() {
   appendLine(getPrompt());
 }

--- a/src/repl-window/repl-window-doc.ts
+++ b/src/repl-window/repl-window-doc.ts
@@ -407,7 +407,7 @@ export function setNamespaceFromCurrentFile() {
   );
   setSession(session, ns);
   replSession.updateReplSessionType();
-  output.replWindowAppendPrompt();
+  void output.replWindowAppendPrompt();
 }
 
 function appendFormGrabbingSessionAndNS(topLevel: boolean): void {
@@ -550,7 +550,7 @@ export function appendLine(text = '', onAppended?: OnAppendedCallback): void {
 
 export function discardPendingPrints(): void {
   resultsBuffer = [];
-  output.replWindowAppendPrompt();
+  void output.replWindowAppendPrompt();
 }
 
 export type OutputStacktraceEntry = { uri: vscode.Uri; line: number };
@@ -608,18 +608,19 @@ export function printLastStacktrace(): void {
   });
 }
 
-export function appendPrompt(onAppended?: OnAppendedCallback) {
+export async function appendPrompt() {
   const prompt = getPrompt();
   if (!lastAppended.trimEnd().endsWith(prompt.trimEnd())) {
-    appendLine(getPrompt(), onAppended);
-  } else if (onAppended) {
-    // Resolve promise though no append is actually needed
-    onAppended(undefined);
+    return new Promise<void>((resolve) => {
+      appendLine(getPrompt(), () => {
+        resolve();
+      });
+    });
   }
 }
 
-export function forceAppendPrompt(onAppended?: OnAppendedCallback) {
-  appendLine(getPrompt(), onAppended);
+export async function forceAppendPrompt() {
+  appendLine(getPrompt());
 }
 
 function getUriForCurrentNamespace(): Promise<vscode.Uri> {

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -520,22 +520,20 @@ export function appendLineOtherErr(message: string, after?: AfterAppendCallback)
 
 /**
  * Appends a prompt to the repl window.
- * Needs to be called via here, because we keep track of wether the last output ended with a newline or not.
- * @param onAppended Optional callback to run after the append
+ * Needs to be called via here, because we keep track of whether the last output ended with a newline or not.
  */
-export function replWindowAppendPrompt(onAppended?: outputWindow.OnAppendedCallback) {
+export async function replWindowAppendPrompt() {
   didLastOutputTerminateLine['repl-window'] = true;
-  outputWindow.appendPrompt(onAppended);
+  await outputWindow.appendPrompt();
 }
 
 /**
  * Forces a prompt to be appended to the repl window, bypassing the duplicate check.
- * Needs to be called via here, because we keep track of wether the last output ended with a newline or not.
- * @param onAppended Optional callback to run after the append
+ * Needs to be called via here, because we keep track of whether the last output ended with a newline or not.
  */
-export function replWindowForceAppendPrompt(onAppended?: outputWindow.OnAppendedCallback) {
+export async function replWindowForceAppendPrompt() {
   didLastOutputTerminateLine['repl-window'] = true;
-  outputWindow.forceAppendPrompt(onAppended);
+  outputWindow.forceAppendPrompt();
 }
 
 function formatStacktrace(stacktrace: any[]) {
@@ -558,7 +556,7 @@ function printStackTrace(stacktrace: any[]) {
   switch (evalResultsOutputDestination) {
     case 'repl-window':
       outputWindow.printLastStacktrace();
-      replWindowAppendPrompt();
+      void replWindowAppendPrompt();
       break;
     case 'output-view':
       appendStackTraceToReplOutputWebview(stacktrace);

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -533,7 +533,7 @@ export async function replWindowAppendPrompt() {
  */
 export async function replWindowForceAppendPrompt() {
   didLastOutputTerminateLine['repl-window'] = true;
-  outputWindow.forceAppendPrompt();
+  await outputWindow.forceAppendPrompt();
 }
 
 function formatStacktrace(stacktrace: any[]) {

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -270,7 +270,7 @@ async function runAllTests(controller: vscode.TestController, document = {}) {
     output.appendLineOtherErr(e);
   }
   updateReplSessionType();
-  output.replWindowAppendPrompt();
+  void output.replWindowAppendPrompt();
 }
 
 function runAllTestsCommand(controller: vscode.TestController) {
@@ -341,7 +341,7 @@ async function runNamespaceTestsImpl(
 
   outputWindow.setSession(session, nss[0]);
   updateReplSessionType();
-  output.replWindowAppendPrompt();
+  void output.replWindowAppendPrompt();
 }
 
 async function runNamespaceTests(controller: vscode.TestController, document: vscode.TextDocument) {
@@ -387,7 +387,7 @@ async function runTestUnderCursor(controller: vscode.TestController) {
   } else {
     output.appendLineOtherOut('No test found at cursor');
   }
-  output.replWindowAppendPrompt();
+  void output.replWindowAppendPrompt();
 }
 
 function runTestUnderCursorCommand(controller: vscode.TestController) {
@@ -422,7 +422,7 @@ async function rerunTests(controller: vscode.TestController, document = {}) {
   } catch (e) {
     output.appendLineOtherErr(e);
   }
-  output.replWindowAppendPrompt();
+  void output.replWindowAppendPrompt();
 }
 
 function rerunTestsCommand(controller: vscode.TestController) {


### PR DESCRIPTION
…lWindowAppendPrompt` and `replWindowForceAppendPrompt` in output.ts now async functions

<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

`appendPrompt` and `replWindowAppendPrompt` are now async so that it is no longer necessary to pass a dummy `onAppended` promise that then needs to be called even when nothing actually needed to be appended in the first place. For keeping symmetry `forceAppendPrompt` and `replWindowForceAppendPrompt` have now also been made async. All call sites have been updated to reflect the change.

Please note: to satisfy the linter I had to add a 'eslint-disable-next-line @typescript-eslint/require-await' annotation to the newly async forceAppendPrompt because it doesn't actually `await` anything (yet). (I would love to see the explicit 'async' pattern taken further into 'appendLine' but that change is too big for me right now.) I can of course imagine that the need for such a linter suppressing annotation is undesirable though...

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2981 (which was fixed already, but this is a better solution).

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [~] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
