### PR TITLE
Refactor REPL window session handling in tests

### DIFF
--- a/src/extension-test/integration/suite/repl-window-targeting-test.ts
+++ b/src/extension-test/integration/suite/repl-window-targeting-test.ts
@@ -74,9 +74,11 @@ suite('REPL Window Targeting suite', function () {
     }
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Reset REPL window to clj session before each test
     replSessionsMenu.setReplWindowSession('clj');
+    // Allow pending async operations (prompt appends, document saves) to settle
+    await testUtil.sleep(100);
   });
 
   test('Initial REPL window targets the secondary (CLJS) session after connection', function () {
@@ -101,7 +103,11 @@ suite('REPL Window Targeting suite', function () {
 
     // Change to cljs via command
     await commands.executeCommand('calva.selectReplWindowSession', 'cljs');
-    await testUtil.sleep(50);
+    await testUtil.waitForCondition(
+      () => outputWindow.getSessionType() === 'cljs',
+      2000,
+      10
+    );
 
     assert.strictEqual(
       outputWindow.getSessionType(),
@@ -109,9 +115,16 @@ suite('REPL Window Targeting suite', function () {
       'After command, session should be cljs'
     );
 
+    // Allow pending prompt operations to settle before next switch
+    await testUtil.sleep(200);
+
     // Change back to clj
     await commands.executeCommand('calva.selectReplWindowSession', 'clj');
-    await testUtil.sleep(50);
+    await testUtil.waitForCondition(
+      () => outputWindow.getSessionType() === 'clj',
+      2000,
+      10
+    );
 
     assert.strictEqual(
       outputWindow.getSessionType(),

--- a/src/extension-test/integration/suite/repl-window-targeting-test.ts
+++ b/src/extension-test/integration/suite/repl-window-targeting-test.ts
@@ -103,11 +103,7 @@ suite('REPL Window Targeting suite', function () {
 
     // Change to cljs via command
     await commands.executeCommand('calva.selectReplWindowSession', 'cljs');
-    await testUtil.waitForCondition(
-      () => outputWindow.getSessionType() === 'cljs',
-      2000,
-      10
-    );
+    await testUtil.waitForCondition(() => outputWindow.getSessionType() === 'cljs', 2000, 10);
 
     assert.strictEqual(
       outputWindow.getSessionType(),
@@ -120,11 +116,7 @@ suite('REPL Window Targeting suite', function () {
 
     // Change back to clj
     await commands.executeCommand('calva.selectReplWindowSession', 'clj');
-    await testUtil.waitForCondition(
-      () => outputWindow.getSessionType() === 'clj',
-      2000,
-      10
-    );
+    await testUtil.waitForCondition(() => outputWindow.getSessionType() === 'clj', 2000, 10);
 
     assert.strictEqual(
       outputWindow.getSessionType(),


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- beforeEach made async with settle delay
- Replaced sleep(50) with waitForCondition
- Added settle delay between rapid session switches: a 200ms delay between  the two executeCommand calls lets pending async prompt operations from the first switch  complete before triggering another switch.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3055

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
