### PR TITLE
Error instrumenting function through command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Error instrumenting function through command palette](https://github.com/BetterThanTomorrow/calva/issues/2966)
+
 ## [2.0.553] - 2026-02-17
 
 - Add Toggle Line Comment Calva command to do a structural Toggle Line Comment. Fixes [Toggle Line Comment uses incorrect indentation for alignment-based forms](https://github.com/BetterThanTomorrow/calva/issues/2872)
 - Add keybinding, binding `;` to the `paredit.insertSemiColon` command. Active when `calva.paredit.hijackVSCodeDefaults` is enabled and Paredit is in strict mode
 - Fix: [Projectless REPL results in "no such file" error expecting a "deps.edn" file](https://github.com/BetterThanTomorrow/calva/issues/2976)
-- Fix: [Error instrumenting function through command palette](https://github.com/BetterThanTomorrow/calva/issues/2966)
 
 ## [2.0.552] - 2026-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes to Calva.
 - Add Toggle Line Comment Calva command to do a structural Toggle Line Comment. Fixes [Toggle Line Comment uses incorrect indentation for alignment-based forms](https://github.com/BetterThanTomorrow/calva/issues/2872)
 - Add `paredit.insertSemiColon` command for structural semicolon insertion that preserves form balance. Active when `calva.paredit.hijackVSCodeDefaults` is enabled and Paredit is in strict mode
 - Fix: [Projectless REPL results in "no such file" error expecting a "deps.edn" file](https://github.com/BetterThanTomorrow/calva/issues/2976)
+- Fix: [Error instrumenting function through command palette](https://github.com/BetterThanTomorrow/calva/issues/2966)
 
 ## [2.0.552] - 2026-02-16
 

--- a/src/debugger/calva-debug.ts
+++ b/src/debugger/calva-debug.ts
@@ -248,7 +248,7 @@ class CalvaDebugSession extends LoggingDebugSession {
       void window.showErrorMessage(
         'An error occurred in the breakpoint-finding logic. We would love if you submitted an issue in the Calva repo with the instrumented code, or a similar reproducible case.'
       );
-      console.error('Error in moveTokenCursorToBreakpoint:', e);
+      console.error('Calva debugger: moveTokenCursorToBreakpoint failed', e);
       this.sendEvent(new TerminatedEvent());
       response.success = false;
       this.sendResponse(response);

--- a/src/debugger/calva-debug.ts
+++ b/src/debugger/calva-debug.ts
@@ -248,6 +248,7 @@ class CalvaDebugSession extends LoggingDebugSession {
       void window.showErrorMessage(
         'An error occurred in the breakpoint-finding logic. We would love if you submitted an issue in the Calva repo with the instrumented code, or a similar reproducible case.'
       );
+      console.error('Error in moveTokenCursorToBreakpoint:', e);
       this.sendEvent(new TerminatedEvent());
       response.success = false;
       this.sendResponse(response);

--- a/src/debugger/decorations.ts
+++ b/src/debugger/decorations.ts
@@ -46,8 +46,7 @@ async function update(
             iSymbolRefLocations: Promise<InstrumentedSymbolReferenceLocations>,
             [namespace, ...instrumentedDefs]: string[]
           ) => {
-            const docSymbols = (await lsp.api.getDocumentSymbols(lspClient, editor.document.uri))[0]
-              .children;
+            const docSymbols = await lsp.api.getDocumentSymbols(lspClient, editor.document.uri);
             const instrumentedDocSymbols = docSymbols.filter((s) =>
               instrumentedDefs.includes(s.name)
             );

--- a/src/debugger/decorations.ts
+++ b/src/debugger/decorations.ts
@@ -17,6 +17,24 @@ interface InstrumentedSymbolReferenceLocations {
 }
 let instrumentedSymbolReferenceLocations: InstrumentedSymbolReferenceLocations = {};
 
+function flattenDocumentSymbols(symbols: vscode.DocumentSymbol[]): vscode.DocumentSymbol[] {
+  const flattened: vscode.DocumentSymbol[] = [];
+  const stack = [...symbols];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+    flattened.push(current);
+    if (current.children && current.children.length > 0) {
+      stack.push(...current.children);
+    }
+  }
+
+  return flattened;
+}
+
 const instrumentedSymbolDecorationType = vscode.window.createTextEditorDecorationType({
   borderStyle: 'solid',
   overviewRulerColor: 'blue',
@@ -47,7 +65,8 @@ async function update(
             [namespace, ...instrumentedDefs]: string[]
           ) => {
             const docSymbols = await lsp.api.getDocumentSymbols(lspClient, editor.document.uri);
-            const instrumentedDocSymbols = docSymbols.filter((s) =>
+            const flatDocSymbols = flattenDocumentSymbols(docSymbols ?? []);
+            const instrumentedDocSymbols = flatDocSymbols.filter((s) =>
               instrumentedDefs.includes(s.name)
             );
             const instrumentedDocSymbolsReferenceRanges = await Promise.all(

--- a/src/debugger/util.ts
+++ b/src/debugger/util.ts
@@ -22,7 +22,11 @@ function moveTokenCursorToBreakpoint(
   debugResponse: any
 ): LispTokenCursor {
   const errorMessage = 'Error finding position of breakpoint';
-  const [defunStart, defunEnd] = tokenCursor.rangeForDefun(tokenCursor.offsetStart);
+  const defunRange = tokenCursor.rangeForDefun(tokenCursor.offsetStart);
+  if (!defunRange) {
+    throw errorMessage + ': no defun range found';
+  }
+  const [defunStart, defunEnd] = defunRange;
   tokenCursor.set(tokenCursor.doc.getTokenCursor(defunStart));
   let inSyntaxQuote = false;
 

--- a/src/debugger/util.ts
+++ b/src/debugger/util.ts
@@ -89,12 +89,15 @@ function moveTokenCursorToBreakpoint(
 
   // Move past the target sexp
   if (!tokenCursor.forwardSexp(true, true, true)) {
-    throw errorMessage;
+    throw errorMessage + `: cannot move forward at coor ${JSON.stringify(coor)}`;
   }
 
   // Make sure we're still inside the original instrumented form, otherwise something went wrong
   if (tokenCursor.offsetStart > defunEnd) {
-    throw errorMessage + ': moved past original instrumented form';
+    throw (
+      errorMessage +
+      `: moved past original instrumented form (defunStart=${defunStart}, defunEnd=${defunEnd}, offset=${tokenCursor.offsetStart})`
+    );
   }
 
   return tokenCursor;

--- a/src/debugger/util.ts
+++ b/src/debugger/util.ts
@@ -67,7 +67,7 @@ function moveTokenCursorToBreakpoint(
     } else {
       for (let k = 0; k < coor[i]; k++) {
         if (!tokenCursor.forwardSexp(true, true, true)) {
-          throw errorMessage;
+          throw errorMessage + `: cannot move down list at coor index ${i}`;
         }
       }
     }

--- a/src/debugger/util.ts
+++ b/src/debugger/util.ts
@@ -90,7 +90,7 @@ function moveTokenCursorToBreakpoint(
 
   // Make sure we're still inside the original instrumented form, otherwise something went wrong
   if (tokenCursor.offsetStart > defunEnd) {
-    throw errorMessage;
+    throw errorMessage + ': moved past original instrumented form';
   }
 
   return tokenCursor;

--- a/src/debugger/util.ts
+++ b/src/debugger/util.ts
@@ -22,7 +22,8 @@ function moveTokenCursorToBreakpoint(
   debugResponse: any
 ): LispTokenCursor {
   const errorMessage = 'Error finding position of breakpoint';
-  const [_, defunEnd] = tokenCursor.rangeForDefun(tokenCursor.offsetStart);
+  const [defunStart, defunEnd] = tokenCursor.rangeForDefun(tokenCursor.offsetStart);
+  tokenCursor.set(tokenCursor.doc.getTokenCursor(defunStart));
   let inSyntaxQuote = false;
 
   const coor = [...debugResponse.coor]; // Copy the array so we do not modify the one stored in state

--- a/test-data/integration-test/projectless/test.clj
+++ b/test-data/integration-test/projectless/test.clj
@@ -1,3 +1,37 @@
 (ns test)
 
-(defn bar [] "bar")
+
+(comment
+  ;; Let's try it without instrumentation first. This
+  ;; function has a bug. Evaluate it the usual way
+  ;; (`Alt+Enter`) first and then call it.
+
+  (defn bar
+    [n]
+    (cond (> n 40) (+ n 20)
+          (> n 20) (- (first n) 20)
+          :else 0))
+
+  (bar 2)  ; works
+  (bar 24) ; throws, what's going on?
+
+  ;; That's a strange error message (maybe you say,
+  ;; depending on how familiar you are with Clojure).
+  ;; Now instrument the function as described above.
+  ;; Calva will indicate code that is instrumented for
+  ;; debugging. Now evaluate the problematic function
+  ;; call. The debugger will start and wait for you
+  ;; to step through the function.
+  ;;
+  ;; To un-instrument the function, just evaluate it
+  ;; the normal way (top level evaluation).
+  ;; Debugger docs here: https://calva.io/debugger/
+
+  ;; NB: If you are new to Clojure you might find some
+  ;; familiarity noting that Calva has a debugger.
+  ;; However, try exploring Interactive Programming,
+  ;; using the REPL first. That's the Clojure Way.
+  ;; This section is here for you to get aware that
+  ;; the debugger exists, for those rare occasions
+  ;; when it is actually needed.
+  :rcf)


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Improved error messages in the breakpoint-finding logic with contextual information
- Fixed token cursor initialization by capturing `defunStart` from the range and resetting cursor position
- Added `console.error` logging for debugging failures in `moveTokenCursorToBreakpoint`
- Fixed document symbol retrieval to properly handle the response structure
- Added comprehensive debugging example in projectless test data

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #2966

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->

## Command palette
[screen-capture (2).webm](https://github.com/user-attachments/assets/4d663839-ef95-4c9c-aaad-859452505b19)

## manually with #dbg 
[screen-capture (3).webm](https://github.com/user-attachments/assets/4f048272-26c5-4a41-b811-58ffcf2f9698)
