### PR TITLE
Fix 3059 undo after insert semicolon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Error instrumenting function through command palette](https://github.com/BetterThanTomorrow/calva/issues/2966)
+- Fix: [paredit.insertSemiColon requires two undo operations in structure-preserving case](https://github.com/BetterThanTomorrow/calva/issues/3059)
 
 ## [2.0.553] - 2026-02-17
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -2621,24 +2621,20 @@ export async function insertSemiColon(doc: EditableDocument, p = doc.selections[
     const cursor = doc.getTokenCursor(p);
     const lineText = doc.model.getLineText(cursor.line);
     const indent = lineText.match(/^\s*/)[0];
-    await doc.model.edit([new ModelEdit('insertString', [p, ';', [p, p], [p + 1, p + 1]])], {
-      selections: [new ModelEditSelection(p + 1)],
-      skipFormat: true,
-      undoStopBefore: true,
-    });
     return doc.model.edit(
       [
         new ModelEdit('insertString', [
-          wouldBreakWhere + 1,
+          wouldBreakWhere,
           '\n' + indent,
           [p + 1, p + 1],
           [p + 1, p + 1],
         ]),
+        new ModelEdit('insertString', [p, ';', [p, p], [p + 1, p + 1]]),
       ],
       {
         selections: [new ModelEditSelection(p + 1)],
         skipFormat: false,
-        undoStopBefore: false,
+        undoStopBefore: true,
       }
     );
   }

--- a/src/extension-test/integration/suite/insert-semicolon-test.ts
+++ b/src/extension-test/integration/suite/insert-semicolon-test.ts
@@ -1,0 +1,101 @@
+import * as assert from 'assert';
+import { after, before, it } from 'mocha';
+import * as path from 'path';
+import * as testUtil from './util';
+import * as vscode from 'vscode';
+import * as textNotation from '../integration-text-notation';
+
+const suiteName = 'Insert Semicolon Undo Suite';
+const testFilePath = path.join(testUtil.testDataDir, 'reformattable.clj');
+const pauseMs = 250;
+
+function getText(doc: vscode.TextDocument, replaceNewLine = false): string {
+  const text = doc.getText(
+    doc.validateRange(
+      new vscode.Range(new vscode.Position(0, 0), new vscode.Position(99999, 99999))
+    )
+  );
+  return replaceNewLine ? text.split(doc.eol === 1 ? '\n' : '\r\n').join('•') : text;
+}
+
+function textNotationFromDocAndSelections(
+  doc: vscode.TextDocument,
+  selections: readonly vscode.Selection[]
+): string {
+  const ranges: [number, number][] = selections.map((selection) => [
+    doc.offsetAt(selection.anchor),
+    doc.offsetAt(selection.active),
+  ]);
+  return textNotation.textNotationFromTextAndSelections(getText(doc, true), ranges, false);
+}
+
+function createSelectionFromOffsets(
+  editor: vscode.TextEditor,
+  [anchorOffset, activeOffset]: [number, number]
+): vscode.Selection {
+  return new vscode.Selection(
+    editor.document.positionAt(anchorOffset),
+    editor.document.positionAt(activeOffset)
+  );
+}
+
+async function resetEditor(editor: vscode.TextEditor, textAndSelections: string): Promise<void> {
+  const [text, selectionsAsOffsets] =
+    textNotation.textNotationToTextAndSelection(textAndSelections);
+  const fullRange = editor.document.validateRange(
+    new vscode.Range(new vscode.Position(0, 0), new vscode.Position(99999, 99999))
+  );
+
+  await editor.edit((editBuilder) => {
+    editBuilder.replace(fullRange, text);
+  });
+  await testUtil.sleep(pauseMs);
+
+  editor.selections = selectionsAsOffsets.map((selection) =>
+    createSelectionFromOffsets(editor, selection)
+  );
+  await testUtil.sleep(pauseMs);
+}
+
+async function undoOnce(editor: vscode.TextEditor): Promise<void> {
+  await vscode.window.showTextDocument(editor.document);
+  await testUtil.sleep(pauseMs);
+  await vscode.commands.executeCommand('default:undo');
+  await testUtil.sleep(pauseMs);
+}
+
+suite(suiteName, () => {
+  before(async () => {
+    testUtil.showMessage(suiteName, 'suite starting');
+    await testUtil.openFile(testFilePath);
+    await testUtil.sleep(1000);
+  });
+
+  after(async () => {
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    testUtil.showMessage(suiteName, 'suite done!');
+  });
+
+  it('undo once restores pre-command state for structure-preserving insertSemiColon', async () => {
+    const editor = vscode.window.activeTextEditor;
+    const initialState = '(defn foo []•  |(println "test"))';
+    const expectedAfterInsert = '(defn foo []•  ;|(println "test")•  )';
+
+    await resetEditor(editor, initialState);
+
+    await vscode.commands.executeCommand('paredit.insertSemiColon');
+    await testUtil.sleep(pauseMs);
+
+    assert.equal(
+      textNotationFromDocAndSelections(editor.document, editor.selections),
+      expectedAfterInsert
+    );
+
+    await undoOnce(editor);
+
+    assert.equal(
+      textNotationFromDocAndSelections(editor.document, editor.selections),
+      initialState
+    );
+  });
+});


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- modified `insertSemiColon` to make a single `doc.model.edit`

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3059

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
