### PR TITLE
Fix 3061 insert semicolon breaking structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 
 - Fix: [Error instrumenting function through command palette](https://github.com/BetterThanTomorrow/calva/issues/2966)
 - Fix: [paredit.insertSemiColon requires two undo operations in structure-preserving case](https://github.com/BetterThanTomorrow/calva/issues/3059)
+- Fix: [paredit.insertSemiColon can break structure before closing delimiter](https://github.com/BetterThanTomorrow/calva/issues/3061)
 
 ## [2.0.553] - 2026-02-17
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -2621,6 +2621,16 @@ export async function insertSemiColon(doc: EditableDocument, p = doc.selections[
     const cursor = doc.getTokenCursor(p);
     const lineText = doc.model.getLineText(cursor.line);
     const indent = lineText.match(/^\s*/)[0];
+    if (wouldBreakWhere === p) {
+      return doc.model.edit(
+        [new ModelEdit('insertString', [p, ';\n' + indent, [p, p], [p + 1, p + 1]])],
+        {
+          selections: [new ModelEditSelection(p + 1)],
+          skipFormat: false,
+          undoStopBefore: true,
+        }
+      );
+    }
     return doc.model.edit(
       [
         new ModelEdit('insertString', [

--- a/src/extension-test/integration/suite/insert-semicolon-test.ts
+++ b/src/extension-test/integration/suite/insert-semicolon-test.ts
@@ -98,4 +98,20 @@ suite(suiteName, () => {
       initialState
     );
   });
+
+  it('keeps closing delimiter outside the inserted comment when cursor is before close', async () => {
+    const editor = vscode.window.activeTextEditor;
+    const initialState = '(bar 24 |)';
+    const expectedAfterInsert = '(bar 24 ;|•     )';
+
+    await resetEditor(editor, initialState);
+
+    await vscode.commands.executeCommand('paredit.insertSemiColon');
+    await testUtil.sleep(pauseMs);
+
+    assert.equal(
+      textNotationFromDocAndSelections(editor.document, editor.selections),
+      expectedAfterInsert
+    );
+  });
 });

--- a/src/extension-test/integration/suite/insert-semicolon-test.ts
+++ b/src/extension-test/integration/suite/insert-semicolon-test.ts
@@ -5,7 +5,7 @@ import * as testUtil from './util';
 import * as vscode from 'vscode';
 import * as textNotation from '../integration-text-notation';
 
-const suiteName = 'Insert Semicolon Undo Suite';
+const suiteName = 'Insert Semicolon Suite';
 const testFilePath = path.join(testUtil.testDataDir, 'reformattable.clj');
 const pauseMs = 250;
 

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -3326,12 +3326,6 @@ describe('paredit util', () => {
       await paredit.insertSemiColon(a);
       expect(textAndSelection(a)).toEqual(textAndSelection(b));
     });
-    it('inserts a semicolon before newline when cursor is right before close token', async () => {
-      const a = docFromTextNotation('(bar 24 |)');
-      const b = docFromTextNotation('(bar 24 ;|•)');
-      await paredit.insertSemiColon(a);
-      expect(textAndSelection(a)).toEqual(textAndSelection(b));
-    });
   });
 
   describe('_semiColonWouldBreakStructureWhere', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -3326,6 +3326,12 @@ describe('paredit util', () => {
       await paredit.insertSemiColon(a);
       expect(textAndSelection(a)).toEqual(textAndSelection(b));
     });
+    it('inserts a semicolon before newline when cursor is right before close token', async () => {
+      const a = docFromTextNotation('(bar 24 |)');
+      const b = docFromTextNotation('(bar 24 ;|•)');
+      await paredit.insertSemiColon(a);
+      expect(textAndSelection(a)).toEqual(textAndSelection(b));
+    });
   });
 
   describe('_semiColonWouldBreakStructureWhere', () => {
@@ -3390,6 +3396,9 @@ describe('paredit util', () => {
       expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" | (d)'))).toBe(
         false
       );
+    });
+    it('returns split position when cursor is immediately before list close', () => {
+      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('(bar 24 |)'))).toBe(8);
     });
     it('returns false if can move by sexp to the end of the line', () => {
       expect(


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- add `wouldBreakWhere === p` condition 
- Rename suite to `"Insert Semicolon Suite"` so it's not "Undo" specific
- Add unit and suite tests

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3061

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
