### PR TITLE
Fix 3063 evaluate selection comment context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [calva.evaluateSelectionAsComment missing from context menu](https://github.com/BetterThanTomorrow/calva/issues/3063)
 - Fix: [Error instrumenting function through command palette](https://github.com/BetterThanTomorrow/calva/issues/2966)
 - Fix: [paredit.insertSemiColon requires two undo operations in structure-preserving case](https://github.com/BetterThanTomorrow/calva/issues/3059)
 - Fix: [paredit.insertSemiColon can break structure before closing delimiter](https://github.com/BetterThanTomorrow/calva/issues/3061)

--- a/src/evaluate-utils.ts
+++ b/src/evaluate-utils.ts
@@ -1,0 +1,29 @@
+export type EvaluateAsCommentOptions = {
+  commentStyle: string;
+};
+
+/**
+ * Normalize the Calva Evaluate Selection as Comment arguments.
+ *
+ * The context menu handler passes the document/context object as the first
+ * parameter, while palette/shortcut invocations pass the options bag first.
+ * To handle both, we inspect the first argument for a `commentStyle` key.
+ */
+export function normalizeEvaluateAsCommentArgs(
+  documentOrOptions,
+  options: EvaluateAsCommentOptions = { commentStyle: 'line' }
+): {
+  options: EvaluateAsCommentOptions;
+  document: unknown;
+} {
+  const opt1CommentStyle = documentOrOptions?.commentStyle;
+  return opt1CommentStyle
+    ? {
+        document: options,
+        options: documentOrOptions as EvaluateAsCommentOptions,
+      }
+    : {
+        document: documentOrOptions,
+        options: options.commentStyle ? options : { ...options, commentStyle: 'line' },
+      };
+}

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -414,12 +414,43 @@ function validateCommentStyle(commentStyle: string) {
   }
 }
 
-function evaluateSelectionAsComment(options = { commentStyle: 'line' }, document = {}) {
-  validateCommentStyle(options.commentStyle);
+type EvaluateAsCommentOptions = {
+  commentStyle: string;
+};
+
+function isEvaluateAsCommentOptions(value: unknown): value is EvaluateAsCommentOptions {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'commentStyle' in value &&
+    typeof (value as { commentStyle?: unknown }).commentStyle === 'string'
+  );
+}
+
+function normalizeEvaluateAsCommentArgs(
+  documentOrOptions: unknown = {},
+  options: EvaluateAsCommentOptions = { commentStyle: 'line' }
+) {
+  if (isEvaluateAsCommentOptions(documentOrOptions)) {
+    return {
+      document: options,
+      options: documentOrOptions,
+    };
+  }
+
+  return {
+    document: documentOrOptions,
+    options,
+  };
+}
+
+function evaluateSelectionAsComment(documentOrOptions = {}, options = { commentStyle: 'line' }) {
+  const normalized = normalizeEvaluateAsCommentArgs(documentOrOptions, options);
+  validateCommentStyle(normalized.options.commentStyle);
   if (util.getConnectedState()) {
     evaluateSelection(
-      document,
-      Object.assign({}, options, {
+      normalized.document,
+      Object.assign({}, normalized.options, {
         comment: true,
         pprintOptions: getConfig().prettyPrintingOptions,
         selectionFn: _currentSelectionElseCurrentForm,
@@ -430,12 +461,13 @@ function evaluateSelectionAsComment(options = { commentStyle: 'line' }, document
   }
 }
 
-function evaluateTopLevelFormAsComment(options = { commentStyle: 'line' }, document = {}) {
-  validateCommentStyle(options.commentStyle);
+function evaluateTopLevelFormAsComment(documentOrOptions = {}, options = { commentStyle: 'line' }) {
+  const normalized = normalizeEvaluateAsCommentArgs(documentOrOptions, options);
+  validateCommentStyle(normalized.options.commentStyle);
   if (util.getConnectedState()) {
     evaluateSelection(
-      document,
-      Object.assign({}, options, {
+      normalized.document,
+      Object.assign({}, normalized.options, {
         comment: true,
         pprintOptions: getConfig().prettyPrintingOptions,
         selectionFn: _currentTopLevelFormText,

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -21,6 +21,7 @@ import * as inspector from './providers/inspector';
 import { resultAsComment } from './util/string-result';
 import { highlight } from './highlight/src/extension';
 import * as flareHandler from './flare-handler';
+import { normalizeEvaluateAsCommentArgs } from './evaluate-utils';
 
 let inspectorDataProvider: inspector.InspectorDataProvider;
 
@@ -412,36 +413,6 @@ function validateCommentStyle(commentStyle: string) {
       `Invalid comment style: ${commentStyle}. Must be one of "line", "ignore", or "rcf".`
     );
   }
-}
-
-type EvaluateAsCommentOptions = {
-  commentStyle: string;
-};
-
-/**
- * Normalize the Calva Evaluate Selection as Comment arguments.
- *
- * The context menu handler passes the document/context object as the first
- * parameter, while palette/shortcut invocations pass the options bag first.
- * To handle both, we inspect the first argument for a `commentStyle` key.
- */
-export function normalizeEvaluateAsCommentArgs(
-  documentOrOptions,
-  options: EvaluateAsCommentOptions = { commentStyle: 'line' }
-): {
-  options: EvaluateAsCommentOptions;
-  document: unknown;
-} {
-  const opt1CommentStyle = documentOrOptions?.commentStyle;
-  return opt1CommentStyle
-    ? {
-        document: options,
-        options: documentOrOptions as EvaluateAsCommentOptions,
-      }
-    : {
-        document: documentOrOptions,
-        options: options.commentStyle ? options : { ...options, commentStyle: 'line' },
-      };
 }
 
 function evaluateSelectionAsComment(options = { commentStyle: 'line' }, document = {}) {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -425,7 +425,7 @@ type EvaluateAsCommentOptions = {
  * parameter, while palette/shortcut invocations pass the options bag first.
  * To handle both, we inspect the first argument for a `commentStyle` key.
  */
-function normalizeEvaluateAsCommentArgs(
+export function normalizeEvaluateAsCommentArgs(
   documentOrOptions,
   options: EvaluateAsCommentOptions = { commentStyle: 'line' }
 ): {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -418,34 +418,34 @@ type EvaluateAsCommentOptions = {
   commentStyle: string;
 };
 
-function isEvaluateAsCommentOptions(value: unknown): value is EvaluateAsCommentOptions {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'commentStyle' in value &&
-    typeof (value as { commentStyle?: unknown }).commentStyle === 'string'
-  );
-}
-
+/**
+ * Normalize the Calva Evaluate Selection as Comment arguments.
+ *
+ * The context menu handler passes the document/context object as the first
+ * parameter, while palette/shortcut invocations pass the options bag first.
+ * To handle both, we inspect the first argument for a `commentStyle` key.
+ */
 function normalizeEvaluateAsCommentArgs(
-  documentOrOptions: unknown = {},
+  documentOrOptions,
   options: EvaluateAsCommentOptions = { commentStyle: 'line' }
-) {
-  if (isEvaluateAsCommentOptions(documentOrOptions)) {
-    return {
-      document: options,
-      options: documentOrOptions,
-    };
-  }
-
-  return {
-    document: documentOrOptions,
-    options,
-  };
+): {
+  options: EvaluateAsCommentOptions;
+  document: unknown;
+} {
+  const opt1CommentStyle = documentOrOptions?.commentStyle;
+  return opt1CommentStyle
+    ? {
+        document: options,
+        options: documentOrOptions as EvaluateAsCommentOptions,
+      }
+    : {
+        document: documentOrOptions,
+        options: options.commentStyle ? options : { ...options, commentStyle: 'line' },
+      };
 }
 
-function evaluateSelectionAsComment(documentOrOptions = {}, options = { commentStyle: 'line' }) {
-  const normalized = normalizeEvaluateAsCommentArgs(documentOrOptions, options);
+function evaluateSelectionAsComment(options = { commentStyle: 'line' }, document = {}) {
+  const normalized = normalizeEvaluateAsCommentArgs(document, options);
   validateCommentStyle(normalized.options.commentStyle);
   if (util.getConnectedState()) {
     evaluateSelection(
@@ -461,8 +461,8 @@ function evaluateSelectionAsComment(documentOrOptions = {}, options = { commentS
   }
 }
 
-function evaluateTopLevelFormAsComment(documentOrOptions = {}, options = { commentStyle: 'line' }) {
-  const normalized = normalizeEvaluateAsCommentArgs(documentOrOptions, options);
+function evaluateTopLevelFormAsComment(options = { commentStyle: 'line' }, document = {}) {
+  const normalized = normalizeEvaluateAsCommentArgs(document, options);
   validateCommentStyle(normalized.options.commentStyle);
   if (util.getConnectedState()) {
     evaluateSelection(

--- a/src/extension-test/unit/normalize-evaluate-comment-args-test.ts
+++ b/src/extension-test/unit/normalize-evaluate-comment-args-test.ts
@@ -1,0 +1,33 @@
+import * as expect from 'expect';
+import { normalizeEvaluateAsCommentArgs } from '../../evaluate';
+
+describe('evaluate-comment-args', () => {
+  it('normalizes command invocation (options first)', () => {
+    const documentArg = { some: 'document-context' };
+    const normalized = normalizeEvaluateAsCommentArgs(
+      { commentStyle: 'ignore' },
+      documentArg as any
+    );
+
+    expect(normalized.options.commentStyle).toBe('ignore');
+    expect(normalized.document).toBe(documentArg);
+  });
+
+  it('normalizes context menu invocation (document first)', () => {
+    const documentArg = { some: 'document-context' };
+    const normalized = normalizeEvaluateAsCommentArgs(documentArg, {
+      commentStyle: 'rcf',
+    });
+
+    expect(normalized.document).toBe(documentArg);
+    expect(normalized.options.commentStyle).toBe('rcf');
+  });
+
+  it('defaults comment style to line when context menu invocation omits options', () => {
+    const documentArg = { some: 'document-context' };
+    const normalized = normalizeEvaluateAsCommentArgs(documentArg);
+
+    expect(normalized.document).toBe(documentArg);
+    expect(normalized.options.commentStyle).toBe('line');
+  });
+});

--- a/src/extension-test/unit/normalize-evaluate-comment-args-test.ts
+++ b/src/extension-test/unit/normalize-evaluate-comment-args-test.ts
@@ -1,7 +1,7 @@
 import * as expect from 'expect';
-import { normalizeEvaluateAsCommentArgs } from '../../evaluate';
+import { normalizeEvaluateAsCommentArgs } from '../../evaluate-utils';
 
-describe('evaluate-comment-args', () => {
+describe('normalizeEvaluateAsCommentArgs', () => {
   it('normalizes command invocation (options first)', () => {
     const documentArg = { some: 'document-context' };
     const normalized = normalizeEvaluateAsCommentArgs(


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

Fixed the argument handling in `evaluateSelectionAsComment` and `evaluateTopLevelFormAsComment` functions to work correctly when invoked from the editor context menu. The issue was that the context menu was passing arguments in a different order than the function expected.

- Added `normalizeEvaluateAsCommentArgs` function to normalize arguments regardless of order


<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3063

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
