### PR TITLE
Defer disconnect of previous same-named connect-sequence until we know more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Connecting a REPL sequence disconnects the previous prematurely](https://github.com/BetterThanTomorrow/calva/issues/3065)
+
 ## [2.0.554] - 2026-02-17
 
 - Fix: [Evaluate Current Form to Comment missing from context menu](https://github.com/BetterThanTomorrow/calva/issues/3063)

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -108,7 +108,12 @@ async function connectToHost(
   const projectRoot = state.getProjectRootUri().toString();
   const useSecondarySession = secondarySession.shouldUseSecondarySession(connectSequence);
 
-  const resolution = sessionNameResolver.resolveSessionNames(baseSessionNames, projectRoot);
+  const resolution = sessionNameResolver.resolveSessionNames(
+    baseSessionNames,
+    projectRoot,
+    hostname,
+    isJackIn ? null : port
+  );
   const sessionRoleKeys = resolution.finalNames;
 
   if (resolution.reconnectClientKey) {
@@ -1043,6 +1048,8 @@ export async function connect(
   const portFile = projectTypes.nreplPortFileUri(connectSequence);
   void state.extensionContext.workspaceState.update('selectedCljsTypeName', cljsTypeName);
   void state.extensionContext.workspaceState.update('selectedConnectSequence', connectSequence);
+  // Used to decide whether to suppress auto-connect when a matching connection already exists.
+  const portWasExplicitlyProvided = port !== undefined;
 
   let result: ConnectResult = { connected: false };
   try {
@@ -1068,7 +1075,16 @@ export async function connect(
     if (port) {
       hostname = hostname !== undefined ? hostname : 'localhost';
       output.appendLineOtherOut(`Using host:port ${hostname}:${port} ...`);
-      if (isAutoConnect) {
+      // Suppress auto-connect when a matching connection already exists,
+      // UNLESS explicit host:port was provided or this is a jack-in.
+      const baseSessionNames = sessionRoleUtils.deriveSessionRoleKeys(connectSequence);
+      const projectRoot = state.getProjectRootUri().toString();
+      const hasExistingMatch =
+        !portWasExplicitlyProvided &&
+        !isJackIn &&
+        sessionNameResolver.hasMatchingBaseConnection(baseSessionNames, projectRoot);
+      const effectiveAutoConnect = isAutoConnect && !hasExistingMatch;
+      if (effectiveAutoConnect) {
         result = await connectToHost(hostname, parseInt(port), connectSequence, true, isJackIn);
         if (!result.connected) {
           output.appendLineOtherOut('Prompting for nREPL connection...');

--- a/src/extension-test/integration/suite/jack-in-and-connect-test.ts
+++ b/src/extension-test/integration/suite/jack-in-and-connect-test.ts
@@ -299,6 +299,7 @@ suite('Jack-in and Connect suite', () => {
     const clients1 = clientRegistry.listClients();
     assert.strictEqual(clients1.length, 1, 'Should have one client after first jack-in');
     const firstClientKey = clients1[0].key;
+    const firstClientHost = clients1[0].host;
     const firstClientPort = clients1[0].port;
 
     const sessions1 = sessionRegistry.listSessions();
@@ -343,8 +344,8 @@ suite('Jack-in and Connect suite', () => {
     // Open the file to set the correct project root context
     await testUtil.openFile(path.join(testUtil.testDataDir, testFile1));
 
-    // Connect directly using the same sequence and port as the first jack-in
-    await connectDirect(sequence1, true, 'localhost', String(firstClientPort));
+    // Connect directly using the same sequence, host, and port as the first jack-in
+    await connectDirect(sequence1, true, firstClientHost, String(firstClientPort));
     await testUtil.sleep(1000);
 
     testUtil.log(suite, 'Reconnection complete');

--- a/src/extension-test/unit/session-name-resolver-test.ts
+++ b/src/extension-test/unit/session-name-resolver-test.ts
@@ -23,7 +23,12 @@ describe('session-name-resolver', () => {
       it('returns base names when no sessions exist', () => {
         const baseNames = { primary: 'clj', secondary: 'cljs' };
 
-        const resolution = sessionNameResolver.resolveSessionNames(baseNames, '/project-a');
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          '/project-a',
+          'localhost',
+          1234
+        );
 
         expect(resolution.finalNames).toEqual(baseNames);
         expect(resolution.suffix).toBeUndefined();
@@ -34,7 +39,12 @@ describe('session-name-resolver', () => {
         sessionRegistry.registerSession('bb', createSession('client-a'), {});
 
         const baseNames = { primary: 'clj', secondary: 'cljs' };
-        const resolution = sessionNameResolver.resolveSessionNames(baseNames, '/project-b');
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          '/project-b',
+          'localhost',
+          1234
+        );
 
         expect(resolution.finalNames).toEqual(baseNames);
         expect(resolution.suffix).toBeUndefined();
@@ -43,7 +53,12 @@ describe('session-name-resolver', () => {
       it('handles primary-only sessions', () => {
         const baseNames = { primary: 'bb' };
 
-        const resolution = sessionNameResolver.resolveSessionNames(baseNames, '/project-a');
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          '/project-a',
+          'localhost',
+          1234
+        );
 
         expect(resolution.finalNames).toEqual({ primary: 'bb' });
         expect(resolution.suffix).toBeUndefined();
@@ -55,7 +70,12 @@ describe('session-name-resolver', () => {
         sessionRegistry.registerSession('clj', createSession('client-a'), {});
 
         const baseNames = { primary: 'clj', secondary: 'cljs' };
-        const resolution = sessionNameResolver.resolveSessionNames(baseNames, '/project-b');
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          '/project-b',
+          'localhost',
+          1234
+        );
 
         expect(resolution.finalNames.primary).toMatch(/^clj:\w+$/);
         expect(resolution.finalNames.secondary).toMatch(/^cljs:\w+$/);
@@ -66,7 +86,12 @@ describe('session-name-resolver', () => {
         sessionRegistry.registerSession('cljs', createSession('client-a'), {});
 
         const baseNames = { primary: 'clj', secondary: 'cljs' };
-        const resolution = sessionNameResolver.resolveSessionNames(baseNames, '/project-b');
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          '/project-b',
+          'localhost',
+          1234
+        );
 
         expect(resolution.finalNames.primary).toMatch(/^clj:\w+$/);
         expect(resolution.finalNames.secondary).toMatch(/^cljs:\w+$/);
@@ -77,7 +102,12 @@ describe('session-name-resolver', () => {
         sessionRegistry.registerSession('clj', createSession('client-a'), {});
 
         const baseNames = { primary: 'clj', secondary: 'cljs' };
-        const resolution = sessionNameResolver.resolveSessionNames(baseNames, '/project-b');
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          '/project-b',
+          'localhost',
+          1234
+        );
 
         const suffix = resolution.suffix;
         expect(resolution.finalNames.primary).toBe(`clj:${suffix}`);
@@ -88,7 +118,12 @@ describe('session-name-resolver', () => {
         sessionRegistry.registerSession('clj', createSession('client-a'), {});
 
         const baseNames = { primary: 'clj', secondary: 'cljs' };
-        const resolution1 = sessionNameResolver.resolveSessionNames(baseNames, '/project-b');
+        const resolution1 = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          '/project-b',
+          'localhost',
+          1234
+        );
 
         // Register the first suffixed session
         sessionRegistry.registerSession(
@@ -97,26 +132,37 @@ describe('session-name-resolver', () => {
           {}
         );
 
-        const resolution2 = sessionNameResolver.resolveSessionNames(baseNames, '/project-c');
+        const resolution2 = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          '/project-c',
+          'localhost',
+          1234
+        );
 
         expect(resolution1.suffix).not.toBe(resolution2.suffix);
       });
     });
 
-    describe('reconnection scenario', () => {
-      it('detects reconnection with same baseNames and projectRoot', () => {
+    describe('reconnection scenario (manual connect)', () => {
+      it('detects reconnection when baseNames, host, and port match', () => {
         const baseNames = { primary: 'clj', secondary: 'cljs' };
         const projectRoot = '/project-a';
 
-        // Register client with baseSessionNames in connection state
         clientRegistry.registerClient(createMockClient('client-a'), {
           projectRoot,
+          host: 'localhost',
+          port: 1234,
           connectionState: {
             baseSessionNames: baseNames,
           },
         });
 
-        const resolution = sessionNameResolver.resolveSessionNames(baseNames, projectRoot);
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          projectRoot,
+          'localhost',
+          1234
+        );
 
         expect(resolution.reconnectClientKey).toBe('client-a');
         expect(resolution.finalNames).toEqual(baseNames);
@@ -127,78 +173,189 @@ describe('session-name-resolver', () => {
         const baseNames = { primary: 'clj', secondary: 'cljs' };
         const projectRoot = '/project-a';
 
-        // Register client with suffix in connection state
         clientRegistry.registerClient(createMockClient('client-a'), {
           projectRoot,
+          host: 'localhost',
+          port: 1234,
           connectionState: {
             baseSessionNames: baseNames,
             suffix: '2',
           },
         });
 
-        const resolution = sessionNameResolver.resolveSessionNames(baseNames, projectRoot);
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          projectRoot,
+          'localhost',
+          1234
+        );
 
         expect(resolution.reconnectClientKey).toBe('client-a');
         expect(resolution.finalNames).toEqual({ primary: 'clj:2', secondary: 'cljs:2' });
         expect(resolution.suffix).toBe('2');
       });
 
-      it('does not detect reconnection when projectRoot differs', () => {
+      it('detects reconnection even when projectRoot differs (matches on host:port)', () => {
         const baseNames = { primary: 'clj', secondary: 'cljs' };
 
         clientRegistry.registerClient(createMockClient('client-a'), {
           projectRoot: '/project-a',
+          host: 'localhost',
+          port: 1234,
           connectionState: {
             baseSessionNames: baseNames,
           },
         });
 
-        // Different projectRoot but same baseNames - should NOT be reconnection
-        // But sessions exist, so should get suffix
-        sessionRegistry.registerSession('clj', createSession('client-a'), {});
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          '/project-b',
+          'localhost',
+          1234
+        );
 
-        const resolution = sessionNameResolver.resolveSessionNames(baseNames, '/project-b');
-
-        expect(resolution.reconnectClientKey).toBeUndefined();
-        expect(resolution.suffix).toBeDefined();
+        expect(resolution.reconnectClientKey).toBe('client-a');
       });
 
       it('does not detect reconnection when baseNames differ', () => {
         clientRegistry.registerClient(createMockClient('client-a'), {
           projectRoot: '/project-a',
+          host: 'localhost',
+          port: 1234,
           connectionState: {
             baseSessionNames: { primary: 'clj', secondary: 'cljs' },
           },
         });
 
-        // Same projectRoot but different baseNames - should NOT be reconnection
-        const resolution = sessionNameResolver.resolveSessionNames({ primary: 'bb' }, '/project-a');
+        const resolution = sessionNameResolver.resolveSessionNames(
+          { primary: 'bb' },
+          '/project-a',
+          'localhost',
+          1234
+        );
 
         expect(resolution.reconnectClientKey).toBeUndefined();
         expect(resolution.finalNames).toEqual({ primary: 'bb' });
+      });
+
+      it('does not detect reconnection when host differs', () => {
+        const baseNames = { primary: 'clj', secondary: 'cljs' };
+        const projectRoot = '/project-a';
+
+        clientRegistry.registerClient(createMockClient('client-a'), {
+          projectRoot,
+          host: 'localhost',
+          port: 1234,
+          connectionState: {
+            baseSessionNames: baseNames,
+          },
+        });
+
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          projectRoot,
+          'remotehost',
+          1234
+        );
+
+        expect(resolution.reconnectClientKey).toBeUndefined();
+      });
+
+      it('does not detect reconnection when port differs', () => {
+        const baseNames = { primary: 'clj', secondary: 'cljs' };
+        const projectRoot = '/project-a';
+
+        clientRegistry.registerClient(createMockClient('client-a'), {
+          projectRoot,
+          host: 'localhost',
+          port: 1234,
+          connectionState: {
+            baseSessionNames: baseNames,
+          },
+        });
+
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          projectRoot,
+          'localhost',
+          5678
+        );
+
+        expect(resolution.reconnectClientKey).toBeUndefined();
+      });
+    });
+
+    describe('reconnection scenario (port-unaware, e.g. jack-in)', () => {
+      it('detects reconnection when baseNames and projectRoot match (port is null)', () => {
+        const baseNames = { primary: 'bb' };
+        const projectRoot = '/project-a';
+
+        clientRegistry.registerClient(createMockClient('client-a'), {
+          projectRoot,
+          host: 'localhost',
+          port: 1234,
+          connectionState: {
+            baseSessionNames: baseNames,
+          },
+        });
+
+        // null port means "don't care about port"
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          projectRoot,
+          'localhost',
+          null
+        );
+
+        expect(resolution.reconnectClientKey).toBe('client-a');
+      });
+
+      it('does not detect reconnection when projectRoot differs', () => {
+        const baseNames = { primary: 'bb' };
+
+        clientRegistry.registerClient(createMockClient('client-a'), {
+          projectRoot: '/project-a',
+          host: 'localhost',
+          port: 1234,
+          connectionState: {
+            baseSessionNames: baseNames,
+          },
+        });
+
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          '/project-b',
+          'localhost',
+          null
+        );
+
+        expect(resolution.reconnectClientKey).toBeUndefined();
       });
 
       it('reserves suffix on reconnection so other connections cannot steal it', () => {
         const baseNames = { primary: 'clj', secondary: 'cljs' };
         const projectRoot = '/project-a';
 
-        // Simulate a connection that has a suffix
         clientRegistry.registerClient(createMockClient('client-a'), {
           projectRoot,
+          host: 'localhost',
+          port: 1234,
           connectionState: {
             baseSessionNames: baseNames,
             suffix: 'apple',
           },
         });
 
-        // Reconnection resolution - returns the existing suffix
-        const resolution = sessionNameResolver.resolveSessionNames(baseNames, projectRoot);
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          projectRoot,
+          'localhost',
+          1234
+        );
 
         expect(resolution.reconnectClientKey).toBe('client-a');
         expect(resolution.suffix).toBe('apple');
 
-        // The suffix should be marked as in-use after resolution
-        // so another connection cannot grab it between disconnect and re-register
         expect(nameSuffix.getUsedSuffixes()).toContain('apple');
       });
     });
@@ -216,9 +373,78 @@ describe('session-name-resolver', () => {
         const baseNames = { primary: 'clj', secondary: 'cljs' };
 
         expect(() => {
-          sessionNameResolver.resolveSessionNames(baseNames, '/project-b');
+          sessionNameResolver.resolveSessionNames(baseNames, '/project-b', 'localhost', 1234);
         }).toThrow(/too many REPLs/);
       });
+    });
+  });
+
+  describe('hasMatchingBaseConnection', () => {
+    it('returns true when baseNames and projectRoot match', () => {
+      const baseNames = { primary: 'clj', secondary: 'cljs' };
+      const projectRoot = '/project-a';
+
+      clientRegistry.registerClient(createMockClient('client-a'), {
+        projectRoot,
+        host: 'localhost',
+        port: 1234,
+        connectionState: {
+          baseSessionNames: baseNames,
+        },
+      });
+
+      expect(sessionNameResolver.hasMatchingBaseConnection(baseNames, projectRoot)).toBe(true);
+    });
+
+    it('returns true regardless of host/port', () => {
+      const baseNames = { primary: 'clj', secondary: 'cljs' };
+      const projectRoot = '/project-a';
+
+      clientRegistry.registerClient(createMockClient('client-a'), {
+        projectRoot,
+        host: 'remotehost',
+        port: 9999,
+        connectionState: {
+          baseSessionNames: baseNames,
+        },
+      });
+
+      expect(sessionNameResolver.hasMatchingBaseConnection(baseNames, projectRoot)).toBe(true);
+    });
+
+    it('returns false when projectRoot differs', () => {
+      clientRegistry.registerClient(createMockClient('client-a'), {
+        projectRoot: '/project-a',
+        connectionState: {
+          baseSessionNames: { primary: 'clj', secondary: 'cljs' },
+        },
+      });
+
+      expect(
+        sessionNameResolver.hasMatchingBaseConnection(
+          { primary: 'clj', secondary: 'cljs' },
+          '/project-b'
+        )
+      ).toBe(false);
+    });
+
+    it('returns false when baseNames differ', () => {
+      clientRegistry.registerClient(createMockClient('client-a'), {
+        projectRoot: '/project-a',
+        connectionState: {
+          baseSessionNames: { primary: 'clj', secondary: 'cljs' },
+        },
+      });
+
+      expect(sessionNameResolver.hasMatchingBaseConnection({ primary: 'bb' }, '/project-a')).toBe(
+        false
+      );
+    });
+
+    it('returns false when no clients registered', () => {
+      expect(sessionNameResolver.hasMatchingBaseConnection({ primary: 'clj' }, '/project-a')).toBe(
+        false
+      );
     });
   });
 });

--- a/src/nrepl/session-name-resolver.ts
+++ b/src/nrepl/session-name-resolver.ts
@@ -29,28 +29,56 @@ function sameBaseNames(a: SessionRoleKeys, b: SessionRoleKeys): boolean {
 }
 
 /**
- * Find an existing client that has the same base session names and project root.
- * This indicates a reconnection scenario.
+ * Find an existing client that indicates a reconnection scenario.
+ *
+ * When port is provided: matches base names + host + port (the caller knows
+ * specifically which server to reconnect to).
+ *
+ * When port is null: matches base names + project root (the caller doesn't
+ * know the port yet — e.g. jack-in starts a new server on a new port).
  */
 function findReconnectionCandidate(
   baseNames: SessionRoleKeys,
-  projectRoot: string
+  projectRoot: string,
+  host: string,
+  port: number | null
 ): string | undefined {
   const clients = clientRegistry.listClients();
   for (const client of clients) {
     const connState = client.connectionState;
-    const clientProjectRoot = client.projectRoot;
 
-    // Check if this client has matching baseSessionNames and projectRoot
-    if (
-      connState.baseSessionNames &&
-      sameBaseNames(connState.baseSessionNames, baseNames) &&
-      clientProjectRoot === projectRoot
-    ) {
-      return client.key;
+    if (!connState.baseSessionNames || !sameBaseNames(connState.baseSessionNames, baseNames)) {
+      continue;
+    }
+
+    if (port === null) {
+      if (client.projectRoot === projectRoot) {
+        return client.key;
+      }
+    } else {
+      if (client.host === host && client.port === port) {
+        return client.key;
+      }
     }
   }
   return undefined;
+}
+
+/**
+ * Check if any registered client has matching base session names and project root,
+ * regardless of host:port.
+ */
+export function hasMatchingBaseConnection(
+  baseNames: SessionRoleKeys,
+  projectRoot: string
+): boolean {
+  const clients = clientRegistry.listClients();
+  return clients.some(
+    (client) =>
+      client.connectionState.baseSessionNames &&
+      sameBaseNames(client.connectionState.baseSessionNames, baseNames) &&
+      client.projectRoot === projectRoot
+  );
 }
 
 /**
@@ -102,9 +130,11 @@ function applySuffixToNames(baseNames: SessionRoleKeys, suffix: string): Session
  */
 export function resolveSessionNames(
   baseNames: SessionRoleKeys,
-  projectRoot: string
+  projectRoot: string,
+  host: string,
+  port: number | null
 ): SessionNameResolution {
-  const reconnectClientKey = findReconnectionCandidate(baseNames, projectRoot);
+  const reconnectClientKey = findReconnectionCandidate(baseNames, projectRoot, host, port);
   if (reconnectClientKey) {
     const existingState = clientRegistry.getConnectionState(reconnectClientKey);
     const existingSuffix = existingState?.suffix;


### PR DESCRIPTION
## What has changed?

* Fixes #3065

Instead of blindly disconnecting when a connect sequence is selected that matches a connected sequence, we defer disconnection until:

* The user has actually initiated connect, AND
* The user connects on the same host + port


## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [~] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
