### PR TITLE
toggle multi line comment can break strcuture and break indent + comments in same column and then indent

### DIFF
--- a/src/edit.ts
+++ b/src/edit.ts
@@ -87,7 +87,6 @@ async function applyStructuralCommentsToSingleSelectionLines(
   const descendingLineNumbers = [...new Set(affectedLineNumbers)].sort((a, b) => b - a);
   const affectedLineSet = new Set(affectedLineNumbers);
   const originalFirstNonWSMap = new Map<number, number>();
-  const preservedIndentAfterPrefixMap = new Map<number, number>();
   let alignedCommentColumn: number | undefined;
 
   // Calculate aligned comment column and
@@ -106,16 +105,6 @@ async function applyStructuralCommentsToSingleSelectionLines(
 
   const resolvedAlignedCommentColumn = alignedCommentColumn ?? 0;
 
-  // Calculate preserved indent after comment prefix for each line
-  for (const lineNum of affectedLineNumbers) {
-    const firstNonWhitespace = originalFirstNonWSMap.get(lineNum) ?? 0;
-    const preservedIndentAfterPrefix =
-      affectedLineNumbers.length > 1
-        ? Math.max(0, firstNonWhitespace - resolvedAlignedCommentColumn)
-        : 0;
-    preservedIndentAfterPrefixMap.set(lineNum, preservedIndentAfterPrefix);
-  }
-
   const mirrorDoc = docMirror.getDocument(editor.document);
   const structureBreakLineNums = new Set<number>();
 
@@ -127,15 +116,13 @@ async function applyStructuralCommentsToSingleSelectionLines(
         const firstNonWhitespace = originalFirstNonWSMap.get(lineNum) ?? 0;
         const insertionColumn =
           affectedLineNumbers.length > 1 ? resolvedAlignedCommentColumn : firstNonWhitespace;
-        const preservedIndentAfterPrefix = preservedIndentAfterPrefixMap.get(lineNum) ?? 0;
-        const commentPrefix = ';; ' + ' '.repeat(preservedIndentAfterPrefix);
         const insertionOffset = editor.document.offsetAt(
           new vscode.Position(lineNum, firstNonWhitespace)
         );
 
         const wouldBreakWhere = _semiColonWouldBreakStructureWhere(mirrorDoc, insertionOffset);
 
-        editBuilder.insert(new vscode.Position(lineNum, insertionColumn), commentPrefix);
+        editBuilder.insert(new vscode.Position(lineNum, insertionColumn), ';; ');
 
         if (wouldBreakWhere !== false) {
           let breakOffset = wouldBreakWhere;

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -84,7 +84,6 @@ async function applyStructuralCommentsToSingleSelectionLines(
   editor: vscode.TextEditor,
   affectedLineNumbers: number[]
 ) {
-  const originalSelections = [...editor.selections];
   const descendingLineNumbers = [...new Set(affectedLineNumbers)].sort((a, b) => b - a);
   const affectedLineSet = new Set(affectedLineNumbers);
   const mirrorDoc = docMirror.getDocument(editor.document);
@@ -105,13 +104,26 @@ async function applyStructuralCommentsToSingleSelectionLines(
         editBuilder.insert(new vscode.Position(lineNum, insertionColumn), ';; ');
 
         if (wouldBreakWhere !== false) {
-          const skipBreak =
-            affectedLineNumbers.length > 1 &&
-            shouldSkipStructuralBreak(mirrorDoc, wouldBreakWhere, affectedLineSet);
+          let breakOffset = wouldBreakWhere;
+          let skipBreak = false;
+
+          if (affectedLineNumbers.length > 1) {
+            const resolvedBreakOffset = resolveStructuralBreakOffset(
+              mirrorDoc,
+              wouldBreakWhere,
+              affectedLineSet
+            );
+            if (resolvedBreakOffset === false) {
+              skipBreak = true;
+            } else {
+              breakOffset = resolvedBreakOffset;
+            }
+          }
+
           if (!skipBreak) {
             structureBreakLineNums.add(lineNum);
             const indent = currentLine.text.match(/^\s*/)[0];
-            editBuilder.insert(editor.document.positionAt(wouldBreakWhere), '\n' + indent);
+            editBuilder.insert(editor.document.positionAt(breakOffset), '\n' + indent);
           }
         }
       }
@@ -133,49 +145,26 @@ async function applyStructuralCommentsToSingleSelectionLines(
     return lineNum + shift;
   });
 
-  await reformatEnclosingFormsForLines(editor, shiftedLineNumbers);
-
-  // Cursor positions captured after formatting so indentation changes are reflected
-  editor.selections = originalSelections.map((selection) => {
-    const originalLineNum = selection.active.line;
-    let shift = 0;
-    for (const breakLineNum of structureBreakLineNums) {
-      if (breakLineNum < originalLineNum) {
-        shift++;
-      }
-    }
-    const shiftedLine = originalLineNum + shift;
-
-    if (shiftedLine < editor.document.lineCount) {
-      const line = editor.document.lineAt(shiftedLine);
-      const firstNonWS = line.firstNonWhitespaceCharacterIndex;
-      const lineContent = line.text.slice(firstNonWS);
-      if (lineContent.startsWith(';; ')) {
-        const pos = new vscode.Position(shiftedLine, firstNonWS + 3);
-        return new vscode.Selection(pos, pos);
-      }
-    }
-
-    return selection;
-  });
+  if (affectedLineNumbers.length > 1) {
+    await editor.edit(() => undefined, { undoStopBefore: false, undoStopAfter: true });
+  } else {
+    await reformatEnclosingFormsForLines(editor, shiftedLineNumbers);
+  }
 }
 
 /**
- * Determines whether a structural break reported by
- * `_semiColonWouldBreakStructureWhere` can be safely skipped because the
- * affected delimiters are balanced within the selected lines.
+ * Resolves where a structural break should be inserted (or if it can be skipped)
+ * for multiline commenting.
  *
- * When commenting multiple lines, a structural break is unnecessary if every
- * closing delimiter from the break position to the end of the line has its
- * matching opener on a line that is also being commented. Similarly, if the
- * break position is a multi-line sexp whose end falls within the selected
- * lines, the break can be skipped.
+ * Returns:
+ * - an offset where break should be inserted (possibly adjusted), or
+ * - `false` when the break can be skipped entirely.
  */
-function shouldSkipStructuralBreak(
+function resolveStructuralBreakOffset(
   mirrorDoc: EditableDocument,
   wouldBreakWhere: number,
   affectedLineSet: Set<number>
-): boolean {
+): number | false {
   const cursor = mirrorDoc.getTokenCursor(wouldBreakWhere);
   const token = cursor.getToken();
 
@@ -186,25 +175,24 @@ function shouldSkipStructuralBreak(
       const tok = probe.getToken();
       if (tok.type === 'close') {
         const finder = probe.clone();
-        finder.next();
-        if (!finder.backwardSexp()) {
-          return false;
+        if (!finder.backwardList()) {
+          return probe.offsetStart;
         }
         if (!affectedLineSet.has(finder.line)) {
-          return false;
+          return probe.offsetStart;
         }
       }
       probe.next();
     }
-    return true;
+    return false;
   }
 
   const endCursor = cursor.clone();
   if (endCursor.forwardSexp(true, true, true)) {
-    return affectedLineSet.has(endCursor.line);
+    return affectedLineSet.has(endCursor.line) ? false : wouldBreakWhere;
   }
 
-  return false;
+  return wouldBreakWhere;
 }
 
 type OffsetRange = [number, number];

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -86,6 +86,36 @@ async function applyStructuralCommentsToSingleSelectionLines(
 ) {
   const descendingLineNumbers = [...new Set(affectedLineNumbers)].sort((a, b) => b - a);
   const affectedLineSet = new Set(affectedLineNumbers);
+  const originalFirstNonWSMap = new Map<number, number>();
+  const preservedIndentAfterPrefixMap = new Map<number, number>();
+  let alignedCommentColumn: number | undefined;
+
+  // Calculate aligned comment column and
+  // store original first non-whitespace character index for each line
+  for (const lineNum of affectedLineNumbers) {
+    const line = editor.document.lineAt(lineNum);
+    const firstNonWhitespace = line.firstNonWhitespaceCharacterIndex;
+    originalFirstNonWSMap.set(lineNum, firstNonWhitespace);
+    if (!line.isEmptyOrWhitespace) {
+      alignedCommentColumn =
+        alignedCommentColumn === undefined
+          ? firstNonWhitespace
+          : Math.min(alignedCommentColumn, firstNonWhitespace);
+    }
+  }
+
+  const resolvedAlignedCommentColumn = alignedCommentColumn ?? 0;
+
+  // Calculate preserved indent after comment prefix for each line
+  for (const lineNum of affectedLineNumbers) {
+    const firstNonWhitespace = originalFirstNonWSMap.get(lineNum) ?? 0;
+    const preservedIndentAfterPrefix =
+      affectedLineNumbers.length > 1
+        ? Math.max(0, firstNonWhitespace - resolvedAlignedCommentColumn)
+        : 0;
+    preservedIndentAfterPrefixMap.set(lineNum, preservedIndentAfterPrefix);
+  }
+
   const mirrorDoc = docMirror.getDocument(editor.document);
   const structureBreakLineNums = new Set<number>();
 
@@ -94,14 +124,18 @@ async function applyStructuralCommentsToSingleSelectionLines(
     (editBuilder) => {
       for (const lineNum of descendingLineNumbers) {
         const currentLine = editor.document.lineAt(lineNum);
-        const insertionColumn = currentLine.firstNonWhitespaceCharacterIndex;
+        const firstNonWhitespace = originalFirstNonWSMap.get(lineNum) ?? 0;
+        const insertionColumn =
+          affectedLineNumbers.length > 1 ? resolvedAlignedCommentColumn : firstNonWhitespace;
+        const preservedIndentAfterPrefix = preservedIndentAfterPrefixMap.get(lineNum) ?? 0;
+        const commentPrefix = ';; ' + ' '.repeat(preservedIndentAfterPrefix);
         const insertionOffset = editor.document.offsetAt(
-          new vscode.Position(lineNum, insertionColumn)
+          new vscode.Position(lineNum, firstNonWhitespace)
         );
 
         const wouldBreakWhere = _semiColonWouldBreakStructureWhere(mirrorDoc, insertionOffset);
 
-        editBuilder.insert(new vscode.Position(lineNum, insertionColumn), ';; ');
+        editBuilder.insert(new vscode.Position(lineNum, insertionColumn), commentPrefix);
 
         if (wouldBreakWhere !== false) {
           let breakOffset = wouldBreakWhere;

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -254,7 +254,16 @@ suite(suiteName, () => {
   it('should structurally comment two selected lines and preserve closing delimiter', async () => {
     assert.equal(
       await toggleCommentTextUsingActiveEditor('(assoc {}•         |:a•         :b|)'),
-      '(assoc {}•       ;; :a•       ;; :b•       )'
+      '(assoc {}•         ;; :a•         ;; :b•         )'
+    );
+  });
+
+  it('should preserve indentation and structure for selected multiline expression in with-open', async () => {
+    assert.equal(
+      await toggleCommentTextUsingActiveEditor(
+        '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    |(mod (->> #(.read r)•              repeatedly•              (filter #(not (>= % 200)))•              (take 1)•              doall•              first)•         100)|)•  :rcf)'
+      ),
+      '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    ;; (mod (->> #(.read r)•              ;; repeatedly•              ;; (filter #(not (>= % 200)))•              ;; (take 1)•              ;; doall•              ;; first)•         ;; 100)•         )•  :rcf)'
     );
   });
 });

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -226,7 +226,7 @@ suite(suiteName, () => {
   it('should comment a complete multi-line top-level form without structural breaks', async () => {
     assert.equal(
       await toggleCommentTextUsingActiveEditor('|(defn foo []•  (prn "hi"))|'),
-      ';; (defn foo []•;;     (prn "hi"))'
+      ';; (defn foo []•;;   (prn "hi"))'
     );
   });
 
@@ -240,14 +240,14 @@ suite(suiteName, () => {
   it('should comment multi-line nested forms when all lines selected', async () => {
     assert.equal(
       await toggleCommentTextUsingActiveEditor('|(do•  (prn "a")•  (prn "b"))|'),
-      ';; (do•;;     (prn "a")•;;     (prn "b"))'
+      ';; (do•;;   (prn "a")•;;   (prn "b"))'
     );
   });
 
   it('should comment complete multi-line let binding without displacing bracket', async () => {
     assert.equal(
       await toggleCommentTextUsingActiveEditor('|(let [a 1•        b 2])|'),
-      ';; (let [a 1•;;                 b 2])'
+      ';; (let [a 1•;;         b 2])'
     );
   });
 
@@ -263,7 +263,7 @@ suite(suiteName, () => {
       await toggleCommentTextUsingActiveEditor(
         '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    |(mod (->> #(.read r)•              repeatedly•              (filter #(not (>= % 200)))•              (take 1)•              doall•              first)•         100)|)•  :rcf)'
       ),
-      '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    ;; (mod (->> #(.read r)•    ;;                     repeatedly•    ;;                     (filter #(not (>= % 200)))•    ;;                     (take 1)•    ;;                     doall•    ;;                     first)•    ;;           100)•         )•  :rcf)'
+      '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    ;; (mod (->> #(.read r)•    ;;           repeatedly•    ;;           (filter #(not (>= % 200)))•    ;;           (take 1)•    ;;           doall•    ;;           first)•    ;;      100)•         )•  :rcf)'
     );
   });
 });

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -226,7 +226,7 @@ suite(suiteName, () => {
   it('should comment a complete multi-line top-level form without structural breaks', async () => {
     assert.equal(
       await toggleCommentTextUsingActiveEditor('|(defn foo []•  (prn "hi"))|'),
-      ';; (defn foo []•  ;; (prn "hi"))'
+      ';; (defn foo []•;;     (prn "hi"))'
     );
   });
 
@@ -240,14 +240,14 @@ suite(suiteName, () => {
   it('should comment multi-line nested forms when all lines selected', async () => {
     assert.equal(
       await toggleCommentTextUsingActiveEditor('|(do•  (prn "a")•  (prn "b"))|'),
-      ';; (do•  ;; (prn "a")•  ;; (prn "b"))'
+      ';; (do•;;     (prn "a")•;;     (prn "b"))'
     );
   });
 
   it('should comment complete multi-line let binding without displacing bracket', async () => {
     assert.equal(
       await toggleCommentTextUsingActiveEditor('|(let [a 1•        b 2])|'),
-      ';; (let [a 1•        ;; b 2])'
+      ';; (let [a 1•;;                 b 2])'
     );
   });
 
@@ -263,7 +263,7 @@ suite(suiteName, () => {
       await toggleCommentTextUsingActiveEditor(
         '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    |(mod (->> #(.read r)•              repeatedly•              (filter #(not (>= % 200)))•              (take 1)•              doall•              first)•         100)|)•  :rcf)'
       ),
-      '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    ;; (mod (->> #(.read r)•              ;; repeatedly•              ;; (filter #(not (>= % 200)))•              ;; (take 1)•              ;; doall•              ;; first)•         ;; 100)•         )•  :rcf)'
+      '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    ;; (mod (->> #(.read r)•    ;;                     repeatedly•    ;;                     (filter #(not (>= % 200)))•    ;;                     (take 1)•    ;;                     doall•    ;;                     first)•    ;;           100)•         )•  :rcf)'
     );
   });
 });


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Fix cases where structure and indent were broken
```clojure
(with-open [r (java.io.FileInputStream. "/dev/urandom")]
  |(mod (->> #(.read r)
            repeatedly
            (filter #(< % 200))
            (take 1)
            doall
            first)
      100))|
```
- Add every line comment in same column and indent after comment

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
