### PR TITLE
Fix insert semicolon when a multi-line form starts at the beginning of the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes to Calva.
 - Fix: [Connecting a REPL sequence disconnects the previous prematurely](https://github.com/BetterThanTomorrow/calva/issues/3065)
 - Fix: [Toggle Line Comment produces incorrect output for multi-line selections](https://github.com/BetterThanTomorrow/calva/issues/3066)
 - Fix: [Toggle Line Comment loses the selection when you run the command](https://github.com/BetterThanTomorrow/calva/issues/3067)
+- Fix: [insertSemiColon does not work correctly in unsaved files](https://github.com/BetterThanTomorrow/calva/issues/3072)
 
 ## [2.0.554] - 2026-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changes to Calva.
 - Fix: [Connecting a REPL sequence disconnects the previous prematurely](https://github.com/BetterThanTomorrow/calva/issues/3065)
 - Fix: [Toggle Line Comment produces incorrect output for multi-line selections](https://github.com/BetterThanTomorrow/calva/issues/3066)
 - Fix: [Toggle Line Comment loses the selection when you run the command](https://github.com/BetterThanTomorrow/calva/issues/3067)
-- Fix: [insertSemiColon does not work correctly in unsaved files](https://github.com/BetterThanTomorrow/calva/issues/3072)
+- Fix: [Insert Semicolon does not work correctly in the first line of a file](https://github.com/BetterThanTomorrow/calva/issues/3072)
 
 ## [2.0.554] - 2026-02-17
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -2617,7 +2617,7 @@ export function _semiColonWouldBreakStructureWhere(
 
 export async function insertSemiColon(doc: EditableDocument, p = doc.selections[0].active) {
   const wouldBreakWhere = _semiColonWouldBreakStructureWhere(doc, p);
-  if (wouldBreakWhere) {
+  if (wouldBreakWhere !== false) {
     const cursor = doc.getTokenCursor(p);
     const lineText = doc.model.getLineText(cursor.line);
     const indent = lineText.match(/^\s*/)[0];

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -3420,7 +3420,9 @@ describe('paredit util', () => {
     });
     it('returns 0 when a multi-line form starts at offset 0', () => {
       expect(
-        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('|(defn hi []•  (prn "hi"))'))
+        paredit._semiColonWouldBreakStructureWhere(
+          docFromTextNotation('|(defn hi []•  (prn "hi"))')
+        )
       ).toBe(0);
     });
   });

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -3326,6 +3326,12 @@ describe('paredit util', () => {
       await paredit.insertSemiColon(a);
       expect(textAndSelection(a)).toEqual(textAndSelection(b));
     });
+    it('inserts a newline to preserve structure at offset 0', async () => {
+      const a = docFromTextNotation('|(defn hi []•  (prn "hi"))');
+      const b = docFromTextNotation(';|•(defn hi []•  (prn "hi"))');
+      await paredit.insertSemiColon(a);
+      expect(textAndSelection(a)).toEqual(textAndSelection(b));
+    });
   });
 
   describe('_semiColonWouldBreakStructureWhere', () => {
@@ -3411,6 +3417,11 @@ describe('paredit util', () => {
       expect(
         paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('|a (b {•} c•) d '))
       ).toBe(2);
+    });
+    it('returns 0 when a multi-line form starts at offset 0', () => {
+      expect(
+        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('|(defn hi []•  (prn "hi"))'))
+      ).toBe(0);
     });
   });
 });


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

The condition `if (wouldBreakWhere)` was falsy when wouldBreakWhere was 0,
which occurs when a multi-line form starts at the beginning of the file. Changed to `if (wouldBreakWhere !== false)`

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3072

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
