### PR TITLE
Toggle Comment: Full commented form including every ;; gets selected

### DIFF
--- a/src/edit.ts
+++ b/src/edit.ts
@@ -206,7 +206,11 @@ async function applyStructuralCommentsToSingleSelectionLines(
     return inserted;
   }
 
-  function adjustPosition(pos: vscode.Position): vscode.Position {
+  function adjustPosition(
+    pos: vscode.Position,
+    boundary: 'start' | 'end',
+    selectionIsEmpty: boolean
+  ): vscode.Position {
     const shiftedLine = pos.line + countInsertedLinesBefore(pos.line);
 
     if (shiftedLine >= editor.document.lineCount) {
@@ -220,12 +224,16 @@ async function applyStructuralCommentsToSingleSelectionLines(
     if (lineContent.startsWith(';; ')) {
       const origFirstNonWS = originalFirstNonWSMap.get(pos.line) ?? pos.character;
       const insertionColumn = originalInsertionColumnMap.get(pos.line);
-      const baseColumnForOffset =
-        pos.line === singleSelection.start.line &&
+      if (
+        !selectionIsEmpty &&
+        boundary === 'start' &&
         insertionColumn !== undefined &&
-        insertionColumn > origFirstNonWS
-          ? insertionColumn
-          : origFirstNonWS;
+        pos.character === insertionColumn
+      ) {
+        return new vscode.Position(shiftedLine, insertionColumn);
+      }
+
+      const baseColumnForOffset = insertionColumn ?? origFirstNonWS;
       const contentOffset = Math.max(0, pos.character - baseColumnForOffset);
       const newCol = Math.min(newFirstNonWS + 3 + contentOffset, line.text.length);
       return new vscode.Position(shiftedLine, newCol);
@@ -240,9 +248,12 @@ async function applyStructuralCommentsToSingleSelectionLines(
   }
 
   editor.selections = originalSelections.map((selection) => {
-    const newAnchor = adjustPosition(selection.anchor);
-    const newActive = adjustPosition(selection.active);
-    return new vscode.Selection(newAnchor, newActive);
+    const newStart = adjustPosition(selection.start, 'start', selection.isEmpty);
+    const newEnd = adjustPosition(selection.end, 'end', selection.isEmpty);
+    const isReversed = selection.anchor.isAfter(selection.active);
+    return isReversed
+      ? new vscode.Selection(newEnd, newStart)
+      : new vscode.Selection(newStart, newEnd);
   });
 }
 

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -90,6 +90,7 @@ async function applyStructuralCommentsToSingleSelectionLines(
   const affectedLineSet = new Set(affectedLineNumbers);
   const originalFirstNonWSMap = new Map<number, number>();
   const originalInsertionColumnMap = new Map<number, number>();
+  let partialSelectionStartOffset: number | undefined;
   let alignedCommentColumn: number | undefined;
 
   // Calculate aligned comment column and store original indentation.
@@ -100,11 +101,16 @@ async function applyStructuralCommentsToSingleSelectionLines(
 
     let insertionColumnCandidate = firstNonWhitespace;
     if (
-      affectedLineNumbers.length > 1 &&
       lineNum === singleSelection.start.line &&
+      !singleSelection.isEmpty &&
       singleSelection.start.character > firstNonWhitespace
     ) {
       insertionColumnCandidate = singleSelection.start.character;
+      if (affectedLineNumbers.length > 1) {
+        partialSelectionStartOffset = editor.document.offsetAt(
+          new vscode.Position(lineNum, singleSelection.start.character)
+        );
+      }
     }
     originalInsertionColumnMap.set(lineNum, insertionColumnCandidate);
 
@@ -128,7 +134,9 @@ async function applyStructuralCommentsToSingleSelectionLines(
         const currentLine = editor.document.lineAt(lineNum);
         const firstNonWhitespace = originalFirstNonWSMap.get(lineNum) ?? 0;
         const rawInsertionColumn =
-          affectedLineNumbers.length > 1 ? resolvedAlignedCommentColumn : firstNonWhitespace;
+          affectedLineNumbers.length > 1
+            ? resolvedAlignedCommentColumn
+            : originalInsertionColumnMap.get(lineNum) ?? firstNonWhitespace;
         const insertionColumn = Math.min(rawInsertionColumn, currentLine.text.length);
         originalInsertionColumnMap.set(lineNum, insertionColumn);
         const insertionOffset = editor.document.offsetAt(
@@ -147,7 +155,8 @@ async function applyStructuralCommentsToSingleSelectionLines(
             const resolvedBreakOffset = resolveStructuralBreakOffset(
               mirrorDoc,
               wouldBreakWhere,
-              affectedLineSet
+              affectedLineSet,
+              partialSelectionStartOffset
             );
             if (resolvedBreakOffset === false) {
               skipBreak = true;
@@ -248,7 +257,8 @@ async function applyStructuralCommentsToSingleSelectionLines(
 function resolveStructuralBreakOffset(
   mirrorDoc: EditableDocument,
   wouldBreakWhere: number,
-  affectedLineSet: Set<number>
+  affectedLineSet: Set<number>,
+  partialSelectionStartOffset?: number
 ): number | false {
   const cursor = mirrorDoc.getTokenCursor(wouldBreakWhere);
   const token = cursor.getToken();
@@ -261,6 +271,12 @@ function resolveStructuralBreakOffset(
       if (tok.type === 'close') {
         const finder = probe.clone();
         if (!finder.backwardList()) {
+          return probe.offsetStart;
+        }
+        if (
+          partialSelectionStartOffset !== undefined &&
+          finder.offsetStart < partialSelectionStartOffset
+        ) {
           return probe.offsetStart;
         }
         if (!affectedLineSet.has(finder.line)) {

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -270,16 +270,12 @@ function resolveStructuralBreakOffset(
       const tok = probe.getToken();
       if (tok.type === 'close') {
         const finder = probe.clone();
-        if (!finder.backwardList()) {
-          return probe.offsetStart;
-        }
         if (
-          partialSelectionStartOffset !== undefined &&
-          finder.offsetStart < partialSelectionStartOffset
+          !finder.backwardList() ||
+          (partialSelectionStartOffset !== undefined &&
+            finder.offsetStart < partialSelectionStartOffset) ||
+          !affectedLineSet.has(finder.line)
         ) {
-          return probe.offsetStart;
-        }
-        if (!affectedLineSet.has(finder.line)) {
           return probe.offsetStart;
         }
       }

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -211,6 +211,18 @@ async function applyStructuralCommentsToSingleSelectionLines(
     boundary: 'start' | 'end',
     selectionIsEmpty: boolean
   ): vscode.Position {
+    const isSelectionStartAtInsertionColumn = (
+      insertionColumn: number | undefined,
+      position: vscode.Position
+    ) => {
+      return (
+        !selectionIsEmpty &&
+        boundary === 'start' &&
+        insertionColumn !== undefined &&
+        position.character === insertionColumn
+      );
+    };
+
     const shiftedLine = pos.line + countInsertedLinesBefore(pos.line);
 
     if (shiftedLine >= editor.document.lineCount) {
@@ -220,26 +232,20 @@ async function applyStructuralCommentsToSingleSelectionLines(
     const line = editor.document.lineAt(shiftedLine);
     const newFirstNonWS = line.firstNonWhitespaceCharacterIndex;
     const lineContent = line.text.slice(newFirstNonWS);
+    const insertionColumn = originalInsertionColumnMap.get(pos.line);
+
+    if (isSelectionStartAtInsertionColumn(insertionColumn, pos)) {
+      return new vscode.Position(shiftedLine, insertionColumn);
+    }
 
     if (lineContent.startsWith(';; ')) {
       const origFirstNonWS = originalFirstNonWSMap.get(pos.line) ?? pos.character;
-      const insertionColumn = originalInsertionColumnMap.get(pos.line);
-      if (
-        !selectionIsEmpty &&
-        boundary === 'start' &&
-        insertionColumn !== undefined &&
-        pos.character === insertionColumn
-      ) {
-        return new vscode.Position(shiftedLine, insertionColumn);
-      }
-
       const baseColumnForOffset = insertionColumn ?? origFirstNonWS;
       const contentOffset = Math.max(0, pos.character - baseColumnForOffset);
       const newCol = Math.min(newFirstNonWS + 3 + contentOffset, line.text.length);
       return new vscode.Position(shiftedLine, newCol);
     }
 
-    const insertionColumn = originalInsertionColumnMap.get(pos.line);
     if (insertionColumn !== undefined && pos.character >= insertionColumn) {
       return new vscode.Position(shiftedLine, Math.min(pos.character + 3, line.text.length));
     }

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -85,9 +85,11 @@ async function applyStructuralCommentsToSingleSelectionLines(
   affectedLineNumbers: number[]
 ) {
   const originalSelections = [...editor.selections];
+  const singleSelection = editor.selections[0];
   const descendingLineNumbers = [...new Set(affectedLineNumbers)].sort((a, b) => b - a);
   const affectedLineSet = new Set(affectedLineNumbers);
   const originalFirstNonWSMap = new Map<number, number>();
+  const originalInsertionColumnMap = new Map<number, number>();
   let alignedCommentColumn: number | undefined;
 
   // Calculate aligned comment column and store original indentation.
@@ -95,11 +97,22 @@ async function applyStructuralCommentsToSingleSelectionLines(
     const line = editor.document.lineAt(lineNum);
     const firstNonWhitespace = line.firstNonWhitespaceCharacterIndex;
     originalFirstNonWSMap.set(lineNum, firstNonWhitespace);
+
+    let insertionColumnCandidate = firstNonWhitespace;
+    if (
+      affectedLineNumbers.length > 1 &&
+      lineNum === singleSelection.start.line &&
+      singleSelection.start.character > firstNonWhitespace
+    ) {
+      insertionColumnCandidate = singleSelection.start.character;
+    }
+    originalInsertionColumnMap.set(lineNum, insertionColumnCandidate);
+
     if (!line.isEmptyOrWhitespace) {
       alignedCommentColumn =
         alignedCommentColumn === undefined
-          ? firstNonWhitespace
-          : Math.min(alignedCommentColumn, firstNonWhitespace);
+          ? insertionColumnCandidate
+          : Math.min(alignedCommentColumn, insertionColumnCandidate);
     }
   }
 
@@ -114,10 +127,12 @@ async function applyStructuralCommentsToSingleSelectionLines(
       for (const lineNum of descendingLineNumbers) {
         const currentLine = editor.document.lineAt(lineNum);
         const firstNonWhitespace = originalFirstNonWSMap.get(lineNum) ?? 0;
-        const insertionColumn =
+        const rawInsertionColumn =
           affectedLineNumbers.length > 1 ? resolvedAlignedCommentColumn : firstNonWhitespace;
+        const insertionColumn = Math.min(rawInsertionColumn, currentLine.text.length);
+        originalInsertionColumnMap.set(lineNum, insertionColumn);
         const insertionOffset = editor.document.offsetAt(
-          new vscode.Position(lineNum, firstNonWhitespace)
+          new vscode.Position(lineNum, insertionColumn)
         );
 
         const wouldBreakWhere = _semiColonWouldBreakStructureWhere(mirrorDoc, insertionOffset);
@@ -193,14 +208,26 @@ async function applyStructuralCommentsToSingleSelectionLines(
     const newFirstNonWS = line.firstNonWhitespaceCharacterIndex;
     const lineContent = line.text.slice(newFirstNonWS);
 
-    if (!lineContent.startsWith(';; ')) {
-      return new vscode.Position(shiftedLine, Math.min(pos.character, line.text.length));
+    if (lineContent.startsWith(';; ')) {
+      const origFirstNonWS = originalFirstNonWSMap.get(pos.line) ?? pos.character;
+      const insertionColumn = originalInsertionColumnMap.get(pos.line);
+      const baseColumnForOffset =
+        pos.line === singleSelection.start.line &&
+        insertionColumn !== undefined &&
+        insertionColumn > origFirstNonWS
+          ? insertionColumn
+          : origFirstNonWS;
+      const contentOffset = Math.max(0, pos.character - baseColumnForOffset);
+      const newCol = Math.min(newFirstNonWS + 3 + contentOffset, line.text.length);
+      return new vscode.Position(shiftedLine, newCol);
     }
 
-    const origFirstNonWS = originalFirstNonWSMap.get(pos.line) ?? pos.character;
-    const contentOffset = Math.max(0, pos.character - origFirstNonWS);
-    const newCol = Math.min(newFirstNonWS + 3 + contentOffset, line.text.length);
-    return new vscode.Position(shiftedLine, newCol);
+    const insertionColumn = originalInsertionColumnMap.get(pos.line);
+    if (insertionColumn !== undefined && pos.character >= insertionColumn) {
+      return new vscode.Position(shiftedLine, Math.min(pos.character + 3, line.text.length));
+    }
+
+    return new vscode.Position(shiftedLine, Math.min(pos.character, line.text.length));
   }
 
   editor.selections = originalSelections.map((selection) => {

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -256,21 +256,17 @@ suite(suiteName, () => {
     );
   });
 
-  it('nested threading ->>', async () => {
+  it('should structurally comment a multiline partial selection at insertion column', async () => {
     assert.equal(
-      await toggleCommentUsingActiveEditor(
-        '(with-open [r (java.io.FileInputStream. "/dev/urandom")]•  (mod |(->> #(.read r)•            repeatedly•            (filter #(not (>= % 200)))•            (take 1)•            doall•            first)|•  100)•         )'
-      ),
-      '(with-open [r (java.io.FileInputStream. "/dev/urandom")]•  (mod ;; |(->> #(.read r)•       ;;      repeatedly•       ;;      (filter #(not (>= % 200)))•       ;;      (take 1)•       ;;      doall•       ;;      f|irst)•  100)•         )'
+      await toggleCommentUsingActiveEditor('(a |(b c•      d)|•   e)'),
+      '(a ;; |(b c•   ;;  | d)•   e)'
     );
   });
 
-  it('more nested edge case: should structurally comment selected nested -> inside as-> in with-open and preserve selection', async () => {
+  it('should structurally comment a multiline selection nested in another form', async () => {
     assert.equal(
-      await toggleCommentUsingActiveEditor(
-        '(defn a [a]•  (comment•    (-main)•    (System/getProperty "user.dir")•    (rand-int 100)•    (with-open [r (java.io.FileInputStream. "/dev/urandom")]•      (mod (-> (+ 2 2)•               (- 2)•               (as-> $ •                   |(-> $ •                       (+ 2)•                       (- 3))|))•           100))•    :rcf))'
-      ),
-      '(defn a [a]•  (comment•    (-main)•    (System/getProperty "user.dir")•    (rand-int 100)•    (with-open [r (java.io.FileInputStream. "/dev/urandom")]•      (mod (-> (+ 2 2)•               (- 2)•               (as-> $ •                   ;; |(-> $ •                   ;;     (+ 2)•                   ;;     (-| 3))•                       ))•           100))•    :rcf))'
+      await toggleCommentUsingActiveEditor('(x•  (y |(a b•        c)|)•  z)'),
+      '(x•  (y ;; |(a b•     ;;  | c))•  z)'
     );
   });
 });

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -259,28 +259,28 @@ suite(suiteName, () => {
   it('should structurally comment multiline partial selection and keep full selection over commented text', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(a |(b c•      d)|•   e)'),
-      '(a ;; |(b c•   ;;    d)|•   e)'
+      '(a |;; (b c•   ;;    d)|•   e)'
     );
   });
 
   it('should structurally comment multiline selection nested in parent form and preserve full selected range', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(x•  (y |(a b•        c)|)•  z)'),
-      '(x•  (y ;; |(a b•     ;;    c)|•        )•  z)'
+      '(x•  (y |;; (a b•     ;;    c)|•        )•  z)'
     );
   });
 
   it('should structurally comment multiline selection nested in j/y forms and keep full selected range', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(x• (j |(y •     (a b c))|)• z)'),
-      '(x• (j ;; |(y •    ;;  (a b c))|•     )• z)'
+      '(x• (j |;; (y •    ;;  (a b c))|•     )• z)'
     );
   });
 
   it('should insert structural comment at selection start for single-line nested selection', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(x• (j (y |(a b c)|))• z)'),
-      '(x• (j (y ;; |(a b c)|•     ))• z)'
+      '(x• (j (y |;; (a b c)|•     ))• z)'
     );
   });
 });

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -95,6 +95,12 @@ async function toggleComment(editor: vscode.TextEditor, textAndSelections: strin
   return textNotationFromDocAndSelections(editor.document, editor.selections);
 }
 
+/** Toggle line comment and return text only (no cursor notation). */
+async function toggleCommentText(editor: vscode.TextEditor, textAndSelections: string) {
+  await performToggle(editor, textAndSelections);
+  return getText(editor.document, true);
+}
+
 /** Toggle line comment using active editor */
 async function toggleCommentUsingActiveEditor(textAndSelections: string) {
   return toggleComment(vscode.window.activeTextEditor, textAndSelections);
@@ -253,6 +259,24 @@ suite(suiteName, () => {
         '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    |(mod (->> #(.read r)•              repeatedly•              (filter #(not (>= % 200)))•              (take 1)•              doall•              first)•         100)|)•  :rcf)'
       ),
       '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    ;; |(mod (->> #(.read r)•    ;;           repeatedly•    ;;           (filter #(not (>= % 200)))•    ;;           (take 1)•    ;;           doall•    ;;           first)•    ;;     | 100)•         )•  :rcf)'
+    );
+  });
+
+  it('nested threading ->>', async () => {
+    assert.equal(
+      await toggleCommentUsingActiveEditor(
+        '(with-open [r (java.io.FileInputStream. "/dev/urandom")]•  (mod |(->> #(.read r)•            repeatedly•            (filter #(not (>= % 200)))•            (take 1)•            doall•            first)|•  100)•         )'
+      ),
+      '(with-open [r (java.io.FileInputStream. "/dev/urandom")]•  (mod ;; |(->> #(.read r)•       ;;      repeatedly•       ;;      (filter #(not (>= % 200)))•       ;;      (take 1)•       ;;      doall•       ;;      f|irst)•  100)•         )'
+    );
+  });
+
+  it('more nested edge case: should structurally comment selected nested -> inside as-> in with-open and preserve selection', async () => {
+    assert.equal(
+      await toggleCommentUsingActiveEditor(
+        '(defn a [a]•  (comment•    (-main)•    (System/getProperty "user.dir")•    (rand-int 100)•    (with-open [r (java.io.FileInputStream. "/dev/urandom")]•      (mod (-> (+ 2 2)•               (- 2)•               (as-> $ •                   |(-> $ •                       (+ 2)•                       (- 3))|))•           100))•    :rcf))'
+      ),
+      '(defn a [a]•  (comment•    (-main)•    (System/getProperty "user.dir")•    (rand-int 100)•    (with-open [r (java.io.FileInputStream. "/dev/urandom")]•      (mod (-> (+ 2 2)•               (- 2)•               (as-> $ •                   ;; |(-> $ •                   ;;     (+ 2)•                   ;;     (-| 3))•                       ))•           100))•    :rcf))'
     );
   });
 });

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -95,12 +95,6 @@ async function toggleComment(editor: vscode.TextEditor, textAndSelections: strin
   return textNotationFromDocAndSelections(editor.document, editor.selections);
 }
 
-/** Toggle line comment and return text only (no cursor notation). */
-async function toggleCommentText(editor: vscode.TextEditor, textAndSelections: string) {
-  await performToggle(editor, textAndSelections);
-  return getText(editor.document, true);
-}
-
 /** Toggle line comment using active editor */
 async function toggleCommentUsingActiveEditor(textAndSelections: string) {
   return toggleComment(vscode.window.activeTextEditor, textAndSelections);

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -256,17 +256,31 @@ suite(suiteName, () => {
     );
   });
 
-  it('should structurally comment a multiline partial selection at insertion column', async () => {
+  it('should structurally comment a multiline partial selection at selection start column', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(a |(b c•      d)|•   e)'),
-      '(a ;; |(b c•   ;;  | d)•   e)'
+      '(a ;; |(b c•   ;;   | d)•   e)'
     );
   });
 
-  it('should structurally comment a multiline selection nested in another form', async () => {
+  it('should structurally comment multiline selection nested in parent form and preserve outer closers', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(x•  (y |(a b•        c)|)•  z)'),
-      '(x•  (y ;; |(a b•     ;;  | c))•  z)'
+      '(x•  (y ;; |(a b•     ;;   | c)•        )•  z)'
+    );
+  });
+
+  it('should structurally comment multiline selection nested in j/y forms', async () => {
+    assert.equal(
+      await toggleCommentUsingActiveEditor('(x• (j |(y •     (a b c))|)• z)'),
+      '(x• (j ;; |(y •    ;;  (a b c)|)•     )• z)'
+    );
+  });
+
+  it('should insert structural comment at selection start for single-line nested selection', async () => {
+    assert.equal(
+      await toggleCommentUsingActiveEditor('(x• (j (y |(a b c)|))• z)'),
+      '(x• (j (y ;; |(a b c)|•     ))• z)'
     );
   });
 });

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -215,35 +215,35 @@ suite(suiteName, () => {
   it('should comment a complete multi-line top-level form without structural breaks and preserve selection', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('|(defn foo []•  (prn "hi"))|'),
-      ';; |(defn foo []•;;   (prn "hi"|))'
+      '|;; (defn foo []•;;   (prn "hi"))|'
     );
   });
 
   it('should comment selected lines inside a containing form, preserving outside closers and selection', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(do•  |(prn "a")•  (prn "b")|)'),
-      '(do•  ;; |(prn "a")•  ;; (prn "b")|•  )'
+      '(do•  |;; (prn "a")•  ;; (prn "b")|•  )'
     );
   });
 
   it('should comment multi-line nested forms when all lines selected and preserve selection', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('|(do•  (prn "a")•  (prn "b"))|'),
-      ';; |(do•;;   (prn "a")•;;   (prn "b"|))'
+      '|;; (do•;;   (prn "a")•;;   (prn "b"))|'
     );
   });
 
   it('should comment complete multi-line let binding without displacing bracket and preserve selection', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('|(let [a 1•        b 2])|'),
-      ';; |(let [a 1•;;      |   b 2])'
+      '|;; (let [a 1•;;         b 2])|'
     );
   });
 
   it('should structurally comment two selected lines and preserve closing delimiter and selection', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(assoc {}•         |:a•         :b|)'),
-      '(assoc {}•         ;; |:a•         ;; :b|•         )'
+      '(assoc {}•         |;; :a•         ;; :b|•         )'
     );
   });
 
@@ -252,28 +252,28 @@ suite(suiteName, () => {
       await toggleCommentUsingActiveEditor(
         '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    |(mod (->> #(.read r)•              repeatedly•              (filter #(not (>= % 200)))•              (take 1)•              doall•              first)•         100)|)•  :rcf)'
       ),
-      '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    ;; |(mod (->> #(.read r)•    ;;           repeatedly•    ;;           (filter #(not (>= % 200)))•    ;;           (take 1)•    ;;           doall•    ;;           first)•    ;;     | 100)•         )•  :rcf)'
+      '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    |;; (mod (->> #(.read r)•    ;;           repeatedly•    ;;           (filter #(not (>= % 200)))•    ;;           (take 1)•    ;;           doall•    ;;           first)•    ;;      100)|•         )•  :rcf)'
     );
   });
 
-  it('should structurally comment a multiline partial selection at selection start column', async () => {
+  it('should structurally comment multiline partial selection and keep full selection over commented text', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(a |(b c•      d)|•   e)'),
-      '(a ;; |(b c•   ;;   | d)•   e)'
+      '(a ;; |(b c•   ;;    d)|•   e)'
     );
   });
 
-  it('should structurally comment multiline selection nested in parent form and preserve outer closers', async () => {
+  it('should structurally comment multiline selection nested in parent form and preserve full selected range', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(x•  (y |(a b•        c)|)•  z)'),
-      '(x•  (y ;; |(a b•     ;;   | c)•        )•  z)'
+      '(x•  (y ;; |(a b•     ;;    c)|•        )•  z)'
     );
   });
 
-  it('should structurally comment multiline selection nested in j/y forms', async () => {
+  it('should structurally comment multiline selection nested in j/y forms and keep full selected range', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(x• (j |(y •     (a b c))|)• z)'),
-      '(x• (j ;; |(y •    ;;  (a b c)|)•     )• z)'
+      '(x• (j ;; |(y •    ;;  (a b c))|•     )• z)'
     );
   });
 


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Changed selection logic in toggle comment. Pushes the cursor right so the new end position of the form is catched
- Also the initial position is moved left so every `;;` included the firsts are catched
- This is a checkout from #3074

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3066

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
        - Changelog was added in #3071 
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
