### PR TITLE
Issue 3078 toggle comemnts off indent glitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
-<<<<<<< issue-3078-toggle-comemnts-off-indent-glitch
 - Fix: [Toggle comments off, indent glitch](https://github.com/BetterThanTomorrow/calva/issues/3078)
-=======
 - Fix: [Clojure-lsp not starting when offline](https://github.com/BetterThanTomorrow/calva/issues/1299)
->>>>>>> dev
 
 ## [2.0.555] - 2026-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Toggle comments off, indent glitch](https://github.com/BetterThanTomorrow/calva/issues/3078)
+
 ## [2.0.555] - 2026-02-19
 
 - Fix: [Connecting a REPL sequence disconnects the previous prematurely](https://github.com/BetterThanTomorrow/calva/issues/3065)

--- a/src/comment-prefix.ts
+++ b/src/comment-prefix.ts
@@ -1,6 +1,15 @@
 /** Matches one or more leading semicolons (`;`, `;;`, `;;;`, etc.) */
 export const commentPrefixPattern = /^;+/;
 
+/**
+ * Calculates the end index for removing a comment prefix (semicolons + trailing space)
+ * from a line of text. Returns the index up to which characters should be removed,
+ * accounting for the semicolon(s) and a single trailing space
+ *
+ * @param lineText - The full text of the line
+ * @param firstNonWhitespace - The index of the first non-whitespace character in the line
+ * @returns The end index for removal, or `undefined` if no comment prefix is found
+ */
 export function calculateCommentPrefixRemovalEnd(
   lineText: string,
   firstNonWhitespace: number
@@ -12,7 +21,8 @@ export function calculateCommentPrefixRemovalEnd(
   }
 
   let removalEnd = firstNonWhitespace + match[0].length;
-  while (removalEnd < lineText.length && lineText[removalEnd] === ' ') {
+  // If there is a space immediately following the semicolons, include it in the removal
+  if (removalEnd < lineText.length && lineText[removalEnd] === ' ') {
     removalEnd++;
   }
 

--- a/src/comment-prefix.ts
+++ b/src/comment-prefix.ts
@@ -4,7 +4,8 @@ export const commentPrefixPattern = /^;+/;
 /**
  * Calculates the end index for removing a comment prefix (semicolons + trailing space)
  * from a line of text. Returns the index up to which characters should be removed,
- * accounting for the semicolon(s) and a single trailing space
+ * accounting for the semicolon(s) and a single trailing space (or all trailing spaces
+ * if the line is otherwise empty after the prefix).
  *
  * @param lineText - The full text of the line
  * @param firstNonWhitespace - The index of the first non-whitespace character in the line
@@ -21,9 +22,20 @@ export function calculateCommentPrefixRemovalEnd(
   }
 
   let removalEnd = firstNonWhitespace + match[0].length;
-  // If there is a space immediately following the semicolons, include it in the removal
   if (removalEnd < lineText.length && lineText[removalEnd] === ' ') {
-    removalEnd++;
+    let spaceRunEnd = removalEnd;
+    // If the line is otherwise empty after the comment prefix, remove all trailing spaces as well
+    while (spaceRunEnd < lineText.length && lineText[spaceRunEnd] === ' ') {
+      spaceRunEnd++;
+    }
+
+    // If we reached the end of the line, remove all spaces.
+    //  Otherwise, just remove one space after the comment prefix.
+    if (spaceRunEnd === lineText.length) {
+      removalEnd = spaceRunEnd;
+    } else {
+      removalEnd++;
+    }
   }
 
   return removalEnd;

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -395,7 +395,7 @@ async function updateLineComments(
   affectedLineNumbers: number[],
   shouldUncomment: boolean
 ) {
-  const descendingLineNumbers = [...new Set(affectedLineNumbers)].sort((a, b) => b - a);
+  const descendingLineNumbers = affectedLineNumbers.sort((a, b) => b - a);
 
   await editor.edit(
     (editBuilder) => {

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -157,6 +157,24 @@ suite(suiteName, () => {
     );
   });
 
+  it('should preserve nested indentation when uncommenting selected multiline block (issue #3078)', async () => {
+    assert.equal(
+      await toggleCommentUsingActiveEditor(
+        '|;; (a (b c•;;       (d e•;;          f)•;;       g•;;       h)•;;    i•;;    j)|'
+      ),
+      '|(a (b c•      (d e•         f)•      g•      h)•   i•   j)|'
+    );
+  });
+
+  it('should preserve nested indentation when uncommenting selected multiline block inside defn (issue #3078)', async () => {
+    assert.equal(
+      await toggleCommentUsingActiveEditor(
+        '(defn foo []•  |;; (a (b c•  ;;       (d e•  ;;          f)•  ;;       g•  ;;       h)•  ;;    i•  ;;    j)|•     )'
+      ),
+      '(defn foo []•  |(a (b c•        (d e•           f)•        g•        h)•     i•     j)|)'
+    );
+  });
+
   it('should comment an empty line inside assoc with alignment indent (issue #2872)', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(assoc m•       :key :val•|)'),

--- a/src/extension-test/unit/edit/comment-prefix-test.ts
+++ b/src/extension-test/unit/edit/comment-prefix-test.ts
@@ -23,8 +23,16 @@ describe('prefix removal', () => {
     expect(stripLeadingCommentPrefix('  ;;; header')).toBe('  header');
   });
 
-  it('strips semicolon prefix and all immediate following spaces', () => {
-    expect(stripLeadingCommentPrefix(';;;   header')).toBe('header');
+  it('strips semicolon prefix and one separating space before content', () => {
+    expect(stripLeadingCommentPrefix(';;;   header')).toBe('  header');
+  });
+
+  it('preserves indentation spaces after comment prefix', () => {
+    expect(stripLeadingCommentPrefix(';;       h)')).toBe('      h)');
+  });
+
+  it('strips fully blank commented line to empty', () => {
+    expect(stripLeadingCommentPrefix(';;      ')).toBe('');
   });
 
   it('keeps non-comment lines unchanged', () => {


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Fix `calculateCommentPrefixRemovalEnd` logic by deleting only a space after `;;` and not every blank char. Every blank char is only removed if line is empty after `;;`

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3078 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
