### PR TITLE
Toggle comment on unformatted partial selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Toggle comments off, indent glitch](https://github.com/BetterThanTomorrow/calva/issues/3078)
+- Fix: [Toggle Line Comment can break structure for unformatted partial multiline selections](https://github.com/BetterThanTomorrow/calva/issues/3083)
 
 ## [2.0.555] - 2026-02-19
 

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -86,6 +86,10 @@ async function applyStructuralCommentsToSingleSelectionLines(
 ) {
   const originalSelections = [...editor.selections];
   const singleSelection = editor.selections[0];
+  const partialSelectionStartColumn =
+    !singleSelection.isEmpty && affectedLineNumbers.length > 1
+      ? singleSelection.start.character
+      : undefined;
   const descendingLineNumbers = [...new Set(affectedLineNumbers)].sort((a, b) => b - a);
   const affectedLineSet = new Set(affectedLineNumbers);
   const originalFirstNonWSMap = new Map<number, number>();
@@ -137,7 +141,11 @@ async function applyStructuralCommentsToSingleSelectionLines(
           affectedLineNumbers.length > 1
             ? resolvedAlignedCommentColumn
             : originalInsertionColumnMap.get(lineNum) ?? firstNonWhitespace;
-        const insertionColumn = Math.min(rawInsertionColumn, currentLine.text.length);
+        const firstLineInsertionColumn =
+          partialSelectionStartColumn !== undefined && lineNum === singleSelection.start.line
+            ? Math.max(rawInsertionColumn, partialSelectionStartColumn)
+            : rawInsertionColumn;
+        const insertionColumn = Math.min(firstLineInsertionColumn, currentLine.text.length);
         originalInsertionColumnMap.set(lineNum, insertionColumn);
         const insertionOffset = editor.document.offsetAt(
           new vscode.Position(lineNum, insertionColumn)

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -281,6 +281,20 @@ suite(suiteName, () => {
     );
   });
 
+  it('should structurally comment unformatted multiline partial selection in a defn body', async () => {
+    assert.equal(
+      await toggleCommentUsingActiveEditor('(defn foo []•(a |(b c•d•e)|•f))'),
+      '(defn foo []•(a |;; (b c•;; d•;; e)|•f))'
+    );
+  });
+
+  it('should structurally comment unformatted nested multiline partial selection without breaking structure', async () => {
+    assert.equal(
+      await toggleCommentUsingActiveEditor('(defn foo []•(a |(b c•(d e•f)•g•h)|•i•j))'),
+      '(defn foo []•(a |;; (b c•;; (d e•;; f)•;; g•;; h)|•i•j))'
+    );
+  });
+
   it('should structurally comment multiline selection nested in parent form and preserve full selected range', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(x•  (y |(a b•        c)|)•  z)'),


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Checkout from #3082 to avoid conflicts
- change `firstLineInsertionColumn` calculation. It is now the max between the first char in selection and each rows selection

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3083

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
