### PR TITLE
Uncomment with not first column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Toggle comments off, indent glitch](https://github.com/BetterThanTomorrow/calva/issues/3078)
+- Fix: [Toggle comments off fails when first line doesn't start with ;;](https://github.com/BetterThanTomorrow/calva/issues/3081)
 - Fix: [Toggle Line Comment can break structure for unformatted partial multiline selections](https://github.com/BetterThanTomorrow/calva/issues/3083)
 
 ## [2.0.555] - 2026-02-19

--- a/src/comment-prefix.ts
+++ b/src/comment-prefix.ts
@@ -1,5 +1,21 @@
 /** Matches one or more leading semicolons (`;`, `;;`, `;;;`, etc.) */
-export const commentPrefixPattern = /^;+/;
+const commentPrefixPattern = /^;+/;
+
+/**
+ * Returns the first position from `candidatePositions` where a comment prefix
+ * (one or more semicolons) starts, or `undefined` if none match.
+ */
+export function findCommentPrefixStart(
+  lineText: string,
+  candidatePositions: number[]
+): number | undefined {
+  for (const pos of candidatePositions) {
+    if (commentPrefixPattern.test(lineText.slice(pos))) {
+      return pos;
+    }
+  }
+  return undefined;
+}
 
 /**
  * Calculates the end index for removing a comment prefix (semicolons + trailing space)
@@ -8,20 +24,20 @@ export const commentPrefixPattern = /^;+/;
  * if the line is otherwise empty after the prefix).
  *
  * @param lineText - The full text of the line
- * @param firstNonWhitespace - The index of the first non-whitespace character in the line
+ * @param removalStart - The index at which the comment prefix starts
  * @returns The end index for removal, or `undefined` if no comment prefix is found
  */
 export function calculateCommentPrefixRemovalEnd(
   lineText: string,
-  firstNonWhitespace: number
+  removalStart: number
 ): number | undefined {
-  const remainder = lineText.slice(firstNonWhitespace);
+  const remainder = lineText.slice(removalStart);
   const match = remainder.match(commentPrefixPattern);
   if (!match) {
     return undefined;
   }
 
-  let removalEnd = firstNonWhitespace + match[0].length;
+  let removalEnd = removalStart + match[0].length;
   if (removalEnd < lineText.length && lineText[removalEnd] === ' ') {
     let spaceRunEnd = removalEnd;
     // If the line is otherwise empty after the comment prefix, remove all trailing spaces as well

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -60,7 +60,8 @@ function getAffectedLineNumbers(editor: vscode.TextEditor, lineCount: number): n
 
 function areAllNonEmptyTargetLinesCommented(
   document: vscode.TextDocument,
-  lineNumbers: number[]
+  lineNumbers: number[],
+  selections?: readonly vscode.Selection[]
 ): boolean {
   const nonEmptyLines = lineNumbers.filter(
     (lineNum) => !document.lineAt(lineNum).isEmptyOrWhitespace
@@ -69,8 +70,23 @@ function areAllNonEmptyTargetLinesCommented(
     nonEmptyLines.length > 0 &&
     nonEmptyLines.every((lineNum) => {
       const line = document.lineAt(lineNum);
-      const lineText = line.text.slice(line.firstNonWhitespaceCharacterIndex);
-      return commentPrefixPattern.test(lineText);
+      const lineText = line.text;
+      const firstNonWhitespace = line.firstNonWhitespaceCharacterIndex;
+      if (commentPrefixPattern.test(lineText.slice(firstNonWhitespace))) {
+        return true;
+      }
+      // For partial selections, the comment prefix may be at the selection
+      // start column rather than the line's first non-whitespace position.
+      if (selections) {
+        for (const sel of selections) {
+          if (sel.start.line === lineNum && sel.start.character > firstNonWhitespace) {
+            if (commentPrefixPattern.test(lineText.slice(sel.start.character))) {
+              return true;
+            }
+          }
+        }
+      }
+      return false;
     })
   );
 }
@@ -401,7 +417,8 @@ async function reformatEnclosingFormsForLines(
 async function updateLineComments(
   editor: vscode.TextEditor,
   affectedLineNumbers: number[],
-  shouldUncomment: boolean
+  shouldUncomment: boolean,
+  selections?: readonly vscode.Selection[]
 ) {
   const descendingLineNumbers = affectedLineNumbers.sort((a, b) => b - a);
 
@@ -413,14 +430,30 @@ async function updateLineComments(
         const lineText = line.text;
 
         if (shouldUncomment) {
-          const removalEnd = calculateCommentPrefixRemovalEnd(lineText, firstNonWhitespace);
+          let removalStart = firstNonWhitespace;
+          let removalEnd = calculateCommentPrefixRemovalEnd(lineText, firstNonWhitespace);
+
+          // Fallback: check at the selection start column for partial selections
+          if (removalEnd === undefined && selections) {
+            for (const sel of selections) {
+              if (sel.start.line === lineNum && sel.start.character > firstNonWhitespace) {
+                const altEnd = calculateCommentPrefixRemovalEnd(lineText, sel.start.character);
+                if (altEnd !== undefined) {
+                  removalStart = sel.start.character;
+                  removalEnd = altEnd;
+                  break;
+                }
+              }
+            }
+          }
+
           if (removalEnd === undefined) {
             continue;
           }
 
           editBuilder.delete(
             new vscode.Range(
-              new vscode.Position(lineNum, firstNonWhitespace),
+              new vscode.Position(lineNum, removalStart),
               new vscode.Position(lineNum, removalEnd)
             )
           );
@@ -444,9 +477,10 @@ async function updateLineComments(
 async function toggleCommentsThenReformatEnclosingForms(
   editor: vscode.TextEditor,
   affectedLineNumbers: number[],
-  shouldUncomment: boolean
+  shouldUncomment: boolean,
+  selections?: readonly vscode.Selection[]
 ) {
-  await updateLineComments(editor, affectedLineNumbers, shouldUncomment);
+  await updateLineComments(editor, affectedLineNumbers, shouldUncomment, selections);
   await reformatEnclosingFormsForLines(editor, affectedLineNumbers);
 }
 
@@ -477,7 +511,8 @@ export async function toggleLineCommentCommand() {
 
   const allNonEmptyLinesCommented = areAllNonEmptyTargetLinesCommented(
     document,
-    affectedLineNumbers
+    affectedLineNumbers,
+    editor.selections
   );
 
   const isSingleSelection = editor.selections.length === 1;
@@ -489,7 +524,8 @@ export async function toggleLineCommentCommand() {
   await toggleCommentsThenReformatEnclosingForms(
     editor,
     affectedLineNumbers,
-    allNonEmptyLinesCommented
+    allNonEmptyLinesCommented,
+    editor.selections
   );
 }
 

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -6,9 +6,7 @@ import * as select from './select';
 import * as printer from './printer';
 import { _semiColonWouldBreakStructureWhere } from './cursor-doc/paredit';
 import * as format from './calva-fmt/src/format';
-import { calculateCommentPrefixRemovalEnd, commentPrefixPattern } from './comment-prefix';
-
-export { commentPrefixPattern } from './comment-prefix';
+import { calculateCommentPrefixRemovalEnd, findCommentPrefixStart } from './comment-prefix';
 
 // Relies on that `when` claus guards this from being called
 // when the cursor is before the comment marker
@@ -58,10 +56,30 @@ function getAffectedLineNumbers(editor: vscode.TextEditor, lineCount: number): n
     .sort((a, b) => a - b);
 }
 
+/**
+ * Builds candidate positions where a comment prefix might start on a line:
+ * first non-whitespace, then any selection start columns past that point.
+ */
+function commentCandidatePositions(
+  firstNonWhitespace: number,
+  lineNum: number,
+  selections?: readonly vscode.Selection[]
+): number[] {
+  const positions = [firstNonWhitespace];
+  if (selections) {
+    for (const sel of selections) {
+      if (sel.start.line === lineNum && sel.start.character > firstNonWhitespace) {
+        positions.push(sel.start.character);
+      }
+    }
+  }
+  return positions;
+}
+
 function areAllNonEmptyTargetLinesCommented(
   document: vscode.TextDocument,
   lineNumbers: number[],
-  selections?: readonly vscode.Selection[]
+  candidatesMap: Map<number, number[]>
 ): boolean {
   const nonEmptyLines = lineNumbers.filter(
     (lineNum) => !document.lineAt(lineNum).isEmptyOrWhitespace
@@ -69,24 +87,8 @@ function areAllNonEmptyTargetLinesCommented(
   return (
     nonEmptyLines.length > 0 &&
     nonEmptyLines.every((lineNum) => {
-      const line = document.lineAt(lineNum);
-      const lineText = line.text;
-      const firstNonWhitespace = line.firstNonWhitespaceCharacterIndex;
-      if (commentPrefixPattern.test(lineText.slice(firstNonWhitespace))) {
-        return true;
-      }
-      // For partial selections, the comment prefix may be at the selection
-      // start column rather than the line's first non-whitespace position.
-      if (selections) {
-        for (const sel of selections) {
-          if (sel.start.line === lineNum && sel.start.character > firstNonWhitespace) {
-            if (commentPrefixPattern.test(lineText.slice(sel.start.character))) {
-              return true;
-            }
-          }
-        }
-      }
-      return false;
+      const candidates = candidatesMap.get(lineNum) ?? [];
+      return findCommentPrefixStart(document.lineAt(lineNum).text, candidates) !== undefined;
     })
   );
 }
@@ -418,7 +420,7 @@ async function updateLineComments(
   editor: vscode.TextEditor,
   affectedLineNumbers: number[],
   shouldUncomment: boolean,
-  selections?: readonly vscode.Selection[]
+  candidatesMap: Map<number, number[]>
 ) {
   const descendingLineNumbers = affectedLineNumbers.sort((a, b) => b - a);
 
@@ -426,27 +428,14 @@ async function updateLineComments(
     (editBuilder) => {
       for (const lineNum of descendingLineNumbers) {
         const line = editor.document.lineAt(lineNum);
-        const firstNonWhitespace = line.firstNonWhitespaceCharacterIndex;
         const lineText = line.text;
 
         if (shouldUncomment) {
-          let removalStart = firstNonWhitespace;
-          let removalEnd = calculateCommentPrefixRemovalEnd(lineText, firstNonWhitespace);
-
-          // Fallback: check at the selection start column for partial selections
-          if (removalEnd === undefined && selections) {
-            for (const sel of selections) {
-              if (sel.start.line === lineNum && sel.start.character > firstNonWhitespace) {
-                const altEnd = calculateCommentPrefixRemovalEnd(lineText, sel.start.character);
-                if (altEnd !== undefined) {
-                  removalStart = sel.start.character;
-                  removalEnd = altEnd;
-                  break;
-                }
-              }
-            }
+          const removalStart = findCommentPrefixStart(lineText, candidatesMap.get(lineNum) ?? []);
+          if (removalStart === undefined) {
+            continue;
           }
-
+          const removalEnd = calculateCommentPrefixRemovalEnd(lineText, removalStart);
           if (removalEnd === undefined) {
             continue;
           }
@@ -458,7 +447,10 @@ async function updateLineComments(
             )
           );
         } else {
-          editBuilder.insert(new vscode.Position(lineNum, firstNonWhitespace), ';; ');
+          editBuilder.insert(
+            new vscode.Position(lineNum, line.firstNonWhitespaceCharacterIndex),
+            ';; '
+          );
         }
       }
     },
@@ -478,9 +470,9 @@ async function toggleCommentsThenReformatEnclosingForms(
   editor: vscode.TextEditor,
   affectedLineNumbers: number[],
   shouldUncomment: boolean,
-  selections?: readonly vscode.Selection[]
+  candidatesMap: Map<number, number[]>
 ) {
-  await updateLineComments(editor, affectedLineNumbers, shouldUncomment, selections);
+  await updateLineComments(editor, affectedLineNumbers, shouldUncomment, candidatesMap);
   await reformatEnclosingFormsForLines(editor, affectedLineNumbers);
 }
 
@@ -509,10 +501,19 @@ export async function toggleLineCommentCommand() {
     return;
   }
 
+  const candidatesMap = new Map<number, number[]>();
+  for (const lineNum of affectedLineNumbers) {
+    const line = document.lineAt(lineNum);
+    candidatesMap.set(
+      lineNum,
+      commentCandidatePositions(line.firstNonWhitespaceCharacterIndex, lineNum, editor.selections)
+    );
+  }
+
   const allNonEmptyLinesCommented = areAllNonEmptyTargetLinesCommented(
     document,
     affectedLineNumbers,
-    editor.selections
+    candidatesMap
   );
 
   const isSingleSelection = editor.selections.length === 1;
@@ -525,7 +526,7 @@ export async function toggleLineCommentCommand() {
     editor,
     affectedLineNumbers,
     allNonEmptyLinesCommented,
-    editor.selections
+    candidatesMap
   );
 }
 

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -160,7 +160,7 @@ async function applyStructuralCommentsToSingleSelectionLines(
         const rawInsertionColumn =
           affectedLineNumbers.length > 1
             ? resolvedAlignedCommentColumn
-            : (originalInsertionColumnMap.get(lineNum) ?? firstNonWhitespace);
+            : originalInsertionColumnMap.get(lineNum) ?? firstNonWhitespace;
         const firstLineInsertionColumn =
           partialSelectionStartColumn !== undefined && lineNum === singleSelection.start.line
             ? Math.max(rawInsertionColumn, partialSelectionStartColumn)

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -8,6 +8,8 @@ import { _semiColonWouldBreakStructureWhere } from './cursor-doc/paredit';
 import * as format from './calva-fmt/src/format';
 import { calculateCommentPrefixRemovalEnd, findCommentPrefixStart } from './comment-prefix';
 
+type CandidatesMap = Map<number, number[]>;
+
 // Relies on that `when` claus guards this from being called
 // when the cursor is before the comment marker
 export function continueCommentCommand() {
@@ -79,7 +81,7 @@ function commentCandidatePositions(
 function areAllNonEmptyTargetLinesCommented(
   document: vscode.TextDocument,
   lineNumbers: number[],
-  candidatesMap: Map<number, number[]>
+  candidatesMap: CandidatesMap
 ): boolean {
   const nonEmptyLines = lineNumbers.filter(
     (lineNum) => !document.lineAt(lineNum).isEmptyOrWhitespace
@@ -158,7 +160,7 @@ async function applyStructuralCommentsToSingleSelectionLines(
         const rawInsertionColumn =
           affectedLineNumbers.length > 1
             ? resolvedAlignedCommentColumn
-            : originalInsertionColumnMap.get(lineNum) ?? firstNonWhitespace;
+            : (originalInsertionColumnMap.get(lineNum) ?? firstNonWhitespace);
         const firstLineInsertionColumn =
           partialSelectionStartColumn !== undefined && lineNum === singleSelection.start.line
             ? Math.max(rawInsertionColumn, partialSelectionStartColumn)
@@ -420,7 +422,7 @@ async function updateLineComments(
   editor: vscode.TextEditor,
   affectedLineNumbers: number[],
   shouldUncomment: boolean,
-  candidatesMap: Map<number, number[]>
+  candidatesMap: CandidatesMap
 ) {
   const descendingLineNumbers = affectedLineNumbers.sort((a, b) => b - a);
 
@@ -470,7 +472,7 @@ async function toggleCommentsThenReformatEnclosingForms(
   editor: vscode.TextEditor,
   affectedLineNumbers: number[],
   shouldUncomment: boolean,
-  candidatesMap: Map<number, number[]>
+  candidatesMap: CandidatesMap
 ) {
   await updateLineComments(editor, affectedLineNumbers, shouldUncomment, candidatesMap);
   await reformatEnclosingFormsForLines(editor, affectedLineNumbers);

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -157,24 +157,6 @@ suite(suiteName, () => {
     );
   });
 
-  it('should preserve nested indentation when uncommenting selected multiline block (issue #3078)', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor(
-        '|;; (a (b c•;;       (d e•;;          f)•;;       g•;;       h)•;;    i•;;    j)|'
-      ),
-      '|(a (b c•      (d e•         f)•      g•      h)•   i•   j)|'
-    );
-  });
-
-  it('should preserve nested indentation when uncommenting selected multiline block inside defn (issue #3078)', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor(
-        '(defn foo []•  |;; (a (b c•  ;;       (d e•  ;;          f)•  ;;       g•  ;;       h)•  ;;    i•  ;;    j)|•     )'
-      ),
-      '(defn foo []•  |(a (b c•        (d e•           f)•        g•        h)•     i•     j)|)'
-    );
-  });
-
   it('should comment an empty line inside assoc with alignment indent (issue #2872)', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(assoc m•       :key :val•|)'),
@@ -314,5 +296,17 @@ suite(suiteName, () => {
       await toggleCommentUsingActiveEditor('(x• (j (y |(a b c)|))• z)'),
       '(x• (j (y |;; (a b c)|•     ))• z)'
     );
+  });
+
+  it('should uncomment a partial-selection comment round-trip (issue #3081)', async () => {
+    const editor = vscode.window.activeTextEditor;
+    const original = '(a |(b c•      d)|•   e)';
+    // First toggle: comment the partial selection
+    await performToggle(editor, original);
+    // Second toggle: uncomment should restore original text
+    await vscode.commands.executeCommand('calva.toggleLineComment');
+    await new Promise((resolve) => setTimeout(resolve, pauseMs));
+    const result = textNotationFromDocAndSelections(editor.document, editor.selections);
+    assert.equal(result, '(a |(b c•      d)|•   e)');
   });
 });

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -157,6 +157,24 @@ suite(suiteName, () => {
     );
   });
 
+  it('should preserve nested indentation when uncommenting selected multiline block (issue #3078)', async () => {
+    assert.equal(
+      await toggleCommentUsingActiveEditor(
+        '|;; (a (b c•;;       (d e•;;          f)•;;       g•;;       h)•;;    i•;;    j)|'
+      ),
+      '|(a (b c•      (d e•         f)•      g•      h)•   i•   j)|'
+    );
+  });
+
+  it('should preserve nested indentation when uncommenting selected multiline block inside defn (issue #3078)', async () => {
+    assert.equal(
+      await toggleCommentUsingActiveEditor(
+        '(defn foo []•  |;; (a (b c•  ;;       (d e•  ;;          f)•  ;;       g•  ;;       h)•  ;;    i•  ;;    j)|•     )'
+      ),
+      '(defn foo []•  |(a (b c•        (d e•           f)•        g•        h)•     i•     j)|)'
+    );
+  });
+
   it('should comment an empty line inside assoc with alignment indent (issue #2872)', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(assoc m•       :key :val•|)'),

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -298,15 +298,27 @@ suite(suiteName, () => {
     );
   });
 
-  it('should uncomment a partial-selection comment round-trip (issue #3081)', async () => {
+  it('should uncomment partial-selection comments round-trip (issue #3081)', async () => {
     const editor = vscode.window.activeTextEditor;
-    const original = '(a |(b c•      d)|•   e)';
-    // First toggle: comment the partial selection
-    await performToggle(editor, original);
-    // Second toggle: uncomment should restore original text
+
+    // Simple partial selection
+    const simple = '(a |(b c•      d)|•   e)';
+    await performToggle(editor, simple);
+    const simpleCommented = textNotationFromDocAndSelections(editor.document, editor.selections);
+    assert.equal(simpleCommented, '(a |;; (b c•   ;;    d)|•   e)');
     await vscode.commands.executeCommand('calva.toggleLineComment');
     await new Promise((resolve) => setTimeout(resolve, pauseMs));
-    const result = textNotationFromDocAndSelections(editor.document, editor.selections);
-    assert.equal(result, '(a |(b c•      d)|•   e)');
+    const simpleUncommented = textNotationFromDocAndSelections(editor.document, editor.selections);
+    assert.equal(simpleUncommented, simple);
+
+    // Nested partial selection
+    const nested = '(a |(b c•      (d e•         f)•      g)|•   e)';
+    await performToggle(editor, nested);
+    const nestedCommented = textNotationFromDocAndSelections(editor.document, editor.selections);
+    assert.equal(nestedCommented, '(a |;; (b c•   ;;    (d e•   ;;       f)•   ;;    g)|•   e)');
+    await vscode.commands.executeCommand('calva.toggleLineComment');
+    await new Promise((resolve) => setTimeout(resolve, pauseMs));
+    const nestedUncommented = textNotationFromDocAndSelections(editor.document, editor.selections);
+    assert.equal(nestedUncommented, nested);
   });
 });


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Create commentCandidatePositions wich finds not white space indexes in a line
- `findCommentPrefixStart` finds first comment in those not white space indexes
- This is used to decide if we sould comment or uncomment (in `areAllNonEmptyTargetLinesCommented`) and to know what column we have to start the uncomment from (in `updateLineComments`)
- in `calculateCommentPrefixRemovalEnd` rename `firstNonWhitespace` to `removalStart` wich is more precise because it may not be the first non whitespace
- this is a checkout of #3084 

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3081

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
