### PR TITLE
Make status bar items individually hide-able

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Allow users to hide individual status bar items](https://github.com/BetterThanTomorrow/calva/issues/3094)
+
 ## [2.0.555] - 2026-02-19
 
 - Fix: [Connecting a REPL sequence disconnects the previous prematurely](https://github.com/BetterThanTomorrow/calva/issues/3065)

--- a/src/lsp/provider.ts
+++ b/src/lsp/provider.ts
@@ -69,7 +69,7 @@ export const createClientProvider = (params: CreateClientProviderParams) => {
 
   const status_bar_item = vscode.window.createStatusBarItem('clojureLSP.manage', vscode.StatusBarAlignment.Left, 0);
   status_bar_item.command = 'calva.clojureLsp.manage';
-  status_bar_item.name = 'Calva: clojure-lsp'
+  status_bar_item.name = 'Calva: clojure-lsp Menu'
 
   const updateStatusBar = () => {
     const any_starting = Array.from(clients.values()).find(

--- a/src/lsp/provider.ts
+++ b/src/lsp/provider.ts
@@ -69,7 +69,7 @@ export const createClientProvider = (params: CreateClientProviderParams) => {
 
   const status_bar_item = vscode.window.createStatusBarItem('clojureLSP.manage', vscode.StatusBarAlignment.Left, 0);
   status_bar_item.command = 'calva.clojureLsp.manage';
-  status_bar_item.name = 'Calva: Manage Clojure LSP'
+  status_bar_item.name = 'Calva: clojure-lsp'
 
   const updateStatusBar = () => {
     const any_starting = Array.from(clients.values()).find(

--- a/src/lsp/provider.ts
+++ b/src/lsp/provider.ts
@@ -67,8 +67,9 @@ type CreateClientProviderParams = {
 export const createClientProvider = (params: CreateClientProviderParams) => {
   const clients: defs.LspClientStore = new Map();
 
-  const status_bar_item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+  const status_bar_item = vscode.window.createStatusBarItem('clojureLSP.manage', vscode.StatusBarAlignment.Left, 0);
   status_bar_item.command = 'calva.clojureLsp.manage';
+  status_bar_item.name = 'Calva: Manage Clojure LSP'
 
   const updateStatusBar = () => {
     const any_starting = Array.from(clients.values()).find(

--- a/src/lsp/provider.ts
+++ b/src/lsp/provider.ts
@@ -67,9 +67,13 @@ type CreateClientProviderParams = {
 export const createClientProvider = (params: CreateClientProviderParams) => {
   const clients: defs.LspClientStore = new Map();
 
-  const status_bar_item = vscode.window.createStatusBarItem('clojureLSP.manage', vscode.StatusBarAlignment.Left, 0);
+  const status_bar_item = vscode.window.createStatusBarItem(
+    'clojureLSP.manage',
+    vscode.StatusBarAlignment.Left,
+    0
+  );
   status_bar_item.command = 'calva.clojureLsp.manage';
-  status_bar_item.name = 'Calva: clojure-lsp Menu'
+  status_bar_item.name = 'Calva: clojure-lsp Menu';
 
   const updateStatusBar = () => {
     const any_starting = Array.from(clients.values()).find(

--- a/src/paredit/statusbar.ts
+++ b/src/paredit/statusbar.ts
@@ -10,10 +10,11 @@ export class StatusBar {
   private _toggleBarItem: StatusBarItem;
 
   constructor(keymap: string) {
-    this._toggleBarItem = window.createStatusBarItem(StatusBarAlignment.Right);
+    this._toggleBarItem = window.createStatusBarItem('paredit', StatusBarAlignment.Right, null);
     this._toggleBarItem.text = '(λ)';
     this._toggleBarItem.tooltip = '';
     this._toggleBarItem.command = 'paredit.togglemode';
+    this._toggleBarItem.name = 'Calva: Toggle paredit'
     this._visible = false;
     this.keyMap = keymap;
 

--- a/src/paredit/statusbar.ts
+++ b/src/paredit/statusbar.ts
@@ -14,7 +14,7 @@ export class StatusBar {
     this._toggleBarItem.text = '(λ)';
     this._toggleBarItem.tooltip = '';
     this._toggleBarItem.command = 'paredit.togglemode';
-    this._toggleBarItem.name = 'Calva: Toggle paredit'
+    this._toggleBarItem.name = 'Calva: Paredit Strict Mode'
     this._visible = false;
     this.keyMap = keymap;
 

--- a/src/paredit/statusbar.ts
+++ b/src/paredit/statusbar.ts
@@ -14,7 +14,7 @@ export class StatusBar {
     this._toggleBarItem.text = '(λ)';
     this._toggleBarItem.tooltip = '';
     this._toggleBarItem.command = 'paredit.togglemode';
-    this._toggleBarItem.name = 'Calva: Paredit Strict Mode'
+    this._toggleBarItem.name = 'Calva: Paredit Strict Mode';
     this._visible = false;
     this.keyMap = keymap;
 

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -9,11 +9,41 @@ import * as sessionRouting from './nrepl/session-routing';
 import * as sessionRegistry from './nrepl/session-registry';
 import * as clientRegistry from './nrepl/client-registry';
 
-const connectionStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1);
-const typeStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1);
-const cljsBuildStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1);
-const shadowRuntimeStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1);
-const prettyPrintToggle = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 1);
+const connectionStatus = vscode.window.createStatusBarItem(
+  'connectionStatus',
+  vscode.StatusBarAlignment.Left,
+  1
+);
+connectionStatus.name = 'Calva: REPL connection status';
+
+const typeStatus = vscode.window.createStatusBarItem(
+  'typeStatus',
+  vscode.StatusBarAlignment.Left,
+  1
+);
+typeStatus.name = 'Calva: REPL session type';
+
+const cljsBuildStatus = vscode.window.createStatusBarItem(
+  'cljsBuildStatus',
+  vscode.StatusBarAlignment.Left,
+  1
+);
+cljsBuildStatus.name = 'Calva: Clojurescript build status';
+
+const shadowRuntimeStatus = vscode.window.createStatusBarItem(
+  'shadowRuntimeStatus',
+  vscode.StatusBarAlignment.Left,
+  1
+);
+shadowRuntimeStatus.name = 'Calva: Shadow CLJS runtime status';
+
+const prettyPrintToggle = vscode.window.createStatusBarItem(
+  'prettyPrintToggle',
+  vscode.StatusBarAlignment.Right,
+  1
+);
+prettyPrintToggle.name = 'Calva: Pretty print toggle';
+
 const color = {
   active: 'white',
   inactive: '#b3b3b3',

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -14,35 +14,35 @@ const connectionStatus = vscode.window.createStatusBarItem(
   vscode.StatusBarAlignment.Left,
   1
 );
-connectionStatus.name = 'Calva: REPL connection status';
+connectionStatus.name = 'Calva: REPL Menu';
 
 const typeStatus = vscode.window.createStatusBarItem(
   'typeStatus',
   vscode.StatusBarAlignment.Left,
   1
 );
-typeStatus.name = 'Calva: REPL session type';
+typeStatus.name = 'Calva: REPL Sessions Menu';
 
 const cljsBuildStatus = vscode.window.createStatusBarItem(
   'cljsBuildStatus',
   vscode.StatusBarAlignment.Left,
   1
 );
-cljsBuildStatus.name = 'Calva: Clojurescript build status';
+cljsBuildStatus.name = 'Calva: Clojurescript Builds Menu';
 
 const shadowRuntimeStatus = vscode.window.createStatusBarItem(
   'shadowRuntimeStatus',
   vscode.StatusBarAlignment.Left,
   1
 );
-shadowRuntimeStatus.name = 'Calva: Shadow CLJS runtime status';
+shadowRuntimeStatus.name = 'Calva: Shadow CLJS Runtimes Menu';
 
 const prettyPrintToggle = vscode.window.createStatusBarItem(
   'prettyPrintToggle',
   vscode.StatusBarAlignment.Right,
   1
 );
-prettyPrintToggle.name = 'Calva: Pretty print toggle';
+prettyPrintToggle.name = 'Calva: Pretty Print Toggle';
 
 const color = {
   active: 'white',


### PR DESCRIPTION
Fixes https://github.com/BetterThanTomorrow/calva/issues/3094

<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

The 3-arity overload of createStatusBarItems was added to VSCode more recently, and allows you to provide an ID. If you use it, then the status bar items are individually hide-able by right-clicking on the status bar.

Switch to using that arity everywhere in Calva, and assign names to the status bar items so you can tell which is which in the status bar right-click menu.

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
