### PR TITLE
Configurable Toggle Comment Behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Add: [Structural comment toggle using #_ as default](https://github.com/BetterThanTomorrow/calva/issues/3086). Controlled by the `calva.paredit.toggleCommentBehavior` setting (`ignoreCurrentForm`, `ignoreParentForm`, or `commentCurrentLine`)
+
 ## [2.0.555] - 2026-02-19
 
 - Fix: [Connecting a REPL sequence disconnects the previous prematurely](https://github.com/BetterThanTomorrow/calva/issues/3065)

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -153,7 +153,7 @@ Default keybinding                | Action | Description
  `ctrl+alt+shift+e`                        | **Wrap Around #{}** | Wraps the current form, or selection, with set. <br>
  `ctrl+alt+shift+q`                        | **Wrap Around ""** | Wraps the current form, or selection, with double quotes. Inside strings it will quote the quotes. <br> ![](images/paredit/wrap-around-quotes.gif)
  `ctrl+alt+r`<br>`ctrl+alt+p`/`s`/`c`/`q`/`h`                        | **Rewrap** | Changes enclosing brackets of the current form to parens/square brackets/curlies/double quotes and set (`#{}`) <br> ![](images/paredit/rewrap.gif)
-`ctrl+/` (win/linux)<br>`cmd+/` (mac)                        | **Toggle Line Comment** | Comments or uncomments current line(s) with Clojure-aware behavior. For a single selection (cursor or range), commenting uses structural analysis to place semicolons safely and then reformats enclosing forms. For other cases (including multi-cursor and uncomment), it updates line comments directly and then reformats enclosing forms.
+`ctrl+/` (win/linux)<br>`cmd+/` (mac)                        | **Toggle Line Comment** | When there is no selection and the cursor is not in a line comment, toggles `#_` (ignore/discard) on the current form by default. This behavior is controlled by the `calva.paredit.toggleCommentBehavior` setting (see [Toggle Comment Behavior](#toggle-comment-behavior) below). When text is selected or the cursor is in a `;;` comment, uses `;;` line commenting: structural analysis places semicolons safely and reformats enclosing forms.
 
 !!! Note "Copy to Clipboard when killing text"
     You can have the *kill* commands always copy the deleted code to the clipboard by setting `calva.paredit.killAlsoCutsToClipboard` to `true`.  If you want to do this more on-demand, you can kill text by using the [selection commands](#selecting) and then *Cut* once you have the selection.
@@ -170,6 +170,24 @@ When dragging forms inside maps and binding boxes, such as with `let`, `for`, `b
 And like so (wait for it):
 
 ![](images/paredit/drag-pairs-in-maps.gif)
+
+## Toggle Comment Behavior
+
+The **Toggle Line Comment** command (`ctrl+/` / `cmd+/`) behavior when there is no text selected and the cursor is not in a line comment is controlled by the `calva.paredit.toggleCommentBehavior` setting:
+
+| Value | Description |
+|---|---|
+| `ignoreCurrentForm` (default) | Toggle `#_` (ignore/discard) on the current form at the cursor |
+| `ignoreParentForm` | Toggle `#_` (ignore/discard) on the enclosing/parent form |
+| `commentCurrentLine` | Toggle `;;` line comment on the current line (classic behavior) |
+
+Using `#_` preserves the structural integrity of your code — the form remains readable by the editor and can be toggled back without any reformatting side effects. The `;;` line comment behavior is still used when text is selected, when the cursor is in an existing `;;` comment, or when using multiple cursors.
+
+```json
+{
+  "calva.paredit.toggleCommentBehavior": "ignoreCurrentForm"
+}
+```
 
 ## Customizing Paredit Behavior
 

--- a/docs/site/paredit.md
+++ b/docs/site/paredit.md
@@ -181,7 +181,7 @@ The **Toggle Line Comment** command (`ctrl+/` / `cmd+/`) behavior when there is 
 | `ignoreParentForm` | Toggle `#_` (ignore/discard) on the enclosing/parent form |
 | `commentCurrentLine` | Toggle `;;` line comment on the current line (classic behavior) |
 
-Using `#_` preserves the structural integrity of your code — the form remains readable by the editor and can be toggled back without any reformatting side effects. The `;;` line comment behavior is still used when text is selected, when the cursor is in an existing `;;` comment, or when using multiple cursors.
+Using `#_` preserves the structural integrity of your code: the form remains readable by the editor and can be toggled back without any reformatting side effects. The `;;` line comment behavior is used when text is selected, when the cursor is in an existing `;;` comment, or when using multiple cursors.
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -1284,6 +1284,18 @@
               "type": "string"
             },
             "scope": "window"
+          },
+          "calva.paredit.toggleCommentBehavior": {
+            "type": "string",
+            "markdownDescription": "Controls the behavior of Toggle Line Comment when there is no text selected and the cursor is not in a line comment.",
+            "default": "ignoreCurrentForm",
+            "enum": ["ignoreCurrentForm", "ignoreParentForm", "commentCurrentLine"],
+            "enumDescriptions": [
+              "Toggle #_ (ignore/discard) on the current form at cursor",
+              "Toggle #_ (ignore/discard) on the parent/enclosing form",
+              "Toggle ;; line comment on the current line (classic behavior)"
+            ],
+            "scope": "window"
           }
         }
       },

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -49,8 +49,10 @@ export function continueCommentCommand() {
 function getAffectedLineNumbers(editor: vscode.TextEditor, lineCount: number): number[] {
   const affectedLines = new Set<number>();
   for (const selection of editor.selections) {
-    for (let line = selection.start.line; line <= selection.end.line; line++) {
-      affectedLines.add(line);
+    if (selection && selection.start && selection.end) {
+      for (let line = selection.start.line; line <= selection.end.line; line++) {
+        affectedLines.add(line);
+      }
     }
   }
   return Array.from(affectedLines)
@@ -70,7 +72,7 @@ function commentCandidatePositions(
   const positions = [firstNonWhitespace];
   if (selections) {
     for (const sel of selections) {
-      if (sel.start.line === lineNum && sel.start.character > firstNonWhitespace) {
+      if (sel && sel.start && sel.start.line === lineNum && sel.start.character > firstNonWhitespace) {
         positions.push(sel.start.character);
       }
     }
@@ -489,40 +491,62 @@ async function toggleIgnoreForm(
   document: vscode.TextDocument,
   useParentForm: boolean
 ) {
-  const position = editor.selections[0].active;
+  const selection = editor.selections[0];
+  if (!selection) {
+    return;
+  }
 
+  const position = selection.active;
+  const cursorOffset = document.offsetAt(position);
+
+  // Check if there's a #_ immediately before the cursor position
+  const textBeforeCursor = cursorOffset >= 2
+    ? document.getText(new vscode.Range(document.positionAt(cursorOffset - 2), document.positionAt(cursorOffset)))
+    : '';
+  const hasIgnoreBeforeCursor = textBeforeCursor === '#_';
+
+  if (hasIgnoreBeforeCursor) {
+    // Cursor is between #_ and the form - remove the #_
+    await editor.edit(
+      (editBuilder) => {
+        editBuilder.delete(
+          new vscode.Range(document.positionAt(cursorOffset - 2), document.positionAt(cursorOffset))
+        );
+      },
+      { undoStopBefore: true, undoStopAfter: true }
+    );
+    return;
+  }
+
+  //Try getFormSelection first
   const formRange = useParentForm
     ? select.getEnclosingFormSelection(document, position)
     : select.getFormSelection(document, position, false);
 
   if (!formRange) {
+    // If getFormSelection returns undefined, fall back to regular commenting
     return;
   }
 
   const formStartOffset = document.offsetAt(formRange.start);
-  const mirrorDoc = docMirror.getDocument(document);
-  const cursor = mirrorDoc.getTokenCursor(formStartOffset);
 
-  // Check if there's a #_ token immediately before the form
-  const probe = cursor.clone();
-  probe.backwardWhitespace();
-  const prevToken = probe.getPrevToken();
+  // Check if there's a #_ already before the form
+  const textBeforeForm = formStartOffset >= 2
+    ? document.getText(new vscode.Range(document.positionAt(formStartOffset - 2), document.positionAt(formStartOffset)))
+    : '';
 
-  if (prevToken.type === 'ignore') {
-    // Remove the #_ token
-    probe.previous();
-    const ignoreStart = probe.offsetStart;
-    const ignoreEnd = ignoreStart + prevToken.raw.length;
+  if (textBeforeForm === '#_') {
+    // Remove the existing #_
     await editor.edit(
       (editBuilder) => {
         editBuilder.delete(
-          new vscode.Range(document.positionAt(ignoreStart), document.positionAt(ignoreEnd))
+          new vscode.Range(document.positionAt(formStartOffset - 2), document.positionAt(formStartOffset))
         );
       },
       { undoStopBefore: true, undoStopAfter: true }
     );
   } else {
-    // Insert #_ before the form
+    // Add #_ before the form
     await editor.edit(
       (editBuilder) => {
         editBuilder.insert(document.positionAt(formStartOffset), '#_');
@@ -570,21 +594,23 @@ export async function toggleLineCommentCommand() {
   // When there's a single empty selection (just a cursor) not in a comment,
   // check the toggleCommentBehavior setting for #_ toggle
   const isSingleSelection = editor.selections.length === 1;
-  const selection = editor.selections[0];
-  if (
-    isSingleSelection &&
-    selection.isEmpty &&
-    !isCursorInLineComment(document, selection.active)
-  ) {
-    const behavior = vscode.workspace
-      .getConfiguration('calva.paredit')
-      .get<string>('toggleCommentBehavior', 'ignoreCurrentForm');
-    const isIgnoreParentForm = behavior === 'ignoreParentForm';
-    if (behavior === 'ignoreCurrentForm' || isIgnoreParentForm) {
-      await toggleIgnoreForm(editor, document, isIgnoreParentForm);
-      return;
+  if (isSingleSelection) {
+    const selection = editor.selections[0];
+    if (
+      selection &&
+      selection.isEmpty &&
+      !isCursorInLineComment(document, selection.active)
+    ) {
+      const behavior = vscode.workspace
+        .getConfiguration('calva.paredit')
+        .get<string>('toggleCommentBehavior', 'ignoreCurrentForm');
+      const isIgnoreParentForm = behavior === 'ignoreParentForm';
+      if (behavior === 'ignoreCurrentForm' || isIgnoreParentForm) {
+        await toggleIgnoreForm(editor, document, isIgnoreParentForm);
+        return;
+      }
+      // 'commentCurrentLine' falls through to existing ;; behavior
     }
-    // 'commentCurrentLine' falls through to existing ;; behavior
   }
 
   const affectedLineNumbers = getAffectedLineNumbers(editor, document.lineCount);

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -486,6 +486,51 @@ async function toggleCommentsThenReformatEnclosingForms(
 }
 
 /**
+ * Finds a preceding `#_` ignore marker before the given offset, allowing
+ * optional whitespace between the marker and the offset position.
+ *
+ * @param document The document being edited.
+ * @param offset The offset whose left side should be inspected.
+ * @returns The exact range of the `#_` marker when found, otherwise `undefined`.
+ */
+function findIgnoreMarkerBeforeOffset(
+  document: vscode.TextDocument,
+  offset: number
+): vscode.Range | undefined {
+  if (offset < 2) {
+    return undefined;
+  }
+
+  let scanOffset = offset - 1;
+  while (scanOffset >= 0) {
+    const ch = document.getText(
+      new vscode.Range(document.positionAt(scanOffset), document.positionAt(scanOffset + 1))
+    );
+    if (/\s/.test(ch)) {
+      scanOffset -= 1;
+    } else {
+      break;
+    }
+  }
+
+  if (scanOffset < 1) {
+    return undefined;
+  }
+
+  const maybeIgnore = document.getText(
+    new vscode.Range(document.positionAt(scanOffset - 1), document.positionAt(scanOffset + 1))
+  );
+  if (maybeIgnore === '#_') {
+    return new vscode.Range(
+      document.positionAt(scanOffset - 1),
+      document.positionAt(scanOffset + 1)
+    );
+  }
+
+  return undefined;
+}
+
+/**
  * Toggles `#_` (ignore/discard) on the form at the cursor position.
  * If the form already has a preceding `#_`, it is removed; otherwise `#_` is inserted.
  *
@@ -504,22 +549,13 @@ async function toggleIgnoreForm(
   const position = selection.active;
   const cursorOffset = document.offsetAt(position);
 
-  // Check if there's a #_ immediately before the cursor position
-  const textBeforeCursor =
-    cursorOffset >= 2
-      ? document.getText(
-          new vscode.Range(document.positionAt(cursorOffset - 2), document.positionAt(cursorOffset))
-        )
-      : '';
-  const hasIgnoreBeforeCursor = textBeforeCursor === '#_';
+  const ignoreBeforeCursor = findIgnoreMarkerBeforeOffset(document, cursorOffset);
 
-  if (hasIgnoreBeforeCursor) {
-    // Cursor is between #_ and the form - remove the #_
+  if (ignoreBeforeCursor) {
+    // Cursor is between #_ and the form (optionally separated by whitespace) - remove the #_
     await editor.edit(
       (editBuilder) => {
-        editBuilder.delete(
-          new vscode.Range(document.positionAt(cursorOffset - 2), document.positionAt(cursorOffset))
-        );
+        editBuilder.delete(ignoreBeforeCursor);
       },
       { undoStopBefore: true, undoStopAfter: true }
     );
@@ -538,27 +574,13 @@ async function toggleIgnoreForm(
 
   const formStartOffset = document.offsetAt(formRange.start);
 
-  // Check if there's a #_ already before the form
-  const textBeforeForm =
-    formStartOffset >= 2
-      ? document.getText(
-          new vscode.Range(
-            document.positionAt(formStartOffset - 2),
-            document.positionAt(formStartOffset)
-          )
-        )
-      : '';
+  const ignoreBeforeForm = findIgnoreMarkerBeforeOffset(document, formStartOffset);
 
-  if (textBeforeForm === '#_') {
+  if (ignoreBeforeForm) {
     // Remove the existing #_
     await editor.edit(
       (editBuilder) => {
-        editBuilder.delete(
-          new vscode.Range(
-            document.positionAt(formStartOffset - 2),
-            document.positionAt(formStartOffset)
-          )
-        );
+        editBuilder.delete(ignoreBeforeForm);
       },
       { undoStopBefore: true, undoStopAfter: true }
     );

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -443,8 +443,77 @@ async function toggleCommentsThenReformatEnclosingForms(
 }
 
 /**
+ * Toggles `#_` (ignore/discard) on the form at the cursor position.
+ * If the form already has a preceding `#_`, it is removed; otherwise `#_` is inserted.
+ *
+ * @param useParentForm When true, targets the enclosing/parent form instead of the current form.
+ */
+async function toggleIgnoreForm(
+  editor: vscode.TextEditor,
+  document: vscode.TextDocument,
+  useParentForm: boolean
+) {
+  const position = editor.selections[0].active;
+
+  const formRange = useParentForm
+    ? select.getEnclosingFormSelection(document, position)
+    : select.getFormSelection(document, position, false);
+
+  if (!formRange) {
+    return;
+  }
+
+  const formStartOffset = document.offsetAt(formRange.start);
+  const mirrorDoc = docMirror.getDocument(document);
+  const cursor = mirrorDoc.getTokenCursor(formStartOffset);
+
+  // Check if there's a #_ token immediately before the form
+  const probe = cursor.clone();
+  probe.backwardWhitespace();
+  const prevToken = probe.getPrevToken();
+
+  if (prevToken.type === 'ignore') {
+    // Remove the #_ token
+    probe.previous();
+    const ignoreStart = probe.offsetStart;
+    const ignoreEnd = ignoreStart + prevToken.raw.length;
+    await editor.edit(
+      (editBuilder) => {
+        editBuilder.delete(
+          new vscode.Range(document.positionAt(ignoreStart), document.positionAt(ignoreEnd))
+        );
+      },
+      { undoStopBefore: true, undoStopAfter: true }
+    );
+  } else {
+    // Insert #_ before the form
+    await editor.edit(
+      (editBuilder) => {
+        editBuilder.insert(document.positionAt(formStartOffset), '#_');
+      },
+      { undoStopBefore: true, undoStopAfter: true }
+    );
+  }
+}
+
+/**
+ * Returns true if the cursor is currently positioned within a ;; line comment.
+ */
+function isCursorInLineComment(document: vscode.TextDocument, position: vscode.Position): boolean {
+  const mirrorDoc = docMirror.getDocument(document);
+  const offset = document.offsetAt(position);
+  const cursor = mirrorDoc.getTokenCursor(offset);
+  return cursor.getToken().type === 'comment' || cursor.getPrevToken().type === 'comment';
+}
+
+/**
  * Toggle line comments with Clojure-aware indentation.
  *
+ * - When the cursor has no selection and is not in a line comment, the behavior
+ *   is controlled by the `calva.paredit.toggleCommentBehavior` setting:
+ *   - `ignoreCurrentForm` (default): Toggle `#_` on the current form
+ *   - `ignoreParentForm`: Toggle `#_` on the enclosing/parent form
+ *   - `commentCurrentLine`: Use `;;` line comment (classic behavior)
  * - For a single selection (cursor or range), comments are inserted structurally
  *   using paredit structural analysis to preserve delimiter balance, then
  *   enclosing forms are reformatted.
@@ -462,6 +531,28 @@ export async function toggleLineCommentCommand() {
     return;
   }
 
+  // When there's a single empty selection (just a cursor) not in a comment,
+  // check the toggleCommentBehavior setting for #_ toggle
+  const isSingleSelection = editor.selections.length === 1;
+  const selection = editor.selections[0];
+  if (
+    isSingleSelection &&
+    selection.isEmpty &&
+    !isCursorInLineComment(document, selection.active)
+  ) {
+    const behavior = vscode.workspace
+      .getConfiguration('calva.paredit')
+      .get<string>('toggleCommentBehavior', 'ignoreCurrentForm');
+    if (behavior === 'ignoreCurrentForm') {
+      await toggleIgnoreForm(editor, document, false);
+      return;
+    } else if (behavior === 'ignoreParentForm') {
+      await toggleIgnoreForm(editor, document, true);
+      return;
+    }
+    // 'commentCurrentLine' falls through to existing ;; behavior
+  }
+
   const affectedLineNumbers = getAffectedLineNumbers(editor, document.lineCount);
   if (affectedLineNumbers.length === 0) {
     return;
@@ -472,7 +563,6 @@ export async function toggleLineCommentCommand() {
     affectedLineNumbers
   );
 
-  const isSingleSelection = editor.selections.length === 1;
   if (!allNonEmptyLinesCommented && isSingleSelection) {
     await applyStructuralCommentsToSingleSelectionLines(editor, affectedLineNumbers);
     return;

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -72,7 +72,12 @@ function commentCandidatePositions(
   const positions = [firstNonWhitespace];
   if (selections) {
     for (const sel of selections) {
-      if (sel && sel.start && sel.start.line === lineNum && sel.start.character > firstNonWhitespace) {
+      if (
+        sel &&
+        sel.start &&
+        sel.start.line === lineNum &&
+        sel.start.character > firstNonWhitespace
+      ) {
         positions.push(sel.start.character);
       }
     }
@@ -500,9 +505,12 @@ async function toggleIgnoreForm(
   const cursorOffset = document.offsetAt(position);
 
   // Check if there's a #_ immediately before the cursor position
-  const textBeforeCursor = cursorOffset >= 2
-    ? document.getText(new vscode.Range(document.positionAt(cursorOffset - 2), document.positionAt(cursorOffset)))
-    : '';
+  const textBeforeCursor =
+    cursorOffset >= 2
+      ? document.getText(
+          new vscode.Range(document.positionAt(cursorOffset - 2), document.positionAt(cursorOffset))
+        )
+      : '';
   const hasIgnoreBeforeCursor = textBeforeCursor === '#_';
 
   if (hasIgnoreBeforeCursor) {
@@ -531,16 +539,25 @@ async function toggleIgnoreForm(
   const formStartOffset = document.offsetAt(formRange.start);
 
   // Check if there's a #_ already before the form
-  const textBeforeForm = formStartOffset >= 2
-    ? document.getText(new vscode.Range(document.positionAt(formStartOffset - 2), document.positionAt(formStartOffset)))
-    : '';
+  const textBeforeForm =
+    formStartOffset >= 2
+      ? document.getText(
+          new vscode.Range(
+            document.positionAt(formStartOffset - 2),
+            document.positionAt(formStartOffset)
+          )
+        )
+      : '';
 
   if (textBeforeForm === '#_') {
     // Remove the existing #_
     await editor.edit(
       (editBuilder) => {
         editBuilder.delete(
-          new vscode.Range(document.positionAt(formStartOffset - 2), document.positionAt(formStartOffset))
+          new vscode.Range(
+            document.positionAt(formStartOffset - 2),
+            document.positionAt(formStartOffset)
+          )
         );
       },
       { undoStopBefore: true, undoStopAfter: true }
@@ -596,11 +613,7 @@ export async function toggleLineCommentCommand() {
   const isSingleSelection = editor.selections.length === 1;
   if (isSingleSelection) {
     const selection = editor.selections[0];
-    if (
-      selection &&
-      selection.isEmpty &&
-      !isCursorInLineComment(document, selection.active)
-    ) {
+    if (selection && selection.isEmpty && !isCursorInLineComment(document, selection.active)) {
       const behavior = vscode.workspace
         .getConfiguration('calva.paredit')
         .get<string>('toggleCommentBehavior', 'ignoreCurrentForm');

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -579,11 +579,9 @@ export async function toggleLineCommentCommand() {
     const behavior = vscode.workspace
       .getConfiguration('calva.paredit')
       .get<string>('toggleCommentBehavior', 'ignoreCurrentForm');
-    if (behavior === 'ignoreCurrentForm') {
-      await toggleIgnoreForm(editor, document, false);
-      return;
-    } else if (behavior === 'ignoreParentForm') {
-      await toggleIgnoreForm(editor, document, true);
+    const isIgnoreParentForm = behavior === 'ignoreParentForm';
+    if (behavior === 'ignoreCurrentForm' || isIgnoreParentForm) {
+      await toggleIgnoreForm(editor, document, isIgnoreParentForm);
       return;
     }
     // 'commentCurrentLine' falls through to existing ;; behavior

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -351,11 +351,6 @@ suite(suiteName, () => {
   });
 
   describe('ignoreCurrentForm and ignoreParentForm behavior', () => {
-    afterEach(async () => {
-      // Restore commentCurrentLine for consistency with other tests
-      await setToggleCommentBehavior('commentCurrentLine');
-    });
-
     it('should add #_ to current form when cursor is on a symbol (ignoreCurrentForm)', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -301,7 +301,6 @@ suite(suiteName, () => {
       await toggleCommentUsingActiveEditor('(defn foo []•  |(println "test"))'),
       '(defn foo []•  #_|(println "test"))'
     );
-    await setToggleCommentBehavior('commentCurrentLine');
   });
 
   it('should remove #_ from current form when cursor is inside ignored form', async () => {
@@ -310,7 +309,6 @@ suite(suiteName, () => {
       await toggleCommentUsingActiveEditor('(defn foo []•  #_|(println "test"))'),
       '(defn foo []•  |(println "test"))'
     );
-    await setToggleCommentBehavior('commentCurrentLine');
   });
 
   it('should add #_ to current literal when cursor is on it (ignoreCurrentForm)', async () => {
@@ -319,7 +317,6 @@ suite(suiteName, () => {
       await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |1 2)))'),
       '(defn foo []•  (when true•    (+ #_|1 2)))'
     );
-    await setToggleCommentBehavior('commentCurrentLine');
   });
 
   it('should remove #_ from current literal (ignoreCurrentForm)', async () => {
@@ -328,7 +325,6 @@ suite(suiteName, () => {
       await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ #_|1 2)))'),
       '(defn foo []•  (when true•    (+ |1 2)))'
     );
-    await setToggleCommentBehavior('commentCurrentLine');
   });
 
   it('should add #_ to parent form when using ignoreParentForm', async () => {
@@ -337,7 +333,6 @@ suite(suiteName, () => {
       await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |1 2)))'),
       '(defn foo []•  (when true•    #_(+ |1 2)))'
     );
-    await setToggleCommentBehavior('commentCurrentLine');
   });
 
   it('should fall back to ;; when text is selected even with ignoreCurrentForm', async () => {
@@ -346,7 +341,6 @@ suite(suiteName, () => {
       await toggleCommentUsingActiveEditor('|(defn foo []•  (prn "hi"))|'),
       '|;; (defn foo []•;;   (prn "hi"))|'
     );
-    await setToggleCommentBehavior('commentCurrentLine');
   });
 
   it('should fall back to ;; uncomment when cursor is in comment with ignoreCurrentForm', async () => {
@@ -355,7 +349,6 @@ suite(suiteName, () => {
       await toggleCommentUsingActiveEditor('(defn foo []•  ;; |(println "test"))'),
       '(defn foo []•  |(println "test"))'
     );
-    await setToggleCommentBehavior('commentCurrentLine');
   });
 
   it('should add #_ to top-level form with ignoreCurrentForm', async () => {
@@ -364,7 +357,6 @@ suite(suiteName, () => {
       await toggleCommentUsingActiveEditor('|(defn foo [])'),
       '#_|(defn foo [])'
     );
-    await setToggleCommentBehavior('commentCurrentLine');
   });
 
   it('should remove #_ from top-level form with ignoreCurrentForm', async () => {
@@ -373,6 +365,5 @@ suite(suiteName, () => {
       await toggleCommentUsingActiveEditor('#_|(defn foo [])'),
       '|(defn foo [])'
     );
-    await setToggleCommentBehavior('commentCurrentLine');
   });
 });

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -350,70 +350,71 @@ suite(suiteName, () => {
     assert.equal(nestedUncommented, nested);
   });
 
-  // #_ (ignore/discard) toggle tests
-  it('should add #_ to current form when cursor is on a symbol (ignoreCurrentForm)', async () => {
-    await setToggleCommentBehavior('ignoreCurrentForm');
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(defn foo []•  |(println "test"))'),
-      '(defn foo []•  #_|(println "test"))'
-    );
-  });
+  describe('ignoreCurrentForm and ignoreParentForm behavior', () => {
+    it('should add #_ to current form when cursor is on a symbol (ignoreCurrentForm)', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(defn foo []•  |(println "test"))'),
+        '(defn foo []•  #_|(println "test"))'
+      );
+    });
 
-  it('should remove #_ from current form when cursor is inside ignored form', async () => {
-    await setToggleCommentBehavior('ignoreCurrentForm');
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(defn foo []•  #_|(println "test"))'),
-      '(defn foo []•  |(println "test"))'
-    );
-  });
+    it('should remove #_ from current form when cursor is inside ignored form', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(defn foo []•  #_|(println "test"))'),
+        '(defn foo []•  |(println "test"))'
+      );
+    });
 
-  it('should add #_ to current literal when cursor is on it (ignoreCurrentForm)', async () => {
-    await setToggleCommentBehavior('ignoreCurrentForm');
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |1 2)))'),
-      '(defn foo []•  (when true•    (+ #_|1 2)))'
-    );
-  });
+    it('should add #_ to current literal when cursor is on it (ignoreCurrentForm)', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |1 2)))'),
+        '(defn foo []•  (when true•    (+ #_|1 2)))'
+      );
+    });
 
-  it('should remove #_ from current literal (ignoreCurrentForm)', async () => {
-    await setToggleCommentBehavior('ignoreCurrentForm');
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ #_|1 2)))'),
-      '(defn foo []•  (when true•    (+ |1 2)))'
-    );
-  });
+    it('should remove #_ from current literal (ignoreCurrentForm)', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ #_|1 2)))'),
+        '(defn foo []•  (when true•    (+ |1 2)))'
+      );
+    });
 
-  it('should add #_ to parent form when using ignoreParentForm', async () => {
-    await setToggleCommentBehavior('ignoreParentForm');
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |1 2)))'),
-      '(defn foo []•  (when true•    #_(+ |1 2)))'
-    );
-  });
+    it('should add #_ to parent form when using ignoreParentForm', async () => {
+      await setToggleCommentBehavior('ignoreParentForm');
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |1 2)))'),
+        '(defn foo []•  (when true•    #_(+ |1 2)))'
+      );
+    });
 
-  it('should fall back to ;; when text is selected even with ignoreCurrentForm', async () => {
-    await setToggleCommentBehavior('ignoreCurrentForm');
-    assert.equal(
-      await toggleCommentUsingActiveEditor('|(defn foo []•  (prn "hi"))|'),
-      '|;; (defn foo []•;;   (prn "hi"))|'
-    );
-  });
+    it('should fall back to ;; when text is selected even with ignoreCurrentForm', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(
+        await toggleCommentUsingActiveEditor('|(defn foo []•  (prn "hi"))|'),
+        '|;; (defn foo []•;;   (prn "hi"))|'
+      );
+    });
 
-  it('should fall back to ;; uncomment when cursor is in comment with ignoreCurrentForm', async () => {
-    await setToggleCommentBehavior('ignoreCurrentForm');
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(defn foo []•  ;; |(println "test"))'),
-      '(defn foo []•  |(println "test"))'
-    );
-  });
+    it('should fall back to ;; uncomment when cursor is in comment with ignoreCurrentForm', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(defn foo []•  ;; |(println "test"))'),
+        '(defn foo []•  |(println "test"))'
+      );
+    });
 
-  it('should add #_ to top-level form with ignoreCurrentForm', async () => {
-    await setToggleCommentBehavior('ignoreCurrentForm');
-    assert.equal(await toggleCommentUsingActiveEditor('|(defn foo [])'), '#_|(defn foo [])');
-  });
+    it('should add #_ to top-level form with ignoreCurrentForm', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(await toggleCommentUsingActiveEditor('|(defn foo [])'), '#_|(defn foo [])');
+    });
 
-  it('should remove #_ from top-level form with ignoreCurrentForm', async () => {
-    await setToggleCommentBehavior('ignoreCurrentForm');
-    assert.equal(await toggleCommentUsingActiveEditor('#_|(defn foo [])'), '|(defn foo [])');
+    it('should remove #_ from top-level form with ignoreCurrentForm', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(await toggleCommentUsingActiveEditor('#_|(defn foo [])'), '|(defn foo [])');
+    });
   });
 });

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { suite, describe, before, after, afterEach, it } from 'mocha';
+import { suite, describe, before, after, it } from 'mocha';
 import * as path from 'path';
 import * as testUtil from './util';
 import * as vscode from 'vscode';
@@ -370,24 +370,24 @@ suite(suiteName, () => {
     it('should add #_ to current literal when cursor is on it (ignoreCurrentForm)', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(
-        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |5 2)))'),
-        '(defn foo []•  (when true•    (+ #_|5 2)))'
+        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |-5 2)))'),
+        '(defn foo []•  (when true•    (+ #_|-5 2)))'
       );
     });
 
     it('should remove #_ from current literal (ignoreCurrentForm)', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(
-        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ #_|5 2)))'),
-        '(defn foo []•  (when true•    (+ |5 2)))'
+        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ #_|-5 2)))'),
+        '(defn foo []•  (when true•    (+ |-5 2)))'
       );
     });
 
     it('should add #_ to parent form when using ignoreParentForm', async () => {
       await setToggleCommentBehavior('ignoreParentForm');
       assert.equal(
-        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |5 2)))'),
-        '(defn foo []•  (when true•    #_(+ |5 2)))'
+        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |-5 2)))'),
+        '(defn foo []•  (when true•    #_(+ |-5 2)))'
       );
     });
 

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -100,15 +100,25 @@ async function toggleCommentUsingActiveEditor(textAndSelections: string) {
   return toggleComment(vscode.window.activeTextEditor, textAndSelections);
 }
 
+async function setToggleCommentBehavior(behavior: string | undefined) {
+  await vscode.workspace
+    .getConfiguration('calva.paredit')
+    .update('toggleCommentBehavior', behavior, vscode.ConfigurationTarget.Global);
+}
+
 suite(suiteName, () => {
   before(async () => {
     testUtil.showMessage(suiteName, `suite starting`);
+    // Set commentCurrentLine so existing ;; tests continue to work as before
+    await setToggleCommentBehavior('commentCurrentLine');
     return testUtil.openFile(testFilePath).then((x) => {
       return new Promise((resolve) => setTimeout(resolve, 1000));
     });
   });
 
   after(async () => {
+    // Restore default setting
+    await setToggleCommentBehavior(undefined);
     console.log('Finally, toggle comment suite is closing the active editor');
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     testUtil.showMessage(suiteName, `suite done!`);
@@ -282,5 +292,87 @@ suite(suiteName, () => {
       await toggleCommentUsingActiveEditor('(x• (j (y |(a b c)|))• z)'),
       '(x• (j (y |;; (a b c)|•     ))• z)'
     );
+  });
+
+  // #_ (ignore/discard) toggle tests
+  it('should add #_ to current form when cursor is on a symbol (ignoreCurrentForm)', async () => {
+    await setToggleCommentBehavior('ignoreCurrentForm');
+    assert.equal(
+      await toggleCommentUsingActiveEditor('(defn foo []•  |(println "test"))'),
+      '(defn foo []•  #_|(println "test"))'
+    );
+    await setToggleCommentBehavior('commentCurrentLine');
+  });
+
+  it('should remove #_ from current form when cursor is inside ignored form', async () => {
+    await setToggleCommentBehavior('ignoreCurrentForm');
+    assert.equal(
+      await toggleCommentUsingActiveEditor('(defn foo []•  #_|(println "test"))'),
+      '(defn foo []•  |(println "test"))'
+    );
+    await setToggleCommentBehavior('commentCurrentLine');
+  });
+
+  it('should add #_ to current literal when cursor is on it (ignoreCurrentForm)', async () => {
+    await setToggleCommentBehavior('ignoreCurrentForm');
+    assert.equal(
+      await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |1 2)))'),
+      '(defn foo []•  (when true•    (+ #_|1 2)))'
+    );
+    await setToggleCommentBehavior('commentCurrentLine');
+  });
+
+  it('should remove #_ from current literal (ignoreCurrentForm)', async () => {
+    await setToggleCommentBehavior('ignoreCurrentForm');
+    assert.equal(
+      await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ #_|1 2)))'),
+      '(defn foo []•  (when true•    (+ |1 2)))'
+    );
+    await setToggleCommentBehavior('commentCurrentLine');
+  });
+
+  it('should add #_ to parent form when using ignoreParentForm', async () => {
+    await setToggleCommentBehavior('ignoreParentForm');
+    assert.equal(
+      await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |1 2)))'),
+      '(defn foo []•  (when true•    #_(+ |1 2)))'
+    );
+    await setToggleCommentBehavior('commentCurrentLine');
+  });
+
+  it('should fall back to ;; when text is selected even with ignoreCurrentForm', async () => {
+    await setToggleCommentBehavior('ignoreCurrentForm');
+    assert.equal(
+      await toggleCommentUsingActiveEditor('|(defn foo []•  (prn "hi"))|'),
+      '|;; (defn foo []•;;   (prn "hi"))|'
+    );
+    await setToggleCommentBehavior('commentCurrentLine');
+  });
+
+  it('should fall back to ;; uncomment when cursor is in comment with ignoreCurrentForm', async () => {
+    await setToggleCommentBehavior('ignoreCurrentForm');
+    assert.equal(
+      await toggleCommentUsingActiveEditor('(defn foo []•  ;; |(println "test"))'),
+      '(defn foo []•  |(println "test"))'
+    );
+    await setToggleCommentBehavior('commentCurrentLine');
+  });
+
+  it('should add #_ to top-level form with ignoreCurrentForm', async () => {
+    await setToggleCommentBehavior('ignoreCurrentForm');
+    assert.equal(
+      await toggleCommentUsingActiveEditor('|(defn foo [])'),
+      '#_|(defn foo [])'
+    );
+    await setToggleCommentBehavior('commentCurrentLine');
+  });
+
+  it('should remove #_ from top-level form with ignoreCurrentForm', async () => {
+    await setToggleCommentBehavior('ignoreCurrentForm');
+    assert.equal(
+      await toggleCommentUsingActiveEditor('#_|(defn foo [])'),
+      '|(defn foo [])'
+    );
+    await setToggleCommentBehavior('commentCurrentLine');
   });
 });

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -351,6 +351,11 @@ suite(suiteName, () => {
   });
 
   describe('ignoreCurrentForm and ignoreParentForm behavior', () => {
+    afterEach(async () => {
+      // Restore commentCurrentLine for consistency with other tests
+      await setToggleCommentBehavior('commentCurrentLine');
+    });
+
     it('should add #_ to current form when cursor is on a symbol (ignoreCurrentForm)', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(
@@ -364,30 +369,6 @@ suite(suiteName, () => {
       assert.equal(
         await toggleCommentUsingActiveEditor('(defn foo []•  #_|(println "test"))'),
         '(defn foo []•  |(println "test"))'
-      );
-    });
-
-    it('should add #_ to current literal when cursor is on it (ignoreCurrentForm)', async () => {
-      await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(
-        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |1 2)))'),
-        '(defn foo []•  (when true•    (+ #_|1 2)))'
-      );
-    });
-
-    it('should remove #_ from current literal (ignoreCurrentForm)', async () => {
-      await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(
-        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ #_|1 2)))'),
-        '(defn foo []•  (when true•    (+ |1 2)))'
-      );
-    });
-
-    it('should add #_ to parent form when using ignoreParentForm', async () => {
-      await setToggleCommentBehavior('ignoreParentForm');
-      assert.equal(
-        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |1 2)))'),
-        '(defn foo []•  (when true•    #_(+ |1 2)))'
       );
     });
 

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { before, after, it } from 'mocha';
+import { suite, before, after, it } from 'mocha';
 import * as path from 'path';
 import * as testUtil from './util';
 import * as vscode from 'vscode';

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -367,6 +367,19 @@ suite(suiteName, () => {
       );
     });
 
+    it('should remove #_ when cursor is between #_ and form on next line (ignoreCurrentForm)', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(await toggleCommentUsingActiveEditor('#_|•(defn foo [])'), '|•(defn foo [])');
+    });
+
+    it('should remove #_ when cursor is between #_ and form with many spaces (ignoreCurrentForm)', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(
+        await toggleCommentUsingActiveEditor('#_     |     (defn foo [])'),
+        '     |     (defn foo [])'
+      );
+    });
+
     it('should add #_ to current literal when cursor is on it (ignoreCurrentForm)', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -351,11 +351,6 @@ suite(suiteName, () => {
   });
 
   describe('ignoreCurrentForm and ignoreParentForm behavior', () => {
-    afterEach(async () => {
-      // Restore commentCurrentLine for consistency with other tests
-      await setToggleCommentBehavior('commentCurrentLine');
-    });
-
     it('should add #_ to current form when cursor is on a symbol (ignoreCurrentForm)', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(
@@ -417,16 +412,5 @@ suite(suiteName, () => {
       assert.equal(await toggleCommentUsingActiveEditor('|(defn foo [])'), '#_|(defn foo [])');
     });
 
-    it('should remove #_ from top-level form with ignoreCurrentForm', async () => {
-      await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(await toggleCommentUsingActiveEditor('#_|(defn foo [])'), '|(defn foo [])');
-    });
-  });
-
-  it('should handle comment toggle at top-level form (no parent form)', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('|(defn foo [])'),
-      ';; |(defn foo [])'
-    );
   });
 });

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -367,6 +367,30 @@ suite(suiteName, () => {
       );
     });
 
+    it('should add #_ to current literal when cursor is on it (ignoreCurrentForm)', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |5 2)))'),
+        '(defn foo []•  (when true•    (+ #_|5 2)))'
+      );
+    });
+
+    it('should remove #_ from current literal (ignoreCurrentForm)', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ #_|5 2)))'),
+        '(defn foo []•  (when true•    (+ |5 2)))'
+      );
+    });
+
+    it('should add #_ to parent form when using ignoreParentForm', async () => {
+      await setToggleCommentBehavior('ignoreParentForm');
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |5 2)))'),
+        '(defn foo []•  (when true•    #_(+ |5 2)))'
+      );
+    });
+
     it('should fall back to ;; when text is selected even with ignoreCurrentForm', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(
@@ -387,6 +411,5 @@ suite(suiteName, () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(await toggleCommentUsingActiveEditor('|(defn foo [])'), '#_|(defn foo [])');
     });
-
   });
 });

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -351,6 +351,11 @@ suite(suiteName, () => {
   });
 
   describe('ignoreCurrentForm and ignoreParentForm behavior', () => {
+    afterEach(async () => {
+      // Restore commentCurrentLine for consistency with other tests
+      await setToggleCommentBehavior('commentCurrentLine');
+    });
+
     it('should add #_ to current form when cursor is on a symbol (ignoreCurrentForm)', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { suite, before, after, it } from 'mocha';
+import { suite, describe, before, after, afterEach, it } from 'mocha';
 import * as path from 'path';
 import * as testUtil from './util';
 import * as vscode from 'vscode';
@@ -421,5 +421,12 @@ suite(suiteName, () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(await toggleCommentUsingActiveEditor('#_|(defn foo [])'), '|(defn foo [])');
     });
+  });
+
+  it('should handle comment toggle at top-level form (no parent form)', async () => {
+    assert.equal(
+      await toggleCommentUsingActiveEditor('|(defn foo [])'),
+      ';; |(defn foo [])'
+    );
   });
 });


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Added new config option in `package.json`, `calva.paredit.toggleCommentBehavior` with 3 options
- Updated docs describing `toggleCommentBehavior` options
- Added `toggleIgnoreForm` wich is trigered when config is not `commentCurrentLine` and there's a single cursor with no selection and not in a comment
-  

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3086

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
