### PR TITLE
Issue 3096 toggle inside brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Toggling selection inside a bracketed form brakes structure](https://github.com/BetterThanTomorrow/calva/issues/3096)
+
 ## [2.0.560] - 2026-02-21
 
 - Add: [Structural comment toggle using #_ as default](https://github.com/BetterThanTomorrow/calva/issues/3086). Controlled by the `calva.paredit.toggleCommentBehavior` setting (`ignoreParentForm`, `ignoreCurrentForm`, or `commentCurrentLine`)

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -2598,18 +2598,63 @@ export function _semiColonWouldBreakStructureWhere(
   if (startCursor.withinComment() || startCursor.withinString()) {
     return false;
   }
+
+  const hasEnclosingList = startCursor.clone().backwardList();
+
+  const previousSameLineCloseOffset = (cursor: LispTokenCursor): number | false => {
+    const previousToken = cursor.getPrevToken();
+    if (previousToken.type !== 'close') {
+      return false;
+    }
+    const candidateOffset = Math.max(cursor.offsetStart - previousToken.raw.length, 0);
+    const candidateCursor = doc.getTokenCursor(candidateOffset);
+    return candidateCursor.line === startCursor.line && candidateCursor.getToken().type === 'close'
+      ? candidateOffset
+      : false;
+  };
+
   const probeCursor = startCursor.clone();
   while (true) {
     probeCursor.forwardWhitespace(true);
     if (probeCursor.line !== startCursor.line || probeCursor.atEnd()) {
       return false; // at end of the starting line possibly in whitespace or comment
     }
+
+    if (probeCursor.getToken().type === 'close') {
+      return probeCursor.offsetStart;
+    }
+
     const offsetBeforeMoving = probeCursor.offsetStart;
     const moved = probeCursor.forwardSexp(true, true, true);
     if (probeCursor.line !== startCursor.line) {
       return offsetBeforeMoving; // the sexp in front ends on a different line
     }
-    if (!moved) {
+
+    if (moved) {
+      const afterSexpCursor = probeCursor.clone();
+      afterSexpCursor.forwardWhitespace(false);
+      if (
+        afterSexpCursor.line === startCursor.line &&
+        afterSexpCursor.getToken().type === 'close'
+      ) {
+        return afterSexpCursor.offsetStart;
+      }
+      if (afterSexpCursor.atEnd()) {
+        const previousCloseOffset = previousSameLineCloseOffset(afterSexpCursor);
+        if (hasEnclosingList && previousCloseOffset !== false && offsetBeforeMoving !== p) {
+          return previousCloseOffset;
+        }
+        if (hasEnclosingList && offsetBeforeMoving !== p) {
+          const lineStartOffset = p - startCursor.rowCol[1];
+          const lineText = doc.model.getLineText(startCursor.line);
+          const searchStart = Math.max(offsetBeforeMoving - lineStartOffset, 0);
+          const trailingCloseIndex = lineText.slice(searchStart).search(/[\])}]/);
+          if (trailingCloseIndex !== -1) {
+            return lineStartOffset + searchStart + trailingCloseIndex;
+          }
+        }
+      }
+    } else {
       return probeCursor.offsetStart; // inside a list ending on the same line
     }
   }

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -191,7 +191,8 @@ async function applyStructuralCommentsToSingleSelectionLines(
               mirrorDoc,
               wouldBreakWhere,
               affectedLineSet,
-              partialSelectionStartOffset
+              partialSelectionStartOffset,
+              editor.document.offsetAt(singleSelection.end)
             );
             if (resolvedBreakOffset === false) {
               skipBreak = true;
@@ -310,7 +311,8 @@ function resolveStructuralBreakOffset(
   mirrorDoc: EditableDocument,
   wouldBreakWhere: number,
   affectedLineSet: Set<number>,
-  partialSelectionStartOffset?: number
+  partialSelectionStartOffset?: number,
+  partialSelectionEndOffset?: number
 ): number | false {
   const cursor = mirrorDoc.getTokenCursor(wouldBreakWhere);
   const token = cursor.getToken();
@@ -321,6 +323,19 @@ function resolveStructuralBreakOffset(
     while (!probe.atEnd() && probe.line === startLine) {
       const tok = probe.getToken();
       if (tok.type === 'close') {
+        if (
+          partialSelectionStartOffset !== undefined &&
+          partialSelectionEndOffset !== undefined &&
+          probe.offsetStart === partialSelectionEndOffset
+        ) {
+          const tail = probe.clone();
+          tail.next();
+          tail.forwardWhitespace(true);
+          if (tail.atEnd() || !affectedLineSet.has(tail.line)) {
+            return probe.offsetStart;
+          }
+        }
+
         const finder = probe.clone();
         if (
           !finder.backwardList() ||

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -350,6 +350,14 @@ suite(suiteName, () => {
     assert.equal(nestedUncommented, nested);
   });
 
+  it('should toggle comments inside bracketed form and properly handle structure (issue #3096)', async () => {
+    assert.equal(await toggleCommentUsingActiveEditor('(|a•  b|)'), '(|;; a• ;;  b|•  )');
+  });
+
+  it('should toggle comments inside bracketed form and keep structure with trailing code (issue #3096)', async () => {
+    assert.equal(await toggleCommentUsingActiveEditor('(|a•  b|)•(c)'), '(|;; a• ;;  b|•  )•(c)');
+  });
+
   describe('ignoreCurrentForm and ignoreParentForm behavior', () => {
     it('should add #_ to current form when cursor is on a symbol (ignoreCurrentForm)', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -3392,7 +3392,7 @@ describe('paredit util', () => {
         paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a (b {|•} c•) d '))
       ).toBe(false);
     });
-    it('returns true before a list ending on the same line', () => {
+    it('returns false before a list ending on the same line', () => {
       expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" | (d)'))).toBe(
         false
       );

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -3425,5 +3425,8 @@ describe('paredit util', () => {
         )
       ).toBe(0);
     });
+    it('Multiline inside a list where close is at the end of current line (#3096)', () => {
+      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('(a •|b)'))).toBe(5);
+    });
   });
 });


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->


### `_semiColonWouldBreakStructureWhere`

- Added `hasEnclosingList` guard computed early via `backwardList()` probe.
- Moved all closing-token detection into the predicate, including line-end close detection.
- Added proper context guards to prevent false positives at top-level (before list) positions.
- Uses regex `/[\])}]/` for detecting trailing closing delimiters on the same line.

### `resolveStructuralBreakOffset` Helper (edit.ts)

- Filters structural breaks for multiline selection scenarios.
- Preserves close-token breaks only when the close is at selection-end AND the tail is at EOF/outside affected lines.
- Ensures #3096 behavior: closing paren is pushed to a new line when toggling comments inside bracketed forms.


<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3096

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
