### PR TITLE
Format after toggle comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Toggle comments structurally does not re-format](https://github.com/BetterThanTomorrow/calva/issues/3095)
+
 ## [2.0.563] - 2026-02-26
 
 - Fix: [REPL menu defaults to "Start your project" even when REPL is already running](https://github.com/BetterThanTomorrow/calva/issues/3106)

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -302,7 +302,16 @@ function _calculateFormatRange(
   if (!isUndefined(rangeForCurrentForm)) {
     if (rangeForCurrentForm[0] === rangeForTopLevelForm[0]) {
       if (topLevelStartCursor.rowCol[1] !== 0) {
-        return;
+        const formStart = rangeForCurrentForm[0];
+        // Allow formatting when the form is directly preceded by a #_ discard
+        // macro. Inserting '#_' shifts the form to column 2 but the enclosing
+        // top-level construct (the #_ reader macro) starts at column 0, so it
+        // is safe and desirable to reformat the form contents.
+        const precededByIgnore =
+          formStart >= 2 && cursor.doc.getText(formStart - 2, formStart) === '#_';
+        if (!precededByIgnore) {
+          return;
+        }
       }
     }
     if (rangeForCurrentForm.includes(index)) {

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -2820,35 +2820,6 @@ function findIgnoreMarkerBeforeOffset(
 }
 
 /**
- * Finds a `#_` ignore marker immediately after the given offset, allowing
- * optional whitespace between the offset position and the marker.
- */
-function findIgnoreMarkerAfterOffset(
-  doc: EditableDocument,
-  offset: number
-): { start: number; end: number } | undefined {
-  let scanOffset = offset;
-  while (true) {
-    const ch = doc.model.getText(scanOffset, scanOffset + 1);
-    if (ch === '') {
-      return undefined;
-    }
-    if (/\s/.test(ch)) {
-      scanOffset++;
-    } else {
-      break;
-    }
-  }
-
-  const maybeIgnore = doc.model.getText(scanOffset, scanOffset + 2);
-  if (maybeIgnore === '#_') {
-    return { start: scanOffset, end: scanOffset + 2 };
-  }
-
-  return undefined;
-}
-
-/**
  * Toggles `#_` (ignore/discard) on the form at the cursor position.
  * Uses the paredit editing pipeline so formatting is applied after the edit.
  */
@@ -2864,13 +2835,11 @@ export async function toggleIgnoreForm(
   const cursorOffset = selection.active;
 
   const ignoreBeforeCursor = findIgnoreMarkerBeforeOffset(doc, cursorOffset);
-  const ignore =
-    ignoreBeforeCursor || (!useParentForm && findIgnoreMarkerAfterOffset(doc, cursorOffset));
 
-  if (ignore) {
-    const deleteLength = ignore.end - ignore.start;
-    const cursorShift = ignore.start < cursorOffset ? deleteLength : 0;
-    return doc.model.edit([new ModelEdit('deleteRange', [ignore.start, deleteLength])], {
+  if (ignoreBeforeCursor) {
+    const deleteLength = ignoreBeforeCursor.end - ignoreBeforeCursor.start;
+    const cursorShift = ignoreBeforeCursor.start < cursorOffset ? deleteLength : 0;
+    return doc.model.edit([new ModelEdit('deleteRange', [ignoreBeforeCursor.start, deleteLength])], {
       selections: [new ModelEditSelection(cursorOffset - cursorShift)],
       skipFormat: false,
       undoStopBefore: true,

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -2837,13 +2837,27 @@ export async function toggleIgnoreForm(
   const ignoreBeforeCursor = findIgnoreMarkerBeforeOffset(doc, cursorOffset);
 
   if (ignoreBeforeCursor) {
-    const deleteLength = ignoreBeforeCursor.end - ignoreBeforeCursor.start;
-    const cursorShift = ignoreBeforeCursor.start < cursorOffset ? deleteLength : 0;
-    return doc.model.edit([new ModelEdit('deleteRange', [ignoreBeforeCursor.start, deleteLength])], {
-      selections: [new ModelEditSelection(cursorOffset - cursorShift)],
-      skipFormat: false,
-      undoStopBefore: true,
-    });
+    // Also delete any whitespace between #_ and the next form, so
+    // e.g. '#_•(foo)' and '#_   (foo)' both reduce cleanly to '(foo)'.
+    let formStart = ignoreBeforeCursor.end;
+    while (/\s/.test(doc.model.getText(formStart, formStart + 1))) {
+      formStart++;
+    }
+    const deleteLength = formStart - ignoreBeforeCursor.start;
+    const newCursorOffset =
+      cursorOffset < ignoreBeforeCursor.start
+        ? cursorOffset
+        : cursorOffset < formStart
+        ? ignoreBeforeCursor.start
+        : cursorOffset - deleteLength;
+    return doc.model.edit(
+      [new ModelEdit('deleteRange', [ignoreBeforeCursor.start, deleteLength])],
+      {
+        selections: [new ModelEditSelection(newCursorOffset)],
+        skipFormat: false,
+        undoStopBefore: true,
+      }
+    );
   }
 
   let formRange: [number, number] | undefined;

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -2784,3 +2784,137 @@ export async function addRichComment(
     }
   );
 }
+
+/**
+ * Finds a preceding `#_` ignore marker before the given offset, allowing
+ * optional whitespace between the marker and the offset position.
+ */
+function findIgnoreMarkerBeforeOffset(
+  doc: EditableDocument,
+  offset: number
+): { start: number; end: number } | undefined {
+  if (offset < 2) {
+    return undefined;
+  }
+
+  let scanOffset = offset - 1;
+  while (scanOffset >= 0) {
+    const ch = doc.model.getText(scanOffset, scanOffset + 1);
+    if (/\s/.test(ch)) {
+      scanOffset--;
+    } else {
+      break;
+    }
+  }
+
+  if (scanOffset < 1) {
+    return undefined;
+  }
+
+  const maybeIgnore = doc.model.getText(scanOffset - 1, scanOffset + 1);
+  if (maybeIgnore === '#_') {
+    return { start: scanOffset - 1, end: scanOffset + 1 };
+  }
+
+  return undefined;
+}
+
+/**
+ * Finds a `#_` ignore marker immediately after the given offset, allowing
+ * optional whitespace between the offset position and the marker.
+ */
+function findIgnoreMarkerAfterOffset(
+  doc: EditableDocument,
+  offset: number
+): { start: number; end: number } | undefined {
+  let scanOffset = offset;
+  while (true) {
+    const ch = doc.model.getText(scanOffset, scanOffset + 1);
+    if (ch === '') {
+      return undefined;
+    }
+    if (/\s/.test(ch)) {
+      scanOffset++;
+    } else {
+      break;
+    }
+  }
+
+  const maybeIgnore = doc.model.getText(scanOffset, scanOffset + 2);
+  if (maybeIgnore === '#_') {
+    return { start: scanOffset, end: scanOffset + 2 };
+  }
+
+  return undefined;
+}
+
+/**
+ * Toggles `#_` (ignore/discard) on the form at the cursor position.
+ * Uses the paredit editing pipeline so formatting is applied after the edit.
+ */
+export async function toggleIgnoreForm(
+  doc: EditableDocument,
+  useParentForm: boolean
+): Promise<boolean | void> {
+  const selection = doc.selections[0];
+  if (!selection) {
+    return;
+  }
+
+  const cursorOffset = selection.active;
+
+  const ignoreBeforeCursor = findIgnoreMarkerBeforeOffset(doc, cursorOffset);
+  const ignore =
+    ignoreBeforeCursor || (!useParentForm && findIgnoreMarkerAfterOffset(doc, cursorOffset));
+
+  if (ignore) {
+    const deleteLength = ignore.end - ignore.start;
+    const cursorShift = ignore.start < cursorOffset ? deleteLength : 0;
+    return doc.model.edit([new ModelEdit('deleteRange', [ignore.start, deleteLength])], {
+      selections: [new ModelEditSelection(cursorOffset - cursorShift)],
+      skipFormat: false,
+      undoStopBefore: true,
+    });
+  }
+
+  let formRange: [number, number] | undefined;
+  if (useParentForm) {
+    const cursor = doc.getTokenCursor(cursorOffset);
+    if (cursor.backwardList()) {
+      cursor.backwardUpList();
+      const start = cursor.offsetStart;
+      const endCursor = cursor.clone();
+      if (endCursor.forwardSexp()) {
+        formRange = [start, endCursor.offsetStart];
+      }
+    }
+  } else {
+    const cursor = doc.getTokenCursor(cursorOffset);
+    formRange = cursor.rangeForCurrentForm(cursorOffset);
+  }
+
+  if (!formRange) {
+    return;
+  }
+
+  const formStartOffset = formRange[0];
+
+  const ignoreBeforeForm = findIgnoreMarkerBeforeOffset(doc, formStartOffset);
+
+  if (ignoreBeforeForm) {
+    const deleteLength = ignoreBeforeForm.end - ignoreBeforeForm.start;
+    const shift = formStartOffset > ignoreBeforeForm.start ? -deleteLength : 0;
+    return doc.model.edit([new ModelEdit('deleteRange', [ignoreBeforeForm.start, deleteLength])], {
+      selections: [new ModelEditSelection(cursorOffset + shift)],
+      skipFormat: false,
+      undoStopBefore: true,
+    });
+  } else {
+    const shift = cursorOffset >= formStartOffset ? 2 : 0;
+    return doc.model.edit([new ModelEdit('insertString', [formStartOffset, '#_'])], {
+      selections: [new ModelEditSelection(cursorOffset + shift)],
+      skipFormat: false,
+      undoStopBefore: true,
+    });
+  }
+}

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -176,14 +176,18 @@ export class DocumentModel implements EditableModel {
     // Now that the document has been edited, calculate the reformatting:
     const reformatChange: respacer.WhitespaceChange[] = sortedUniq(offsets.sort((a, b) => b - a))
       .flatMap((p) => {
-        const doc = this.document.document;
-        const formattedInfo = formatter.formatDocIndexesInfo(
-          doc,
-          true,
-          p,
-          editor.selections.map((s) => s.active).map((p) => doc.offsetAt(p))
-        );
-        return formattedInfo ? formattedInfo.changes : [];
+        try {
+          const doc = this.document.document;
+          const formattedInfo = formatter.formatDocIndexesInfo(
+            doc,
+            true,
+            p,
+            editor.selections.map((s) => s.active).map((p) => doc.offsetAt(p))
+          );
+          return formattedInfo ? formattedInfo.changes : [];
+        } catch (e) {
+          return [];
+        }
       })
       .filter(
         (function () {

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -178,7 +178,10 @@ async function applyStructuralCommentsToSingleSelectionLines(
           new vscode.Position(lineNum, insertionColumn)
         );
 
-        const wouldBreakWhere = paredit._semiColonWouldBreakStructureWhere(mirrorDoc, insertionOffset);
+        const wouldBreakWhere = paredit._semiColonWouldBreakStructureWhere(
+          mirrorDoc,
+          insertionOffset
+        );
 
         editBuilder.insert(new vscode.Position(lineNum, insertionColumn), ';; ');
 
@@ -496,7 +499,6 @@ async function toggleCommentsThenReformatEnclosingForms(
   await updateLineComments(editor, affectedLineNumbers, shouldUncomment, candidatesMap);
   await reformatEnclosingFormsForLines(editor, affectedLineNumbers);
 }
-
 
 /**
  * Returns true if the cursor is currently positioned within a ;; line comment.

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -4,7 +4,7 @@ import * as docMirror from './doc-mirror/index';
 import { EditableDocument, ModelEdit } from './cursor-doc/model';
 import * as select from './select';
 import * as printer from './printer';
-import { _semiColonWouldBreakStructureWhere } from './cursor-doc/paredit';
+import * as paredit from './cursor-doc/paredit';
 import * as format from './calva-fmt/src/format';
 import { calculateCommentPrefixRemovalEnd, findCommentPrefixStart } from './comment-prefix';
 
@@ -178,7 +178,7 @@ async function applyStructuralCommentsToSingleSelectionLines(
           new vscode.Position(lineNum, insertionColumn)
         );
 
-        const wouldBreakWhere = _semiColonWouldBreakStructureWhere(mirrorDoc, insertionOffset);
+        const wouldBreakWhere = paredit._semiColonWouldBreakStructureWhere(mirrorDoc, insertionOffset);
 
         editBuilder.insert(new vscode.Position(lineNum, insertionColumn), ';; ');
 
@@ -497,115 +497,6 @@ async function toggleCommentsThenReformatEnclosingForms(
   await reformatEnclosingFormsForLines(editor, affectedLineNumbers);
 }
 
-/**
- * Finds a preceding `#_` ignore marker before the given offset, allowing
- * optional whitespace between the marker and the offset position.
- *
- * @param document The document being edited.
- * @param offset The offset whose left side should be inspected.
- * @returns The exact range of the `#_` marker when found, otherwise `undefined`.
- */
-function findIgnoreMarkerBeforeOffset(
-  document: vscode.TextDocument,
-  offset: number
-): vscode.Range | undefined {
-  if (offset < 2) {
-    return undefined;
-  }
-
-  let scanOffset = offset - 1;
-  while (scanOffset >= 0) {
-    const ch = document.getText(
-      new vscode.Range(document.positionAt(scanOffset), document.positionAt(scanOffset + 1))
-    );
-    if (/\s/.test(ch)) {
-      scanOffset -= 1;
-    } else {
-      break;
-    }
-  }
-
-  if (scanOffset < 1) {
-    return undefined;
-  }
-
-  const maybeIgnore = document.getText(
-    new vscode.Range(document.positionAt(scanOffset - 1), document.positionAt(scanOffset + 1))
-  );
-  if (maybeIgnore === '#_') {
-    return new vscode.Range(
-      document.positionAt(scanOffset - 1),
-      document.positionAt(scanOffset + 1)
-    );
-  }
-
-  return undefined;
-}
-
-/**
- * Toggles `#_` (ignore/discard) on the form at the cursor position.
- * If the form already has a preceding `#_`, it is removed; otherwise `#_` is inserted.
- *
- * @param useParentForm When true, targets the enclosing/parent form instead of the current form.
- */
-async function toggleIgnoreForm(
-  editor: vscode.TextEditor,
-  document: vscode.TextDocument,
-  useParentForm: boolean
-) {
-  const selection = editor.selections[0];
-  if (!selection) {
-    return;
-  }
-
-  const position = selection.active;
-  const cursorOffset = document.offsetAt(position);
-
-  const ignoreBeforeCursor = findIgnoreMarkerBeforeOffset(document, cursorOffset);
-
-  if (ignoreBeforeCursor) {
-    // Cursor is between #_ and the form (optionally separated by whitespace) - remove the #_
-    await editor.edit(
-      (editBuilder) => {
-        editBuilder.delete(ignoreBeforeCursor);
-      },
-      { undoStopBefore: true, undoStopAfter: true }
-    );
-    return;
-  }
-
-  //Try getFormSelection first
-  const formRange = useParentForm
-    ? select.getEnclosingFormSelection(document, position)
-    : select.getFormSelection(document, position, false);
-
-  if (!formRange) {
-    // If getFormSelection returns undefined, fall back to regular commenting
-    return;
-  }
-
-  const formStartOffset = document.offsetAt(formRange.start);
-
-  const ignoreBeforeForm = findIgnoreMarkerBeforeOffset(document, formStartOffset);
-
-  if (ignoreBeforeForm) {
-    // Remove the existing #_
-    await editor.edit(
-      (editBuilder) => {
-        editBuilder.delete(ignoreBeforeForm);
-      },
-      { undoStopBefore: true, undoStopAfter: true }
-    );
-  } else {
-    // Add #_ before the form
-    await editor.edit(
-      (editBuilder) => {
-        editBuilder.insert(document.positionAt(formStartOffset), '#_');
-      },
-      { undoStopBefore: true, undoStopAfter: true }
-    );
-  }
-}
 
 /**
  * Returns true if the cursor is currently positioned within a ;; line comment.
@@ -673,8 +564,8 @@ export async function toggleLineCommentCommand(behaviorArg?: ToggleCommentBehavi
       }
       const isIgnoreParentForm = behavior === 'ignoreParentForm';
       if (behavior === 'ignoreCurrentForm' || isIgnoreParentForm) {
-        await toggleIgnoreForm(editor, document, isIgnoreParentForm);
-        return;
+        const mirrorDoc = docMirror.getDocument(document);
+        return paredit.toggleIgnoreForm(mirrorDoc, isIgnoreParentForm);
       }
       // 'commentCurrentLine' falls through to existing ;; behavior
     }

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -392,22 +392,7 @@ suite(suiteName, () => {
   });
 
   describe('ignoreCurrentForm and ignoreParentForm behavior', () => {
-    it('should add #_ to current form when cursor is on a symbol (ignoreCurrentForm)', async () => {
-      await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(
-        await toggleCommentUsingActiveEditor('(defn foo []•  |(println "test"))'),
-        '(defn foo []•  #_|(println "test"))'
-      );
-    });
-
-    it('should remove #_ from current form when cursor is inside ignored form', async () => {
-      await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(
-        await toggleCommentUsingActiveEditor('(defn foo []•  #_|(println "test"))'),
-        '(defn foo []•  |(println "test"))'
-      );
-    });
-
+   
     it('should remove #_ when cursor is between #_ and form on next line (ignoreCurrentForm)', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(await toggleCommentUsingActiveEditor('#_|•(defn foo [])'), '|(defn foo [])');
@@ -418,22 +403,6 @@ suite(suiteName, () => {
       assert.equal(
         await toggleCommentUsingActiveEditor('#_     |     (defn foo [])'),
         '|(defn foo [])'
-      );
-    });
-
-    it('should add #_ to current literal when cursor is on it (ignoreCurrentForm)', async () => {
-      await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(
-        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |-5 2)))'),
-        '(defn foo []•  (when true•    (+ #_|-5 2)))'
-      );
-    });
-
-    it('should remove #_ from current literal (ignoreCurrentForm)', async () => {
-      await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(
-        await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ #_|-5 2)))'),
-        '(defn foo []•  (when true•    (+ |-5 2)))'
       );
     });
 

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -410,14 +410,14 @@ suite(suiteName, () => {
 
     it('should remove #_ when cursor is between #_ and form on next line (ignoreCurrentForm)', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(await toggleCommentUsingActiveEditor('#_|•(defn foo [])'), '|•(defn foo [])');
+      assert.equal(await toggleCommentUsingActiveEditor('#_|•(defn foo [])'), '|(defn foo [])');
     });
 
     it('should remove #_ when cursor is between #_ and form with many spaces (ignoreCurrentForm)', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(
         await toggleCommentUsingActiveEditor('#_     |     (defn foo [])'),
-        '     |     (defn foo [])'
+        '|(defn foo [])'
       );
     });
 
@@ -466,9 +466,20 @@ suite(suiteName, () => {
       assert.equal(await toggleCommentUsingActiveEditor('|(defn foo [])'), '#_|(defn foo [])');
     });
 
-    it('should remove #_ in front of next form when cursor is before it (ignoreCurrentForm) - issue #3108', async () => {
+    it('should format unformatted code when adding #_ (ignoreCurrentForm)', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(await toggleCommentUsingActiveEditor(':bar |#_"foo"'), ':bar |"foo"');
+      assert.equal(
+        await toggleCommentUsingActiveEditor('|(when true•(println "Hello, World!"))'),
+        '#_|(when true•    (println "Hello, World!"))'
+      );
+    });
+
+    it('should format unformatted code when removing #_ (ignoreCurrentForm)', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(
+        await toggleCommentUsingActiveEditor('#_|(when true•(println "Hello, World!"))'),
+        '|(when true•  (println "Hello, World!"))'
+      );
     });
   });
 

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -465,6 +465,11 @@ suite(suiteName, () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(await toggleCommentUsingActiveEditor('|(defn foo [])'), '#_|(defn foo [])');
     });
+
+    it('should remove #_ in front of next form when cursor is before it (ignoreCurrentForm) - issue #3108', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(await toggleCommentUsingActiveEditor(':bar |#_"foo"'), ':bar |"foo"');
+    });
   });
 
   describe('args.behavior overrides setting', () => {

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -3429,4 +3429,60 @@ describe('paredit util', () => {
       expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('(a •|b)'))).toBe(5);
     });
   });
+
+  describe('toggle ignore form', () => {
+    describe('in parent form', () => {
+      it('toggles ignore form on a list', async () => {
+        const a = docFromTextNotation('(foo| bar)');
+        const b = docFromTextNotation('#_(foo| bar)');
+        await paredit.toggleIgnoreForm(a, true);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('should add #_ to parent form when cursor is in literal', async () => {
+        const a = docFromTextNotation('(defn foo []•  (when true•    (+ |-5 2)))');
+        const b = docFromTextNotation('(defn foo []•  (when true•    #_(+ |-5 2)))');
+        await paredit.toggleIgnoreForm(a, true);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('should remove #_ from current literal', async () => {
+        const a = docFromTextNotation('(defn foo []•  (when true•    (+ #_|-5 2)))');
+        const b = docFromTextNotation('(defn foo []•  (when true•    (+ |-5 2)))');
+        await paredit.toggleIgnoreForm(a, true);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+    });
+
+    describe('in current form', () => {
+      it('should add #_ to current form when cursor is on a symbol', async () => {
+        const a = docFromTextNotation('(defn foo []•  |(println "test"))');
+        const b = docFromTextNotation('(defn foo []•  #_|(println "test"))');
+        await paredit.toggleIgnoreForm(a, false);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('should remove #_ from current form when cursor is inside ignored form (ignoreCurrentForm)', async () => {
+        const a = docFromTextNotation('(defn foo []•  #_|(println "test"))');
+        const b = docFromTextNotation('(defn foo []•  |(println "test"))');
+        await paredit.toggleIgnoreForm(a, false);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('should add #_ to current literal when cursor is on it', async () => {
+        const a = docFromTextNotation('(defn foo []•  (when true•    (+ |-5 2)))');
+        const b = docFromTextNotation('(defn foo []•  (when true•    (+ #_|-5 2)))');
+        await paredit.toggleIgnoreForm(a, false);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('should remove #_ from current literal', async () => {
+        const a = docFromTextNotation('(defn foo []•  (when true•    (+ #_|-5 2)))');
+        const b = docFromTextNotation('(defn foo []•  (when true•    (+ |-5 2)))');
+        await paredit.toggleIgnoreForm(a, false);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      // it('should format unformatted code when adding #_', async () => {
+      //   const a = docFromTextNotation('|(when true•(println "Hello, World!"))');
+      //   const b = docFromTextNotation('#_|(when true•    (println "Hello, World!"))');
+      //   await paredit.toggleIgnoreForm(a, false);
+      //   expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      // });
+    });
+  });
 });

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -3477,12 +3477,13 @@ describe('paredit util', () => {
         await paredit.toggleIgnoreForm(a, false);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
-      // it('should format unformatted code when adding #_', async () => {
-      //   const a = docFromTextNotation('|(when true•(println "Hello, World!"))');
-      //   const b = docFromTextNotation('#_|(when true•    (println "Hello, World!"))');
-      //   await paredit.toggleIgnoreForm(a, false);
-      //   expect(textAndSelection(a)).toEqual(textAndSelection(b));
-      // });
+      it('should add #_ before form (formatting verified in integration tests)', async () => {
+        // StringDocument has no formatter; formatting is exercised by integration tests.
+        const a = docFromTextNotation('|(when true•(println "Hello, World!"))');
+        const b = docFromTextNotation('#_|(when true•(println "Hello, World!"))');
+        await paredit.toggleIgnoreForm(a, false);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Added `reformatFormAtPosition`, it is called after `toggleIgnoreForm`. Finds the enclosing form and formats.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3095

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
