### PR TITLE
Issue 3096 toggle inside brackets

### DIFF
--- a/src/edit.ts
+++ b/src/edit.ts
@@ -323,24 +323,21 @@ function resolveStructuralBreakOffset(
     while (!probe.atEnd() && probe.line === startLine) {
       const tok = probe.getToken();
       if (tok.type === 'close') {
+        // Bracket at or beyond the selection end is outside the selection → must move
         if (
           partialSelectionStartOffset !== undefined &&
           partialSelectionEndOffset !== undefined &&
-          probe.offsetStart === partialSelectionEndOffset
+          probe.offsetStart >= partialSelectionEndOffset
         ) {
-          const tail = probe.clone();
-          tail.next();
-          tail.forwardWhitespace(true);
-          if (tail.atEnd() || !affectedLineSet.has(tail.line)) {
-            return probe.offsetStart;
-          }
+          return probe.offsetStart;
         }
 
+        // Bracket whose matching open is at/before selection start, or on a non-affected line → must move
         const finder = probe.clone();
         if (
           !finder.backwardList() ||
           (partialSelectionStartOffset !== undefined &&
-            finder.offsetStart < partialSelectionStartOffset) ||
+            finder.offsetStart <= partialSelectionStartOffset) ||
           !affectedLineSet.has(finder.line)
         ) {
           return probe.offsetStart;

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -305,6 +305,13 @@ suite(suiteName, () => {
     );
   });
 
+  it('should structurally comment multiline selection starting inside a nested form (issue #3096)', async () => {
+    assert.equal(
+      await toggleCommentUsingActiveEditor('(a (|b•    c|))'),
+      '(a (|;; b•    ;; c|•    ))'
+    );
+  });
+
   it('should structurally comment multiline selection nested in parent form and preserve full selected range', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(x•  (y |(a b•        c)|)•  z)'),


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

Fix bracket detection in resolveStructuralBreakOffset
Replace complex tail lookahead with simpler offset comparison:
- Check `probe.offsetStart >= partialSelectionEndOffset` instead of complex
  `tail.atEnd()` checks. This correctly identifies brackets at or beyond the
  selection end that must be moved.
- Change `finder.offsetStart` `<` to `<=` when comparing against selection start.
  `backwardList()` positions cursor at the first element **inside** the list,
  not at the opening bracket, so `<=` is required to detect when the form
  opens just before the selection starts.

Fixes structural comment handling for selections starting inside nested forms.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3096

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
