### PR TITLE
Fix REPL menu to remember last selection per connection state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [REPL menu defaults to "Start your project" even when REPL is already running](https://github.com/BetterThanTomorrow/calva/issues/3106)
+
 ## [2.0.562] - 2026-02-25
 
 - Fix: [Code navigation fail after starting repl](https://github.com/BetterThanTomorrow/calva/issues/2804)

--- a/src/nrepl/repl-menu.ts
+++ b/src/nrepl/repl-menu.ts
@@ -146,10 +146,11 @@ export async function showReplMenu() {
   const menuItems: MenuItem[] = shouldShowConnectedMenu()
     ? composeMenu([...connectedMenuItems(), ...(await drams.createProjectMenuItems())])
     : composeMenu([...disconnectedMenuItems(), ...(await drams.createProjectMenuItems())]);
+  const { prefix, suffix } = menuSlugForProjectRoot();
   const pickedItem = await utilities.quickPickSingle({
     title: 'Calva REPL commands',
     values: menuItems,
-    saveAs: 'calva.showReplMenu',
+    saveAs: `calva.showReplMenu.${prefix}.${suffix}`,
   });
   if (pickedItem) {
     const menuItem = menuItems.find((item) => item.label === pickedItem.label);


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

- The REPL menu (`showReplMenu`) previously used a single static `saveAs` key (`'calva.showReplMenu'`) to persist the user's last selection across both connected and disconnected states.
- This caused the menu to default-highlight "Start your project with a REPL" even when the project REPL was already running, because that was the last item selected while disconnected.
- The `saveAs` key now incorporates the project root and connection state via the existing `menuSlugForProjectRoot()` function, so connected and disconnected menus each remember their own last-used option independently.

Fixes #3106

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~ (No docs changes needed for this internal UX fix)
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).