### PR TITLE
Current form includes #_ forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Toggle comments structurally does not re-format](https://github.com/BetterThanTomorrow/calva/issues/3095)
-- Improve: Toggling `#_` discard comments now works correctly when cursor is positioned directly before the marker
 - Rename 'Toggle Line Comment' to 'Toggle Comment' 
+- Fix: [Toggle line comment with ignoreCurrentForm discards wrong form](https://github.com/BetterThanTomorrow/calva/issues/3108)
 
 ## [2.0.563] - 2026-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Toggle comments structurally does not re-format](https://github.com/BetterThanTomorrow/calva/issues/3095)
+- Improve: `rangeForCurrentForm` now includes `#_` discard marker when cursor is positioned directly before it, making the current form behavior more intuitive
 - Rename 'Toggle Line Comment' to 'Toggle Comment' 
 
 ## [2.0.563] - 2026-02-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Toggle comments structurally does not re-format](https://github.com/BetterThanTomorrow/calva/issues/3095)
-- Improve: `rangeForCurrentForm` now includes `#_` discard marker when cursor is positioned directly before it, making the current form behavior more intuitive
+- Improve: Toggling `#_` discard comments now works correctly when cursor is positioned directly before the marker
 - Rename 'Toggle Line Comment' to 'Toggle Comment' 
 
 ## [2.0.563] - 2026-02-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Changes to Calva.
 
 - Fix: [Toggle comments structurally does not re-format](https://github.com/BetterThanTomorrow/calva/issues/3095)
 - Rename 'Toggle Line Comment' to 'Toggle Comment' 
-- Fix: [Toggle line comment with ignoreCurrentForm discards wrong form](https://github.com/BetterThanTomorrow/calva/issues/3108)
+- Current form takes `#_` commented forms
+  - Fix: [Toggle line comment with ignoreCurrentForm discards wrong form](https://github.com/BetterThanTomorrow/calva/issues/3108)
 
 ## [2.0.563] - 2026-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changes to Calva.
 
 - Fix: [Toggle comments structurally does not re-format](https://github.com/BetterThanTomorrow/calva/issues/3095)
 - Rename 'Toggle Line Comment' to 'Toggle Comment' 
-- Current form takes `#_` commented forms
+- When the cursor is at a `#_` marker, **Current Form** now includes both the marker and the ignored form
   - Fix: [Toggle line comment with ignoreCurrentForm discards wrong form](https://github.com/BetterThanTomorrow/calva/issues/3108)
 
 ## [2.0.563] - 2026-02-26

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -2882,6 +2882,25 @@ export async function toggleIgnoreForm(
 
   const formStartOffset = formRange[0];
 
+  // When rangeForCurrentForm includes a leading #_ (cursor was directly adjacent
+  // before the marker), remove it rather than adding another one.
+  if (doc.model.getText(formStartOffset, formStartOffset + 2) === '#_') {
+    let deleteEnd = formStartOffset + 2;
+    while (/\s/.test(doc.model.getText(deleteEnd, deleteEnd + 1))) {
+      deleteEnd++;
+    }
+    const deleteLength = deleteEnd - formStartOffset;
+    const newCursorOffset =
+      cursorOffset > formStartOffset
+        ? Math.max(formStartOffset, cursorOffset - deleteLength)
+        : cursorOffset;
+    return doc.model.edit([new ModelEdit('deleteRange', [formStartOffset, deleteLength])], {
+      selections: [new ModelEditSelection(newCursorOffset)],
+      skipFormat: false,
+      undoStopBefore: true,
+    });
+  }
+
   const ignoreBeforeForm = findIgnoreMarkerBeforeOffset(doc, formStartOffset);
 
   if (ignoreBeforeForm) {

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -684,7 +684,7 @@ export class LispTokenCursor extends TokenCursor {
       const pTk = this.getPrevToken();
       let isAdjacentBefore =
         tk.type === 'reader' ||
-        tk.type === 'ignore' || // #_ discard markers are also "adjacent before" a form
+        tk.type === 'ignore' ||
         this.tokenBeginsMetadata() ||
         pTk.type === 'reader' ||
         this.prevTokenBeginsMetadata() ||

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -684,6 +684,7 @@ export class LispTokenCursor extends TokenCursor {
       const pTk = this.getPrevToken();
       let isAdjacentBefore =
         tk.type === 'reader' ||
+        tk.type === 'ignore' || // #_ discard markers are also "adjacent before" a form
         this.tokenBeginsMetadata() ||
         pTk.type === 'reader' ||
         this.prevTokenBeginsMetadata() ||
@@ -707,8 +708,17 @@ export class LispTokenCursor extends TokenCursor {
       if (isAdjacentBefore) {
         const cursor = this.clone();
         cursor.forwardWhitespace();
+        const formStart = cursor.offsetStart;
+        const tokenTypeAtFormStart = cursor.getToken().type;
         if (cursor.forwardSexp(true, true)) {
           afterCurrentFormOffset = cursor.offsetStart;
+          // When cursor is directly at a #_ ignore marker, return early with the
+          // correct range. The normal backwardSexp from afterCurrentFormOffset
+          // would not include the leading #_ because backwardThroughAnyReader
+          // only handles 'reader' tokens, not 'ignore' tokens.
+          if (tokenTypeAtFormStart === 'ignore') {
+            return [formStart, afterCurrentFormOffset];
+          }
         }
       }
     }

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -449,6 +449,14 @@ suite(suiteName, () => {
         '|(when true•  (println "Hello, World!"))'
       );
     });
+
+    it('should remove #_ when cursor is directly before the marker (decision 3)', async () => {
+      await setToggleCommentBehavior('ignoreCurrentForm');
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(foo :bar |#_(println "test") :baz)'),
+        '(foo :bar |(println "test") :baz)'
+      );
+    });
   });
 
   describe('args.behavior overrides setting', () => {

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -449,6 +449,7 @@ suite(suiteName, () => {
         '|(when true•  (println "Hello, World!"))'
       );
     });
+  });
 
   describe('args.behavior overrides setting', () => {
     it('should use ignoreCurrentForm arg even when setting is commentCurrentLine', async () => {

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -450,15 +450,6 @@ suite(suiteName, () => {
       );
     });
 
-    it('should remove #_ when cursor is directly before the marker (decision 3)', async () => {
-      await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(
-        await toggleCommentUsingActiveEditor('(foo :bar |#_(println "test") :baz)'),
-        '(foo :bar |(println "test") :baz)'
-      );
-    });
-  });
-
   describe('args.behavior overrides setting', () => {
     it('should use ignoreCurrentForm arg even when setting is commentCurrentLine', async () => {
       await setToggleCommentBehavior('commentCurrentLine');

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -3477,6 +3477,18 @@ describe('paredit util', () => {
         await paredit.toggleIgnoreForm(a, false);
         expect(textAndSelection(a)).toEqual(textAndSelection(b));
       });
+      it('should remove #_ when cursor is directly before the marker (decision 3)', async () => {
+        const a = docFromTextNotation(':bar |#_"foo"');
+        const b = docFromTextNotation(':bar |"foo"');
+        await paredit.toggleIgnoreForm(a, false);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
+      it('should remove #_ when cursor is at start of file before the marker', async () => {
+        const a = docFromTextNotation('|#_(foo bar)');
+        const b = docFromTextNotation('|(foo bar)');
+        await paredit.toggleIgnoreForm(a, false);
+        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      });
     });
   });
 });

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -761,6 +761,18 @@ describe('Token Cursor', () => {
       const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toBeUndefined();
     });
+    it('2: selects ignore form including #_ when cursor is before the marker', () => {
+      const a = docFromTextNotation(':bar |#_"foo"');
+      const b = docFromTextNotation(':bar |#_"foo"|');
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+    });
+    it('2: selects ignore form including #_ when cursor is before marker at start of file', () => {
+      const a = docFromTextNotation('|#_(foo bar)');
+      const b = docFromTextNotation('|#_(foo bar)|');
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+    });
   });
 
   describe('Top Level Form', () => {


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Make rangeForCurrentForm include #_ when cursor precedes it

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3108

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
