### PR TITLE
Current form takes `#_` commented forms with cursor in all positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changes to Calva.
 - Rename 'Toggle Line Comment' to 'Toggle Comment' 
 - Current form takes `#_` commented forms
   - Fix: [Toggle line comment with ignoreCurrentForm discards wrong form](https://github.com/BetterThanTomorrow/calva/issues/3108)
+  - Current form includes `#_` at all cursor positions within the form
+  - Fix: `nsFromCursorDoc` no longer treats `#_`-discarded ns forms as valid namespace declarations
 
 ## [2.0.563] - 2026-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@ Changes to Calva.
 
 - Fix: [Toggle comments structurally does not re-format](https://github.com/BetterThanTomorrow/calva/issues/3095)
 - Rename 'Toggle Line Comment' to 'Toggle Comment' 
-- When the cursor is at a `#_` marker, **Current Form** now includes both the marker and the ignored form
+- Current form takes `#_` commented forms at all cursor positions within the form
   - Fix: [Toggle line comment with ignoreCurrentForm discards wrong form](https://github.com/BetterThanTomorrow/calva/issues/3108)
-  - Current form includes `#_` at all cursor positions within the form
   - Fix: No longer treat `#_` discarded ns forms as namespace declarations
 
 ## [2.0.563] - 2026-02-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changes to Calva.
 - Current form takes `#_` commented forms
   - Fix: [Toggle line comment with ignoreCurrentForm discards wrong form](https://github.com/BetterThanTomorrow/calva/issues/3108)
   - Current form includes `#_` at all cursor positions within the form
-  - Fix: `nsFromCursorDoc` no longer treats `#_`-discarded ns forms as valid namespace declarations
+  - Fix: No longer treat `#_` discarded ns forms as namespace declarations
 
 ## [2.0.563] - 2026-02-26
 

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -657,6 +657,11 @@ export class LispTokenCursor extends TokenCursor {
       !this.tokenBeginsMetadata()
     ) {
       afterCurrentFormOffset = this.offsetEnd;
+      // If preceded by #_, include the ignore marker in the range
+      const ignoreCursor = this.clone();
+      if (ignoreCursor.backwardThroughAnyIgnore()) {
+        return [ignoreCursor.offsetStart, afterCurrentFormOffset];
+      }
     }
     // console.log(0, afterCurrentFormOffset);
 
@@ -669,9 +674,16 @@ export class LispTokenCursor extends TokenCursor {
         cursor.getToken().type !== 'reader' &&
         !cursor.tokenBeginsMetadata() &&
         cursor.getPrevToken().type !== 'reader' &&
+        cursor.getPrevToken().type !== 'ignore' &&
         !cursor.prevTokenBeginsMetadata()
       ) {
         if (cursor.backwardSexp() && !cursor.tokenBeginsMetadata()) {
+          // If the cursor is at end-of-line and the form is immediately preceded
+          // by #_ (no whitespace between), include the ignore marker in the range.
+          if (this.getToken().type === 'eol' && cursor.getPrevToken().type === 'ignore') {
+            cursor.previous();
+            return [cursor.offsetStart, offset];
+          }
           afterCurrentFormOffset = offset;
         }
       }
@@ -718,6 +730,12 @@ export class LispTokenCursor extends TokenCursor {
           // only handles 'reader' tokens, not 'ignore' tokens.
           if (tokenTypeAtFormStart === 'ignore') {
             return [formStart, afterCurrentFormOffset];
+          }
+          // When the form at formStart is preceded by #_, include the ignore
+          // marker in the range (e.g. cursor between #_ and the form).
+          const ignoreCursor = this.doc.getTokenCursor(formStart);
+          if (ignoreCursor.backwardThroughAnyIgnore()) {
+            return [ignoreCursor.offsetStart, afterCurrentFormOffset];
           }
         }
       }

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -832,7 +832,10 @@ export class LispTokenCursor extends TokenCursor {
           return lastCandidateRange;
         }
       } else {
-        lastCandidateRange = cursor.rangeForCurrentForm(cursor.offsetStart);
+        const end = cursor.offsetStart;
+        const sc = cursor.clone();
+        sc.backwardSexp(true, true);
+        lastCandidateRange = [sc.offsetStart, end];
       }
     }
     return lastCandidateRange;

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -678,9 +678,9 @@ export class LispTokenCursor extends TokenCursor {
         !cursor.prevTokenBeginsMetadata()
       ) {
         if (cursor.backwardSexp() && !cursor.tokenBeginsMetadata()) {
-          // If the cursor is at end-of-line and the form is preceded by #_
-          // (with optional whitespace between), include the ignore marker.
-          if (this.getToken().type === 'eol' && cursor.backwardThroughAnyIgnore()) {
+          // If the form is preceded by #_ (with optional whitespace between),
+          // include the ignore marker in the range.
+          if (cursor.backwardThroughAnyIgnore()) {
             return [cursor.offsetStart, offset];
           }
           afterCurrentFormOffset = offset;

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -678,10 +678,9 @@ export class LispTokenCursor extends TokenCursor {
         !cursor.prevTokenBeginsMetadata()
       ) {
         if (cursor.backwardSexp() && !cursor.tokenBeginsMetadata()) {
-          // If the cursor is at end-of-line and the form is immediately preceded
-          // by #_ (no whitespace between), include the ignore marker in the range.
-          if (this.getToken().type === 'eol' && cursor.getPrevToken().type === 'ignore') {
-            cursor.previous();
+          // If the cursor is at end-of-line and the form is preceded by #_
+          // (with optional whitespace between), include the ignore marker.
+          if (this.getToken().type === 'eol' && cursor.backwardThroughAnyIgnore()) {
             return [cursor.offsetStart, offset];
           }
           afterCurrentFormOffset = offset;

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -797,6 +797,12 @@ describe('Token Cursor', () => {
       const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
     });
+    it('selects ignore form including #_ when cursor is at end of #_     :a (spaces between)', () => {
+      const a = docFromTextNotation('#_     :a|');
+      const b = docFromTextNotation('|#_     :a|');
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+    });
   });
 
   describe('Top Level Form', () => {

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -791,9 +791,9 @@ describe('Token Cursor', () => {
         expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(expected);
       }
     });
-    it('selects only the keyword when cursor is in whitespace after #_:a in #_:a :b', () => {
+    it('selects ignore form including #_ when cursor after #_:a in #_:a :b', () => {
       const a = docFromTextNotation('#_:a| :b');
-      const b = docFromTextNotation('#_|:a| :b');
+      const b = docFromTextNotation('|#_:a| :b');
       const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
     });

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -1010,6 +1010,12 @@ describe('Token Cursor', () => {
         const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
         expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
       });
+      it('Does not include ignore marker with no whitespaces', () => {
+        const a = docFromTextNotation('aaa (comment #_[bbb ccc|]  ddd)');
+        const b = docFromTextNotation('aaa (comment #_|[bbb ccc]|  ddd)');
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+      });
     });
   });
 

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -773,6 +773,30 @@ describe('Token Cursor', () => {
       const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
     });
+    it('selects ignore form including #_ for all cursor positions within #_:a', () => {
+      const b = docFromTextNotation('|#_:a|');
+      const expected = textAndSelection(b)[1];
+      for (const notation of ['|#_:a', '#|_:a', '#_|:a', '#_:|a', '#_:a|']) {
+        const a = docFromTextNotation(notation);
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+        expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(expected);
+      }
+    });
+    it('selects ignore form including #_ for cursor before, within, and adjacent to #_(foo bar)', () => {
+      const b = docFromTextNotation('|#_(foo bar)|');
+      const expected = textAndSelection(b)[1];
+      for (const notation of ['|#_(foo bar)', '#|_(foo bar)', '#_|(foo bar)']) {
+        const a = docFromTextNotation(notation);
+        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+        expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(expected);
+      }
+    });
+    it('selects only the keyword when cursor is in whitespace after #_:a in #_:a :b', () => {
+      const a = docFromTextNotation('#_:a| :b');
+      const b = docFromTextNotation('#_|:a| :b');
+      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+    });
   });
 
   describe('Top Level Form', () => {

--- a/src/extension-test/unit/util/ns-form-test.ts
+++ b/src/extension-test/unit/util/ns-form-test.ts
@@ -125,13 +125,10 @@ describe('ns-form util', () => {
       ).toStrictEqual(['a', "(in-ns 'a)"]);
     });
 
-    // TODO: Figure what to do with ignored forms
-    //       For now, this is what they do (nothing)
-    it('Finds ns in top level ignored form', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('#_ (ns a-b.c-d)|'))).toStrictEqual([
-        'a-b.c-d',
-        '(ns a-b.c-d)',
-      ]);
+    it('Does not find ns in top level ignored form', function () {
+      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('#_ (ns a-b.c-d)|'))).toStrictEqual(
+        null
+      );
     });
     it('Finds ns in ignored rich comments', function () {
       expect(

--- a/src/util/ns-form.ts
+++ b/src/util/ns-form.ts
@@ -64,9 +64,12 @@ export function nsRangeFromCursorDoc(
   const topLevelRange = cursor.rangeForDefun(p);
   if (topLevelRange) {
     const topLevelRangeCursor = cursorDoc.getTokenCursor(topLevelRange[0]);
-    const ns = nsSymbolOfCurrentForm(topLevelRangeCursor, 'downList');
-    if (ns) {
-      return [ns, topLevelRange];
+    // A top-level #_ discards the following form, so it's not a valid ns declaration
+    if (topLevelRangeCursor.getToken().type !== 'ignore') {
+      const ns = nsSymbolOfCurrentForm(topLevelRangeCursor, 'downList');
+      if (ns) {
+        return [ns, topLevelRange];
+      }
     }
   }
   // Special case 2, find ns form from start of document
@@ -77,7 +80,13 @@ export function nsRangeFromCursorDoc(
     while (cursor.forwardSexp(true, true, true)) {
       const ns = nsSymbolOfCurrentForm(cursor, 'backwardDownList');
       if (ns) {
-        return [ns, cursor.rangeForCurrentForm(cursor.offsetEnd)];
+        const range = cursor.rangeForCurrentForm(cursor.offsetEnd);
+        // Skip forms preceded by #_ (discard macro)
+        const rangeCursor = cursorDoc.getTokenCursor(range[0]);
+        if (rangeCursor.getToken().type === 'ignore') {
+          continue;
+        }
+        return [ns, range];
       }
     }
     return null;
@@ -88,7 +97,13 @@ export function nsRangeFromCursorDoc(
     while (cursor.backwardSexp()) {
       const ns = nsSymbolOfCurrentForm(cursor, 'downList');
       if (ns) {
-        return [ns, cursor.rangeForCurrentForm(cursor.offsetStart)];
+        const range = cursor.rangeForCurrentForm(cursor.offsetStart);
+        // Skip forms preceded by #_ (discard macro)
+        const rangeCursor = cursorDoc.getTokenCursor(range[0]);
+        if (rangeCursor.getToken().type === 'ignore') {
+          continue;
+        }
+        return [ns, range];
       }
     }
   }

--- a/src/util/ns-form.ts
+++ b/src/util/ns-form.ts
@@ -28,6 +28,18 @@ export function resolveNsName(sourcePaths: string[], filePath: string): string {
   return pathToNs(path.basename(filePath));
 }
 
+/** Returns [ns, range] if the range does not start with a #_ ignore token, else null. */
+function nsRangeIfNotIgnored(
+  cursorDoc: model.EditableDocument,
+  ns: string,
+  range: [number, number]
+): [string, [number, number]] | null {
+  if (cursorDoc.getTokenCursor(range[0]).getToken().type === 'ignore') {
+    return null;
+  }
+  return [ns, range];
+}
+
 function nsSymbolOfCurrentForm(
   cursor: tokenCursor.LispTokenCursor,
   downList: 'downList' | 'backwardDownList'
@@ -80,13 +92,8 @@ export function nsRangeFromCursorDoc(
     while (cursor.forwardSexp(true, true, true)) {
       const ns = nsSymbolOfCurrentForm(cursor, 'backwardDownList');
       if (ns) {
-        const range = cursor.rangeForCurrentForm(cursor.offsetEnd);
-        // Skip forms preceded by #_ (discard macro)
-        const rangeCursor = cursorDoc.getTokenCursor(range[0]);
-        if (rangeCursor.getToken().type === 'ignore') {
-          continue;
-        }
-        return [ns, range];
+        const result = nsRangeIfNotIgnored(cursorDoc, ns, cursor.rangeForCurrentForm(cursor.offsetEnd));
+        if (result) return result;
       }
     }
     return null;
@@ -97,13 +104,8 @@ export function nsRangeFromCursorDoc(
     while (cursor.backwardSexp()) {
       const ns = nsSymbolOfCurrentForm(cursor, 'downList');
       if (ns) {
-        const range = cursor.rangeForCurrentForm(cursor.offsetStart);
-        // Skip forms preceded by #_ (discard macro)
-        const rangeCursor = cursorDoc.getTokenCursor(range[0]);
-        if (rangeCursor.getToken().type === 'ignore') {
-          continue;
-        }
-        return [ns, range];
+        const result = nsRangeIfNotIgnored(cursorDoc, ns, cursor.rangeForCurrentForm(cursor.offsetStart));
+        if (result) return result;
       }
     }
   }

--- a/src/util/ns-form.ts
+++ b/src/util/ns-form.ts
@@ -92,8 +92,14 @@ export function nsRangeFromCursorDoc(
     while (cursor.forwardSexp(true, true, true)) {
       const ns = nsSymbolOfCurrentForm(cursor, 'backwardDownList');
       if (ns) {
-        const result = nsRangeIfNotIgnored(cursorDoc, ns, cursor.rangeForCurrentForm(cursor.offsetEnd));
-        if (result) return result;
+        const result = nsRangeIfNotIgnored(
+          cursorDoc,
+          ns,
+          cursor.rangeForCurrentForm(cursor.offsetEnd)
+        );
+        if (result) {
+          return result;
+        }
       }
     }
     return null;
@@ -104,8 +110,14 @@ export function nsRangeFromCursorDoc(
     while (cursor.backwardSexp()) {
       const ns = nsSymbolOfCurrentForm(cursor, 'downList');
       if (ns) {
-        const result = nsRangeIfNotIgnored(cursorDoc, ns, cursor.rangeForCurrentForm(cursor.offsetStart));
-        if (result) return result;
+        const result = nsRangeIfNotIgnored(
+          cursorDoc,
+          ns,
+          cursor.rangeForCurrentForm(cursor.offsetStart)
+        );
+        if (result) {
+          return result;
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Current form includes #_ at all cursor positions
- nsFromCursorDoc no longer treats `#_` discarded ns forms as valid 
    - All three code paths in `nsRangeFromCursorDoc` now check if the   
  form range starts with an ignore token and skip it. This prevents `#_` discarded forms
   from being treated as valid ns declarations.

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3115

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
