### PR TITLE
[ISSUE 3117] allow custom comment forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [allow other forms to create a new toplevel context like comment does](https://github.com/BetterThanTomorrow/calva/issues/3117)
 - Fix: [Toggle comments structurally does not re-format](https://github.com/BetterThanTomorrow/calva/issues/3095)
 - Rename 'Toggle Line Comment' to 'Toggle Comment' 
 - When the cursor is at a `#_` marker, **Current Form** now includes both the marker and the ignored form

--- a/src/NotebookProvider.ts
+++ b/src/NotebookProvider.ts
@@ -6,6 +6,7 @@ import * as repl from './api/repl-v1';
 import _ = require('lodash');
 import { isInteger } from 'lodash';
 import { getNamespace } from './api/document';
+import { isCommentFormHead } from './utilities';
 
 export class NotebookProvider implements vscode.NotebookSerializer {
   private readonly decoder = new TextDecoder();
@@ -64,7 +65,7 @@ function parseClojure(content: string): vscode.NotebookCellData[] {
     const endForm = cursor.doc.getTokenCursor(end - endAdjustment);
     const afterForm = cursor.doc.getTokenCursor(end);
 
-    if (endForm.getFunctionName() === 'comment') {
+    if (isCommentFormHead(endForm.getFunctionName())) {
       const commentRange = afterForm.rangeForCurrentForm(0);
       const commentStartCursor = cursor.doc.getTokenCursor(commentRange[0]);
       const commentCells = [];

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -236,7 +236,7 @@ export function formatDocIndexesInfo(
   } = formatIndexes(doc.getText(), formatRange, cursorIndexes, eol, onType, {
     ...config.getConfigNow(),
     ...extraConfig,
-    'comment-form?': cursor.getFunctionName() === 'comment',
+    'comment-form?': util.isCommentFormHead(cursor.getFunctionName()),
   });
   const range: vscode.Range = new vscode.Range(
     doc.positionAt(formatted.range[0]),

--- a/src/config.ts
+++ b/src/config.ts
@@ -301,6 +301,7 @@ function getConfig() {
       pareditOptions.get<Partial<ThreadingMacrosConfig>>('customThreadingMacros', {}),
       state.getProjectConfig()?.customThreadingMacros ?? {}
     ),
+    customCommentForms: configOptions.get<string[]>('customCommentForms', []),
     aliasMap: {
       ...(pareditOptions.get<{ [alias: string]: string }>('aliasMap') ?? {}),
       ...(state.getProjectConfig()?.aliasMap ?? {}),

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -23,6 +23,7 @@ import {
   resolveAliasedSymbol,
 } from './paredit-config';
 import { Token } from './lexer';
+import { isCommentFormHead } from '../utilities';
 
 const OPEN_DELIMITERS_REGEX = /[([{"]/;
 
@@ -2736,7 +2737,7 @@ export async function addRichComment(
   if (!contents && insideNextTopLevelFormPos !== insertStart) {
     const checkIfRichCommentExistsCursor = doc.getTokenCursor(insideNextTopLevelFormPos);
     checkIfRichCommentExistsCursor.forwardWhitespace(true);
-    if (checkIfRichCommentExistsCursor.getToken().raw == 'comment') {
+    if (isCommentFormHead(checkIfRichCommentExistsCursor.getToken().raw)) {
       checkIfRichCommentExistsCursor.forwardSexp();
       checkIfRichCommentExistsCursor.forwardWhitespace(false);
       // insert nothing, just place cursor

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -1,5 +1,6 @@
 import { getFirstEol, LineInputModel } from './model';
 import { Token, validPair } from './clojure-lexer';
+import { isCommentFormHead } from '../utilities';
 
 function tokenIsWhiteSpace(token: Token) {
   return token.type === 'eol' || token.type == 'ws';
@@ -807,7 +808,7 @@ export class LispTokenCursor extends TokenCursor {
     while (cursor.forwardList() && cursor.upList()) {
       const commentCursor = cursor.clone();
       commentCursor.backwardDownList();
-      if (commentCreatesTopLevel && getFunctionPositionText(commentCursor) === 'comment') {
+      if (commentCreatesTopLevel && isCommentFormHead(getFunctionPositionText(commentCursor))) {
         if (commentCursor.getToken().raw !== ')') {
           commentCursor.upList();
           return commentCursor.rangeForCurrentForm(commentCursor.offsetStart);
@@ -996,7 +997,7 @@ export class LispTokenCursor extends TokenCursor {
   atTopLevel(commentCreatesTopLevel: boolean = false): boolean {
     const tlCursor = this.clone();
     if (tlCursor.forwardList() && tlCursor.upList()) {
-      if (commentCreatesTopLevel && this.getFunctionName() === 'comment') {
+      if (commentCreatesTopLevel && isCommentFormHead(this.getFunctionName())) {
         return true;
       }
       return false;

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -5,7 +5,7 @@ import { isArray } from 'util';
 import * as docMirror from '../../doc-mirror/index';
 import { Token, validPair } from '../../cursor-doc/clojure-lexer';
 import { LispTokenCursor } from '../../cursor-doc/token-cursor';
-import { tryToGetActiveTextEditor, getActiveTextEditor } from '../../utilities';
+import { tryToGetActiveTextEditor, getActiveTextEditor, isCommentFormHead } from '../../utilities';
 
 type StackItem = {
   char: string;
@@ -325,7 +325,7 @@ function updateRainbowBrackets() {
         char = token.raw,
         charLength = char.length;
       // Highlight (comment ...) forms
-      if (!in_comment_form && char === 'comment') {
+      if (!in_comment_form && isCommentFormHead(char)) {
         const peekCursor = cursor.clone();
         peekCursor.backwardWhitespace();
         if (peekCursor.getPrevToken().raw === '(') {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -12,6 +12,8 @@ import * as url from 'url';
 import { isUndefined } from 'lodash';
 import * as fiddleFiles from './fiddle-files';
 import * as output from './results-output/output';
+import { getConfig } from './config';
+import { resolveAliasedSymbol } from './cursor-doc/paredit-config';
 
 const specialWords = ['-', '+', '/', '*']; //TODO: Add more here
 const syntaxQuoteSymbol = '`';
@@ -645,6 +647,19 @@ function pathExists(path: string): boolean {
   return fs.existsSync(path);
 }
 
+function isCommentFormHead(symbol: string): boolean {
+  if (symbol === 'comment') {
+    return true;
+  }
+
+  const { customCommentForms, aliasMap } = getConfig();
+  return (
+    symbol === 'comment' ||
+    customCommentForms.includes(symbol) ||
+    customCommentForms.includes(resolveAliasedSymbol(symbol, aliasMap))
+  );
+}
+
 export function lastLineIsEmpty(
   doc: vscode.TextDocument = vscode.window.activeTextEditor.document
 ): boolean {
@@ -654,6 +669,7 @@ export function lastLineIsEmpty(
 }
 
 export {
+  isCommentFormHead,
   distinct,
   getWordAtPosition,
   tryToGetDocument,


### PR DESCRIPTION
## What has changed?

- added the `customCommentForms` config key, with the value being a string array
- added `isCommentFormHead` to `utilities`, which compares with `comment` or else checks if the symbol or the resolution (per `aliasMap`) thereof is in `customCommentForms`
- replaced all checks that compared a form head with `comment` to `isCommentFormHead` calls

Fixes #3117

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
