### PR TITLE
Fix nightly clojure-lsp downloads to resolve actual version and avoid redundant re-downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Nightly clojure-lsp downloads re-download on every startup even when already up to date](https://github.com/BetterThanTomorrow/calva/issues/3125)
+
 ## [2.0.563] - 2026-02-26
 
 - Fix: [REPL menu defaults to "Start your project" even when REPL is already running](https://github.com/BetterThanTomorrow/calva/issues/3106)

--- a/package.json
+++ b/package.json
@@ -496,6 +496,7 @@
           "calva.clojureLspVersion": {
             "type": "string",
             "default": "latest",
+            "examples": ["latest", "nightly"],
             "markdownDescription": "The version of `clojure-lsp` to download and use. This should be a release tag-name, or `latest` (default), or `nightly`. Will take effect after a restart of clojure-lsp. See [calva.io/clojure-lsp](https://calva.io/clojure-lsp) for information about how to manage the clojure-lsp process. NB: _This setting will be ignored if `calva.clojureLspPath` is set to something non-blank._",
             "pattern": "^(latest|nightly|\\d{4}\\.\\d{2}\\.\\d{2}-\\d{2}\\.\\d{2}\\.\\d{2})$"
           },

--- a/src/lsp/client/downloader-utils.ts
+++ b/src/lsp/client/downloader-utils.ts
@@ -34,6 +34,7 @@ export async function downloadWithBackupRecovery(
 ): Promise<{
   path: string;
   restored: boolean;
+  error?: string;
 }> {
   const backupPath = await backupFile(filePath);
   try {
@@ -46,11 +47,13 @@ export async function downloadWithBackupRecovery(
     if (!backupPath) {
       throw e;
     }
-    console.log('Download failed, recovering from backup:', e.message);
+    const errorMessage = e instanceof Error ? e.message : String(e);
+    console.error('Download failed, recovering from backup:', errorMessage);
     const restored = await restoreFile(backupPath, filePath);
     return {
       path: restored ? filePath : backupPath,
       restored: true,
+      error: errorMessage,
     };
   }
 }

--- a/src/lsp/client/downloader.ts
+++ b/src/lsp/client/downloader.ts
@@ -73,6 +73,23 @@ async function getLatestVersion(): Promise<string> {
   }
 }
 
+async function getLatestNightlyVersion(): Promise<string> {
+  try {
+    const releaseJSON = await Promise.race([
+      util.fetchFromUrl(
+        'https://api.github.com/repos/clojure-lsp/clojure-lsp-dev-builds/releases/latest'
+      ),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Version check timed out')), VERSION_CHECK_TIMEOUT_MS)
+      ),
+    ]);
+    const release = JSON.parse(releaseJSON);
+    return release.tag_name;
+  } catch (err) {
+    return '';
+  }
+}
+
 function downloadArtifact(url: string, filePath: string): Promise<void> {
   console.log('Downloading clojure-lsp from', url);
   return new Promise((resolve, reject) => {
@@ -115,15 +132,14 @@ async function unzipFile(zipFilePath: string, extensionPath: string): Promise<vo
 }
 
 async function downloadClojureLsp(extensionPath: string, version: string): Promise<string> {
+  const isNightly = version.endsWith('-nightly');
   // There were no Apple Silicon builds prior to version 2022.06.22-14.09.50
   const artifactName =
-    version >= '2022.06.22-14.09.50' || process.platform !== 'darwin'
+    version >= '2022.06.22-14.09.50' || isNightly || process.platform !== 'darwin'
       ? getArtifactDownloadName()
       : getArtifactDownloadName('darwin', 'x64');
-  const url =
-    version !== 'nightly'
-      ? `https://github.com/clojure-lsp/clojure-lsp/releases/download/${version}/${artifactName}`
-      : `https://github.com/clojure-lsp/clojure-lsp-dev-builds/releases/latest/download/${artifactName}`;
+  const repo = isNightly ? 'clojure-lsp-dev-builds' : 'clojure-lsp';
+  const url = `https://github.com/clojure-lsp/${repo}/releases/download/${version}/${artifactName}`;
   const downloadPath = path.join(extensionPath, artifactName);
   const clojureLspPath = getClojureLspPath(extensionPath);
 
@@ -139,8 +155,9 @@ async function downloadClojureLsp(extensionPath: string, version: string): Promi
   });
 
   if (result.restored) {
+    const reason = result.error ? `: ${result.error}` : '';
     void vscode.window.showWarningMessage(
-      `Error downloading clojure-lsp, version: ${version}. Using previously downloaded clojure-lsp`
+      `Failed to download clojure-lsp ${version}${reason}. Falling back to previously downloaded version.`
     );
   }
   return result.path;
@@ -155,6 +172,8 @@ export const ensureServerDownloaded = async (
   const clojureLspPath = getClojureLspPath(context.extensionPath);
   const downloadVersion = ['', 'latest'].includes(configuredVersion)
     ? await getLatestVersion()
+    : configuredVersion === 'nightly'
+    ? await getLatestNightlyVersion()
     : configuredVersion;
 
   const exists = await fs.promises
@@ -173,7 +192,6 @@ export const ensureServerDownloaded = async (
   } else if (
     (currentVersion !== downloadVersion && downloadVersion !== '') ||
     forceDownload ||
-    downloadVersion === 'nightly' ||
     !exists
   ) {
     return await downloadClojureLsp(context.extensionPath, downloadVersion);


### PR DESCRIPTION
## What has changed?

When `calva.clojureLspVersion` is set to `"nightly"`, the downloader now resolves the actual latest nightly tag from the [clojure-lsp-dev-builds](https://github.com/clojure-lsp/clojure-lsp-dev-builds) GitHub API before downloading. This fixes three issues:

- **Redundant downloads on every startup**: Previously, the literal string `"nightly"` was written to the version file, so the `downloadVersion === 'nightly'` condition was always true and triggered a full ~41 MB download on every editor startup — even if the user already had the latest nightly. Now the resolved tag (e.g. `2026.03.12-18.21.43-nightly`) is stored in the version file, and the download is skipped when the version matches.

- **Silent download failures**: When a nightly download failed, the error was swallowed and the user was silently rolled back to a previous binary with only a generic warning toast. The error reason (e.g. "Download timed out") is now included in the warning message and logged via `console.error`.

- **No way to identify installed nightly version**: The version file previously contained the literal `"nightly"` string, making it impossible to tell which build was actually installed. It now contains the actual release tag.

### Changes

- **`src/lsp/client/downloader.ts`**:
  - Added `getLatestNightlyVersion()` — queries the GitHub `/releases/latest` endpoint for `clojure-lsp-dev-builds` to resolve the actual nightly tag.
  - `ensureServerDownloaded` now resolves `"nightly"` to the real tag before comparing versions.
  - `downloadClojureLsp` detects nightly versions via `.endsWith('-nightly')` and routes to the correct GitHub repo.
  - Removed the `downloadVersion === 'nightly'` always-download condition — the standard version comparison handles it.
  - Warning message now includes the specific error reason on download failure.

- **`src/lsp/client/downloader-utils.ts`**:
  - `downloadWithBackupRecovery` now returns the `error` message in its result so callers can surface it.
  - Changed `console.log` to `console.error` for download failure logging.

Fixes #3125

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [x] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).
