### PR TITLE
docs: remove broken Discord links from getting started guide

### DIFF
--- a/docs/site/get-started-with-clojure.md
+++ b/docs/site/get-started-with-clojure.md
@@ -91,7 +91,6 @@ We Clojurians inhabit a lot of community platforms. I'll list some of the more p
 * [ClojureVerse](https://clojureverse.org) - a web forum. Lots of Clojurians, lots of Clojure knowledge collected, easy to search, easy to join
 * [/r/Clojure](https://www.reddit.com/r/Clojure/) - Reddit when Reddit is at its best, lots of Clojurians here
 * [Clojurians on Zulip](https://clojurians.zulipchat.com/) - An other web forum using the Zulip platform
-* On Discord there are two active servers: [Clojurians](https://discordapp.com/invite/v9QMy9D) and [Discord](https://discord.gg/)
 
 You can also ask questions, and find answers, about Clojure at [ask.clojure.org](https://ask.clojure.org)
 


### PR DESCRIPTION
## Summary
Removes the Discord server links from the community resources list in the Getting Started guide. One link was broken (pointed to `discord.gg/` with no invite code) and PEZ noted the servers aren't particularly active anymore.

Fixes #2705