### PR TITLE
docs: clarify Reveal alias must be in project deps.edn

### DIFF
--- a/docs/site/reveal.md
+++ b/docs/site/reveal.md
@@ -24,7 +24,10 @@ This will make Reveal to start together with your project.
     This will make all Calva evaluations go to Reveal. Too chatty for you? Take the _dependencies only_ approach.
 
 
-Add this alias `deps.edn`:
+Add this alias to your **project's** `deps.edn`:
+
+!!! Note
+    The alias must be in the project's `deps.edn`, not in `~/.clojure/deps.edn`. Calva reads aliases from the project file to build the Jack-in command line, so aliases defined in the user-level `deps.edn` will not be visible to Calva and their `:main-opts` will be overwritten.
 
 ```clojure
 :aliases


### PR DESCRIPTION
## Summary
Clarifies that the Reveal alias must be defined in the project's `deps.edn`, not in `~/.clojure/deps.edn`. Calva reads aliases from the project file to build the Jack-in command line, so aliases in the user-level config are invisible to Calva and their `:main-opts` get silently overwritten.

Fixes #1045