### PR TITLE
docs: add cljsType to REBL connect sequence examples

### DIFF
--- a/docs/site/rebl.md
+++ b/docs/site/rebl.md
@@ -46,6 +46,7 @@ Create a Calva custom connect sequence for your VSCode editor. (Read [Custom REP
         {
             "name": "Rebl Connect",
             "projectType": "deps.edn",
+            "cljsType": "none",
             "menuSelections": {
                 "cljAliases": [
                     "rebl",
@@ -95,6 +96,7 @@ Create a Calva custom connect sequence for your VSCode editor. (Read [Custom REP
         {
             "name": "Lein REBL",
             "projectType": "Leiningen",
+            "cljsType": "none",
             "menuSelections": {
                 "leinProfiles": ["rebl", "rebl-12", ":nrebl"]
             },


### PR DESCRIPTION
## Summary
Adds `"cljsType": "none"` to both the deps.edn and Leiningen REBL connect sequence examples. Without this, Calva prompts for a ClojureScript REPL type during connection, which is confusing since REBL is Clojure-only.

Fixes #1234