### PR TITLE
Fix clojure-lsp setting descriptions: restart → window reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -500,13 +500,13 @@
               "latest",
               "nightly"
             ],
-            "markdownDescription": "The version of `clojure-lsp` to download and use. This should be a release tag-name, or `latest` (default), or `nightly`. Will take effect after a restart of clojure-lsp. See [calva.io/clojure-lsp](https://calva.io/clojure-lsp) for information about how to manage the clojure-lsp process. NB: _This setting will be ignored if `calva.clojureLspPath` is set to something non-blank._",
+            "markdownDescription": "The version of `clojure-lsp` to download and use. This should be a release tag-name, or `latest` (default), or `nightly`. Will take effect after a reload of the VS Code window. See [calva.io/clojure-lsp](https://calva.io/clojure-lsp) for information about how to manage the clojure-lsp process. NB: _This setting will be ignored if `calva.clojureLspPath` is set to something non-blank._",
             "pattern": "^(latest|nightly|\\d{4}\\.\\d{2}\\.\\d{2}-\\d{2}\\.\\d{2}\\.\\d{2})$"
           },
           "calva.clojureLspPath": {
             "type": "string",
             "default": "",
-            "markdownDescription": "The absolute path to the `clojure-lsp` native binary you want Calva to use. When non-blank the `calva.clojureLspVersion` setting will be ignored, and the binary at the path set will be used instead. Will take effect after a restart of clojure-lsp. See [calva.io/clojure-lsp](https://calva.io/clojure-lsp) for information about how to manage the clojure-lsp process."
+            "markdownDescription": "The absolute path to the `clojure-lsp` native binary you want Calva to use. When non-blank the `calva.clojureLspVersion` setting will be ignored, and the binary at the path set will be used instead. Will take effect after a reload of the VS Code window. See [calva.io/clojure-lsp](https://calva.io/clojure-lsp) for information about how to manage the clojure-lsp process."
           },
           "calva.openBrowserWhenFigwheelStarted": {
             "type": "boolean",


### PR DESCRIPTION
## Summary
Both `calva.clojureLspVersion` and `calva.clojureLspPath` setting descriptions said they take effect after "a restart of clojure-lsp" but they actually require a reload of the VS Code window.

Fixes #2557