### PR TITLE
Replace GitHub API version checks with redirect-based lookups to avoid rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Replace GitHub API version checks with redirect-based lookups to avoid rate limits](https://github.com/BetterThanTomorrow/calva/issues/3142)
+- 
+## [2.0.566] - 2026-03-18
+
+- Fix: [Option-Return at the end of an expression prefixed with #_ is no longer triggering evaluation](https://github.com/BetterThanTomorrow/calva/issues/3144)
+
 ## [2.0.565] - 2026-03-14
 
 - Fix: [Edit performance regression in v2.0.564](https://github.com/BetterThanTomorrow/calva/issues/3138)

--- a/src/lsp/client/downloader.ts
+++ b/src/lsp/client/downloader.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode';
 import * as fs from 'node:fs';
 import { downloadWithBackupRecovery } from './downloader-utils';
 
-const VERSION_CHECK_TIMEOUT_MS = 10_000;
 const DOWNLOAD_TIMEOUT_MS = 120_000;
 
 const versionFileName = 'clojure-lsp-version';
@@ -55,38 +54,6 @@ export async function readVersionFile(extensionPath: string) {
     return await fs.promises.readFile(filePath, 'utf8');
   } catch (e) {
     console.error('Could not read clojure-lsp version file.', e.message);
-  }
-}
-
-async function getLatestVersion(): Promise<string> {
-  try {
-    const releasesJSON = await Promise.race([
-      util.fetchFromUrl('https://api.github.com/repos/clojure-lsp/clojure-lsp/releases'),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('Version check timed out')), VERSION_CHECK_TIMEOUT_MS)
-      ),
-    ]);
-    const releases = JSON.parse(releasesJSON);
-    return releases[0].tag_name;
-  } catch (err) {
-    return '';
-  }
-}
-
-async function getLatestNightlyVersion(): Promise<string> {
-  try {
-    const releaseJSON = await Promise.race([
-      util.fetchFromUrl(
-        'https://api.github.com/repos/clojure-lsp/clojure-lsp-dev-builds/releases/latest'
-      ),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('Version check timed out')), VERSION_CHECK_TIMEOUT_MS)
-      ),
-    ]);
-    const release = JSON.parse(releaseJSON);
-    return release.tag_name;
-  } catch (err) {
-    return '';
   }
 }
 
@@ -171,9 +138,9 @@ export const ensureServerDownloaded = async (
   const configuredVersion: string = config.getConfig().clojureLspVersion;
   const clojureLspPath = getClojureLspPath(context.extensionPath);
   const downloadVersion = ['', 'latest'].includes(configuredVersion)
-    ? await getLatestVersion()
+    ? await util.getLatestGitHubReleaseTag('clojure-lsp/clojure-lsp')
     : configuredVersion === 'nightly'
-    ? await getLatestNightlyVersion()
+    ? await util.getLatestGitHubReleaseTag('clojure-lsp/clojure-lsp-dev-builds')
     : configuredVersion;
 
   const exists = await fs.promises

--- a/src/nrepl/deps-clj.ts
+++ b/src/nrepl/deps-clj.ts
@@ -6,14 +6,6 @@ import { https } from 'follow-redirects';
 const DEPS_CLJ_FILE = 'deps.clj.jar';
 const DEPS_CLJ_VERSION_FILE = 'deps-clj-version';
 
-async function getLatestVersion(): Promise<string> {
-  const releasesJSON = await util.fetchFromUrl(
-    'https://api.github.com/repos/borkdude/deps.clj/releases'
-  );
-  const releases = JSON.parse(releasesJSON);
-  return releases[0].tag_name;
-}
-
 function backupExistingFile(depsCljPath: string, backupPath: string): string {
   const backupDir = path.dirname(backupPath);
   try {
@@ -87,7 +79,7 @@ export async function downloadDepsClj(extensionPath: string): Promise<string> {
   try {
     const currentVersion = readVersionFile(extensionPath);
     console.log(`Current deps.clj.jar version: ${currentVersion}`);
-    const latestVersion = await getLatestVersion();
+    const latestVersion = await util.getLatestGitHubReleaseTag('borkdude/deps.clj');
     console.log(`Latest deps.clj.jar version: ${latestVersion}`);
     if (latestVersion !== currentVersion) {
       const artifactName = `deps.clj-${latestVersion.substring(1)}-standalone.jar`;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -545,6 +545,22 @@ async function downloadFromUrl(fileUrl: string, savePath: string) {
   });
 }
 
+function getLatestGitHubReleaseTag(ownerRepo: string, timeoutMs = 10_000): Promise<string> {
+  const releaseUrl = `https://github.com/${ownerRepo}/releases/latest`;
+  return new Promise((resolve) => {
+    const request = https
+      .get(releaseUrl, (response) => {
+        response.resume();
+        resolve(response.responseUrl.split('/tag/').pop());
+      })
+      .on('error', () => resolve(''));
+    request.setTimeout(timeoutMs, () => {
+      request.destroy();
+      resolve('');
+    });
+  });
+}
+
 async function fetchFromUrl(fullUrl: string): Promise<string> {
   const q = url.parse(fullUrl);
   return new Promise((resolve, reject) => {
@@ -708,6 +724,7 @@ export {
   writeTextToFile,
   downloadFromUrl,
   fetchFromUrl,
+  getLatestGitHubReleaseTag,
   cljsLib,
   randomSlug,
   isWindows,


### PR DESCRIPTION


## What has changed?

Replaced GitHub REST API calls (`api.github.com`) with redirect-based version lookups using the `/releases/latest` page URL to avoid the [60 requests/hour unauthenticated rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#primary-rate-limit-for-unauthenticated-users).

- Added a shared `getLatestGitHubReleaseTag` utility in `src/utilities.ts` that extracts the version tag from the [GitHub releases redirect](https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases#linking-to-the-latest-release) URL.
- Replaced `getLatestVersion` and `getLatestNightlyVersion` in `src/lsp/client/downloader.ts` with calls to the shared utility.
- Replaced the API-based `getLatestVersion` in `src/nrepl/deps-clj.ts` with a call to the same shared utility.



Fixes #3142

## My Calva PR Checklist


I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [ ] Tests
  - [ ] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).