### PR TITLE
Fix: Evaluating `#_` prefixed forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- Fix: Evaluating `#_`-prefixed forms now strips the `#_` reader discard before sending to the REPL, so the form is actually evaluated instead of silently discarded
+- Fix: Evaluating `#_`-prefixed forms
 
 ## [2.0.565] - 2026-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- Fix: Evaluating `#_`-prefixed forms
+- Fix: [Evaluating `#_`-prefixed forms](https://github.com/BetterThanTomorrow/calva/issues/3144)
 
 ## [2.0.565] - 2026-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
-- Fix: [Evaluating `#_`-prefixed forms](https://github.com/BetterThanTomorrow/calva/issues/3144)
+- Fix: [Option-Return at the end of an expression prefixed with #_ is no longer triggering evaluation](https://github.com/BetterThanTomorrow/calva/issues/3144)
 
 ## [2.0.565] - 2026-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: Evaluating `#_`-prefixed forms now strips the `#_` reader discard before sending to the REPL, so the form is actually evaluated instead of silently discarded
+
 ## [2.0.565] - 2026-03-14
 
 - Fix: [Edit performance regression in v2.0.564](https://github.com/BetterThanTomorrow/calva/issues/3138)

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -333,6 +333,11 @@ async function evaluateSelection(document = {}, options) {
     let code = selection[1];
     [codeSelection, code]; //TODO: What's this doing here?
 
+    // Strip leading #_ and optional whitespace so that
+    // evaluating with the cursor at the end of #_(form) sends just (form)
+    // to the REPL instead of the silently-discarded #_(form).
+    code = code.replace(/^#_\s*/, '');
+
     const doc = util.getDocument(document);
     if (vscode.window.tabGroups?.activeTabGroup?.activeTab?.isPreview) {
       void vscode.window.showTextDocument(doc, { preview: false });

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -336,8 +336,9 @@ async function evaluateSelection(document = {}, options) {
     // Strip leading #_ and optional whitespace so that
     // evaluating with the cursor at the end of #_(form) sends just (form)
     // to the REPL instead of the silently-discarded #_(form).
-    code = code.replace(/^#_\s*/, '');
-
+    if (editor.selections[0].isEmpty) {
+      code = code.replace(/^#_\s*/, '');
+    }
     const doc = util.getDocument(document);
     if (vscode.window.tabGroups?.activeTabGroup?.activeTab?.isPreview) {
       void vscode.window.showTextDocument(doc, { preview: false });


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

## What has changed?

<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Strip the #_ reader discard prefix from code text in `evaluateSelection()` before sending to the REPL

<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if there isn't one already. -->

Fixes #3144 

## My Calva PR Checklist
<!--
PLEASE DO NOT REMOVE THIS CHECKLIST. You are supposed to fill it in.
Strike out (using `~`) items that do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
