### PR TITLE
3155 api fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [REPL Output Log API bug: `clojureCode` is never populated](https://github.com/BetterThanTomorrow/calva/issues/3155)
 - [Add let-go as a project type](https://github.com/BetterThanTomorrow/calva/issues/3153)
 
 ## [2.0.569] - 2026-03-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [REPL Output Log API bug: `clojureCode` is never populated](https://github.com/BetterThanTomorrow/calva/issues/3155)
+- [Add `ns` and REPL session to Output Log API](https://github.com/BetterThanTomorrow/calva/issues/3156)
 - [Add let-go as a project type](https://github.com/BetterThanTomorrow/calva/issues/3153)
 
 ## [2.0.569] - 2026-03-28

--- a/docs/site/api.md
+++ b/docs/site/api.md
@@ -290,7 +290,7 @@ export function onOutputLogged(
 
 export type OutputCategory =
   | 'evaluationResults'
-  | 'clojureCode'
+  | 'evaluatedCode'
   | 'evaluationOutput'
   | 'evaluationErrorOutput'
   | 'otherOutput'

--- a/docs/site/api.md
+++ b/docs/site/api.md
@@ -299,7 +299,9 @@ export type OutputCategory =
 export interface OutputMessage {
   category: OutputCategory;
   text: string;
-  who?: string;  // Present when the output was triggered by an identified who
+  who?: string;            // Present when the output was triggered by an identified who
+  ns?: string;             // The namespace the output is associated with, when applicable
+  replSessionKey?: string; // The REPL session key (e.g. "clj", "cljs"), when applicable
 }
 ```
 

--- a/src/api/repl-v1.ts
+++ b/src/api/repl-v1.ts
@@ -284,7 +284,7 @@ export const listSessions = (): ReplSessionInfo[] => {
 
 export type OutputCategory =
   | 'evaluationResults'
-  | 'clojureCode'
+  | 'evaluatedCode'
   | 'evaluationOutput'
   | 'evaluationErrorOutput'
   | 'otherOutput'
@@ -298,7 +298,7 @@ export interface OutputMessage {
 
 const outputCategoryToApiCategory: Record<string, OutputCategory> = {
   evalResults: 'evaluationResults',
-  clojure: 'clojureCode',
+  evaluatedCode: 'evaluatedCode',
   evalOut: 'evaluationOutput',
   evalErr: 'evaluationErrorOutput',
   otherOut: 'otherOutput',

--- a/src/api/repl-v1.ts
+++ b/src/api/repl-v1.ts
@@ -79,7 +79,11 @@ export const evaluate = async (
   };
 
   if (description) {
-    resultOutput.appendOtherOut(description, { who: resolvedWho });
+    resultOutput.appendOtherOut(description, {
+      who: resolvedWho,
+      ns,
+      replSessionType: effectiveSessionKey,
+    });
   }
 
   const stdout = (m: string) => {
@@ -294,6 +298,8 @@ export interface OutputMessage {
   category: OutputCategory;
   text: string;
   who?: string;
+  ns?: string;
+  replSessionKey?: string;
 }
 
 const outputCategoryToApiCategory: Record<string, OutputCategory> = {
@@ -309,7 +315,13 @@ export function onOutputLogged(callback: (msg: OutputMessage) => void): vscode.D
   const unsubscribe = resultOutput.subscribe((m: resultOutput.SubscriberOutputMessage) => {
     const cat = outputCategoryToApiCategory[m.category] || 'otherOutput';
     try {
-      callback({ category: cat, text: m.text, who: m.who });
+      callback({
+        category: cat,
+        text: m.text,
+        who: m.who,
+        ns: m.ns,
+        replSessionKey: m.replSessionKey,
+      });
     } catch (error) {
       console.log('API onOutputLogged callback failed', error.message);
     }

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -169,7 +169,7 @@ async function evaluateCodeUpdatingUI(
       line: line + 1,
       column: column + 1,
       stdout: (m) => {
-        output.appendEvalOut(m, { who: 'ui' });
+        output.appendEvalOut(m, { ns, replSessionType: sessionKey, who: 'ui' });
       },
       stderr: (m) => err.push(m),
       pprintOptions: pprintOptions,
@@ -650,7 +650,7 @@ async function loadFile(
   const res = session.loadFile(fileContents, {
     fileName,
     filePath,
-    stdout: (m) => output.appendEvalOut(m, { who: 'ui' }),
+    stdout: (m) => output.appendEvalOut(m, { ns, replSessionType: sessionKey, who: 'ui' }),
     stderr: (m) => {
       output.appendEvalErr(m, { ns, replSessionType: sessionKey, who: 'ui' });
       errorMessages.push(m);

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -21,6 +21,8 @@ export interface SubscriberOutputMessage {
   category: OutputCategory;
   text: string;
   who?: string;
+  ns?: string;
+  replSessionKey?: string;
 }
 
 type Listener = (msg: SubscriberOutputMessage) => void;
@@ -54,6 +56,8 @@ type AppendOptions = {
   outputCategory: OutputCategory;
   after?: AfterAppendCallback;
   who?: string;
+  ns?: string;
+  replSessionKey?: string;
 };
 
 export type AppendClojureOptions = {
@@ -268,13 +272,19 @@ function appendClojure(
   const didLastTerminateLine = didLastOutputTerminateLine[destination];
   didLastOutputTerminateLine[destination] = true;
   if (options.description) {
-    appendOtherOut(options.description, { who: options.who });
+    appendOtherOut(options.description, {
+      who: options.who,
+      ns: options.ns,
+      replSessionType: options.replSessionType,
+    });
   }
   try {
     emit({
       category: options.outputCategory,
       text: `${didLastTerminateLine ? '' : '\n'}${message}`,
       who: options.who,
+      ns: options.ns,
+      replSessionKey: options.replSessionType,
     });
   } catch (e) {
     console.error('Calva output-sink listener error', e.message);
@@ -344,6 +354,8 @@ function append(options: AppendOptions, message: string, after?: AfterAppendCall
       category: options.outputCategory,
       text: util.stripAnsi(message),
       who: options.who,
+      ns: options.ns,
+      replSessionKey: options.replSessionKey,
     });
   } catch (e) {
     console.error('Calva output-sink listener error', e.message);
@@ -394,7 +406,17 @@ export function appendEvalOut(
     destinationSupportsAnsi(destination) && !messageContainsAnsi(message)
       ? themedChalk().evalOut(message)
       : message;
-  append({ destination, outputCategory: 'evalOut', who: options.who }, coloredMessage, after);
+  append(
+    {
+      destination,
+      outputCategory: 'evalOut',
+      who: options.who,
+      ns: options.ns,
+      replSessionKey: options.replSessionType,
+    },
+    coloredMessage,
+    after
+  );
 }
 
 /**
@@ -414,11 +436,15 @@ export function appendEvalErr(
       ? themedChalk().evalErr(message)
       : message;
   // TODO: Figure if it's worth a setting to opt-in on an ns info line
-  append(
-    { destination, outputCategory: 'evalErr', who: options.who },
-    nsInfoLine(destination, options)
-  );
-  append({ destination, outputCategory: 'evalErr', who: options.who }, coloredMessage, after);
+  const evalErrOptions: AppendOptions = {
+    destination,
+    outputCategory: 'evalErr',
+    who: options.who,
+    ns: options.ns,
+    replSessionKey: options.replSessionType,
+  };
+  append(evalErrOptions, nsInfoLine(destination, options));
+  append(evalErrOptions, coloredMessage, after);
   saveLastInfoLineData(destination, options);
 }
 
@@ -440,7 +466,13 @@ export function appendOtherOut(
       ? themedChalk().otherOut(message)
       : message;
   append(
-    { destination, outputCategory: 'otherOut', who: options.who ?? 'ui' },
+    {
+      destination,
+      outputCategory: 'otherOut',
+      who: options.who ?? 'ui',
+      ns: options.ns,
+      replSessionKey: options.replSessionType,
+    },
     coloredMessage,
     after
   );
@@ -464,7 +496,13 @@ export function appendOtherErr(
       ? themedChalk().otherErr(message)
       : message;
   append(
-    { destination, outputCategory: 'otherErr', who: options.who ?? 'ui' },
+    {
+      destination,
+      outputCategory: 'otherErr',
+      who: options.who ?? 'ui',
+      ns: options.ns,
+      replSessionKey: options.replSessionType,
+    },
     coloredMessage,
     after
   );
@@ -479,6 +517,8 @@ function appendLine(options: AppendOptions, message: string, after?: AfterAppend
         category: options.outputCategory,
         text: util.stripAnsi(message),
         who: options.who,
+        ns: options.ns,
+        replSessionKey: options.replSessionKey,
       });
     } catch (e) {
       console.error('Calva output-sink listener error', e.message);


### PR DESCRIPTION
* Fixes #3155
* Fixes #3156


## What has changed?

* Fix the bug with not populating `clojureCode` in the output log API emitts, and also rename it to `evaluatedCode`
* Add `ns` and `replSessionKey` to the output log API messages

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
