### PR TITLE
3166 update repl ui defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Update REPL UI configuration defaults to match Getting Started REPL](https://github.com/BetterThanTomorrow/calva/issues/3166)
+  - Use `terminal` as the default destination for all output categories
+  - Echoing of the evaluated code to the output evaluation result destionation is now default enabled
+  - The configured output evaluation result destionation will uncoditionally always show code evaluated via the API (such as when Backseat Driver evaluates things)
+
 ## [2.0.572] - 2026-04-10
 
 - [Add config for always prompting for nREPL port](https://github.com/BetterThanTomorrow/calva/issues/3162)

--- a/dev/docs/evaluated-code-routing-plan.md
+++ b/dev/docs/evaluated-code-routing-plan.md
@@ -1,0 +1,90 @@
+# Evaluated Code Routing Plan
+
+## Goal
+
+After this change, Calva treats evaluated code as a semantic event separate from visible output routing. API v1 subscribers to `repl.onOutputLogged()` always receive exactly one `evaluatedCode` message per evaluation, regardless of `calva.evaluationSendCodeToOutputWindow`. API v1 shows evaluated code in the configured eval-results destination and does not use the REPL Window as a default echo target. Manual/UI evaluations can still retain REPL-oriented echo behavior. The setting is no longer the API v1 visibility switch; it becomes a manual/UI echo concern. Scope: API v1 and the shared evaluated-code routing path. API v0 is out of scope, and deprecated `repl.evaluateCode()` is only a mechanical follow-up if the shared implementation makes that the lowest-risk option.
+
+## Verified Constraints
+
+- Direct REPL Window writes bypass the API sink; only routed output reaches `repl.onOutputLogged()` subscribers.
+- The `evaluatedCode` category already exists in the output router and API v1 type surface.
+- `src/evaluate.ts` currently mixes direct REPL Window writes with conditional routed mirroring.
+- `src/api/repl-v1.ts` currently uses `calva.evaluationSendCodeToOutputWindow` as the gate for evaluated-code routing.
+- There is no focused automated coverage for exactly-once `evaluatedCode` sink behavior today.
+
+## Phases
+
+### Phase 1: Extract an Evaluated-Code Routing Primitive
+
+Create one internal path that can emit evaluated code once to subscribers and then fan out to caller-selected visible destinations without double-emitting. This phase is internal only and should not change user-visible behavior yet.
+
+- [ ] Add a dedicated helper in `src/results-output/output.ts` for evaluated code instead of further overloading `appendClojureEval`
+- [ ] Split sink emission from destination-specific writes just enough to support one subscriber event and caller-controlled visible writes
+- [ ] Preserve `evaluatedCode`, `who`, `ns`, and `replSessionKey` metadata end to end
+- [ ] Add unit coverage for category preservation and the one-emit rule
+- [ ] No new lint errors
+- [ ] Relevant unit tests pass
+
+**What the system can do now:** The shared output layer can represent the desired evaluated-code semantics without changing caller behavior yet.
+
+---
+
+### Phase 2: Adopt the Helper in API v1
+
+Make `repl.evaluate()` the first caller to use the new primitive. This establishes the API contract before the manual UI path adopts the same plumbing.
+
+- [ ] Replace the evaluated-code block in `src/api/repl-v1.ts` with one unconditional evaluated-code sink emission
+- [ ] Make API v1 route visible evaluated code to the configured eval-results destination independently of `calva.evaluationSendCodeToOutputWindow`
+- [ ] Ensure API v1 does not automatically echo evaluated code to the REPL Window
+- [ ] Add integration coverage for API v1 with settings on and off, confirming the sink event and destination-visible behavior are unchanged across setting values
+- [ ] No new lint errors
+- [ ] Relevant unit and integration tests pass
+- [ ] Manually verify `repl.onOutputLogged()` receives one `evaluatedCode` message per evaluation and that the visible copy appears once in the configured eval-results destination
+
+**What the system can do now:** API v1 subscribers see exactly one evaluated-code event per evaluation, and API-triggered visible code appears in the configured eval-results destination without REPL Window echo.
+
+---
+
+### Phase 3: Adopt the Primitive in Manual Evaluation
+
+Reuse the same primitive in the manual evaluation path without forcing API v1 visibility policy onto manual/UI behavior. Keep the existing REPL-oriented overrides intact.
+
+- [ ] Replace the direct REPL Window write plus conditional mirror in `src/evaluate.ts` with the shared helper
+- [ ] Preserve manual/UI REPL echo behavior as a separate policy from API v1 destination-visible routing
+- [ ] Keep per-call overrides from snippets, hover, and REPL-window self-evaluation working
+- [ ] Ensure evaluating from the REPL Window suppresses only the extra REPL append, not the sink event or the non-REPL eval-results copy
+- [ ] Add integration coverage for evaluation from a normal editor and from the REPL Window
+- [ ] No new lint errors
+- [ ] Relevant unit and integration tests pass
+- [ ] Manually verify there is no duplicate visible code in the REPL Window
+
+**What the system can do now:** API v1 and manual evaluation share one evaluated-code routing primitive while intentionally keeping different visible-output policies.
+
+---
+
+### Phase 4: Align Configuration and Documentation
+
+Once behavior is stable, align the setting, docs, and user-visible naming so the contract is legible.
+
+- [ ] Update `package.json` setting text and any related command title so the setting clearly means manual/UI REPL echo behavior rather than API v1 output routing
+- [ ] Apply the chosen default value for `calva.evaluationSendCodeToOutputWindow`
+- [ ] Update `docs/site/api.md` to state that `evaluatedCode` always reaches `repl.onOutputLogged()` exactly once and that API v1 visible code routes to the configured eval-results destination
+- [ ] Review `docs/site/custom-commands.md`, `docs/site/output.md`, and `docs/site/repl-window.md` for wording that assumes the old behavior, and update as needed
+- [ ] No new lint errors
+- [ ] Relevant unit and integration tests pass
+
+**What the system can do now:** The code, setting text, and docs describe the same behavior.
+
+---
+
+## Open Questions / Assumptions
+
+- `ASSUMPTION:` API v1 `onOutputLogged()` should expose evaluated code as a semantic event independent of visible routing choices.
+- `ASSUMPTION:` API v1 should always route visible evaluated code to the configured eval-results destination, regardless of `calva.evaluationSendCodeToOutputWindow`.
+- `ASSUMPTION:` The sink should continue to receive the code text once per evaluation, not one event per visible destination.
+- `OPEN QUESTION:` Should deprecated `repl.evaluateCode()` be mechanically aligned in the same change to avoid two behaviors inside `src/api/repl-v1.ts`, or can it intentionally lag behind the API v1 contract work?
+- `OPEN QUESTION:` Should evaluated-code sink text preserve the current leading-newline behavior from the output router, or be normalized to the raw code string?
+
+## Original Plan-producing Prompt
+
+Write a markdown implementation plan for Calva to change evaluated-code routing semantics. Scope is API v1 and the shared evaluated-code routing path only; ignore API v0, and treat deprecated `repl.evaluateCode()` as an optional mechanical follow-up rather than a product concern. The desired behavior is: (1) evaluated code always reaches the API output log sink (`repl.onOutputLogged()`) once and exactly once, regardless of `calva.evaluationSendCodeToOutputWindow`; (2) API v1 routes visible evaluated code to the configured eval-results destination and does not use the REPL Window as its default echo target; (3) manual/UI evaluation can retain REPL-oriented echo behavior; (4) direct REPL Window writes must not create duplicate sink events. Base the plan on the current code in `src/api/repl-v1.ts`, `src/evaluate.ts`, `src/results-output/output.ts`, the setting declaration in `package.json`, and the current API docs in `docs/site/api.md`. Include safe, shippable phases, concrete test and validation steps, the relevant documentation follow-up, and any explicit assumptions or open questions that should be resolved before implementation.

--- a/docs/site/api.md
+++ b/docs/site/api.md
@@ -305,6 +305,8 @@ export interface OutputMessage {
 }
 ```
 
+Calva emits exactly one `evaluatedCode` message per evaluation. For `repl.evaluate()`, that message is independent of `calva.evaluationSendCodeToOutputWindow`, and the visible copy of the evaluated code goes to the configured eval-results destination. The setting now only controls the extra REPL Window echo used by manual/UI evaluations.
+
 ### `repl.evaluateCode()` *(deprecated)*
 
 !!! Warning "Deprecated"

--- a/docs/site/custom-commands.md
+++ b/docs/site/custom-commands.md
@@ -22,7 +22,7 @@ The `calva.customREPLCommandSnippets` is an array of objects with the following 
 * `key`: A key can be used to reference the snippet from **Run Custom REPL Command** keyboard shortcut arguments. It will also be used in the quick-pick menu.
 * `ns`: A namespace to evaluate the command in. If omitted the command will be executed in the namespace of the current editor.
 * `repl`: Which repl session to use for the evaluation. Either `"clj"` or `"cljs"`. Omit if you want to use the session of the current editor.
-* `evaluationSendCodeToOutputWindow`: (default `true`) Whether the evaluated code should also be echoed to the REPL Window. This only controls the extra REPL-window echo.
+* `evaluationSendCodeToOutputWindow`: (default `true`) Whether the evaluated code should also be echoed to the configured output destination for results.
 
 There are also substitutions available, which will take elements from the current state of Calva and splice them in to the text of your command before executing it. They are
 

--- a/docs/site/custom-commands.md
+++ b/docs/site/custom-commands.md
@@ -22,7 +22,7 @@ The `calva.customREPLCommandSnippets` is an array of objects with the following 
 * `key`: A key can be used to reference the snippet from **Run Custom REPL Command** keyboard shortcut arguments. It will also be used in the quick-pick menu.
 * `ns`: A namespace to evaluate the command in. If omitted the command will be executed in the namespace of the current editor.
 * `repl`: Which repl session to use for the evaluation. Either `"clj"` or `"cljs"`. Omit if you want to use the session of the current editor.
-* `evaluationSendCodeToOutputWindow`: (default `true`) Whether the evaluated code should be echoed to the Output/REPL window.
+* `evaluationSendCodeToOutputWindow`: (default `true`) Whether the evaluated code should also be echoed to the REPL Window. This only controls the extra REPL-window echo.
 
 There are also substitutions available, which will take elements from the current state of Calva and splice them in to the text of your command before executing it. They are
 

--- a/docs/site/output.md
+++ b/docs/site/output.md
@@ -13,10 +13,10 @@ Calva categorizes output into three types:
 
 With the setting `calva.outputDestinations`, you can configure where each category of output should go to. These are the allowed values and their descriptions:
 
-* `"repl-window"` - The [REPL Window](repl-window.md) (an editor-based read/write output view). This is the default value.
-* `"output-view"` - The [output view](output-view.md) (a read-only view that is much more performant than the REPL Window)
-* `"output-channel"` - The _Calva Says_ Output Channel
-* `"terminal"` - The _Calva Output_ (pseudo) Terminal
+* `"terminal"` - The _Calva Output_ (pseudo) Terminal. This is the default value.
+* `"repl-window"` - The [REPL Window](repl-window.md) (an editor-based read/write output view).
+* `"output-view"` - The [output view](output-view.md) (a read-only view that is much more performant than the REPL Window).
+* `"output-channel"` - The _Calva Says_ Output Channel.
 
 The reason there are several options for this is partly legacy and partly because VS Code restricts the placement of
 different views in different ways. We hope you will find a combination of output destinations that suits you.

--- a/docs/site/output.md
+++ b/docs/site/output.md
@@ -21,8 +21,6 @@ With the setting `calva.outputDestinations`, you can configure where each catego
 The reason there are several options for this is partly legacy and partly because VS Code restricts the placement of
 different views in different ways. We hope you will find a combination of output destinations that suits you.
 
-The evaluated code itself is also logged as a separate semantic event. For manual/UI evaluations, `calva.evaluationSendCodeToOutputWindow` controls whether Calva also echoes that code to the REPL Window. API subscribers to `repl.onOutputLogged()` still receive the `evaluatedCode` message regardless of that setting.
-
 ### Output Destinations Feature Comparison
 
 The table below lists the features of the different output destinations.

--- a/docs/site/output.md
+++ b/docs/site/output.md
@@ -21,6 +21,8 @@ With the setting `calva.outputDestinations`, you can configure where each catego
 The reason there are several options for this is partly legacy and partly because VS Code restricts the placement of
 different views in different ways. We hope you will find a combination of output destinations that suits you.
 
+The evaluated code itself is also logged as a separate semantic event. For manual/UI evaluations, `calva.evaluationSendCodeToOutputWindow` controls whether Calva also echoes that code to the REPL Window. API subscribers to `repl.onOutputLogged()` still receive the `evaluatedCode` message regardless of that setting.
+
 ### Output Destinations Feature Comparison
 
 The table below lists the features of the different output destinations.

--- a/docs/site/repl-window.md
+++ b/docs/site/repl-window.md
@@ -17,6 +17,8 @@ The first prompt is from when the `clj` REPL is connected, and the second from `
 
 By default the REPL Window doubles as the place where Calva sends output like stdout/stderr and other messages. See [Calva Output](output.md) for more about this and how to change this behaviour.
 
+If you want manual evaluations to also echo the code itself there, use the `calva.evaluationSendCodeToOutputWindow` setting.
+
 ## Finding the REPL Window
 
 If you quickly want to open and/or switch to the REPL Window there is the command **Calva: Show/Open REPL Window**, `ctrl+alt+o r`.

--- a/package.json
+++ b/package.json
@@ -366,7 +366,7 @@
           "calva.evaluationSendCodeToOutputWindow": {
             "type": "boolean",
             "default": true,
-            "description": "Also echo manually evaluated code to the REPL Window"
+            "description": "Also echo manually evaluated code to the configured output destination for results"
           },
           "calva.testOnSave": {
             "type": "boolean",
@@ -549,7 +549,7 @@
                 },
                 "evaluationSendCodeToOutputWindow": {
                   "type": "boolean",
-                  "markDownDescription": "Should the evaluated code snippet also be echoed to the REPL Window? This only controls the extra REPL-window echo."
+                  "markDownDescription": "Should the evaluated code snippet also be echoed to the configured output destination for results?"
                 }
               },
               "required": [

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
                   "terminal",
                   "output-view"
                 ],
-                "default": "repl-window",
+                "default": "terminal",
                 "markdownDescription": "Destination for evaluation results. (Clojure data returned from an evaluation)."
               },
               "evalOutput": {
@@ -189,7 +189,7 @@
                   "terminal",
                   "output-view"
                 ],
-                "default": "repl-window",
+                "default": "terminal",
                 "markdownDescription": "Destination for evaluation output (stdout/stderr from an evaluation)."
               },
               "otherOutput": {
@@ -200,14 +200,14 @@
                   "terminal",
                   "output-view"
                 ],
-                "default": "repl-window",
+                "default": "terminal",
                 "markdownDescription": "Destination for other output (Calva messages, out-of-band stdout/stderr, etcetera)."
               }
             },
             "default": {
-              "evalResults": "repl-window",
-              "evalOutput": "repl-window",
-              "otherOutput": "repl-window"
+              "evalResults": "terminal",
+              "evalOutput": "terminal",
+              "otherOutput": "terminal"
             }
           },
           "calva.fiddleFilePaths": {

--- a/package.json
+++ b/package.json
@@ -366,7 +366,7 @@
           "calva.evaluationSendCodeToOutputWindow": {
             "type": "boolean",
             "default": true,
-            "description": "Also send evaluated code to the REPL Window"
+            "description": "Also echo manually evaluated code to the REPL Window"
           },
           "calva.testOnSave": {
             "type": "boolean",
@@ -549,7 +549,7 @@
                 },
                 "evaluationSendCodeToOutputWindow": {
                   "type": "boolean",
-                  "markDownDescription": "Should the code snippet evaluated be echoed to the REPL Window?"
+                  "markDownDescription": "Should the evaluated code snippet also be echoed to the REPL Window? This only controls the extra REPL-window echo."
                 }
               },
               "required": [
@@ -1584,7 +1584,7 @@
       },
       {
         "command": "calva.toggleEvaluationSendCodeToOutputWindow",
-        "title": "Toggle also sending evaluated code to the REPL Window",
+        "title": "Toggle also echoing manually evaluated code to the REPL Window",
         "category": "Calva",
         "enablement": "calva:connected"
       },

--- a/package.json
+++ b/package.json
@@ -1045,7 +1045,7 @@
           "calva.enableInspectorRainbow": {
             "type": "boolean",
             "markdownDescription": "Should the Calva Inspector items use rainbow colors? When enabled, the collection items will be colored with the same colors as VS Code uses for bracket pairs. See https://calva.io/inspector for info.",
-            "default": false
+            "default": true
           },
           "calva.keybindingsEnabled": {
             "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -365,7 +365,7 @@
           },
           "calva.evaluationSendCodeToOutputWindow": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "description": "Also send evaluated code to the REPL Window"
           },
           "calva.testOnSave": {

--- a/src/api/repl-v1.ts
+++ b/src/api/repl-v1.ts
@@ -111,14 +111,10 @@ export const evaluate = async (
   whoTracking.recordEvaluation(effectiveSessionKey, resolvedWho);
   whoTracking.setCurrentWho(session.sessionId, resolvedWho);
 
-  if (getConfig().evaluationSendCodeToOutputWindow) {
-    if (resultOutput.getDestinationConfiguration().evalResults !== 'repl-window') {
-      resultOutput.appendClojureEval(code, {
-        ...evalOptions,
-        outputCategory: 'evaluatedCode',
-      });
-    }
-  }
+  resultOutput.appendEvaluatedCode(code, {
+    destination: resultOutput.getDestinationConfiguration().evalResults,
+    ...evalOptions,
+  });
 
   let result: Result;
   try {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -181,16 +181,17 @@ async function evaluateCodeUpdatingUI(
 
     try {
       const evalResultsDestination = output.getDestinationConfiguration().evalResults;
-      const shouldEchoToReplWindow =
+      const shouldWriteVisibleEvaluatedCode =
         evaluationSendCodeToOutputWindow && !replWindow.isReplWindowDoc(editor?.document);
 
       output.appendEvaluatedCode(code, {
-        destination: shouldEchoToReplWindow ? 'repl-window' : evalResultsDestination,
+        destination: shouldWriteVisibleEvaluatedCode ? 'repl-window' : evalResultsDestination,
         additionalDestinations:
-          shouldEchoToReplWindow && evalResultsDestination !== 'repl-window'
+          shouldWriteVisibleEvaluatedCode && evalResultsDestination !== 'repl-window'
             ? [evalResultsDestination]
             : [],
         sinkDestination: evalResultsDestination,
+        writeVisible: shouldWriteVisibleEvaluatedCode,
         ns,
         replSessionType: sessionKey,
         visibleOutputCategory: 'evaluatedCode',

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -180,17 +180,22 @@ async function evaluateCodeUpdatingUI(
     whoTracking.setCurrentWho(session.sessionId, 'ui');
 
     try {
-      if (evaluationSendCodeToOutputWindow && !replWindow.isReplWindowDoc(editor?.document)) {
-        replWindow.appendLine(code);
-        if (output.getDestinationConfiguration().evalResults !== 'repl-window') {
-          output.appendClojureEval(code, {
-            ns,
-            replSessionType: sessionKey,
-            outputCategory: 'evaluatedCode',
-            who: 'ui',
-          });
-        }
-      }
+      const evalResultsDestination = output.getDestinationConfiguration().evalResults;
+      const shouldEchoToReplWindow =
+        evaluationSendCodeToOutputWindow && !replWindow.isReplWindowDoc(editor?.document);
+
+      output.appendEvaluatedCode(code, {
+        destination: shouldEchoToReplWindow ? 'repl-window' : evalResultsDestination,
+        additionalDestinations:
+          shouldEchoToReplWindow && evalResultsDestination !== 'repl-window'
+            ? [evalResultsDestination]
+            : [],
+        sinkDestination: evalResultsDestination,
+        ns,
+        replSessionType: sessionKey,
+        visibleOutputCategory: 'evaluatedCode',
+        who: 'ui',
+      });
 
       let value = await context.value;
       value = util.stripAnsi(context.pprintOut || value);

--- a/src/extension-test/integration/suite/jack-in-and-connect-test.ts
+++ b/src/extension-test/integration/suite/jack-in-and-connect-test.ts
@@ -22,13 +22,17 @@ import {
 } from '../../../nrepl/connect-sequence-types';
 import * as projectTypes from '../../../nrepl/project-types';
 import { getConfig } from '../../../config';
+import * as output from '../../../results-output/output';
 
 suite('Jack-in and Connect suite', () => {
   const suite = 'Jack-in and Connect';
+  let originalDestinations: any;
 
   before(async () => {
     testUtil.showMessage(suite, 'suite starting!');
     await testUtil.ensureOutputDir(testUtil.testDataDir);
+    const config = vscode.workspace.getConfiguration('calva');
+    originalDestinations = config.inspect('outputDestinations')?.globalValue;
   });
 
   after(async () => {
@@ -41,9 +45,19 @@ suite('Jack-in and Connect suite', () => {
   });
 
   beforeEach(async () => {
+    await setOutputDestinations('repl-window');
     await outputWindow.clearReplWindowDoc();
     resetConnectionTracking();
     await disconnectExistingClients();
+  });
+
+  afterEach(async () => {
+    const config = vscode.workspace.getConfiguration('calva');
+    await config.update(
+      'outputDestinations',
+      originalDestinations,
+      vscode.ConfigurationTarget.Global
+    );
   });
 
   test('start repl and connect (jack-in)', async function () {
@@ -414,7 +428,7 @@ async function loadAndAssert(
   needle: string[],
   options?: { waitForJackInOutput?: boolean }
 ) {
-  const replWindowDoc = await waitForResult(suite, options);
+  await waitForResult(suite, options);
 
   await vscode.workspace.openTextDocument(testFilePath).then((doc) =>
     vscode.window.showTextDocument(doc, {
@@ -424,7 +438,17 @@ async function loadAndAssert(
   testUtil.log(suite, 'opened test.clj document again');
 
   await commands.executeCommand('calva.loadFile');
-  const haystack = replWindowDoc.document.getText().split(/\r?\n/);
+  let haystack: string[] = [];
+  await testUtil.waitForCondition(
+    async () => {
+      const replWindowDoc = await outputWindow.openReplWindowDoc();
+      haystack = getDocument(replWindowDoc).document.getText().split(/\r?\n/);
+      return appearInOrder(needle, haystack);
+    },
+    10_000,
+    50,
+    `Timed out waiting for expected REPL-window output: ${JSON.stringify(needle)}`
+  );
   assert.ok(
     appearInOrder(needle, haystack),
     `Expected output to contain: ${JSON.stringify(needle)}\n, but got: ${JSON.stringify(
@@ -451,7 +475,27 @@ async function waitForNextClient(suite: string): Promise<string> {
 }
 
 async function waitForJackInCompletion(suite: string) {
+  if (output.getDestinationConfiguration().otherOutput !== 'repl-window') {
+    testUtil.log(
+      suite,
+      'Skipping REPL-window jack-in completion wait because other output is not routed there'
+    );
+    return;
+  }
   lastJackInDoneCount = await testUtil.waitForJackInCompletionCount(suite, lastJackInDoneCount);
+}
+
+async function setOutputDestinations(destination: output.OutputDestination) {
+  const config = vscode.workspace.getConfiguration('calva');
+  await config.update(
+    'outputDestinations',
+    {
+      evalResults: destination,
+      evalOutput: destination,
+      otherOutput: destination,
+    },
+    vscode.ConfigurationTarget.Global
+  );
 }
 
 async function startJackInProcedure(

--- a/src/extension-test/integration/suite/session-management-test.ts
+++ b/src/extension-test/integration/suite/session-management-test.ts
@@ -234,7 +234,7 @@ describe(`${suiteName} suite`, () => {
       await config.update(
         'outputDestinations',
         {
-          evalResults: 'output-channel',
+          evalResults: 'repl-window',
           evalOutput: 'output-channel',
           otherOutput: 'output-channel',
         },

--- a/src/extension-test/integration/suite/session-management-test.ts
+++ b/src/extension-test/integration/suite/session-management-test.ts
@@ -1,17 +1,20 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
 import connector from '../../../connector';
 import * as replApi from '../../../api/repl-v1';
 import * as replSession from '../../../nrepl/repl-session';
+import evaluate from '../../../evaluate';
 import * as cljsLib from '../../../../out/cljs-lib/cljs-lib';
 import type { NReplSession, NReplClient } from '../../../nrepl';
 import * as testUtil from './util';
 import * as sessionRouting from '../../../nrepl/session-routing';
 import * as clientRegistry from '../../../nrepl/client-registry';
 import { buildGlobSpecsFromTiers } from '../../../nrepl/globs';
+import { getDocument } from '../../../doc-mirror';
 
 const { describe, before, beforeEach, afterEach, it } = Mocha;
 
@@ -25,8 +28,27 @@ const createSession = (replType: string, clientKey?: string): NReplSession =>
     client: clientKey ? { clientKey } : undefined,
   } as NReplSession);
 
+const createEvaluatingSession = (result: string, clientKey?: string): NReplSession =>
+  ({
+    replType: 'clj',
+    sessionId: 'session-management/evaluate-session-id',
+    client: clientKey ? { clientKey } : undefined,
+    eval: (_code: string, ns: string) => ({
+      value: Promise.resolve(result),
+      ns,
+      outPut: '',
+      errorOutput: '',
+    }),
+    stacktrace: () => Promise.resolve(undefined),
+  } as unknown as NReplSession);
+
 const resetOutputWindowSession = (sessionType: string, ns: string): void => {
   outputWindow.setSession(createSession(sessionType), ns, sessionType);
+};
+
+const getReplWindowText = async (): Promise<string> => {
+  const replWindowDoc = await outputWindow.openReplWindowDoc();
+  return getDocument(replWindowDoc).document.getText();
 };
 
 describe(`${suiteName} suite`, () => {
@@ -104,6 +126,266 @@ describe(`${suiteName} suite`, () => {
       session.projectRoot.includes('projects/deps.edn'),
       `Expected path to include projects/deps.edn but got: ${session.projectRoot}`
     );
+  });
+
+  it('emits evaluatedCode once regardless of the code-echo setting', async () => {
+    const config = vscode.workspace.getConfiguration('calva');
+    const originalDestinations = config.inspect('outputDestinations')?.globalValue;
+    const originalSendCodeSetting = config.inspect('evaluationSendCodeToOutputWindow')?.globalValue;
+    const sessionKey = 'session-management/evaluate';
+    const code = '(inc 1)';
+    const evaluationResult = '2';
+    const who = 'integration-test';
+    const events: replApi.OutputMessage[] = [];
+
+    sessionRegistry.registerSession(sessionKey, createEvaluatingSession(evaluationResult), {
+      globs: ['**/*.clj'],
+    });
+
+    const subscription = replApi.onOutputLogged((message) => events.push(message));
+
+    try {
+      await config.update(
+        'outputDestinations',
+        {
+          evalResults: 'repl-window',
+          evalOutput: 'repl-window',
+          otherOutput: 'repl-window',
+        },
+        vscode.ConfigurationTarget.Global
+      );
+
+      for (const sendCodeToOutputWindow of [false, true]) {
+        events.length = 0;
+        await outputWindow.clearReplWindowDoc();
+        await config.update(
+          'evaluationSendCodeToOutputWindow',
+          sendCodeToOutputWindow,
+          vscode.ConfigurationTarget.Global
+        );
+
+        await replApi.evaluate(code, {
+          sessionKey,
+          ns: 'user',
+          who,
+        });
+
+        await testUtil.waitForCondition(async () => {
+          const replWindowDoc = await outputWindow.openReplWindowDoc();
+          return getDocument(replWindowDoc).document.getText().includes(code);
+        });
+
+        const evaluatedCodeEvents = events.filter(
+          (message) => message.category === 'evaluatedCode'
+        );
+        assert.strictEqual(
+          evaluatedCodeEvents.length,
+          1,
+          `Expected one evaluatedCode event when evaluationSendCodeToOutputWindow=${sendCodeToOutputWindow}`
+        );
+        assert.strictEqual(evaluatedCodeEvents[0].who, who);
+        assert.strictEqual(evaluatedCodeEvents[0].ns, 'user');
+        assert.strictEqual(evaluatedCodeEvents[0].replSessionKey, sessionKey);
+
+        const replWindowDoc = await outputWindow.openReplWindowDoc();
+        const replText = getDocument(replWindowDoc).document.getText();
+        const codeOccurrences = (replText.match(/\(inc 1\)/g) || []).length;
+
+        assert.strictEqual(
+          codeOccurrences,
+          1,
+          `Expected visible evaluated code once when evaluationSendCodeToOutputWindow=${sendCodeToOutputWindow}`
+        );
+      }
+    } finally {
+      subscription.dispose();
+      sessionRegistry.unregisterSession(sessionKey);
+      await config.update(
+        'outputDestinations',
+        originalDestinations,
+        vscode.ConfigurationTarget.Global
+      );
+      await config.update(
+        'evaluationSendCodeToOutputWindow',
+        originalSendCodeSetting,
+        vscode.ConfigurationTarget.Global
+      );
+      await outputWindow.clearReplWindowDoc();
+    }
+  });
+
+  it('manual evaluation emits evaluatedCode once and only echoes to the REPL window when enabled', async () => {
+    const config = vscode.workspace.getConfiguration('calva');
+    const originalDestinations = config.inspect('outputDestinations')?.globalValue;
+    const originalSendCodeSetting = config.inspect('evaluationSendCodeToOutputWindow')?.globalValue;
+    const sessionKey = 'session-management/manual-evaluate';
+    const code = '(inc 1)';
+    const evaluationResult = '2';
+    const events: replApi.OutputMessage[] = [];
+    const editor = await testUtil.openFile(path.join(testUtil.testDataDir, 'test.clj'));
+
+    sessionRegistry.registerSession(sessionKey, createEvaluatingSession(evaluationResult), {
+      globs: ['**/*.clj'],
+    });
+
+    const subscription = replApi.onOutputLogged((message) => events.push(message));
+
+    try {
+      await config.update(
+        'outputDestinations',
+        {
+          evalResults: 'output-channel',
+          evalOutput: 'output-channel',
+          otherOutput: 'output-channel',
+        },
+        vscode.ConfigurationTarget.Global
+      );
+
+      for (const sendCodeToOutputWindow of [false, true]) {
+        events.length = 0;
+        await outputWindow.clearReplWindowDoc();
+        await config.update(
+          'evaluationSendCodeToOutputWindow',
+          sendCodeToOutputWindow,
+          vscode.ConfigurationTarget.Global
+        );
+
+        const activeEditor = await vscode.window.showTextDocument(editor.document, {
+          preview: false,
+        });
+        await testUtil.waitForCondition(
+          () => vscode.window.activeTextEditor?.document.uri.fsPath === editor.document.uri.fsPath,
+          4000,
+          20,
+          'Timed out waiting for the source editor to become active'
+        );
+
+        await evaluate.evaluateInCurrentEditor(activeEditor, code, sessionKey, 'user', {});
+
+        await testUtil.waitForCondition(
+          () => events.filter((message) => message.category === 'evaluatedCode').length === 1,
+          4000,
+          20,
+          'Timed out waiting for manual evaluatedCode event'
+        );
+
+        const evaluatedCodeEvents = events.filter(
+          (message) => message.category === 'evaluatedCode'
+        );
+        assert.strictEqual(
+          evaluatedCodeEvents.length,
+          1,
+          `Expected one manual evaluatedCode event when evaluationSendCodeToOutputWindow=${sendCodeToOutputWindow}`
+        );
+        assert.strictEqual(evaluatedCodeEvents[0].who, 'ui');
+        assert.strictEqual(evaluatedCodeEvents[0].ns, 'user');
+        assert.strictEqual(evaluatedCodeEvents[0].replSessionKey, sessionKey);
+
+        if (sendCodeToOutputWindow) {
+          await testUtil.waitForCondition(
+            async () => (await getReplWindowText()).includes(code),
+            4000,
+            20,
+            'Timed out waiting for manual REPL-window echo'
+          );
+        }
+
+        const replText = await getReplWindowText();
+        const codeOccurrences = (replText.match(/\(inc 1\)/g) || []).length;
+
+        assert.strictEqual(
+          codeOccurrences,
+          sendCodeToOutputWindow ? 1 : 0,
+          `Unexpected REPL-window echo count when evaluationSendCodeToOutputWindow=${sendCodeToOutputWindow}`
+        );
+      }
+    } finally {
+      subscription.dispose();
+      sessionRegistry.unregisterSession(sessionKey);
+      await config.update(
+        'outputDestinations',
+        originalDestinations,
+        vscode.ConfigurationTarget.Global
+      );
+      await config.update(
+        'evaluationSendCodeToOutputWindow',
+        originalSendCodeSetting,
+        vscode.ConfigurationTarget.Global
+      );
+      await outputWindow.clearReplWindowDoc();
+    }
+  });
+
+  it('manual REPL-window evaluation avoids duplicate visible code while still emitting evaluatedCode', async () => {
+    const config = vscode.workspace.getConfiguration('calva');
+    const originalDestinations = config.inspect('outputDestinations')?.globalValue;
+    const sessionKey = 'session-management/repl-window-evaluate';
+    const code = '(inc 1)';
+    const evaluationResult = '2';
+    const events: replApi.OutputMessage[] = [];
+
+    sessionRegistry.registerSession(sessionKey, createEvaluatingSession(evaluationResult), {
+      globs: ['**/*.clj'],
+    });
+
+    const subscription = replApi.onOutputLogged((message) => events.push(message));
+
+    try {
+      await config.update(
+        'outputDestinations',
+        {
+          evalResults: 'output-channel',
+          evalOutput: 'output-channel',
+          otherOutput: 'output-channel',
+        },
+        vscode.ConfigurationTarget.Global
+      );
+
+      await outputWindow.clearReplWindowDoc();
+      await outputWindow.revealReplWindowDoc(false);
+      await testUtil.waitForCondition(
+        () => outputWindow.isReplWindowDoc(vscode.window.activeTextEditor?.document),
+        4000,
+        20,
+        'Timed out waiting for REPL window to become active'
+      );
+
+      outputWindow.appendLine(code);
+      await testUtil.waitForCondition(
+        async () => (await getReplWindowText()).includes(code),
+        4000,
+        20,
+        'Timed out waiting for test code to be appended to the REPL window'
+      );
+
+      await evaluate.evaluateInOutputWindow(code, sessionKey, 'user', {
+        evaluationSendCodeToOutputWindow: false,
+      });
+
+      await testUtil.waitForCondition(
+        () => events.filter((message) => message.category === 'evaluatedCode').length === 1,
+        4000,
+        20,
+        'Timed out waiting for REPL-window evaluatedCode event'
+      );
+
+      const evaluatedCodeEvents = events.filter((message) => message.category === 'evaluatedCode');
+      assert.strictEqual(evaluatedCodeEvents.length, 1);
+      assert.strictEqual(evaluatedCodeEvents[0].replSessionKey, sessionKey);
+
+      const replText = await getReplWindowText();
+      const codeOccurrences = (replText.match(/\(inc 1\)/g) || []).length;
+      assert.strictEqual(codeOccurrences, 1, 'Expected REPL-window code to remain single-copy');
+    } finally {
+      subscription.dispose();
+      sessionRegistry.unregisterSession(sessionKey);
+      await config.update(
+        'outputDestinations',
+        originalDestinations,
+        vscode.ConfigurationTarget.Global
+      );
+      await outputWindow.clearReplWindowDoc();
+    }
   });
 
   it('toggle command cycles cljc target within a connection', () => {

--- a/src/extension-test/integration/suite/util.ts
+++ b/src/extension-test/integration/suite/util.ts
@@ -9,6 +9,7 @@ import * as clientRegistry from '../../../nrepl/client-registry';
 import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as jackIn from '../../../nrepl/jack-in';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
+import * as output from '../../../results-output/output';
 import { getDocument } from '../../../doc-mirror';
 import connector from '../../../connector';
 
@@ -330,6 +331,13 @@ export class JackInHarness {
   }
 
   async waitForJackInCompletion(timeoutMs = 60_000): Promise<void> {
+    if (output.getDestinationConfiguration().otherOutput !== 'repl-window') {
+      log(
+        this.suiteName,
+        'Skipping REPL-window jack-in completion wait because other output is not routed there'
+      );
+      return;
+    }
     this.lastJackInDoneCount = await waitForJackInCompletionCount(
       this.suiteName,
       this.lastJackInDoneCount,

--- a/src/extension-test/unit/results-output/output-test.ts
+++ b/src/extension-test/unit/results-output/output-test.ts
@@ -1,0 +1,40 @@
+import { expect } from 'expect';
+import {
+  routeEvaluatedCode,
+  type EvaluatedCodeMessage,
+  type VisibleEvaluatedCodeWrite,
+} from '../../../results-output/evaluated-code';
+
+describe('routeEvaluatedCode', () => {
+  it('emits one evaluatedCode message while preserving metadata', () => {
+    const messages: EvaluatedCodeMessage[] = [];
+    const visibleWrites: VisibleEvaluatedCodeWrite[] = [];
+
+    routeEvaluatedCode({
+      code: '(inc 1)',
+      didLastTerminateLine: true,
+      ns: 'user',
+      replSessionKey: 'clj',
+      who: 'test-who',
+      emit: (message) => messages.push(message),
+      writeVisible: (write) => visibleWrites.push(write),
+    });
+
+    expect(messages).toEqual([
+      {
+        category: 'evaluatedCode',
+        text: '(inc 1)',
+        who: 'test-who',
+        ns: 'user',
+        replSessionKey: 'clj',
+      },
+    ]);
+    expect(visibleWrites).toEqual([
+      {
+        code: '(inc 1)',
+        didLastTerminateLine: true,
+        outputCategory: 'evalResults',
+      },
+    ]);
+  });
+});

--- a/src/results-output/evaluated-code.ts
+++ b/src/results-output/evaluated-code.ts
@@ -1,0 +1,58 @@
+export type EvaluatedCodeOutputCategory =
+  | 'evalResults'
+  | 'evaluatedCode'
+  | 'clojure'
+  | 'evalOut'
+  | 'evalErr'
+  | 'otherOut'
+  | 'otherErr';
+
+export type EvaluatedCodeMessage = {
+  category: 'evaluatedCode';
+  text: string;
+  who?: string;
+  ns?: string;
+  replSessionKey?: string;
+};
+
+export type VisibleEvaluatedCodeWrite = {
+  code: string;
+  didLastTerminateLine: boolean;
+  outputCategory: EvaluatedCodeOutputCategory;
+};
+
+export function routeEvaluatedCode(options: {
+  code: string;
+  didLastTerminateLine: boolean;
+  who?: string;
+  ns?: string;
+  replSessionKey?: string;
+  visibleOutputCategory?: EvaluatedCodeOutputCategory;
+  emit: (message: EvaluatedCodeMessage) => void;
+  writeVisible: (write: VisibleEvaluatedCodeWrite) => void;
+}) {
+  const {
+    code,
+    didLastTerminateLine,
+    who,
+    ns,
+    replSessionKey,
+    visibleOutputCategory = 'evalResults',
+    emit,
+    writeVisible,
+  } = options;
+
+  emit({
+    category: 'evaluatedCode',
+    text: `${didLastTerminateLine ? '' : '\n'}${code}`,
+    who,
+    ns,
+    replSessionKey,
+  });
+
+  writeVisible({
+    code,
+    didLastTerminateLine,
+    outputCategory: visibleOutputCategory,
+  });
+}

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -14,6 +14,7 @@ import {
 } from '../../out/cljs-lib/cljs-lib';
 import * as replSession from '../nrepl/repl-session';
 import * as jackInVersions from '../nrepl/jack-in-dependency-versions';
+import { routeEvaluatedCode } from './evaluated-code';
 
 const customChalk = new chalk.Instance({ level: 3 });
 
@@ -66,6 +67,16 @@ export type AppendClojureOptions = {
   outputCategory?: OutputCategory;
   who?: string;
   description?: string;
+};
+
+export type AppendEvaluatedCodeOptions = {
+  destination: OutputDestination;
+  additionalDestinations?: OutputDestination[];
+  sinkDestination?: OutputDestination;
+  visibleOutputCategory?: OutputCategory;
+  ns?: string;
+  replSessionType?: string;
+  who?: string;
 };
 
 const lightTheme = {
@@ -263,21 +274,13 @@ function nsInfoLine(destination: OutputDestination, options: AppendClojureOption
   )}${themedChalk().evalSeparatorNs(' ' + options.ns + ' ')}\n`;
 }
 
-function appendClojure(
-  options: AppendOptions & AppendClojureOptions,
+function emitClojureMessage(
+  options: Pick<AppendClojureOptions, 'ns' | 'replSessionType' | 'who'> & {
+    outputCategory: OutputCategory;
+  },
   message: string,
-  after?: AfterAppendCallback
+  didLastTerminateLine: boolean
 ) {
-  const destination = options.destination;
-  const didLastTerminateLine = didLastOutputTerminateLine[destination];
-  didLastOutputTerminateLine[destination] = true;
-  if (options.description) {
-    appendOtherOut(options.description, {
-      who: options.who,
-      ns: options.ns,
-      replSessionType: options.replSessionType,
-    });
-  }
   try {
     emit({
       category: options.outputCategory,
@@ -289,6 +292,15 @@ function appendClojure(
   } catch (e) {
     console.error('Calva output-sink listener error', e.message);
   }
+}
+
+function writeClojure(
+  options: AppendOptions & AppendClojureOptions,
+  message: string,
+  didLastTerminateLine: boolean,
+  after?: AfterAppendCallback
+) {
+  const destination = options.destination;
   if (destination === 'repl-window') {
     outputWindow.appendLine(`${didLastTerminateLine ? '' : '\n'}${message}`, after);
   } else if (destination === 'output-channel') {
@@ -317,7 +329,92 @@ function appendClojure(
       after(undefined, undefined);
     }
   }
+}
+
+function appendClojure(
+  options: AppendOptions & AppendClojureOptions,
+  message: string,
+  after?: AfterAppendCallback
+) {
+  const destination = options.destination;
+  const didLastTerminateLine = didLastOutputTerminateLine[destination];
+  didLastOutputTerminateLine[destination] = true;
+  if (options.description) {
+    appendOtherOut(options.description, {
+      who: options.who,
+      ns: options.ns,
+      replSessionType: options.replSessionType,
+    });
+  }
+  emitClojureMessage(options, message, didLastTerminateLine);
+  writeClojure(options, message, didLastTerminateLine, after);
   saveLastInfoLineData(destination, options);
+}
+
+export function appendEvaluatedCode(
+  code: string,
+  options: AppendEvaluatedCodeOptions,
+  after?: AfterAppendCallback
+) {
+  const {
+    destination,
+    additionalDestinations = [],
+    sinkDestination = destination,
+    visibleOutputCategory = 'evalResults',
+    ...metadataOptions
+  } = options;
+  const visibleDestinations = Array.from(new Set([destination, ...additionalDestinations]));
+  const didLastTerminateLineByDestination = new Map<OutputDestination, boolean>();
+
+  for (const visibleDestination of visibleDestinations) {
+    didLastTerminateLineByDestination.set(
+      visibleDestination,
+      didLastOutputTerminateLine[visibleDestination]
+    );
+    didLastOutputTerminateLine[visibleDestination] = true;
+  }
+
+  const sinkDidLastTerminateLine =
+    didLastTerminateLineByDestination.get(sinkDestination) ??
+    didLastOutputTerminateLine[sinkDestination];
+
+  if (!didLastTerminateLineByDestination.has(sinkDestination)) {
+    didLastOutputTerminateLine[sinkDestination] = true;
+  }
+
+  routeEvaluatedCode({
+    code,
+    didLastTerminateLine: sinkDidLastTerminateLine,
+    who: metadataOptions.who,
+    ns: metadataOptions.ns,
+    replSessionKey: metadataOptions.replSessionType,
+    visibleOutputCategory,
+    emit: (message) => {
+      try {
+        emit(message);
+      } catch (e) {
+        console.error('Calva output-sink listener error', e.message);
+      }
+    },
+    writeVisible: ({ code: visibleCode, didLastTerminateLine, outputCategory }) => {
+      visibleDestinations.forEach((visibleDestination, index) => {
+        writeClojure(
+          {
+            destination: visibleDestination,
+            outputCategory,
+            ...metadataOptions,
+          },
+          visibleCode,
+          didLastTerminateLineByDestination.get(visibleDestination) ?? didLastTerminateLine,
+          index === visibleDestinations.length - 1 ? after : undefined
+        );
+      });
+    },
+  });
+
+  visibleDestinations.forEach((visibleDestination) => {
+    saveLastInfoLineData(visibleDestination, metadataOptions);
+  });
 }
 
 /**

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -73,6 +73,7 @@ export type AppendEvaluatedCodeOptions = {
   destination: OutputDestination;
   additionalDestinations?: OutputDestination[];
   sinkDestination?: OutputDestination;
+  writeVisible?: boolean;
   visibleOutputCategory?: OutputCategory;
   ns?: string;
   replSessionType?: string;
@@ -360,10 +361,13 @@ export function appendEvaluatedCode(
     destination,
     additionalDestinations = [],
     sinkDestination = destination,
+    writeVisible = true,
     visibleOutputCategory = 'evalResults',
     ...metadataOptions
   } = options;
-  const visibleDestinations = Array.from(new Set([destination, ...additionalDestinations]));
+  const visibleDestinations = writeVisible
+    ? Array.from(new Set([destination, ...additionalDestinations]))
+    : [];
   const didLastTerminateLineByDestination = new Map<OutputDestination, boolean>();
 
   for (const visibleDestination of visibleDestinations) {
@@ -397,6 +401,12 @@ export function appendEvaluatedCode(
       }
     },
     writeVisible: ({ code: visibleCode, didLastTerminateLine, outputCategory }) => {
+      if (!visibleDestinations.length) {
+        if (after) {
+          after(undefined, undefined);
+        }
+        return;
+      }
       visibleDestinations.forEach((visibleDestination, index) => {
         writeClojure(
           {


### PR DESCRIPTION
* Fixes #3166

## What has changed?

The changelog pretty much says it:

- [Update REPL UI configuration defaults to match Getting Started REPL](https://github.com/BetterThanTomorrow/calva/issues/3166)
  - Use `terminal` as the default destination for all output categories
  - Echoing of the evaluated code to the output evaluation result destionation is now default enabled
  - The configured output evaluation result destionation will uncoditionally always show code evaluated via the API (such as when Backseat Driver evaluates things)


It took some changing in the plumbing of how output is routed.

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->
