### PR TITLE
Update all TS to use namespace imports and named exports

### DIFF
--- a/.github/agents/calva-nucleus.agent.md
+++ b/.github/agents/calva-nucleus.agent.md
@@ -650,19 +650,18 @@ Calva is a Clojure/ClojureScript IDE in VS Code. It bridges three worlds: the ed
 
 ## Require Map
 
+Namespace imports are the import invariant for Calva TypeScript code. Use named or default imports only when a module's export shape makes namespace imports incorrect or unusable.
+
 ```typescript
 // API Entry Point (public consumer interface)
-import { getApi } from 'calva/api';
+import * as api from 'calva/api';
 
 // nREPL Session Management
 import * as sessionRegistry from 'calva/nrepl/session-registry';
 import * as replSession from 'calva/nrepl/repl-session';
 
-// Connection Management
-import connector from 'calva/connector';
-
 // Configuration
-import { getConfig } from 'calva/config';
+import * as config from 'calva/config';
 
 // Output/Results
 import * as resultOutput from 'calva/results-output/output';

--- a/.github/instructions/workspace-typescript-memory.instructions.md
+++ b/.github/instructions/workspace-typescript-memory.instructions.md
@@ -9,20 +9,22 @@ TypeScript coding conventions and patterns that improve code quality and maintai
 
 ## Import Patterns
 
-### Prefer Module Namespace Imports
-When importing multiple functions from a module, use namespace imports instead of destructuring:
+### Module Namespace Imports Are Required
+In Calva TypeScript and TSX code, treat module namespace imports as the default and required import style:
 
 ```typescript
-// Preferred
+// Required in normal cases
 import * as shadowCljsRuntime from './shadow-cljs-runtime';
 await shadowCljsRuntime.initializeShadowRemoteNotifications();
 
-// Instead of
+// Do not do this for Calva code
 import { initializeShadowRemoteNotifications } from './shadow-cljs-runtime';
 await initializeShadowRemoteNotifications();
 ```
 
-**Why:** This approach provides better context about where functions originate and makes it easier to track module dependencies throughout the codebase.
+Use named imports or default imports only when the module's export shape makes a namespace import incorrect or unusable. Typical exceptions are callable CommonJS-style packages, where the correct form may instead be `import x = require('...')`.
+
+**Why:** Namespace imports make call sites show module ownership explicitly, reduce symbol ambiguity during refactors, and keep import style consistent across the Calva TypeScript codebase.
 
 ## Isolate VS Code Dependencies for Unit Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- internal-dev: Update TypeScript codebase to use namespace imports throughout
+
 ## [2.0.578] - 2026-04-27
 
 - Fix: [Mirror doc init race condition](https://github.com/BetterThanTomorrow/calva/issues/3187)

--- a/src/NotebookProvider.ts
+++ b/src/NotebookProvider.ts
@@ -1,16 +1,15 @@
 import * as vscode from 'vscode';
-import { TextDecoder, TextEncoder } from 'util';
-import { prettyPrint } from '../out/cljs-lib/cljs-lib';
+import * as nodeUtil from 'util';
+import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as tokenCursor from './cursor-doc/token-cursor';
 import * as repl from './api/repl-v1';
 import _ = require('lodash');
-import { isInteger } from 'lodash';
-import { getNamespace } from './api/document';
-import { isCommentFormHead } from './utilities';
+import * as documentApi from './api/document';
+import * as utilities from './utilities';
 
 export class NotebookProvider implements vscode.NotebookSerializer {
-  private readonly decoder = new TextDecoder();
-  private readonly encoder = new TextEncoder();
+  private readonly decoder = new nodeUtil.TextDecoder();
+  private readonly encoder = new nodeUtil.TextEncoder();
 
   deserializeNotebook(
     data: Uint8Array,
@@ -34,7 +33,7 @@ export class NotebookProvider implements vscode.NotebookSerializer {
 }
 
 function substring(content: string, [start, end]) {
-  if (isInteger(start) && isInteger(end)) {
+  if (_.isInteger(start) && _.isInteger(end)) {
     return content.substring(start, end);
   }
   return '';
@@ -65,7 +64,7 @@ function parseClojure(content: string): vscode.NotebookCellData[] {
     const endForm = cursor.doc.getTokenCursor(end - endAdjustment);
     const afterForm = cursor.doc.getTokenCursor(end);
 
-    if (isCommentFormHead(endForm.getFunctionName())) {
+    if (utilities.isCommentFormHead(endForm.getFunctionName())) {
       const commentRange = afterForm.rangeForCurrentForm(0);
       const commentStartCursor = cursor.doc.getTokenCursor(commentRange[0]);
       const commentCells = [];
@@ -184,7 +183,7 @@ async function doExecution(
   controller: vscode.NotebookController
 ): Promise<void> {
   const firstCell = cell.notebook.getCells()[0];
-  const ns = cell !== firstCell ? getNamespace(firstCell.document) : undefined;
+  const ns = cell !== firstCell ? documentApi.getNamespace(firstCell.document) : undefined;
   const execution = controller.createNotebookCellExecution(cell);
   execution.start(Date.now());
 
@@ -209,7 +208,7 @@ async function doExecution(
         }
       )
     ).result;
-    const pretty = prettyPrint(response).value;
+    const pretty = cljsLib.prettyPrint(response).value;
     const output = [
       vscode.NotebookCellOutputItem.text(response),
       vscode.NotebookCellOutputItem.text('```clojure\n' + pretty + '\n```', 'text/markdown'),

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
-import axios from 'axios';
+import * as axiosModule from 'axios';
 import * as _ from 'lodash';
+
+const axios = axiosModule.default;
 
 function userAllowsTelemetry(): boolean {
   const calvaConfig = vscode.workspace.getConfiguration('calva');

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import axios from 'axios';
-import { isUndefined } from 'lodash';
+import * as _ from 'lodash';
 
 function userAllowsTelemetry(): boolean {
   const calvaConfig = vscode.workspace.getConfiguration('calva');
@@ -25,7 +25,7 @@ export default class Analytics {
   private userID(): string {
     const KEY = 'userLogID';
     const value = this.store.get<string>(KEY);
-    if (isUndefined(value)) {
+    if (_.isUndefined(value)) {
       const newID = crypto.randomUUID();
       void this.store.update(KEY, newID);
       return newID;

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode';
-import * as axiosModule from 'axios';
+import * as axios from 'axios';
 import * as _ from 'lodash';
-
-const axios = axiosModule.default;
 
 function userAllowsTelemetry(): boolean {
   const calvaConfig = vscode.workspace.getConfiguration('calva');
@@ -15,7 +13,7 @@ function userAllowsTelemetry(): boolean {
   return calvaTelemetryEnabled;
 }
 
-export default class Analytics {
+export class Analytics {
   private store: vscode.Memento;
   private GA4_TOKEN = process.env.CALVA_DEV_GA4_TOKEN ?? 'GgrUWszmTo2FG538YCUGpw';
   private GA4_MEASUREMENT_ID = process.env.CALVA_DEV_GA4_ID ?? 'G-HYZ3MX6DL1';
@@ -41,7 +39,7 @@ export default class Analytics {
       return;
     }
     try {
-      return axios
+      return axios.default
         .post(
           `https://www.google-analytics.com/mp/collect?measurement_id=${this.GA4_MEASUREMENT_ID}&api_secret=${this.GA4_TOKEN}`,
           {

--- a/src/api/info.ts
+++ b/src/api/info.ts
@@ -1,4 +1,4 @@
-import { clojureDocsCiderNReplLookup } from '../clojuredocs';
+import * as clojuredocs from '../clojuredocs';
 import * as replSession from '../nrepl/repl-session';
 import * as sessionRegistry from '../nrepl/session-registry';
 
@@ -9,7 +9,7 @@ export const getClojureDocsDotOrg = async (symbol: string, ns = 'user') => {
   if (!session) {
     return { error: "Can't retrieve REPL session for session key. Is the REPL connected?" };
   }
-  const clojureDocs = await clojureDocsCiderNReplLookup(session, symbol, ns);
+  const clojureDocs = await clojuredocs.clojureDocsCiderNReplLookup(session, symbol, ns);
   return clojureDocs;
 };
 

--- a/src/api/repl-v0.ts
+++ b/src/api/repl-v0.ts
@@ -1,7 +1,6 @@
 import * as printer from '../printer';
 import * as replSession from '../nrepl/repl-session';
 import * as sessionRegistry from '../nrepl/session-registry';
-import { cljsLib } from '../utilities';
 
 type Result = {
   result: string;

--- a/src/api/repl-v1.ts
+++ b/src/api/repl-v1.ts
@@ -3,10 +3,10 @@ import * as printer from '../printer';
 import * as replSession from '../nrepl/repl-session';
 import * as resultOutput from '../results-output/output';
 import * as util from '../utilities';
-import { getConfig } from '../config';
+import * as config from '../config';
 import * as sessionRegistry from '../nrepl/session-registry';
 import * as whoTracking from './who-tracking';
-import { normalizeDestinations } from '../results-output/output-destinations';
+import * as outputDestinations from '../results-output/output-destinations';
 
 type Result = {
   result: string;
@@ -212,11 +212,11 @@ export const evaluateCode = async (
   sessionRegistry.updateSessionActivity(effectiveSessionKey);
 
   // Honor the evaluationSendCodeToOutputWindow setting like manual evaluations do
-  if (getConfig().evaluationSendCodeToOutputWindow) {
+  if (config.getConfig().evaluationSendCodeToOutputWindow) {
     if (
-      !normalizeDestinations(resultOutput.getDestinationConfiguration().evalResults).includes(
-        'repl-window'
-      )
+      !outputDestinations
+        .normalizeDestinations(resultOutput.getDestinationConfiguration().evalResults)
+        .includes('repl-window')
     ) {
       resultOutput.appendClojureEval(code, {
         ns,

--- a/src/calva-fmt/src/extension.ts
+++ b/src/calva-fmt/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { FormatOnTypeEditProvider } from './providers/ontype_formatter';
-import { RangeEditProvider } from './providers/range_formatter';
+import * as ontypeFormatter from './providers/ontype_formatter';
+import * as rangeFormatter from './providers/range_formatter';
 import * as formatter from './format';
 import * as inferer from './infer';
 import * as docmirror from '../../doc-mirror/index';
@@ -76,7 +76,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.languages.registerOnTypeFormattingEditProvider(
       calvaConfig.documentSelector,
-      new FormatOnTypeEditProvider(),
+      new ontypeFormatter.FormatOnTypeEditProvider(),
       '\r',
       '\n',
       ')',
@@ -87,7 +87,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.languages.registerDocumentRangeFormattingEditProvider(
       calvaConfig.documentSelector,
-      new RangeEditProvider()
+      new rangeFormatter.RangeEditProvider()
     )
   );
   vscode.window.onDidChangeActiveTextEditor(inferer.updateState);

--- a/src/calva-fmt/src/format-index.ts
+++ b/src/calva-fmt/src/format-index.ts
@@ -1,4 +1,4 @@
-import { formatTextAtIdx, formatTextAtIdxOnType, jsify } from '../../../out/cljs-lib/cljs-lib';
+import * as cljsLib from '../../../out/cljs-lib/cljs-lib';
 
 /**
  *
@@ -25,7 +25,9 @@ export function formatIndexes(
     range,
     config,
   };
-  const result = jsify((onType ? formatTextAtIdxOnType : formatTextAtIdx)(d));
+  const result = cljsLib.jsify(
+    (onType ? cljsLib.formatTextAtIdxOnType : cljsLib.formatTextAtIdx)(d)
+  );
   if (!result['error']) {
     return result;
   } else {

--- a/src/calva-fmt/src/format.ts
+++ b/src/calva-fmt/src/format.ts
@@ -1,22 +1,17 @@
 import * as vscode from 'vscode';
 import * as config from '../../formatter-config';
 import * as outputWindow from '../../repl-window/repl-window-doc';
-import {
-  getIndent,
-  getDocumentOffset,
-  getDocument,
-  nonOverlappingRanges,
-} from '../../doc-mirror/index';
-import { formatTextAtRange, formatText, jsify } from '../../../out/cljs-lib/cljs-lib';
+import * as docMirror from '../../doc-mirror/index';
+import * as cljsLib from '../../../out/cljs-lib/cljs-lib';
 import * as util from '../../utilities';
 import * as respacer from './respacer';
 import * as cursorDocUtils from '../../cursor-doc/utilities';
-import { isUndefined, cloneDeep } from 'lodash';
-import { LispTokenCursor } from '../../cursor-doc/token-cursor';
-import { formatIndexes } from './format-index';
+import _ = require('lodash');
+import type * as tokenCursor from '../../cursor-doc/token-cursor';
+import * as formatIndex from './format-index';
 import * as state from '../../state';
 import * as healer from './healer';
-import { nsRangeFromText } from '../../util/ns-form';
+import * as nsForm from '../../util/ns-form';
 
 /**
  * Calculates the indent edit needed for a position without performing it.
@@ -27,9 +22,9 @@ export function calculateIndentEdit(
   position: vscode.Position,
   document: vscode.TextDocument
 ): vscode.TextEdit[] {
-  const indent = getIndent(
-    getDocument(document).model.lineInputModel,
-    getDocumentOffset(document, position),
+  const indent = docMirror.getIndent(
+    docMirror.getDocument(document).model.lineInputModel,
+    docMirror.getDocumentOffset(document, position),
     config.getConfigNow(document)
   );
   const currentIndent = document.lineAt(position.line).firstNonWhitespaceCharacterIndex;
@@ -56,9 +51,9 @@ export function calculateIndentEdit(
 export async function indentPosition(position: vscode.Position, document: vscode.TextDocument) {
   const editor = util.getActiveTextEditor();
   const pos = new vscode.Position(position.line, 0);
-  const indent = getIndent(
-    getDocument(document).model.lineInputModel,
-    getDocumentOffset(document, position),
+  const indent = docMirror.getIndent(
+    docMirror.getDocument(document).model.lineInputModel,
+    docMirror.getDocumentOffset(document, position),
     await config.getConfig(document)
   );
   const newPosition = new vscode.Position(position.line, indent);
@@ -111,8 +106,8 @@ function whitespaceAndNsEdits(
   if (previousText == formattedText) {
     return [];
   } else {
-    const previousNsInfo = nsRangeFromText(previousText);
-    const formattedNsInfo = nsRangeFromText(formattedText);
+    const previousNsInfo = nsForm.nsRangeFromText(previousText);
+    const formattedNsInfo = nsForm.nsRangeFromText(formattedText);
     if (previousNsInfo && formattedNsInfo) {
       const [previousNsName, previousNsRange] = previousNsInfo;
       const [formattedNsName, formattedNsRange] = formattedNsInfo;
@@ -141,7 +136,7 @@ function rangeReformatChanges(
   originalRange: vscode.Range,
   onType: boolean
 ): respacer.WhitespaceChange[] | undefined {
-  const mirrorDoc = getDocument(document);
+  const mirrorDoc = docMirror.getDocument(document);
   const startIndex = document.offsetAt(originalRange.start);
   const cursor = mirrorDoc.getTokenCursor(startIndex);
   // Do not format comments as individual ranges.
@@ -188,8 +183,8 @@ export async function formatRange(document: vscode.TextDocument, range: vscode.R
   const wsEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
   const edits = formatRangeEdits(document, range);
 
-  if (isUndefined(edits)) {
-    console.error('formatRangeEdits returned undefined!', cloneDeep({ document, range }));
+  if (_.isUndefined(edits)) {
+    console.error('formatRangeEdits returned undefined!', _.cloneDeep({ document, range }));
     return false;
   }
 
@@ -203,7 +198,7 @@ export function formatDocIndexRange(
   index: number,
   extraConfig: CljFmtConfig
 ): [number, number] {
-  const mDoc = getDocument(doc);
+  const mDoc = docMirror.getDocument(doc);
   if (mDoc.model.documentVersion != doc.version) {
     console.warn('Model is stale; skipping reformatting');
     return;
@@ -222,7 +217,7 @@ export function formatDocIndexesInfo(
   cursorIndexes: number[],
   extraConfig: CljFmtConfig = {}
 ) {
-  const mDoc = getDocument(doc);
+  const mDoc = docMirror.getDocument(doc);
   const formatRange = formatDocIndexRange(doc, indexOfRange, extraConfig);
   if (!formatRange || (formatRange[0] == -1 && formatRange[1] == -1)) {
     return;
@@ -233,7 +228,7 @@ export function formatDocIndexesInfo(
   const formatted: {
     'range-text': string;
     range: number[];
-  } = formatIndexes(doc.getText(), formatRange, cursorIndexes, eol, onType, {
+  } = formatIndex.formatIndexes(doc.getText(), formatRange, cursorIndexes, eol, onType, {
     ...config.getConfigNow(),
     ...extraConfig,
     'comment-form?': util.isCommentFormHead(cursor.getFunctionName()),
@@ -267,7 +262,7 @@ interface CljFmtConfig {
  */
 function _calculateFormatRange(
   config: CljFmtConfig,
-  cursor: LispTokenCursor,
+  cursor: tokenCursor.LispTokenCursor,
   index: number
 ): [number, number] {
   const rangeForTopLevelForm = cursor.rangeForDefun(index, false);
@@ -299,7 +294,7 @@ function _calculateFormatRange(
   }
 
   const rangeForCurrentForm = cursor.rangeForCurrentForm(index);
-  if (!isUndefined(rangeForCurrentForm)) {
+  if (!_.isUndefined(rangeForCurrentForm)) {
     if (rangeForCurrentForm[0] === rangeForTopLevelForm[0]) {
       if (topLevelStartCursor.rowCol[1] !== 0) {
         const formStart = rangeForCurrentForm[0];
@@ -343,7 +338,7 @@ export async function formatPosition(
       onType
     );
   } else {
-    const dedupedRanges = nonOverlappingRanges(ranges);
+    const dedupedRanges = docMirror.nonOverlappingRanges(ranges);
     const cursorOffsets = editor.selections.map((sel) => doc.offsetAt(sel.active));
     orderedChanges = dedupedRanges
       .map((rng) => rng[0])
@@ -426,7 +421,7 @@ export function formatCode(code: string, eol: number, fullDocument: boolean = tr
     eol: _convertEolNumToStringNotation(eol),
     config: { ...config.getConfigNow(), 'full-document?': fullDocument },
   };
-  const result = jsify(formatText(d));
+  const result = cljsLib.jsify(cljsLib.formatText(d));
   if (!result['error']) {
     return result['range-text'];
   } else {
@@ -448,7 +443,7 @@ async function _formatRange(
     eol: eol,
     config: { ...(await config.getConfig()), 'full-document?': false },
   };
-  const result = jsify(formatTextAtRange(d));
+  const result = cljsLib.jsify(cljsLib.formatTextAtRange(d));
   if (!result['error']) {
     return result['range-text'];
   }

--- a/src/calva-fmt/src/infer.ts
+++ b/src/calva-fmt/src/infer.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { inferParens, inferIndents } from '../../../out/cljs-lib/cljs-lib';
-import { isUndefined, cloneDeep } from 'lodash';
+import * as cljsLib from '../../../out/cljs-lib/cljs-lib';
+import _ = require('lodash');
 
 interface CFEdit {
   edit: string;
@@ -26,7 +26,7 @@ export function inferParensCommand(editor: vscode.TextEditor) {
   const position: vscode.Position = editor.selections[0].active,
     document = editor.document,
     currentText = document.getText(),
-    r: ResultOptions = inferParens({
+    r: ResultOptions = cljsLib.inferParens({
       text: currentText,
       line: position.line,
       character: position.character,
@@ -73,7 +73,7 @@ export function indentCommand(editor: vscode.TextEditor, spacing: string, forwar
       if (doEdit) {
         const position: vscode.Position = editor.selections[0].active,
           currentText = document.getText(),
-          r: ResultOptions = inferIndents({
+          r: ResultOptions = cljsLib.inferIndents({
             text: currentText,
             line: position.line,
             character: position.character,
@@ -98,17 +98,17 @@ function applyResults(r: ResultOptions, editor: vscode.TextEditor) {
     void editor
       .edit(
         (editBuilder) => {
-          if (isUndefined(r.edits)) {
-            console.error('Edits were undefined!', cloneDeep({ editBuilder, r, editor }));
+          if (_.isUndefined(r.edits)) {
+            console.error('Edits were undefined!', _.cloneDeep({ editBuilder, r, editor }));
             return;
           }
           r.edits.forEach((edit: CFEdit) => {
             const start = new vscode.Position(edit.start.line, edit.start.character),
               end = new vscode.Position(edit.end.line, edit.end.character);
-            if (isUndefined(edit.text)) {
+            if (_.isUndefined(edit.text)) {
               console.error(
                 'edit.text was undefined!',
-                cloneDeep({ edit, editBuilder, r, editor })
+                _.cloneDeep({ edit, editBuilder, r, editor })
               );
               return;
             }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,19 +2,19 @@ import * as vscode from 'vscode';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
-import { CustomREPLCommandSnippet } from './custom-snippets';
-import { ReplConnectSequence } from './nrepl/connectSequence';
-import { PrettyPrintingOptions } from './printer';
-import { readConfigEdn } from '../out/cljs-lib/cljs-lib';
+import type * as customSnippets from './custom-snippets';
+import type * as connectSequence from './nrepl/connectSequence';
+import type * as printer from './printer';
+import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as fiddleFilesUtil from './util/fiddle-files';
 import * as state from './state';
 import _ = require('lodash');
-import { isDefined } from './utilities';
+import * as utilities from './utilities';
 import * as converters from './converters';
 import * as nreplUtil from './nrepl/util';
 import * as output from './results-output/output';
-import { getEffectiveJackInDependencyVersions } from './nrepl/jack-in-dependency-versions';
-import type { PairFormConfig, ThreadingMacrosConfig } from './cursor-doc/paredit-config';
+import * as jackInDependencyVersions from './nrepl/jack-in-dependency-versions';
+import type * as pareditConfig from './cursor-doc/paredit-config';
 
 const REPL_FILE_EXT = 'calva-repl';
 const FIDDLE_FILE_EXT = 'fiddle';
@@ -101,9 +101,9 @@ async function updateCalvaConfigFromEdn(uri?: vscode.Uri) {
     let resolvedUri: vscode.Uri;
     const configPath = state.resolvePath('.calva/config.edn');
 
-    if (isDefined(uri)) {
+    if (utilities.isDefined(uri)) {
       resolvedUri = uri;
-    } else if (isDefined(configPath)) {
+    } else if (utilities.isDefined(configPath)) {
       resolvedUri = configPath;
     } else {
       throw new Error('Expected a uri to be passed in or a config to exist at .calva/config.edn');
@@ -116,9 +116,9 @@ async function updateCalvaConfigFromEdn(uri?: vscode.Uri) {
 }
 
 function mergeSnippets(
-  oldSnippets: CustomREPLCommandSnippet[],
-  newSnippets: CustomREPLCommandSnippet[]
-): CustomREPLCommandSnippet[] {
+  oldSnippets: customSnippets.CustomREPLCommandSnippet[],
+  newSnippets: customSnippets.CustomREPLCommandSnippet[]
+): customSnippets.CustomREPLCommandSnippet[] {
   return newSnippets.concat(
     _.reject(
       oldSnippets,
@@ -131,9 +131,9 @@ function mergeSnippets(
  * Merges two threading macro configurations by concatenating their arrays.
  */
 function mergeThreadingMacros(
-  a: Partial<ThreadingMacrosConfig>,
-  b: Partial<ThreadingMacrosConfig>
-): Partial<ThreadingMacrosConfig> {
+  a: Partial<pareditConfig.ThreadingMacrosConfig>,
+  b: Partial<pareditConfig.ThreadingMacrosConfig>
+): Partial<pareditConfig.ThreadingMacrosConfig> {
   return {
     firstArg: [...(a.firstArg ?? []), ...(b.firstArg ?? [])],
     lastArg: [...(a.lastArg ?? []), ...(b.lastArg ?? [])],
@@ -149,7 +149,7 @@ function mergeThreadingMacros(
  */
 function addEdnConfig(data: string) {
   try {
-    const parsed = readConfigEdn(data);
+    const parsed = cljsLib.readConfigEdn(data);
     const old = state.getProjectConfig();
 
     state.setProjectConfig({
@@ -186,21 +186,25 @@ function getConfig() {
   const pareditOptions = vscode.workspace.getConfiguration('calva.paredit');
 
   const commands = (
-    configOptions.inspect<CustomREPLCommandSnippet[]>('customREPLCommandSnippets')
+    configOptions.inspect<customSnippets.CustomREPLCommandSnippet[]>('customREPLCommandSnippets')
       ?.workspaceValue ?? []
   ).concat(
-    (state.getProjectConfig()?.customREPLCommandSnippets as CustomREPLCommandSnippet[]) ?? []
+    (state.getProjectConfig()
+      ?.customREPLCommandSnippets as customSnippets.CustomREPLCommandSnippet[]) ?? []
   );
   const hoverSnippets = (
-    configOptions.inspect<CustomREPLCommandSnippet[]>('customREPLHoverSnippets')?.workspaceValue ??
-    []
-  ).concat((state.getProjectConfig()?.customREPLHoverSnippets as CustomREPLCommandSnippet[]) ?? []);
+    configOptions.inspect<customSnippets.CustomREPLCommandSnippet[]>('customREPLHoverSnippets')
+      ?.workspaceValue ?? []
+  ).concat(
+    (state.getProjectConfig()
+      ?.customREPLHoverSnippets as customSnippets.CustomREPLCommandSnippet[]) ?? []
+  );
 
   const autoEvaluateCode =
     configOptions.inspect<nreplUtil.AutoEvaluateCodeConfig>('autoEvaluateCode');
 
   const replConnectSequencesConfig =
-    configOptions.inspect<ReplConnectSequence[]>('replConnectSequences');
+    configOptions.inspect<connectSequence.ReplConnectSequence[]>('replConnectSequences');
   const normalizeAfterMainReplCode = (code: string | string[] | undefined): string | undefined => {
     if (Array.isArray(code)) {
       return code.join('\n');
@@ -235,7 +239,7 @@ function getConfig() {
     testOnSave: configOptions.get('testOnSave'),
     showDocstringInParameterHelp: configOptions.get<boolean>('showDocstringInParameterHelp'),
     jackInEnv: configOptions.get('jackInEnv'),
-    jackInDependencyVersions: getEffectiveJackInDependencyVersions(),
+    jackInDependencyVersions: jackInDependencyVersions.getEffectiveJackInDependencyVersions(),
     clojureLspVersion: configOptions.get<string>('clojureLspVersion'),
     clojureLspPath: configOptions.get<string>('clojureLspPath'),
     openBrowserWhenFigwheelStarted: configOptions.get<boolean>('openBrowserWhenFigwheelStarted'),
@@ -244,19 +248,20 @@ function getConfig() {
     myLeinProfiles: configOptions.get<string[]>('myLeinProfiles', []).map(_trimAliasName),
     myCljAliases: configOptions.get<string[]>('myCljAliases', []).map(_trimAliasName),
     asyncOutputDestination: configOptions.get<string>('sendAsyncOutputTo'),
-    customREPLCommandSnippets: configOptions.get<CustomREPLCommandSnippet[]>(
+    customREPLCommandSnippets: configOptions.get<customSnippets.CustomREPLCommandSnippet[]>(
       'customREPLCommandSnippets',
       []
     ),
     customREPLCommandSnippetsGlobal:
-      configOptions.inspect<CustomREPLCommandSnippet[]>('customREPLCommandSnippets')?.globalValue ??
-      [],
+      configOptions.inspect<customSnippets.CustomREPLCommandSnippet[]>('customREPLCommandSnippets')
+        ?.globalValue ?? [],
     customREPLCommandSnippetsWorkspace: commands,
     customREPLCommandSnippetsWorkspaceFolder:
-      configOptions.inspect<CustomREPLCommandSnippet[]>('customREPLCommandSnippets')
+      configOptions.inspect<customSnippets.CustomREPLCommandSnippet[]>('customREPLCommandSnippets')
         ?.workspaceFolderValue ?? [],
     customREPLHoverSnippets: hoverSnippets,
-    prettyPrintingOptions: configOptions.get<PrettyPrintingOptions>('prettyPrintingOptions'),
+    prettyPrintingOptions:
+      configOptions.get<printer.PrettyPrintingOptions>('prettyPrintingOptions'),
     evaluationSendCodeToOutputWindow: configOptions.get<boolean>(
       'evaluationSendCodeToOutputWindow'
     ),
@@ -295,10 +300,10 @@ function getConfig() {
     refreshNssBeforeFn: configOptions.get<string>('refreshNssBeforeFn'),
     refreshNssAfterFn: configOptions.get<string>('refreshNssAfterFn'),
     customPairForms: pareditOptions
-      .get<PairFormConfig[]>('customPairForms', [])
+      .get<pareditConfig.PairFormConfig[]>('customPairForms', [])
       .concat(state.getProjectConfig()?.customPairForms ?? []),
     customThreadingMacros: mergeThreadingMacros(
-      pareditOptions.get<Partial<ThreadingMacrosConfig>>('customThreadingMacros', {}),
+      pareditOptions.get<Partial<pareditConfig.ThreadingMacrosConfig>>('customThreadingMacros', {}),
       state.getProjectConfig()?.customThreadingMacros ?? {}
     ),
     customCommentForms: configOptions.get<string[]>('customCommentForms', []),

--- a/src/connector-cljs-builds.ts
+++ b/src/connector-cljs-builds.ts
@@ -1,10 +1,12 @@
-import type { CljsTypeConfig, CljsTypes } from './nrepl/connect-sequence-types';
+import type * as connectSequenceTypes from './nrepl/connect-sequence-types';
 import * as stringUtil from './util/string';
 
 /**
  * Checks if a CLJS type configuration represents a shadow-cljs REPL.
  */
-export function isShadowCljsConnector(cljsType: CljsTypeConfig | CljsTypes): boolean {
+export function isShadowCljsConnector(
+  cljsType: connectSequenceTypes.CljsTypeConfig | connectSequenceTypes.CljsTypes
+): boolean {
   if (typeof cljsType === 'string') {
     return cljsType === 'shadow-cljs';
   }

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -4,7 +4,7 @@ import * as state from './state';
 import * as util from './utilities';
 import * as string from './util/string';
 import open = require('open');
-import * as statusModule from './status';
+import * as status from './status';
 import * as projectTypes from './nrepl/project-types';
 import * as nrepl from './nrepl';
 import * as shadowCljsRuntime from './shadow-cljs-runtime';
@@ -15,7 +15,7 @@ import * as secondarySession from './nrepl/secondary-session';
 import * as printer from './printer';
 import * as outputWindow from './repl-window/repl-window-doc';
 import * as resultsOutputUtil from './results-output/util';
-import * as evaluateModule from './evaluate';
+import * as evaluate from './evaluate';
 import * as liveShareSupport from './live-share';
 import * as calvaDebug from './debugger/calva-debug';
 import * as cljsLib from '../out/cljs-lib/cljs-lib';
@@ -36,9 +36,6 @@ import * as sessionNameResolver from './nrepl/session-name-resolver';
 import * as projectRootUtil from './project-root';
 import * as cljsBuilds from './connector-cljs-builds';
 import * as connectorUtils from './connector-utilities';
-
-const status = statusModule.default;
-const evaluate = evaluateModule.default;
 
 function getSessionGlobMetadata(
   sessionKey: string,
@@ -1338,278 +1335,282 @@ async function disconnectClientByKey(
   status.update();
 }
 
-export default {
-  connectNonProjectREPLCommand: async (context: vscode.ExtensionContext) => {
-    await state.setOrCreateNonProjectRoot(context, true);
-    const connectSequence = await connectSequences.askForConnectSequence(
-      projectTypes.getAllProjectTypes(),
-      connectTypes.ConnectType.Connect,
-      undefined
-    );
-    inspector.revealOnConnect();
-    await outputWindow.initReplWindowDoc();
-    await outputWindow.openReplWindowDoc();
+export async function connectNonProjectREPLCommand(context: vscode.ExtensionContext) {
+  await state.setOrCreateNonProjectRoot(context, true);
+  const connectSequence = await connectSequences.askForConnectSequence(
+    projectTypes.getAllProjectTypes(),
+    connectTypes.ConnectType.Connect,
+    undefined
+  );
+  inspector.revealOnConnect();
+  await outputWindow.initReplWindowDoc();
+  await outputWindow.openReplWindowDoc();
 
-    if (connectSequence) {
-      output.appendLineOtherOut(`Connecting ...`);
-      void state.analytics().logGA4Pageview('/connect-initiated');
-      void state.analytics().logGA4Pageview('/connect-initiated/external-repl-connect');
+  if (connectSequence) {
+    output.appendLineOtherOut(`Connecting ...`);
+    void state.analytics().logGA4Pageview('/connect-initiated');
+    void state.analytics().logGA4Pageview('/connect-initiated/external-repl-connect');
 
-      return connect(connectSequence, false);
-    } else {
-      output.appendLineOtherErr('Aborting connect, error determining connect sequence.');
-    }
-  },
-  connectCommand: async (options?: {
-    host?: string;
-    port?: string;
-    connectSequence?: string | connectSequences.ReplConnectSequence;
-    disableAutoSelect?: boolean;
-  }) => {
-    const host = options && options.host ? options.host : undefined;
-    const port = options && options.port ? options.port : undefined;
-    let connectSequence: connectSequences.ReplConnectSequence;
-    if (options && typeof options.connectSequence === 'string') {
-      connectSequence = connectSequences
-        .getConnectSequences(projectTypes.getAllProjectTypes())
-        .find((s) => s.name === options.connectSequence);
-    } else if (options && options.connectSequence) {
-      connectSequence = options.connectSequence as connectSequences.ReplConnectSequence;
-    }
-    await state
-      .initProjectDir(connectTypes.ConnectType.Connect, connectSequence, options?.disableAutoSelect)
-      .catch((e) => {
-        void vscode.window.showErrorMessage('Failed initializing project root directory: ', e);
-      });
-    const cljTypes = await projectTypes.detectProjectTypes();
-    if (!connectSequence) {
-      try {
-        connectSequence = await connectSequences.askForConnectSequence(
-          cljTypes,
-          connectTypes.ConnectType.Connect,
-          options?.disableAutoSelect
-        );
-      } catch (e) {
-        output.appendLineOtherErr(`${e}\nAborting connect.`);
-        void vscode.window.showErrorMessage(`${e}`, 'OK');
-        return;
-      }
-    }
-    await liveShareSupport.setupLiveShareListener().catch((e) => {
-      console.error('Error initializing LiveShare support: ', e);
+    return connect(connectSequence, false);
+  } else {
+    output.appendLineOtherErr('Aborting connect, error determining connect sequence.');
+  }
+}
+
+export async function connectCommand(options?: {
+  host?: string;
+  port?: string;
+  connectSequence?: string | connectSequences.ReplConnectSequence;
+  disableAutoSelect?: boolean;
+}) {
+  const host = options && options.host ? options.host : undefined;
+  const port = options && options.port ? options.port : undefined;
+  let connectSequence: connectSequences.ReplConnectSequence;
+  if (options && typeof options.connectSequence === 'string') {
+    connectSequence = connectSequences
+      .getConnectSequences(projectTypes.getAllProjectTypes())
+      .find((s) => s.name === options.connectSequence);
+  } else if (options && options.connectSequence) {
+    connectSequence = options.connectSequence as connectSequences.ReplConnectSequence;
+  }
+  await state
+    .initProjectDir(connectTypes.ConnectType.Connect, connectSequence, options?.disableAutoSelect)
+    .catch((e) => {
+      void vscode.window.showErrorMessage('Failed initializing project root directory: ', e);
     });
-    return standaloneConnect(connectSequence, host, port).catch((e) => {
-      void vscode.window.showErrorMessage('Failed connecting to REPL: ', e);
-    });
-  },
-  shouldAutoConnect: async () => {
-    return config.getConfig().autoConnectRepl && nReplPortFileExists();
-  },
-  disconnect: (
-    options: {
-      clientKey?: string;
-      disconnectAll?: boolean;
-      preserveSuffix?: boolean;
-    } | null = null,
-    callback = () => {
-      // do nothing
+  const cljTypes = await projectTypes.detectProjectTypes();
+  if (!connectSequence) {
+    try {
+      connectSequence = await connectSequences.askForConnectSequence(
+        cljTypes,
+        connectTypes.ConnectType.Connect,
+        options?.disableAutoSelect
+      );
+    } catch (e) {
+      output.appendLineOtherErr(`${e}\nAborting connect.`);
+      void vscode.window.showErrorMessage(`${e}`, 'OK');
+      return;
     }
-  ) => {
-    return (async () => {
-      const clients = clientRegistry.listClients();
-      if (clients.length === 0) {
-        callback();
-        return;
-      }
+  }
+  await liveShareSupport.setupLiveShareListener().catch((e) => {
+    console.error('Error initializing LiveShare support: ', e);
+  });
+  return standaloneConnect(connectSequence, host, port).catch((e) => {
+    void vscode.window.showErrorMessage('Failed connecting to REPL: ', e);
+  });
+}
 
-      let disconnectAll = options?.disconnectAll === true;
-      let targetClientKey = options?.clientKey;
-      const preserveSuffix = options?.preserveSuffix ?? false;
+export async function shouldAutoConnect() {
+  return config.getConfig().autoConnectRepl && nReplPortFileExists();
+}
 
-      if (!disconnectAll && !targetClientKey) {
-        const selection = await promptForClientDisconnect(clients);
-        if (!selection) {
-          return;
-        }
-        if (selection.kind === 'all') {
-          disconnectAll = true;
-        } else {
-          targetClientKey = selection.clientKey;
-        }
-      }
-
-      if (disconnectAll) {
-        for (const client of [...clients]) {
-          await disconnectClientByKey(client.key, { preserveSuffix });
-        }
-      } else {
-        const keyToDisconnect = targetClientKey || clients[0].key;
-        await disconnectClientByKey(keyToDisconnect, { preserveSuffix });
-      }
-
+export function disconnect(
+  options: {
+    clientKey?: string;
+    disconnectAll?: boolean;
+    preserveSuffix?: boolean;
+  } | null = null,
+  callback = () => {
+    // do nothing
+  }
+) {
+  return (async () => {
+    const clients = clientRegistry.listClients();
+    if (clients.length === 0) {
       callback();
-    })();
-  },
-  toggleCLJCSession: () => {
-    if (!cljsLib.getStateValue('connected')) {
       return;
     }
 
-    const routingInfo = replSession.getRoutingInfo();
-    if (!routingInfo) {
-      return;
+    let disconnectAll = options?.disconnectAll === true;
+    let targetClientKey = options?.clientKey;
+    const preserveSuffix = options?.preserveSuffix ?? false;
+
+    if (!disconnectAll && !targetClientKey) {
+      const selection = await promptForClientDisconnect(clients);
+      if (!selection) {
+        return;
+      }
+      if (selection.kind === 'all') {
+        disconnectAll = true;
+      } else {
+        targetClientKey = selection.clientKey;
+      }
     }
 
-    const clientKey = sessionRegistry.getClientKeyForSession(routingInfo.sessionKey);
-    if (!clientKey) {
-      return;
+    if (disconnectAll) {
+      for (const client of [...clients]) {
+        await disconnectClientByKey(client.key, { preserveSuffix });
+      }
+    } else {
+      const keyToDisconnect = targetClientKey || clients[0].key;
+      await disconnectClientByKey(keyToDisconnect, { preserveSuffix });
     }
 
-    // Check if this connection has both primary and secondary sessions
-    const secondaryKey = sessionRegistry.getSecondarySessionKeyForClient(clientKey);
-    if (!secondaryKey) {
-      // No secondary session, nothing to toggle
-      return;
-    }
+    callback();
+  })();
+}
 
-    const currentTarget = clientRegistry.getCljcTargetForConnection(clientKey);
-    const newTarget = currentTarget === 'primary' ? 'secondary' : 'primary';
-    clientRegistry.setCljcTargetForConnection(clientKey, newTarget);
+export function toggleCLJCSession() {
+  if (!cljsLib.getStateValue('connected')) {
+    return;
+  }
+
+  const routingInfo = replSession.getRoutingInfo();
+  if (!routingInfo) {
+    return;
+  }
+
+  const clientKey = sessionRegistry.getClientKeyForSession(routingInfo.sessionKey);
+  if (!clientKey) {
+    return;
+  }
+
+  // Check if this connection has both primary and secondary sessions
+  const secondaryKey = sessionRegistry.getSecondarySessionKeyForClient(clientKey);
+  if (!secondaryKey) {
+    // No secondary session, nothing to toggle
+    return;
+  }
+
+  const currentTarget = clientRegistry.getCljcTargetForConnection(clientKey);
+  const newTarget = currentTarget === 'primary' ? 'secondary' : 'primary';
+  clientRegistry.setCljcTargetForConnection(clientKey, newTarget);
+  replSession.updateReplSessionType();
+  status.update();
+}
+
+export async function selectCljcTarget(target?: 'primary' | 'secondary') {
+  if (!cljsLib.getStateValue('connected')) {
+    return;
+  }
+
+  const routingInfo = replSession.getRoutingInfo();
+  if (!routingInfo) {
+    return;
+  }
+
+  const clientKey = sessionRegistry.getClientKeyForSession(routingInfo.sessionKey);
+  if (!clientKey) {
+    return;
+  }
+
+  // Check if this connection has both primary and secondary sessions
+  const secondaryKey = sessionRegistry.getSecondarySessionKeyForClient(clientKey);
+  const primaryKey = sessionRegistry.getPrimarySessionKeyForClient(clientKey);
+  if (!secondaryKey || !primaryKey) {
+    void vscode.window.showInformationMessage(
+      'CLJC target selection requires both CLJ and CLJS sessions.'
+    );
+    return;
+  }
+
+  if (target === 'primary' || target === 'secondary') {
+    clientRegistry.setCljcTargetForConnection(clientKey, target);
     replSession.updateReplSessionType();
     status.update();
-  },
-  selectCljcTarget: async (target?: 'primary' | 'secondary') => {
-    if (!cljsLib.getStateValue('connected')) {
-      return;
-    }
+    return;
+  }
 
-    const routingInfo = replSession.getRoutingInfo();
-    if (!routingInfo) {
-      return;
-    }
+  // Show picker
+  const currentTarget = clientRegistry.getCljcTargetForConnection(clientKey);
+  const items = [
+    {
+      label: currentTarget === 'primary' ? `$(check) ${primaryKey}` : primaryKey,
+      description: 'Primary session (CLJ)',
+      target: 'primary' as const,
+    },
+    {
+      label: currentTarget === 'secondary' ? `$(check) ${secondaryKey}` : secondaryKey,
+      description: 'Secondary session (CLJS)',
+      target: 'secondary' as const,
+    },
+  ];
 
-    const clientKey = sessionRegistry.getClientKeyForSession(routingInfo.sessionKey);
-    if (!clientKey) {
-      return;
-    }
+  const activeDoc = vscode.window.activeTextEditor?.document;
+  const activeFilePath = activeDoc
+    ? projectRootUtil.getPathRelativeToWorkspace(activeDoc.uri)
+    : 'no file selected';
 
-    // Check if this connection has both primary and secondary sessions
-    const secondaryKey = sessionRegistry.getSecondarySessionKeyForClient(clientKey);
-    const primaryKey = sessionRegistry.getPrimarySessionKeyForClient(clientKey);
-    if (!secondaryKey || !primaryKey) {
-      void vscode.window.showInformationMessage(
-        'CLJC target selection requires both CLJ and CLJS sessions.'
-      );
-      return;
-    }
+  const selection = await vscode.window.showQuickPick(items, {
+    title: 'Select CLJC Target',
+    placeHolder: `Current file: ${activeFilePath}`,
+  });
 
-    if (target === 'primary' || target === 'secondary') {
-      clientRegistry.setCljcTargetForConnection(clientKey, target);
-      replSession.updateReplSessionType();
-      status.update();
-      return;
-    }
-
-    // Show picker
-    const currentTarget = clientRegistry.getCljcTargetForConnection(clientKey);
-    const items = [
-      {
-        label: currentTarget === 'primary' ? `$(check) ${primaryKey}` : primaryKey,
-        description: 'Primary session (CLJ)',
-        target: 'primary' as const,
-      },
-      {
-        label: currentTarget === 'secondary' ? `$(check) ${secondaryKey}` : secondaryKey,
-        description: 'Secondary session (CLJS)',
-        target: 'secondary' as const,
-      },
-    ];
-
-    const activeDoc = vscode.window.activeTextEditor?.document;
-    const activeFilePath = activeDoc
-      ? projectRootUtil.getPathRelativeToWorkspace(activeDoc.uri)
-      : 'no file selected';
-
-    const selection = await vscode.window.showQuickPick(items, {
-      title: 'Select CLJC Target',
-      placeHolder: `Current file: ${activeFilePath}`,
-    });
-
-    if (selection) {
-      clientRegistry.setCljcTargetForConnection(clientKey, selection.target);
-      replSession.updateReplSessionType();
-      status.update();
-    }
-  },
-  switchCljsBuild: async () => {
-    // Follow the same pattern as shadow-runtime: routed session → connection state → everything
-    const routedSessionKey = replSession.getReplSessionTypeFromState();
-    if (!routedSessionKey) {
-      return;
-    }
-
-    const connectionStateData = sessionRegistry.getConnectionStateForSession(routedSessionKey);
-    if (!connectionStateData) {
-      return;
-    }
-
-    const connectSequence = connectionStateData.connectSequence;
-    if (!connectSequence || !secondarySession.shouldUseSecondarySession(connectSequence)) {
-      return;
-    }
-
-    // Get everything from connection state
-    const {
-      clientKey,
-      projectRoot,
-      cljsTypeName,
-      sessionRoleKeys: roleKeys,
-      sessionGlobMap: globMap,
-    } = connectionStateData;
-    const projectRootUri = projectRoot ? vscode.Uri.parse(projectRoot) : state.getProjectRootUri();
-
-    if (!roleKeys?.secondary || !globMap) {
-      output.appendLineOtherErr(
-        'Cannot switch build: connection state missing role keys or glob map'
-      );
-      return;
-    }
-
-    // Get the main session for this connection early so we can query active builds
-    const cljSession = sessionRegistry.getPrimarySessionForClient(clientKey);
-    if (!cljSession) {
-      return;
-    }
-
-    // Show build selection menu with active build status
-    const selectedBuild = await selectCljsBuild(cljsTypeName, projectRootUri, cljSession);
-    if (!selectedBuild) {
-      return; // User cancelled or no builds available
-    }
-
-    const isBuiltinType: boolean = typeof connectSequence.cljsType == 'string';
-    const cljsType: connectSequences.CljsTypeConfig = isBuiltinType
-      ? connectSequences.getDefaultCljsType(connectSequence.cljsType as string)
-      : (connectSequence.cljsType as connectSequences.CljsTypeConfig);
-
-    const connector = createCljsReplConnector(
-      cljsType,
-      projectTypes.getCljsTypeName(connectSequence),
-      connectSequence,
-      clientKey,
-      roleKeys,
-      { useDefaultBuild: false, preSelectedBuild: selectedBuild }
-    );
-
-    const [cljsSession, build] = await makeCljsSessionClone(
-      cljSession,
-      connector,
-      cljsTypeName,
-      clientKey
-    );
-    if (cljsSession) {
-      await setUpCljsRepl(cljsSession, build, roleKeys.secondary, clientKey, globMap);
-    }
+  if (selection) {
+    clientRegistry.setCljcTargetForConnection(clientKey, selection.target);
+    replSession.updateReplSessionType();
     status.update();
-  },
-};
+  }
+}
+
+export async function switchCljsBuild() {
+  // Follow the same pattern as shadow-runtime: routed session → connection state → everything
+  const routedSessionKey = replSession.getReplSessionTypeFromState();
+  if (!routedSessionKey) {
+    return;
+  }
+
+  const connectionStateData = sessionRegistry.getConnectionStateForSession(routedSessionKey);
+  if (!connectionStateData) {
+    return;
+  }
+
+  const connectSequence = connectionStateData.connectSequence;
+  if (!connectSequence || !secondarySession.shouldUseSecondarySession(connectSequence)) {
+    return;
+  }
+
+  // Get everything from connection state
+  const {
+    clientKey,
+    projectRoot,
+    cljsTypeName,
+    sessionRoleKeys: roleKeys,
+    sessionGlobMap: globMap,
+  } = connectionStateData;
+  const projectRootUri = projectRoot ? vscode.Uri.parse(projectRoot) : state.getProjectRootUri();
+
+  if (!roleKeys?.secondary || !globMap) {
+    output.appendLineOtherErr(
+      'Cannot switch build: connection state missing role keys or glob map'
+    );
+    return;
+  }
+
+  // Get the main session for this connection early so we can query active builds
+  const cljSession = sessionRegistry.getPrimarySessionForClient(clientKey);
+  if (!cljSession) {
+    return;
+  }
+
+  // Show build selection menu with active build status
+  const selectedBuild = await selectCljsBuild(cljsTypeName, projectRootUri, cljSession);
+  if (!selectedBuild) {
+    return; // User cancelled or no builds available
+  }
+
+  const isBuiltinType: boolean = typeof connectSequence.cljsType == 'string';
+  const cljsType: connectSequences.CljsTypeConfig = isBuiltinType
+    ? connectSequences.getDefaultCljsType(connectSequence.cljsType as string)
+    : (connectSequence.cljsType as connectSequences.CljsTypeConfig);
+
+  const cljsConnector = createCljsReplConnector(
+    cljsType,
+    projectTypes.getCljsTypeName(connectSequence),
+    connectSequence,
+    clientKey,
+    roleKeys,
+    { useDefaultBuild: false, preSelectedBuild: selectedBuild }
+  );
+
+  const [cljsSession, build] = await makeCljsSessionClone(
+    cljSession,
+    cljsConnector,
+    cljsTypeName,
+    clientKey
+  );
+  if (cljsSession) {
+    await setUpCljsRepl(cljsSession, build, roleKeys.secondary, clientKey, globMap);
+  }
+  status.update();
+}

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -3,55 +3,44 @@ import * as _ from 'lodash';
 import * as state from './state';
 import * as util from './utilities';
 import * as string from './util/string';
-import * as open from 'open';
+import open = require('open');
 import status from './status';
 import * as projectTypes from './nrepl/project-types';
-import { NReplClient, NReplSession } from './nrepl';
+import * as nrepl from './nrepl';
 import * as shadowCljsRuntime from './shadow-cljs-runtime';
 import * as jackIn from './nrepl/jack-in';
 import * as connectSequenceInheritance from './nrepl/connect-sequence-inheritance';
-import {
-  CljsTypeConfig,
-  ReplConnectSequence,
-  type SelectedPortBehaviour,
-  getDefaultCljsType,
-  askForConnectSequence,
-  getConnectSequences,
-} from './nrepl/connectSequence';
+import * as connectSequences from './nrepl/connectSequence';
 import * as secondarySession from './nrepl/secondary-session';
-import { disabledPrettyPrinter } from './printer';
-import { initializeDebugger } from './debugger/calva-debug';
+import * as printer from './printer';
 import * as outputWindow from './repl-window/repl-window-doc';
-import { formatAsLineComments } from './results-output/util';
+import * as resultsOutputUtil from './results-output/util';
 import evaluate from './evaluate';
 import * as liveShareSupport from './live-share';
 import * as calvaDebug from './debugger/calva-debug';
-import { setStateValue, getStateValue } from '../out/cljs-lib/cljs-lib';
+import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as replSession from './nrepl/repl-session';
 import * as clojureDocs from './clojuredocs';
-import { addEdnConfig, getConfig } from './config';
-import { getJarContents } from './utilities';
-import { ConnectType } from './nrepl/connect-types';
+import * as config from './config';
+import * as connectTypes from './nrepl/connect-types';
 import * as output from './results-output/output';
 import * as inspector from './providers/inspector';
 import * as sessionRegistry from './nrepl/session-registry';
 import * as sessionRoleUtils from './nrepl/session-role-utils';
-import type { SessionRoleKeys, SessionGlobMap } from './nrepl/session-role-utils';
 import * as sessionRouting from './nrepl/session-routing';
 import * as clientRegistry from './nrepl/client-registry';
-import type { RegisteredClient } from './nrepl/client-registry';
 import * as sessionTeardown from './nrepl/session-teardown';
 import * as clientTeardown from './nrepl/client-teardown';
-import type { SessionGlobSpec } from './nrepl/globs';
+import type * as globs from './nrepl/globs';
 import * as sessionNameResolver from './nrepl/session-name-resolver';
-import { getPathRelativeToWorkspace } from './project-root';
+import * as projectRootUtil from './project-root';
 import * as cljsBuilds from './connector-cljs-builds';
 import * as connectorUtils from './connector-utilities';
 
 function getSessionGlobMetadata(
   sessionKey: string,
-  globMap: SessionGlobMap
-): { globSpecs: SessionGlobSpec[]; globs: string[] } {
+  globMap: sessionRoleUtils.SessionGlobMap
+): { globSpecs: globs.SessionGlobSpec[]; globs: string[] } {
   const globSpecs = sessionRoleUtils.getGlobSpecsFromMap(globMap, sessionKey);
   return {
     globSpecs,
@@ -59,14 +48,14 @@ function getSessionGlobMetadata(
   };
 }
 
-async function readRuntimeConfigs(session: NReplSession) {
+async function readRuntimeConfigs(session: nrepl.NReplSession) {
   const classpath = await session.classpath().catch((e) => {
     console.error('readRuntimeConfigs:', e);
   });
   if (classpath) {
     const configs = classpath.classpath.map(async (element: string) => {
       if (element.endsWith('.jar')) {
-        const edn = await getJarContents(element.concat('!/calva.exports/config.edn'));
+        const edn = await util.getJarContents(element.concat('!/calva.exports/config.edn'));
         return [element, edn];
       } else if (element.endsWith('/resources')) {
         const configUri = vscode.Uri.file(element.concat('/calva.exports/config.edn'));
@@ -87,7 +76,7 @@ async function readRuntimeConfigs(session: NReplSession) {
     // maybe we don't need to keep uri -> edn association, but it would make showing errors easier later
     return files
       .filter(([_, config]) => string.isNonEmptyString(config))
-      .map(([_, config]) => addEdnConfig(config));
+      .map(([_, config]) => config.addEdnConfig(config));
   }
 }
 
@@ -99,12 +88,12 @@ interface ConnectResult {
 async function connectToHost(
   hostname: string,
   port: number,
-  connectSequence: ReplConnectSequence,
+  connectSequence: connectSequences.ReplConnectSequence,
   silent = false,
   isJackIn = false
 ): Promise<ConnectResult> {
-  let mainSession: NReplSession;
-  let localClient: NReplClient | undefined;
+  let mainSession: nrepl.NReplSession;
+  let localClient: nrepl.NReplClient | undefined;
   const baseSessionNames = sessionRoleUtils.deriveSessionRoleKeys(connectSequence);
   const projectRootPath = state.getProjectRootUri().fsPath;
   const projectRoot = state.getProjectRootUri().toString();
@@ -151,7 +140,7 @@ async function connectToHost(
   try {
     output.appendLineOtherOut(`Hooking up nREPL sessions on port ${port}...`);
     // Create an nREPL client. waiting for the connection to be established.
-    localClient = await NReplClient.create({
+    localClient = await nrepl.NReplClient.create({
       host: hostname,
       port: +port,
       onError: (e) => {
@@ -222,12 +211,12 @@ async function connectToHost(
 
     outputWindow.setSession(mainSession, localClient.ns, mainKey);
 
-    if (getConfig().autoEvaluateCode.onConnect.clj) {
+    if (config.getConfig().autoEvaluateCode.onConnect.clj) {
       output.appendLineOtherOut(
         `Evaluating code from settings: 'calva.autoEvaluateCode.onConnect.clj'`
       );
       await evaluate.evaluateInOutputWindow(
-        getConfig().autoEvaluateCode.onConnect.clj,
+        config.getConfig().autoEvaluateCode.onConnect.clj,
         mainKey,
         outputWindow.getNs(),
         {}
@@ -258,9 +247,9 @@ async function connectToHost(
         connectSequence.cljsType != 'none'
       ) {
         const isBuiltinType: boolean = typeof connectSequence.cljsType == 'string';
-        const cljsType: CljsTypeConfig = isBuiltinType
-          ? getDefaultCljsType(connectSequence.cljsType as string)
-          : (connectSequence.cljsType as CljsTypeConfig);
+        const cljsType: connectSequences.CljsTypeConfig = isBuiltinType
+          ? connectSequences.getDefaultCljsType(connectSequence.cljsType as string)
+          : (connectSequence.cljsType as connectSequences.CljsTypeConfig);
 
         const connector = createCljsReplConnector(
           cljsType,
@@ -310,7 +299,7 @@ async function connectToHost(
   await readRuntimeConfigs(mainSession);
 
   // Post-connect initialization
-  initializeDebugger(mainSession);
+  calvaDebug.initializeDebugger(mainSession);
   if (
     !['babashka', 'nbb', 'joyride', 'scittle', 'basilisp', 'generic'].includes(
       connectSequence.projectType
@@ -330,7 +319,7 @@ async function connectToHost(
       console.error(`Basic cider-nrepl dependencies not met (no 'info' op)`);
     }
   }
-  if (getConfig().redirectServerOutputToRepl && mainSession.supports('out-subscribe')) {
+  if (config.getConfig().redirectServerOutputToRepl && mainSession.supports('out-subscribe')) {
     void mainSession.outSubscribe();
   }
 
@@ -357,7 +346,7 @@ function cleanUpAfterError(
   options: {
     clientKey?: string;
     suffix?: string;
-    client?: NReplClient;
+    client?: nrepl.NReplClient;
     silent?: boolean;
   } = {}
 ): ConnectResult {
@@ -393,11 +382,11 @@ function cleanUpAfterError(
 }
 
 async function setUpCljsRepl(
-  session: NReplSession,
+  session: nrepl.NReplSession,
   build: string | null,
   cljsKey: string,
   clientKey: string,
-  globMap: SessionGlobMap
+  globMap: sessionRoleUtils.SessionGlobMap
 ) {
   const globMetadata = getSessionGlobMetadata(cljsKey, globMap);
   // Use project root from owning client to avoid stamping wrong root when multiple connections exist
@@ -416,17 +405,19 @@ async function setUpCljsRepl(
 
   status.update();
   output.appendLineOtherOut(`Connected session: ${cljsKey}${build ? ', repl: ' + build : ''}`);
-  outputWindow.appendLine(formatAsLineComments(outputWindow.CLJS_CONNECT_GREETINGS));
+  outputWindow.appendLine(
+    resultsOutputUtil.formatAsLineComments(outputWindow.CLJS_CONNECT_GREETINGS)
+  );
   const description = await session.describe(true);
   const ns = description.aux?.['current-ns'] || 'user';
   await session.eval(`(in-ns '${ns})`, 'user').value;
   outputWindow.setSession(session, ns, cljsKey);
-  if (getConfig().autoEvaluateCode.onConnect.cljs) {
+  if (config.getConfig().autoEvaluateCode.onConnect.cljs) {
     output.appendLineOtherOut(
       `Evaluating code from settings: 'calva.autoEvaluateCode.onConnect.cljs'`
     );
     await evaluate.evaluateInOutputWindow(
-      getConfig().autoEvaluateCode.onConnect.cljs,
+      config.getConfig().autoEvaluateCode.onConnect.cljs,
       cljsKey,
       ns,
       {}
@@ -466,13 +457,13 @@ async function getFigwheelMainBuilds(projectRootUri?: vscode.Uri) {
 type checkConnectedFn = (value: string, out: any[], err: any[]) => Promise<boolean>;
 type processOutputFn = (output: string) => void;
 type connectFn = (
-  session: NReplSession,
+  session: nrepl.NReplSession,
   name: string,
   checkSuccess: checkConnectedFn
 ) => Promise<boolean | undefined>;
 
 async function evalConnectCode(
-  newCljsSession: NReplSession,
+  newCljsSession: nrepl.NReplSession,
   code: string,
   checkSuccess: checkConnectedFn,
   outputProcessors: processOutputFn[] = [],
@@ -496,7 +487,7 @@ async function evalConnectCode(
           p(util.stripAnsi(x));
         }
       },
-      pprintOptions: disabledPrettyPrinter,
+      pprintOptions: printer.disabledPrettyPrinter,
     });
   const valueResult = await result.value.catch((reason) => {
     console.error('Error evaluating connect form: ', reason);
@@ -531,7 +522,7 @@ async function figwheelOrShadowBuilds(
  */
 async function getActiveBuilds(
   cljsTypeName: string,
-  session: NReplSession
+  session: nrepl.NReplSession
 ): Promise<string[] | undefined> {
   try {
     const code = cljsBuilds.getActiveBuildQueryCode(cljsTypeName);
@@ -557,7 +548,7 @@ async function getActiveBuilds(
 async function selectCljsBuild(
   cljsTypeName: string,
   projectRootUri?: vscode.Uri,
-  session?: NReplSession
+  session?: nrepl.NReplSession
 ): Promise<string | null> {
   const effectiveProjectRoot = projectRootUri ?? state.getProjectRootUri();
   const allBuilds = await figwheelOrShadowBuilds(cljsTypeName, effectiveProjectRoot);
@@ -597,11 +588,11 @@ async function selectCljsBuild(
 const updateInitCode = cljsBuilds.updateInitCode;
 
 function createCljsReplConnector(
-  cljsType: CljsTypeConfig,
+  cljsType: connectSequences.CljsTypeConfig,
   cljsTypeName: string,
-  connectSequence: ReplConnectSequence,
+  connectSequence: connectSequences.ReplConnectSequence,
   clientKey: string,
-  roleKeys: SessionRoleKeys,
+  roleKeys: sessionRoleUtils.SessionRoleKeys,
   options: { useDefaultBuild?: boolean; preSelectedBuild?: string } = {}
 ): CljsReplConnector {
   // This function is only called when a secondary session is expected
@@ -945,7 +936,7 @@ async function makeCljsSessionClone(
   connector: CljsReplConnector,
   projectTypeName: string,
   clientKey: string
-): Promise<[NReplSession | null, string | null]> {
+): Promise<[nrepl.NReplSession | null, string | null]> {
   output.appendLineOtherOut('Creating cljs repl session...');
   let newCljsSession = await session.clone();
   newCljsSession.replType = 'cljs';
@@ -990,7 +981,7 @@ type SelectedPortSource = 'port-file' | 'fallback';
 async function promptForNreplUrlAndConnect(
   hostname: string | undefined,
   port: string | undefined,
-  connectSequence: ReplConnectSequence,
+  connectSequence: connectSequences.ReplConnectSequence,
   reason: PromptReason = 'manual'
 ): Promise<ConnectResult> {
   let currentHost = hostname ?? 'localhost';
@@ -1048,7 +1039,7 @@ async function promptForNreplUrlAndConnect(
 }
 
 export async function connect(
-  connectSequence: ReplConnectSequence,
+  connectSequence: connectSequences.ReplConnectSequence,
   isAutoConnect: boolean,
   hostname?: string,
   port?: string,
@@ -1098,7 +1089,7 @@ export async function connect(
         !isJackIn &&
         sessionNameResolver.hasMatchingBaseConnection(baseSessionNames, projectRoot);
       const effectiveAutoConnect = isAutoConnect && !hasExistingMatch;
-      const selectedPortBehaviour: SelectedPortBehaviour =
+      const selectedPortBehaviour: connectSequences.SelectedPortBehaviour =
         connectSequenceInheritance.effectiveSelectedPortBehaviour(
           connectSequence,
           isAutoConnect ? 'connect' : 'prompt'
@@ -1160,7 +1151,7 @@ export async function connect(
 }
 
 async function standaloneConnect(
-  connectSequence: ReplConnectSequence,
+  connectSequence: connectSequences.ReplConnectSequence,
   hostname?: string,
   port?: string
 ) {
@@ -1173,14 +1164,19 @@ async function standaloneConnect(
     void state.analytics().logGA4Pageview('/connect-initiated');
     void state.analytics().logGA4Pageview('/connect-initiated/standalone-connect');
 
-    return connect(connectSequence, getConfig().autoSelectNReplPortFromPortFile, hostname, port);
+    return connect(
+      connectSequence,
+      config.getConfig().autoSelectNReplPortFromPortFile,
+      hostname,
+      port
+    );
   } else {
     output.appendLineOtherErr('Aborting connect, error determining connect sequence.');
   }
 }
 
 async function nReplPortFileExists() {
-  const sequences = getConnectSequences(projectTypes.getAllProjectTypes());
+  const sequences = connectSequences.getConnectSequences(projectTypes.getAllProjectTypes());
   const portFiles = sequences.map((sequence) => projectTypes.nreplPortFileUri(sequence));
   let fileExists = false;
   await Promise.all(
@@ -1221,14 +1217,14 @@ function formatRelativeProjectRoot(projectRoot?: string): string | undefined {
   }
   try {
     const uri = vscode.Uri.parse(projectRoot);
-    return getPathRelativeToWorkspace(uri);
+    return projectRootUtil.getPathRelativeToWorkspace(uri);
   } catch {
     return projectRoot;
   }
 }
 
 async function promptForClientDisconnect(
-  clients: RegisteredClient[]
+  clients: clientRegistry.RegisteredClient[]
 ): Promise<DisconnectSelection | undefined> {
   const items: DisconnectQuickPickItem[] = clients.map((client) => {
     const sessions = sessionRegistry.listSessionsByClient(client.key);
@@ -1330,7 +1326,7 @@ async function disconnectClientByKey(
   if (remainingSessions === 0) {
     sessionRouting.resetRouting();
     util.setConnectedState(false);
-    setStateValue('current-session-type', null);
+    cljsLib.setStateValue('current-session-type', null);
   } else {
     util.setConnectedState(true);
   }
@@ -1342,9 +1338,9 @@ async function disconnectClientByKey(
 export default {
   connectNonProjectREPLCommand: async (context: vscode.ExtensionContext) => {
     await state.setOrCreateNonProjectRoot(context, true);
-    const connectSequence = await askForConnectSequence(
+    const connectSequence = await connectSequences.askForConnectSequence(
       projectTypes.getAllProjectTypes(),
-      ConnectType.Connect,
+      connectTypes.ConnectType.Connect,
       undefined
     );
     inspector.revealOnConnect();
@@ -1364,30 +1360,30 @@ export default {
   connectCommand: async (options?: {
     host?: string;
     port?: string;
-    connectSequence?: string | ReplConnectSequence;
+    connectSequence?: string | connectSequences.ReplConnectSequence;
     disableAutoSelect?: boolean;
   }) => {
     const host = options && options.host ? options.host : undefined;
     const port = options && options.port ? options.port : undefined;
-    let connectSequence: ReplConnectSequence;
+    let connectSequence: connectSequences.ReplConnectSequence;
     if (options && typeof options.connectSequence === 'string') {
-      connectSequence = getConnectSequences(projectTypes.getAllProjectTypes()).find(
-        (s) => s.name === options.connectSequence
-      );
+      connectSequence = connectSequences
+        .getConnectSequences(projectTypes.getAllProjectTypes())
+        .find((s) => s.name === options.connectSequence);
     } else if (options && options.connectSequence) {
-      connectSequence = options.connectSequence as ReplConnectSequence;
+      connectSequence = options.connectSequence as connectSequences.ReplConnectSequence;
     }
     await state
-      .initProjectDir(ConnectType.Connect, connectSequence, options?.disableAutoSelect)
+      .initProjectDir(connectTypes.ConnectType.Connect, connectSequence, options?.disableAutoSelect)
       .catch((e) => {
         void vscode.window.showErrorMessage('Failed initializing project root directory: ', e);
       });
     const cljTypes = await projectTypes.detectProjectTypes();
     if (!connectSequence) {
       try {
-        connectSequence = await askForConnectSequence(
+        connectSequence = await connectSequences.askForConnectSequence(
           cljTypes,
-          ConnectType.Connect,
+          connectTypes.ConnectType.Connect,
           options?.disableAutoSelect
         );
       } catch (e) {
@@ -1404,7 +1400,7 @@ export default {
     });
   },
   shouldAutoConnect: async () => {
-    return getConfig().autoConnectRepl && nReplPortFileExists();
+    return config.getConfig().autoConnectRepl && nReplPortFileExists();
   },
   disconnect: (
     options: {
@@ -1452,7 +1448,7 @@ export default {
     })();
   },
   toggleCLJCSession: () => {
-    if (!getStateValue('connected')) {
+    if (!cljsLib.getStateValue('connected')) {
       return;
     }
 
@@ -1480,7 +1476,7 @@ export default {
     status.update();
   },
   selectCljcTarget: async (target?: 'primary' | 'secondary') => {
-    if (!getStateValue('connected')) {
+    if (!cljsLib.getStateValue('connected')) {
       return;
     }
 
@@ -1528,7 +1524,7 @@ export default {
 
     const activeDoc = vscode.window.activeTextEditor?.document;
     const activeFilePath = activeDoc
-      ? getPathRelativeToWorkspace(activeDoc.uri)
+      ? projectRootUtil.getPathRelativeToWorkspace(activeDoc.uri)
       : 'no file selected';
 
     const selection = await vscode.window.showQuickPick(items, {
@@ -1589,9 +1585,9 @@ export default {
     }
 
     const isBuiltinType: boolean = typeof connectSequence.cljsType == 'string';
-    const cljsType: CljsTypeConfig = isBuiltinType
-      ? getDefaultCljsType(connectSequence.cljsType as string)
-      : (connectSequence.cljsType as CljsTypeConfig);
+    const cljsType: connectSequences.CljsTypeConfig = isBuiltinType
+      ? connectSequences.getDefaultCljsType(connectSequence.cljsType as string)
+      : (connectSequence.cljsType as connectSequences.CljsTypeConfig);
 
     const connector = createCljsReplConnector(
       cljsType,

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -4,7 +4,7 @@ import * as state from './state';
 import * as util from './utilities';
 import * as string from './util/string';
 import open = require('open');
-import status from './status';
+import * as statusModule from './status';
 import * as projectTypes from './nrepl/project-types';
 import * as nrepl from './nrepl';
 import * as shadowCljsRuntime from './shadow-cljs-runtime';
@@ -15,7 +15,7 @@ import * as secondarySession from './nrepl/secondary-session';
 import * as printer from './printer';
 import * as outputWindow from './repl-window/repl-window-doc';
 import * as resultsOutputUtil from './results-output/util';
-import evaluate from './evaluate';
+import * as evaluateModule from './evaluate';
 import * as liveShareSupport from './live-share';
 import * as calvaDebug from './debugger/calva-debug';
 import * as cljsLib from '../out/cljs-lib/cljs-lib';
@@ -36,6 +36,9 @@ import * as sessionNameResolver from './nrepl/session-name-resolver';
 import * as projectRootUtil from './project-root';
 import * as cljsBuilds from './connector-cljs-builds';
 import * as connectorUtils from './connector-utilities';
+
+const status = statusModule.default;
+const evaluate = evaluateModule.default;
 
 function getSessionGlobMetadata(
   sessionKey: string,

--- a/src/cursor-doc/backspace-on-whitespace.ts
+++ b/src/cursor-doc/backspace-on-whitespace.ts
@@ -1,14 +1,14 @@
-import { FormatterConfig } from '../formatter-config';
-import { getIndent } from './indent';
-import { EditableDocument } from './model';
-import { LispTokenCursor } from './token-cursor';
+import type * as formatterConfig from '../formatter-config';
+import * as indent from './indent';
+import type * as model from './model';
+import type * as tokenCursor from './token-cursor';
 
 export function backspaceOnWhitespace(
-  doc: EditableDocument,
-  cursor: LispTokenCursor,
-  config?: FormatterConfig
+  doc: model.EditableDocument,
+  cursor: tokenCursor.LispTokenCursor,
+  config?: formatterConfig.FormatterConfig
 ) {
-  const origIndent = getIndent(doc.model, cursor.offsetStart, config);
+  const origIndent = indent.getIndent(doc.model, cursor.offsetStart, config);
   const onCloseToken = cursor.getToken().type === 'close';
   let start = doc.selections[0].anchor;
   let token = cursor.getToken();
@@ -36,9 +36,9 @@ export function backspaceOnWhitespace(
   }
 
   const destTokenType = cursor.getToken().type;
-  let indent = destTokenType === 'eol' ? origIndent : 1;
+  let targetIndent = destTokenType === 'eol' ? origIndent : 1;
   if (destTokenType === 'open' || onCloseToken) {
-    indent = 0;
+    targetIndent = 0;
   }
-  return { start, end, indent };
+  return { start, end, indent: targetIndent };
 }

--- a/src/cursor-doc/clojure-lexer.ts
+++ b/src/cursor-doc/clojure-lexer.ts
@@ -14,13 +14,13 @@
 // lit   (['`~#]\s*)*
 // kw    (['`~^]\s*)*
 
-import { LexicalGrammar, Token as LexerToken } from './lexer';
+import * as lexer from './lexer';
 
 /**
  * The 'toplevel' lexical grammar. This grammar contains all normal tokens. Strings are identified as
  * "open", and trigger the lexer to switch to the 'inString' lexical grammar.
  */
-export const toplevel = new LexicalGrammar();
+export const toplevel = new lexer.LexicalGrammar();
 
 /**
  * Returns `true` if open and close are compatible parentheses
@@ -42,7 +42,7 @@ export function validPair(open: string, close: string): boolean {
   return false;
 }
 
-export interface Token extends LexerToken {
+export interface Token extends lexer.Token {
   state: ScannerState;
 }
 
@@ -141,7 +141,7 @@ toplevel.terminal('junk', /[\u0000-\uffff]/, (l, m) => ({ type: 'junk' }));
 
 /** This is inside-string string grammar. It spits out 'close' once it is time to switch back to the 'toplevel' grammar,
  * and 'str-inside' for the words in the string. */
-const inString = new LexicalGrammar();
+const inString = new lexer.LexicalGrammar();
 // end a string
 inString.terminal('close', /"/, (l, m) => ({ type: 'close' }));
 // still within a string
@@ -178,7 +178,7 @@ export class Scanner {
     const tks: Token[] = [];
     this.state = state;
     let lex = (this.state.inString ? inString : toplevel).lex(line, this.maxLength);
-    let tk: LexerToken;
+    let tk: lexer.Token;
     do {
       tk = lex.scan();
       if (tk) {

--- a/src/cursor-doc/cursor-context.ts
+++ b/src/cursor-doc/cursor-context.ts
@@ -1,4 +1,4 @@
-import { EditableDocument } from './model';
+import type * as model from './model';
 
 export const allCursorContexts = [
   'calva:cursorInString',
@@ -16,7 +16,10 @@ export type CursorContext = typeof allCursorContexts[number];
  * Returns true if documentOffset is either at the first char of the token under the cursor, or
  * in the whitespace between the token and the first preceding EOL, otherwise false
  */
-export function isAtLineStartInclWS(doc: EditableDocument, offset = doc.selections[0].active) {
+export function isAtLineStartInclWS(
+  doc: model.EditableDocument,
+  offset = doc.selections[0].active
+) {
   const tokenCursor = doc.getTokenCursor(offset);
   let startOfLine = false;
   //  only at start if we're in ws, or at the 1st char of a non-ws sexp
@@ -34,7 +37,7 @@ export function isAtLineStartInclWS(doc: EditableDocument, offset = doc.selectio
  * Returns true if position is after the last char of the last lisp token on the line, including
  * any trailing whitespace or EOL, otherwise false
  */
-export function isAtLineEndInclWS(doc: EditableDocument, offset = doc.selections[0].active) {
+export function isAtLineEndInclWS(doc: model.EditableDocument, offset = doc.selections[0].active) {
   const tokenCursor = doc.getTokenCursor(offset);
   if (tokenCursor.getToken().type === 'eol') {
     return true;
@@ -58,7 +61,7 @@ export function isAtLineEndInclWS(doc: EditableDocument, offset = doc.selections
 }
 
 export function determineContexts(
-  doc: EditableDocument,
+  doc: model.EditableDocument,
   offset = doc.selections[0].active
 ): CursorContext[] {
   const tokenCursor = doc.getTokenCursor(offset);

--- a/src/cursor-doc/indent.ts
+++ b/src/cursor-doc/indent.ts
@@ -1,9 +1,9 @@
-import { EditableModel } from './model';
+import type * as model from './model';
 import * as _ from 'lodash';
 import * as regexUtil from '../util/regex';
-import { FormatterConfig } from '../formatter-config';
+import type * as formatterConfig from '../formatter-config';
 import * as cljsLib from '../../out/cljs-lib/cljs-lib.js';
-import { escapeStringRegexp } from '../util/string';
+import * as stringUtil from '../util/string';
 
 const whitespace = new Set(['ws', 'comment', 'eol']);
 
@@ -50,9 +50,9 @@ export interface IndentInformation {
  * @param maxLines The maximum number of lines above the position to search until we bail with an imprecise answer.
  */
 export function collectIndents(
-  document: EditableModel,
+  document: model.EditableModel,
   offset: number,
-  config: FormatterConfig,
+  config: formatterConfig.FormatterConfig,
   maxDepth: number = 3,
   maxLines: number = 20
 ): IndentInformation[] {
@@ -118,7 +118,10 @@ export function collectIndents(
         _.find(
           combinedRules,
           (rule) =>
-            regexUtil.testCljOrJsRegex(`#"^(.*/)?${[escapeStringRegexp(rule[0])]}$"`, token) ||
+            regexUtil.testCljOrJsRegex(
+              `#"^(.*/)?${[stringUtil.escapeStringRegexp(rule[0])]}$"`,
+              token
+            ) ||
             (regexUtil.isCljOrJsRegex(rule[0]) && regexUtil.testCljOrJsRegex(rule[0], token))
         );
 
@@ -219,9 +222,9 @@ const calculateIndent = (
 
 /** Returns the expected newline indent for the given position, in characters. */
 export function getIndent(
-  document: EditableModel,
+  document: model.EditableModel,
   offset: number,
-  config: FormatterConfig = {
+  config: formatterConfig.FormatterConfig = {
     'cljfmt-options': {
       indents: indentRules,
     },

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -1,14 +1,20 @@
-import { Scanner, Token, ScannerState } from './clojure-lexer';
-import { LispTokenCursor } from './token-cursor';
-import { deepEqual as equal } from '../util/object';
-import { isNumber, isUndefined } from 'lodash';
-import { TextDocument, Selection, TextEditorEdit } from 'vscode';
+import * as clojureLexer from './clojure-lexer';
+import * as tokenCursor from './token-cursor';
+import * as objectUtil from '../util/object';
+import * as vscode from 'vscode';
 import _ = require('lodash');
 
-let scanner: Scanner;
+type Token = clojureLexer.Token;
+type ScannerState = clojureLexer.ScannerState;
+type TextDocument = vscode.TextDocument;
+type Selection = vscode.Selection;
+type TextEditorEdit = vscode.TextEditorEdit;
+type LispTokenCursor = tokenCursor.LispTokenCursor;
+
+let scanner: clojureLexer.Scanner;
 
 export function initScanner(maxLength: number) {
-  scanner = new Scanner(maxLength);
+  scanner = new clojureLexer.Scanner(maxLength);
 }
 
 /**
@@ -100,10 +106,10 @@ export class ModelEditSelection {
     end?: number,
     isReversed?: boolean
   ) {
-    if (isNumber(anchorOrSelection)) {
+    if (_.isNumber(anchorOrSelection)) {
       const anchor = anchorOrSelection;
       this._anchor = anchor;
-      if (activeOrDoc !== undefined && isNumber(activeOrDoc)) {
+      if (activeOrDoc !== undefined && _.isNumber(activeOrDoc)) {
         this._active = activeOrDoc;
       } else {
         this._active = anchor;
@@ -472,7 +478,10 @@ export class LineInputModel implements EditableModel {
         this.changedLines.add(nextIdx);
         this.lines[nextIdx].processLine(prevState);
         prevState = this.lines[nextIdx].endState;
-      } while (this.lines[++nextIdx] && !equal(this.lines[nextIdx].startState, prevState));
+      } while (
+        this.lines[++nextIdx] &&
+        !objectUtil.deepEqual(this.lines[nextIdx].startState, prevState)
+      );
     }
   }
 
@@ -765,11 +774,15 @@ export class LineInputModel implements EditableModel {
       for (let i = 0; i < line.tokens.length; i++) {
         const tk = line.tokens[i];
         if (previous ? tk.offset > col : tk.offset > col) {
-          return new LispTokenCursor(this, row, previous ? Math.max(0, lastIndex - 1) : lastIndex);
+          return new tokenCursor.LispTokenCursor(
+            this,
+            row,
+            previous ? Math.max(0, lastIndex - 1) : lastIndex
+          );
         }
         lastIndex = i;
       }
-      return new LispTokenCursor(this, row, line.tokens.length - 1);
+      return new tokenCursor.LispTokenCursor(this, row, line.tokens.length - 1);
     } else {
       throw new Error('Unable to get token cursor for LineInputModel!');
     }
@@ -824,7 +837,7 @@ export class StringDocument implements EditableDocument {
   selectionsStack: ModelEditSelection[][] = [];
 
   getTokenCursor(offset?: number, previous?: boolean): LispTokenCursor {
-    if (isUndefined(offset)) {
+    if (_.isUndefined(offset)) {
       throw new Error('Expected a cursor for StringDocument!');
     }
 

--- a/src/cursor-doc/paredit.ts
+++ b/src/cursor-doc/paredit.ts
@@ -1,29 +1,37 @@
-import { FormatterConfig } from '../formatter-config';
-import { validPair } from './clojure-lexer';
-import {
-  ModelEdit,
-  EditableDocument,
-  ModelEditSelection,
-  ModelEditRange,
-  ModelEditDirectedRange,
-  ModelEditOptions,
-} from './model';
-import { LispTokenCursor } from './token-cursor';
-import { backspaceOnWhitespace } from './backspace-on-whitespace';
+import type * as formatterConfig from '../formatter-config';
+import * as clojureLexer from './clojure-lexer';
+import * as model from './model';
+import type * as tokenCursor from './token-cursor';
+import * as whitespaceBackspace from './backspace-on-whitespace';
 import _ = require('lodash');
-import { isEqual, last, property } from 'lodash';
-import { TextEditorEdit } from 'vscode';
-import {
-  PareditConfig,
-  KeywordPairForm,
-  FlatPairForm,
-  AliasMapConfig,
-  defaultGroupedDefaultPairForms,
-  defaultThreadingMacros,
-  resolveAliasedSymbol,
-  isCommentFormHead,
-} from './paredit-config';
-import { Token } from './lexer';
+import * as vscode from 'vscode';
+import * as pareditConfig from './paredit-config';
+import type * as lexer from './lexer';
+
+type FormatterConfig = formatterConfig.FormatterConfig;
+type EditableDocument = model.EditableDocument;
+type ModelEdit<T extends model.ModelEditFunction> = model.ModelEdit<T>;
+type ModelEditSelection = model.ModelEditSelection;
+type ModelEditRange = model.ModelEditRange;
+type ModelEditDirectedRange = model.ModelEditDirectedRange;
+type ModelEditOptions = model.ModelEditOptions;
+type LispTokenCursor = tokenCursor.LispTokenCursor;
+type TextEditorEdit = vscode.TextEditorEdit;
+type PareditConfig = pareditConfig.PareditConfig;
+type KeywordPairForm = pareditConfig.KeywordPairForm;
+type FlatPairForm = pareditConfig.FlatPairForm;
+type AliasMapConfig = pareditConfig.AliasMapConfig;
+type Token = lexer.Token;
+
+const ModelEdit = model.ModelEdit;
+const ModelEditSelection = model.ModelEditSelection;
+const last = _.last;
+const isEqual = _.isEqual;
+const property = _.property;
+const defaultGroupedDefaultPairForms = pareditConfig.defaultGroupedDefaultPairForms;
+const defaultThreadingMacros = pareditConfig.defaultThreadingMacros;
+const resolveAliasedSymbol = pareditConfig.resolveAliasedSymbol;
+const isCommentFormHead = pareditConfig.isCommentFormHead;
 
 const OPEN_DELIMITERS_REGEX = /[([{"]/;
 
@@ -814,7 +822,7 @@ export async function joinSexp(
     cursor.forwardWhitespace();
     const nextToken = cursor.getToken(),
       nextStart = cursor.offsetStart;
-    if (validPair(nextToken.raw[0], prevToken.raw[prevToken.raw.length - 1])) {
+    if (clojureLexer.validPair(nextToken.raw[0], prevToken.raw[prevToken.raw.length - 1])) {
       return doc.model.edit(
         [
           new ModelEdit('changeRange', [
@@ -846,7 +854,7 @@ export async function spliceSexp(
     cursor.forwardList();
     const close = cursor.getToken();
     const end = cursor.offsetStart;
-    if (close.type == 'close' && validPair(open.raw, close.raw)) {
+    if (close.type == 'close' && clojureLexer.validPair(open.raw, close.raw)) {
       return doc.model.edit(
         [
           new ModelEdit('changeRange', [end, end + close.raw.length, '']),
@@ -1135,7 +1143,7 @@ function backspaceOnWhitespaceEdit(
   cursor: LispTokenCursor,
   config?: FormatterConfig
 ) {
-  const changeArgs = backspaceOnWhitespace(doc, cursor, config);
+  const changeArgs = whitespaceBackspace.backspaceOnWhitespace(doc, cursor, config);
   return doc.model.editNow(
     [
       new ModelEdit('deleteRange', [changeArgs.end, changeArgs.start - changeArgs.end]),

--- a/src/cursor-doc/token-cursor.ts
+++ b/src/cursor-doc/token-cursor.ts
@@ -1,6 +1,9 @@
-import { getFirstEol, LineInputModel } from './model';
-import { Token, validPair } from './clojure-lexer';
-import { isCommentFormHead, CommentFormConfig } from './paredit-config';
+import * as model from './model';
+import * as clojureLexer from './clojure-lexer';
+import * as pareditConfig from './paredit-config';
+
+type Token = clojureLexer.Token;
+type CommentFormConfig = pareditConfig.CommentFormConfig;
 
 function tokenIsWhiteSpace(token: Token) {
   return token.type === 'eol' || token.type == 'ws';
@@ -10,7 +13,7 @@ function tokenIsWhiteSpace(token: Token) {
  * A mutable cursor into the token stream.
  */
 export class TokenCursor {
-  constructor(public doc: LineInputModel, public line: number, public token: number) {}
+  constructor(public doc: model.LineInputModel, public line: number, public token: number) {}
 
   /** Create a copy of this cursor. */
   clone() {
@@ -158,7 +161,7 @@ function _rangesForSexpsInList(
 }
 
 export class LispTokenCursor extends TokenCursor {
-  constructor(public doc: LineInputModel, public line: number, public token: number) {
+  constructor(public doc: model.LineInputModel, public line: number, public token: number) {
     super(doc, line, token);
   }
 
@@ -289,7 +292,7 @@ export class LispTokenCursor extends TokenCursor {
           const close = token.raw;
           let open: string;
           while ((open = stack.pop())) {
-            if (validPair(open, close)) {
+            if (clojureLexer.validPair(open, close)) {
               this.next();
               break;
             }
@@ -368,7 +371,7 @@ export class LispTokenCursor extends TokenCursor {
           const open = tk.raw;
           let close: string;
           while ((close = stack.pop())) {
-            if (validPair(open, close)) {
+            if (clojureLexer.validPair(open, close)) {
               break;
             }
           }
@@ -831,7 +834,7 @@ export class LispTokenCursor extends TokenCursor {
       commentCursor.backwardDownList();
       if (
         commentCreatesTopLevel &&
-        isCommentFormHead(getFunctionPositionText(commentCursor), commentFormConfig)
+        pareditConfig.isCommentFormHead(getFunctionPositionText(commentCursor), commentFormConfig)
       ) {
         if (commentCursor.getToken().raw !== ')') {
           commentCursor.upList();
@@ -1027,7 +1030,10 @@ export class LispTokenCursor extends TokenCursor {
   ): boolean {
     const tlCursor = this.clone();
     if (tlCursor.forwardList() && tlCursor.upList()) {
-      if (commentCreatesTopLevel && isCommentFormHead(this.getFunctionName(), commentFormConfig)) {
+      if (
+        commentCreatesTopLevel &&
+        pareditConfig.isCommentFormHead(this.getFunctionName(), commentFormConfig)
+      ) {
         return true;
       }
       return false;
@@ -1050,8 +1056,8 @@ export class LispTokenCursor extends TokenCursor {
  * Creates a `LispTokenCursor` for walking and manipulating the string `s`.
  */
 export function createStringCursor(s: string): LispTokenCursor {
-  const eol = getFirstEol(s);
-  const model = new LineInputModel(eol ? eol.length : 1);
-  model.insertString(0, s);
-  return model.getTokenCursor(0);
+  const eol = model.getFirstEol(s);
+  const inputModel = new model.LineInputModel(eol ? eol.length : 1);
+  inputModel.insertString(0, s);
+  return inputModel.getTokenCursor(0);
 }

--- a/src/cursor-doc/utilities.ts
+++ b/src/cursor-doc/utilities.ts
@@ -1,5 +1,5 @@
 import * as model from './model';
-import { LispTokenCursor } from './token-cursor';
+import type * as tokenCursor from './token-cursor';
 
 export type MissingTexts = {
   append: string;
@@ -35,7 +35,7 @@ export function getMissingBrackets(text: string): MissingTexts {
   }
 }
 
-export function isRightSexpStructural(cursor: LispTokenCursor): boolean {
+export function isRightSexpStructural(cursor: tokenCursor.LispTokenCursor): boolean {
   cursor.forwardWhitespace();
   if (cursor.getToken().type === 'comment') {
     return false;
@@ -50,7 +50,7 @@ export function isRightSexpStructural(cursor: LispTokenCursor): boolean {
   return false;
 }
 
-export function textForRightSexp(cursor: LispTokenCursor): string {
+export function textForRightSexp(cursor: tokenCursor.LispTokenCursor): string {
   const probe = cursor.clone();
   const start = cursor.offsetStart;
   probe.forwardSexp();
@@ -67,7 +67,9 @@ export function textForRightSexp(cursor: LispTokenCursor): string {
  * an array. In both cases the values in the structure are returned as objects of the shape
  * `{ value: any, originalString: string }`.
  * */
-export function structureForRightSexp(cursor: LispTokenCursor): any | any[] | Map<any, any> {
+export function structureForRightSexp(
+  cursor: tokenCursor.LispTokenCursor
+): any | any[] | Map<any, any> {
   const probe = cursor.clone();
   if (!isRightSexpStructural(probe)) {
     return textForRightSexp(probe);

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -5,12 +5,10 @@ import * as getText from './util/get-text';
 import * as namespace from './namespace';
 import * as config from './config';
 import * as replSession from './nrepl/repl-session';
-import * as evaluateModule from './evaluate';
+import * as evaluate from './evaluate';
 import * as state from './state';
 import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as output from './results-output/output';
-
-const evaluate = evaluateModule.default;
 
 export type CustomREPLCommandSnippet = {
   name: string;

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -3,11 +3,11 @@ import * as _ from 'lodash';
 import * as util from './utilities';
 import * as getText from './util/get-text';
 import * as namespace from './namespace';
-import { getConfig } from './config';
+import * as config from './config';
 import * as replSession from './nrepl/repl-session';
 import evaluate from './evaluate';
 import * as state from './state';
-import { getStateValue, interpolateVariables } from '../out/cljs-lib/cljs-lib';
+import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as output from './results-output/output';
 
 export type CustomREPLCommandSnippet = {
@@ -33,7 +33,7 @@ export function evaluateCustomCodeSnippetCommand(codeOrKeyOrSnippet?: string | S
 }
 
 async function evaluateCodeOrKeyOrSnippet(codeOrKeyOrSnippet?: string | SnippetDefinition) {
-  if (!getStateValue('connected')) {
+  if (!cljsLib.getStateValue('connected')) {
     void vscode.window.showErrorMessage('Not connected to a REPL');
     return;
   }
@@ -90,16 +90,16 @@ async function evaluateCodeInContext(
 
 async function getSnippetDefinition(codeOrKey: string, editorNS: string, editorRepl: string) {
   const configErrors: { name: string; keys: string[] }[] = [];
-  const globalSnippets = getConfig().customREPLCommandSnippetsGlobal;
-  const workspaceSnippets = getConfig().customREPLCommandSnippetsWorkspace;
-  const workspaceFolderSnippets = getConfig().customREPLCommandSnippetsWorkspaceFolder;
+  const globalSnippets = config.getConfig().customREPLCommandSnippetsGlobal;
+  const workspaceSnippets = config.getConfig().customREPLCommandSnippetsWorkspace;
+  const workspaceFolderSnippets = config.getConfig().customREPLCommandSnippetsWorkspaceFolder;
   let snippets = [
     ...(workspaceFolderSnippets ? workspaceFolderSnippets : []),
     ...(workspaceSnippets ? workspaceSnippets : []),
     ...(globalSnippets ? globalSnippets : []),
   ];
   if (snippets.length < 1) {
-    snippets = getConfig().customREPLCommandSnippets;
+    snippets = config.getConfig().customREPLCommandSnippets;
   }
   const snippetsDict = {};
   const snippetsMenuItems: vscode.QuickPickItem[] = [];
@@ -199,7 +199,7 @@ export function makeContext(
 export async function evaluateSnippet(editor: vscode.TextEditor, code, context, options) {
   const ns = context.ns;
   const repl = context.repl;
-  const interpolatedCode = interpolateVariables(editor.document.languageId, code, context);
+  const interpolatedCode = cljsLib.interpolateVariables(editor.document.languageId, code, context);
   if (typeof interpolatedCode === 'string') {
     return await evaluate.evaluateInCurrentEditor(editor, interpolatedCode, repl, ns, options);
   } else {

--- a/src/custom-snippets.ts
+++ b/src/custom-snippets.ts
@@ -5,10 +5,12 @@ import * as getText from './util/get-text';
 import * as namespace from './namespace';
 import * as config from './config';
 import * as replSession from './nrepl/repl-session';
-import evaluate from './evaluate';
+import * as evaluateModule from './evaluate';
 import * as state from './state';
 import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as output from './results-output/output';
+
+const evaluate = evaluateModule.default;
 
 export type CustomREPLCommandSnippet = {
   name: string;

--- a/src/debugger/calva-debug.ts
+++ b/src/debugger/calva-debug.ts
@@ -6,17 +6,14 @@ import * as path from 'path';
 import * as docMirror from '../doc-mirror/index';
 import * as vscode from 'vscode';
 import * as debugUtil from './util';
-import * as annotationsModule from '../providers/annotations';
+import * as annotations from '../providers/annotations';
 import type * as nrepl from '../nrepl';
-import * as debugDecorationsModule from './decorations';
+import * as debugDecorations from './decorations';
 import * as cljsLib from '../../out/cljs-lib/cljs-lib';
 import * as util from '../utilities';
 import * as replSession from '../nrepl/repl-session';
 import * as TokenCursor from '../cursor-doc/token-cursor';
 import * as cursorUtil from '../cursor-doc/utilities';
-
-const annotations = annotationsModule.default;
-const debugDecorations = debugDecorationsModule.default;
 
 const CALVA_DEBUG_CONFIGURATION: vscode.DebugConfiguration = {
   type: 'clojure',

--- a/src/debugger/calva-debug.ts
+++ b/src/debugger/calva-debug.ts
@@ -1,46 +1,21 @@
-import {
-  LoggingDebugSession,
-  TerminatedEvent,
-  Thread,
-  StoppedEvent,
-  StackFrame,
-  Source,
-  Scope,
-  Handles,
-  Variable,
-} from '@vscode/debugadapter';
-import { DebugProtocol } from '@vscode/debugprotocol';
-import {
-  debug,
-  window,
-  DebugConfigurationProvider,
-  WorkspaceFolder,
-  DebugConfiguration,
-  CancellationToken,
-  ProviderResult,
-  DebugAdapterDescriptorFactory,
-  DebugAdapterDescriptor,
-  DebugSession,
-  DebugAdapterExecutable,
-  DebugAdapterServer,
-  Position,
-} from 'vscode';
+import * as debugAdapter from '@vscode/debugadapter';
+import * as debugProtocol from '@vscode/debugprotocol';
 import * as Net from 'net';
 import * as state from '../state';
-import { basename, parse } from 'path';
+import * as path from 'path';
 import * as docMirror from '../doc-mirror/index';
 import * as vscode from 'vscode';
-import { moveTokenCursorToBreakpoint } from './util';
+import * as debugUtil from './util';
 import annotations from '../providers/annotations';
-import { NReplSession } from '../nrepl';
+import type * as nrepl from '../nrepl';
 import debugDecorations from './decorations';
-import { setStateValue, getStateValue, parseEdn } from '../../out/cljs-lib/cljs-lib';
+import * as cljsLib from '../../out/cljs-lib/cljs-lib';
 import * as util from '../utilities';
 import * as replSession from '../nrepl/repl-session';
 import * as TokenCursor from '../cursor-doc/token-cursor';
 import * as cursorUtil from '../cursor-doc/utilities';
 
-const CALVA_DEBUG_CONFIGURATION: DebugConfiguration = {
+const CALVA_DEBUG_CONFIGURATION: vscode.DebugConfiguration = {
   type: 'clojure',
   name: 'Calva Debug',
   request: 'attach',
@@ -72,11 +47,11 @@ type ExtractedStructure = {
   originalStrings: string[];
 };
 
-class CalvaDebugSession extends LoggingDebugSession {
+class CalvaDebugSession extends debugAdapter.LoggingDebugSession {
   // We don't support multiple threads, so we can use a hardcoded ID for the default thread
   static THREAD_ID = 1;
 
-  private _variableHandles = new Handles<string>();
+  private _variableHandles = new debugAdapter.Handles<string>();
   private _variableStructures: { [id: string]: any } = {};
 
   public constructor() {
@@ -88,8 +63,8 @@ class CalvaDebugSession extends LoggingDebugSession {
    * to interrogate the features the debug adapter provides.
    */
   protected initializeRequest(
-    response: DebugProtocol.InitializeResponse,
-    args: DebugProtocol.InitializeRequestArguments
+    response: debugProtocol.DebugProtocol.InitializeResponse,
+    args: debugProtocol.DebugProtocol.InitializeRequestArguments
   ): void {
     this.setDebuggerLinesStartAt1(args.linesStartAt1);
     this.setDebuggerColumnsStartAt1(args.columnsStartAt1);
@@ -104,8 +79,8 @@ class CalvaDebugSession extends LoggingDebugSession {
   }
 
   protected attachRequest(
-    response: DebugProtocol.AttachResponse,
-    args: DebugProtocol.AttachRequestArguments
+    response: debugProtocol.DebugProtocol.AttachResponse,
+    args: debugProtocol.DebugProtocol.AttachRequestArguments
   ): void {
     const session = replSession.getSession();
 
@@ -113,16 +88,16 @@ class CalvaDebugSession extends LoggingDebugSession {
   }
 
   protected continueRequest(
-    response: DebugProtocol.ContinueResponse,
-    args: DebugProtocol.ContinueArguments,
-    request?: DebugProtocol.Request
+    response: debugProtocol.DebugProtocol.ContinueResponse,
+    args: debugProtocol.DebugProtocol.ContinueArguments,
+    request?: debugProtocol.DebugProtocol.Request
   ): void {
     const session = replSession.getSession();
 
     if (session) {
-      const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
+      const { id, key } = cljsLib.getStateValue(DEBUG_RESPONSE_KEY);
       void session.sendDebugInput(':continue', id, key).then((response) => {
-        this.sendEvent(new StoppedEvent('breakpoint', CalvaDebugSession.THREAD_ID));
+        this.sendEvent(new debugAdapter.StoppedEvent('breakpoint', CalvaDebugSession.THREAD_ID));
       });
     } else {
       response.success = false;
@@ -132,25 +107,25 @@ class CalvaDebugSession extends LoggingDebugSession {
   }
 
   protected restartRequest(
-    response: DebugProtocol.RestartResponse,
-    args: DebugProtocol.RestartArguments,
-    request?: DebugProtocol.Request
+    response: debugProtocol.DebugProtocol.RestartResponse,
+    args: debugProtocol.DebugProtocol.RestartArguments,
+    request?: debugProtocol.DebugProtocol.Request
   ): void {
     response.success = false;
     this.sendResponse(response);
   }
 
   protected nextRequest(
-    response: DebugProtocol.NextResponse,
-    args: DebugProtocol.NextArguments,
-    request?: DebugProtocol.Request
+    response: debugProtocol.DebugProtocol.NextResponse,
+    args: debugProtocol.DebugProtocol.NextArguments,
+    request?: debugProtocol.DebugProtocol.Request
   ): void {
     const session = replSession.getSession();
 
     if (session) {
-      const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
+      const { id, key } = cljsLib.getStateValue(DEBUG_RESPONSE_KEY);
       void session.sendDebugInput(':next', id, key).then((_) => {
-        this.sendEvent(new StoppedEvent('breakpoint', CalvaDebugSession.THREAD_ID));
+        this.sendEvent(new debugAdapter.StoppedEvent('breakpoint', CalvaDebugSession.THREAD_ID));
       });
     } else {
       response.success = false;
@@ -160,16 +135,16 @@ class CalvaDebugSession extends LoggingDebugSession {
   }
 
   protected stepInRequest(
-    response: DebugProtocol.StepInResponse,
-    args: DebugProtocol.StepInArguments,
-    request?: DebugProtocol.Request
+    response: debugProtocol.DebugProtocol.StepInResponse,
+    args: debugProtocol.DebugProtocol.StepInArguments,
+    request?: debugProtocol.DebugProtocol.Request
   ): void {
     const session = replSession.getSession();
 
     if (session) {
-      const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
+      const { id, key } = cljsLib.getStateValue(DEBUG_RESPONSE_KEY);
       void session.sendDebugInput(':in', id, key).then((_) => {
-        this.sendEvent(new StoppedEvent('breakpoint', CalvaDebugSession.THREAD_ID));
+        this.sendEvent(new debugAdapter.StoppedEvent('breakpoint', CalvaDebugSession.THREAD_ID));
       });
     } else {
       response.success = false;
@@ -179,16 +154,16 @@ class CalvaDebugSession extends LoggingDebugSession {
   }
 
   protected stepOutRequest(
-    response: DebugProtocol.StepOutResponse,
-    args: DebugProtocol.StepOutArguments,
-    request?: DebugProtocol.Request
+    response: debugProtocol.DebugProtocol.StepOutResponse,
+    args: debugProtocol.DebugProtocol.StepOutArguments,
+    request?: debugProtocol.DebugProtocol.Request
   ): void {
     const session = replSession.getSession();
 
     if (session) {
-      const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
+      const { id, key } = cljsLib.getStateValue(DEBUG_RESPONSE_KEY);
       void session.sendDebugInput(':out', id, key).then((_) => {
-        this.sendEvent(new StoppedEvent('breakpoint', CalvaDebugSession.THREAD_ID));
+        this.sendEvent(new debugAdapter.StoppedEvent('breakpoint', CalvaDebugSession.THREAD_ID));
       });
     } else {
       response.success = false;
@@ -198,12 +173,12 @@ class CalvaDebugSession extends LoggingDebugSession {
   }
 
   protected threadsRequest(
-    response: DebugProtocol.ThreadsResponse,
-    request?: DebugProtocol.Request
+    response: debugProtocol.DebugProtocol.ThreadsResponse,
+    request?: debugProtocol.DebugProtocol.Request
   ): void {
     // We do not support multiple threads. Return a dummy thread.
     response.body = {
-      threads: [new Thread(CalvaDebugSession.THREAD_ID, 'thread 1')],
+      threads: [new debugAdapter.Thread(CalvaDebugSession.THREAD_ID, 'thread 1')],
     };
     this.sendResponse(response);
   }
@@ -227,11 +202,11 @@ class CalvaDebugSession extends LoggingDebugSession {
   }
 
   protected async stackTraceRequest(
-    response: DebugProtocol.StackTraceResponse,
-    args: DebugProtocol.StackTraceArguments,
-    request?: DebugProtocol.Request
+    response: debugProtocol.DebugProtocol.StackTraceResponse,
+    args: debugProtocol.DebugProtocol.StackTraceArguments,
+    request?: debugProtocol.DebugProtocol.Request
   ): Promise<void> {
-    const debugResponse = getStateValue(DEBUG_RESPONSE_KEY);
+    const debugResponse = cljsLib.getStateValue(DEBUG_RESPONSE_KEY);
     const uri =
       debugResponse.file.startsWith('jar:') || debugResponse.file.startsWith('file:')
         ? vscode.Uri.parse(debugResponse.file)
@@ -239,17 +214,17 @@ class CalvaDebugSession extends LoggingDebugSession {
     const document = await vscode.workspace.openTextDocument(uri);
     const positionLine = convertOneBasedToZeroBased(debugResponse.line);
     const positionColumn = convertOneBasedToZeroBased(debugResponse.column);
-    const offset = document.offsetAt(new Position(positionLine, positionColumn));
+    const offset = document.offsetAt(new vscode.Position(positionLine, positionColumn));
     const tokenCursor = docMirror.getDocument(document).getTokenCursor(offset);
 
     try {
-      moveTokenCursorToBreakpoint(tokenCursor, debugResponse);
+      debugUtil.moveTokenCursorToBreakpoint(tokenCursor, debugResponse);
     } catch (e) {
-      void window.showErrorMessage(
+      void vscode.window.showErrorMessage(
         'An error occurred in the breakpoint-finding logic. We would love if you submitted an issue in the Calva repo with the instrumented code, or a similar reproducible case.'
       );
       console.error('Calva debugger: moveTokenCursorToBreakpoint failed', e);
-      this.sendEvent(new TerminatedEvent());
+      this.sendEvent(new debugAdapter.TerminatedEvent());
       response.success = false;
       this.sendResponse(response);
       return;
@@ -258,9 +233,9 @@ class CalvaDebugSession extends LoggingDebugSession {
     const [line, column] = tokenCursor.rowCol;
 
     // Pass scheme in path argument to Source contructor so that if it's a jar file it's handled correctly
-    const source = new Source(basename(debugResponse.file), debugResponse.file);
+    const source = new debugAdapter.Source(path.basename(debugResponse.file), debugResponse.file);
     const name = tokenCursor.getFunctionName();
-    const stackFrames = [new StackFrame(0, name, source, line + 1, column + 1)];
+    const stackFrames = [new debugAdapter.StackFrame(0, name, source, line + 1, column + 1)];
 
     response.body = {
       stackFrames,
@@ -273,18 +248,18 @@ class CalvaDebugSession extends LoggingDebugSession {
   }
 
   protected scopesRequest(
-    response: DebugProtocol.ScopesResponse,
-    args: DebugProtocol.ScopesArguments,
-    request?: DebugProtocol.Request
+    response: debugProtocol.DebugProtocol.ScopesResponse,
+    args: debugProtocol.DebugProtocol.ScopesArguments,
+    request?: debugProtocol.DebugProtocol.Request
   ): void {
     response.body = {
-      scopes: [new Scope('Locals', this._variableHandles.create('locals'), false)],
+      scopes: [new debugAdapter.Scope('Locals', this._variableHandles.create('locals'), false)],
     };
 
     this.sendResponse(response);
   }
 
-  private _createVariableFromLocal(local: any[]): Variable {
+  private _createVariableFromLocal(local: any[]): debugAdapter.Variable {
     const value = local[1] as string;
     const name = local[0] as string;
     const cursor = TokenCursor.createStringCursor(value);
@@ -306,14 +281,14 @@ class CalvaDebugSession extends LoggingDebugSession {
   }
 
   protected variablesRequest(
-    response: DebugProtocol.VariablesResponse,
-    args: DebugProtocol.VariablesArguments,
-    request?: DebugProtocol.Request
+    response: debugProtocol.DebugProtocol.VariablesResponse,
+    args: debugProtocol.DebugProtocol.VariablesArguments,
+    request?: debugProtocol.DebugProtocol.Request
   ): void {
     const id = this._variableHandles.get(args.variablesReference);
 
     if (id === 'locals') {
-      const debugResponse = getStateValue(DEBUG_RESPONSE_KEY);
+      const debugResponse = cljsLib.getStateValue(DEBUG_RESPONSE_KEY);
       const variables = debugResponse.locals.map((local) => this._createVariableFromLocal(local));
 
       response.body = { variables };
@@ -379,14 +354,14 @@ class CalvaDebugSession extends LoggingDebugSession {
   }
 
   protected disconnectRequest(
-    response: DebugProtocol.DisconnectResponse,
-    args: DebugProtocol.DisconnectArguments,
-    request?: DebugProtocol.Request
+    response: debugProtocol.DebugProtocol.DisconnectResponse,
+    args: debugProtocol.DebugProtocol.DisconnectArguments,
+    request?: debugProtocol.DebugProtocol.Request
   ): void {
     const session = replSession.getSession();
 
     if (session) {
-      const { id, key } = getStateValue(DEBUG_RESPONSE_KEY);
+      const { id, key } = cljsLib.getStateValue(DEBUG_RESPONSE_KEY);
       void session.sendDebugInput(':quit', id, key);
     }
 
@@ -394,27 +369,31 @@ class CalvaDebugSession extends LoggingDebugSession {
   }
 
   protected terminateRequest(
-    response: DebugProtocol.TerminateResponse,
-    args: DebugProtocol.TerminateArguments,
-    request?: DebugProtocol.Request
+    response: debugProtocol.DebugProtocol.TerminateResponse,
+    args: debugProtocol.DebugProtocol.TerminateArguments,
+    request?: debugProtocol.DebugProtocol.Request
   ): void {
     this.sendResponse(response);
   }
 
   protected customRequest(
     command: string,
-    response: DebugProtocol.Response,
+    response: debugProtocol.DebugProtocol.Response,
     args: any,
-    request?: DebugProtocol.Request
+    request?: debugProtocol.DebugProtocol.Request
   ): void {
     switch (command) {
       case REQUESTS.SEND_TERMINATED_EVENT: {
-        this.sendEvent(new TerminatedEvent());
+        this.sendEvent(new debugAdapter.TerminatedEvent());
         break;
       }
       case REQUESTS.SEND_STOPPED_EVENT: {
         this.sendEvent(
-          new StoppedEvent(args.reason, CalvaDebugSession.THREAD_ID, args.exceptionText)
+          new debugAdapter.StoppedEvent(
+            args.reason,
+            CalvaDebugSession.THREAD_ID,
+            args.exceptionText
+          )
         );
         break;
       }
@@ -426,19 +405,19 @@ class CalvaDebugSession extends LoggingDebugSession {
 
 CalvaDebugSession.run(CalvaDebugSession);
 
-class CalvaDebugConfigurationProvider implements DebugConfigurationProvider {
+class CalvaDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
   /**
    * Massage a debug configuration just before a debug session is being launched,
    * e.g. add all missing attributes to the debug configuration.
    */
   resolveDebugConfiguration(
-    folder: WorkspaceFolder | undefined,
-    config: DebugConfiguration,
-    token?: CancellationToken
-  ): ProviderResult<DebugConfiguration> {
+    folder: vscode.WorkspaceFolder | undefined,
+    config: vscode.DebugConfiguration,
+    token?: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.DebugConfiguration> {
     // If launch.json is missing or empty
     if (!config.type && !config.request && !config.name) {
-      const editor = window.activeTextEditor;
+      const editor = vscode.window.activeTextEditor;
       if (editor && editor.document.languageId === 'clojure') {
         config = { ...config, ...CALVA_DEBUG_CONFIGURATION };
       }
@@ -448,13 +427,13 @@ class CalvaDebugConfigurationProvider implements DebugConfigurationProvider {
   }
 }
 
-class CalvaDebugAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
+class CalvaDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
   private server?: Net.Server;
 
   createDebugAdapterDescriptor(
-    session: DebugSession,
-    executable: DebugAdapterExecutable | undefined
-  ): ProviderResult<DebugAdapterDescriptor> {
+    session: vscode.DebugSession,
+    executable: vscode.DebugAdapterExecutable | undefined
+  ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
     if (!this.server) {
       // Start listening on a random port (0 means an arbitrary unused port will be used)
       this.server = Net.createServer((socket) => {
@@ -465,7 +444,7 @@ class CalvaDebugAdapterDescriptorFactory implements DebugAdapterDescriptorFactor
     }
 
     // Make VS Code connect to debug server
-    return new DebugAdapterServer((this.server.address() as Net.AddressInfo).port);
+    return new vscode.DebugAdapterServer((this.server.address() as Net.AddressInfo).port);
   }
 
   dispose() {
@@ -491,10 +470,10 @@ function handleNeedDebugInput(response: any): void {
     typeof response.column === 'number' &&
     typeof response.line === 'number'
   ) {
-    setStateValue(DEBUG_RESPONSE_KEY, response);
+    cljsLib.setStateValue(DEBUG_RESPONSE_KEY, response);
 
-    if (!debug.activeDebugSession) {
-      void debug.startDebugging(undefined, CALVA_DEBUG_CONFIGURATION);
+    if (!vscode.debug.activeDebugSession) {
+      void vscode.debug.startDebugging(undefined, CALVA_DEBUG_CONFIGURATION);
     }
   } else {
     const session = replSession.getSession();
@@ -505,7 +484,7 @@ function handleNeedDebugInput(response: any): void {
   }
 }
 
-debug.onDidStartDebugSession((session) => {
+vscode.debug.onDidStartDebugSession((session) => {
   if (session.type != CALVA_DEBUG_CONFIGURATION.type) {
     return;
   }
@@ -521,7 +500,7 @@ function convertOneBasedToZeroBased(n: number): number {
   return n === 0 ? n : n - 1;
 }
 
-function initializeDebugger(cljSession: NReplSession): void {
+function initializeDebugger(cljSession: nrepl.NReplSession): void {
   cljSession.initDebugger();
   debugDecorations.activate();
 }

--- a/src/debugger/calva-debug.ts
+++ b/src/debugger/calva-debug.ts
@@ -6,14 +6,17 @@ import * as path from 'path';
 import * as docMirror from '../doc-mirror/index';
 import * as vscode from 'vscode';
 import * as debugUtil from './util';
-import annotations from '../providers/annotations';
+import * as annotationsModule from '../providers/annotations';
 import type * as nrepl from '../nrepl';
-import debugDecorations from './decorations';
+import * as debugDecorationsModule from './decorations';
 import * as cljsLib from '../../out/cljs-lib/cljs-lib';
 import * as util from '../utilities';
 import * as replSession from '../nrepl/repl-session';
 import * as TokenCursor from '../cursor-doc/token-cursor';
 import * as cursorUtil from '../cursor-doc/utilities';
+
+const annotations = annotationsModule.default;
+const debugDecorations = debugDecorationsModule.default;
 
 const CALVA_DEBUG_CONFIGURATION: vscode.DebugConfiguration = {
   type: 'clojure',

--- a/src/debugger/decorations.ts
+++ b/src/debugger/decorations.ts
@@ -1,18 +1,18 @@
 import * as vscode from 'vscode';
-import { LanguageClient } from 'vscode-languageclient/node';
-import { Location } from 'vscode-languageserver-protocol';
+import type * as vscodeLsp from 'vscode-languageclient/node';
+import type * as vscodeLanguageserverProtocol from 'vscode-languageserver-protocol';
 import * as _ from 'lodash';
-import { NReplSession } from '../nrepl';
+import type * as nrepl from '../nrepl';
 import * as util from '../utilities';
 import * as lsp from '../lsp';
-import { getStateValue } from '../../out/cljs-lib/cljs-lib';
+import * as cljsLib from '../../out/cljs-lib/cljs-lib';
 import * as replSession from '../nrepl/repl-session';
 
 let enabled = false;
 
 interface InstrumentedSymbolReferenceLocations {
   [namespace: string]: {
-    [symbol: string]: Location[];
+    [symbol: string]: vscodeLanguageserverProtocol.Location[];
   };
 }
 let instrumentedSymbolReferenceLocations: InstrumentedSymbolReferenceLocations = {};
@@ -51,8 +51,8 @@ const instrumentedSymbolDecorationType = vscode.window.createTextEditorDecoratio
 
 async function update(
   editor: vscode.TextEditor,
-  cljSession: NReplSession,
-  lspClient: LanguageClient
+  cljSession: nrepl.NReplSession,
+  lspClient: vscodeLsp.LanguageClient
 ): Promise<void> {
   if (/(\.clj)$/.test(editor.document.fileName)) {
     if (cljSession && util.getConnectedState() && lspClient) {

--- a/src/debugger/decorations.ts
+++ b/src/debugger/decorations.ts
@@ -166,7 +166,4 @@ function activate() {
   });
 }
 
-export default {
-  activate,
-  triggerUpdateAndRenderDecorations,
-};
+export { activate, triggerUpdateAndRenderDecorations };

--- a/src/debugger/util.ts
+++ b/src/debugger/util.ts
@@ -1,40 +1,40 @@
-import { LispTokenCursor } from '../cursor-doc/token-cursor';
+import type * as tokenCursorTypes from '../cursor-doc/token-cursor';
 
-function moveCursorPastStringInList(tokenCursor: LispTokenCursor, s: string): void {
-  const [listOffsetStart, listOffsetEnd] = tokenCursor.rangeForList(1);
-  const text = tokenCursor.doc.getText(listOffsetStart, listOffsetEnd - 1);
+function moveCursorPastStringInList(cursor: tokenCursorTypes.LispTokenCursor, s: string): void {
+  const [listOffsetStart, listOffsetEnd] = cursor.rangeForList(1);
+  const text = cursor.doc.getText(listOffsetStart, listOffsetEnd - 1);
 
   const stringIndexInList = text.indexOf(s);
   if (stringIndexInList !== -1) {
     const coorOffset = listOffsetStart + stringIndexInList;
-    while (tokenCursor.offsetStart !== coorOffset) {
-      tokenCursor.forwardSexp();
-      tokenCursor.forwardWhitespace();
+    while (cursor.offsetStart !== coorOffset) {
+      cursor.forwardSexp();
+      cursor.forwardWhitespace();
     }
-    tokenCursor.forwardSexp();
+    cursor.forwardSexp();
   } else {
     throw 'Cannot find string in list';
   }
 }
 
 function moveTokenCursorToBreakpoint(
-  tokenCursor: LispTokenCursor,
+  cursor: tokenCursorTypes.LispTokenCursor,
   debugResponse: any
-): LispTokenCursor {
+): tokenCursorTypes.LispTokenCursor {
   const errorMessage = 'Error finding position of breakpoint';
-  const defunRange = tokenCursor.rangeForDefun(tokenCursor.offsetStart);
+  const defunRange = cursor.rangeForDefun(cursor.offsetStart);
   if (!defunRange) {
     throw errorMessage + ': no defun range found';
   }
   const [defunStart, defunEnd] = defunRange;
-  tokenCursor.set(tokenCursor.doc.getTokenCursor(defunStart));
+  cursor.set(cursor.doc.getTokenCursor(defunStart));
   let inSyntaxQuote = false;
 
   const coor = [...debugResponse.coor]; // Copy the array so we do not modify the one stored in state
 
   for (let i = 0; i < coor.length; i++) {
-    tokenCursor.downListSkippingMeta();
-    const previousToken = tokenCursor.getPrevToken();
+    cursor.downListSkippingMeta();
+    const previousToken = cursor.getPrevToken();
 
     // Check if we just entered a syntax quote, since we have to account for how syntax quoted forms are read
     // `(. .) is read as (seq (concat (list .) (list .))).
@@ -68,39 +68,39 @@ function moveTokenCursorToBreakpoint(
 
     // If coor is a string it represents a map key
     if (typeof coor[i] === 'string') {
-      moveCursorPastStringInList(tokenCursor, coor[i]);
+      moveCursorPastStringInList(cursor, coor[i]);
     } else {
       for (let k = 0; k < coor[i]; k++) {
-        if (!tokenCursor.forwardSexp(true, true, true)) {
+        if (!cursor.forwardSexp(true, true, true)) {
           throw errorMessage + `: cannot move down list at coor index ${i}`;
         }
       }
     }
 
-    tokenCursor.forwardWhitespace();
+    cursor.forwardWhitespace();
 
     // If the next sexpr starts with `@` it's dereffing a value, and that is expanded
     // to (deref value) behind the scenes. We will get a coor path to go down the
     // deref form, but can't really act on it. So we break here.
-    if (tokenCursor.getToken().raw.startsWith('@')) {
+    if (cursor.getToken().raw.startsWith('@')) {
       i++;
     }
   }
 
   // Move past the target sexp
-  if (!tokenCursor.forwardSexp(true, true, true)) {
+  if (!cursor.forwardSexp(true, true, true)) {
     throw errorMessage + `: cannot move forward at coor ${JSON.stringify(coor)}`;
   }
 
   // Make sure we're still inside the original instrumented form, otherwise something went wrong
-  if (tokenCursor.offsetStart > defunEnd) {
+  if (cursor.offsetStart > defunEnd) {
     throw (
       errorMessage +
-      `: moved past original instrumented form (defunStart=${defunStart}, defunEnd=${defunEnd}, offset=${tokenCursor.offsetStart})`
+      `: moved past original instrumented form (defunStart=${defunStart}, defunEnd=${defunEnd}, offset=${cursor.offsetStart})`
     );
   }
 
-  return tokenCursor;
+  return cursor;
 }
 
 export { moveTokenCursorToBreakpoint };

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -3,19 +3,23 @@ import * as vscode from 'vscode';
 import * as utilities from '../utilities';
 import * as formatter from '../calva-fmt/src/format';
 import * as respacer from '../calva-fmt/src/respacer';
-import { LispTokenCursor } from '../cursor-doc/token-cursor';
-import {
-  ModelEdit,
-  EditableDocument,
-  EditableModel,
-  ModelEditOptions,
-  LineInputModel,
-  ModelEditRange,
-  ModelEditSelection,
-  ModelEditFunction,
-  selectionsAfterEdits,
-} from '../cursor-doc/model';
-import { isUndefined, sortedUniq } from 'lodash';
+import * as tokenCursor from '../cursor-doc/token-cursor';
+import * as documentModel from '../cursor-doc/model';
+import * as _ from 'lodash';
+
+type LispTokenCursor = tokenCursor.LispTokenCursor;
+type ModelEdit<T extends ModelEditFunction = ModelEditFunction> = documentModel.ModelEdit<T>;
+type EditableDocument = documentModel.EditableDocument;
+type EditableModel = documentModel.EditableModel;
+type ModelEditOptions = documentModel.ModelEditOptions;
+type LineInputModel = documentModel.LineInputModel;
+type ModelEditRange = documentModel.ModelEditRange;
+type ModelEditSelection = documentModel.ModelEditSelection;
+type ModelEditFunction = documentModel.ModelEditFunction;
+
+const ModelEditCtor = documentModel.ModelEdit;
+const LineInputModelCtor = documentModel.LineInputModel;
+const ModelEditSelectionCtor = documentModel.ModelEditSelection;
 
 const documents = new Map<vscode.TextDocument, MirroredDocument>();
 
@@ -100,7 +104,7 @@ export class DocumentModel implements EditableModel {
 
   constructor(private document: MirroredDocument) {
     this.lineEndingLength = document.document.eol == vscode.EndOfLine.CRLF ? 2 : 1;
-    this.lineInputModel = new LineInputModel(this.lineEndingLength);
+    this.lineInputModel = new LineInputModelCtor(this.lineEndingLength);
     this.documentVersion = document.document.version;
   }
 
@@ -127,7 +131,7 @@ export class DocumentModel implements EditableModel {
    */
   resync(document: vscode.TextDocument): void {
     const text = document.getText().replace(/\r\n/g, '\n');
-    const newModel = new LineInputModel(this.lineEndingLength);
+    const newModel = new LineInputModelCtor(this.lineEndingLength);
     newModel.insertString(0, text);
     newModel.flushChanges();
     newModel.dirtyLines = [];
@@ -174,7 +178,7 @@ export class DocumentModel implements EditableModel {
 
   private postEditReformat(editor: vscode.TextEditor, offsets: number[]): Thenable<boolean> {
     // Now that the document has been edited, calculate the reformatting:
-    const reformatChange: respacer.WhitespaceChange[] = sortedUniq(offsets.sort((a, b) => b - a))
+    const reformatChange: respacer.WhitespaceChange[] = _.sortedUniq(offsets.sort((a, b) => b - a))
       .flatMap((p) => {
         try {
           const doc = this.document.document;
@@ -256,15 +260,17 @@ export class DocumentModel implements EditableModel {
       forDocumentVersion: this.document.document.version + 1, // none of this matters if another edit intervenes
       reformatOffsets: options.skipFormat
         ? undefined
-        : selectionsAfterEdits(
-            modelEdits,
-            rangesOrWhole.flatMap((r: ModelEditRange): ModelEditSelection[] => {
-              return [
-                new ModelEditSelection(r[0], r[0], r[0], r[0]),
-                new ModelEditSelection(r[1], r[1], r[1], r[1]),
-              ];
-            })
-          ).flatMap((sel) => [sel.anchor, sel.active]),
+        : documentModel
+            .selectionsAfterEdits(
+              modelEdits,
+              rangesOrWhole.flatMap((r: ModelEditRange): ModelEditSelection[] => {
+                return [
+                  new ModelEditSelectionCtor(r[0], r[0], r[0], r[0]),
+                  new ModelEditSelectionCtor(r[1], r[1], r[1], r[1]),
+                ];
+              })
+            )
+            .flatMap((sel) => [sel.anchor, sel.active]),
       selections: options.selections,
     };
     const postEditPlan =
@@ -402,7 +408,7 @@ export class MirroredDocument implements EditableDocument {
     return editor.selections.map((sel) => {
       const anchor = document.offsetAt(sel.anchor),
         active = document.offsetAt(sel.active);
-      return new ModelEditSelection(anchor, active);
+      return new ModelEditSelectionCtor(anchor, active);
     });
   }
 
@@ -438,7 +444,7 @@ function processChanges(event: vscode.TextDocumentChangeEvent) {
       myEndOffset = model.getOffsetForLine(change.range.end.line) + change.range.end.character;
     void model.lineInputModel.edit(
       [
-        new ModelEdit('changeRange', [
+        new ModelEditCtor('changeRange', [
           myStartOffset,
           myEndOffset,
           change.text.replace(/\r\n/g, '\n'),
@@ -465,7 +471,7 @@ export function tryToGetDocument(doc: vscode.TextDocument) {
 export function getDocument(doc: vscode.TextDocument) {
   const mirrorDoc = tryToGetDocument(doc);
 
-  if (isUndefined(mirrorDoc)) {
+  if (_.isUndefined(mirrorDoc)) {
     throw new Error('Missing mirror document!');
   }
 

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -1,12 +1,12 @@
 import * as vscode from 'vscode';
 import * as util from './utilities';
 import * as docMirror from './doc-mirror/index';
-import { EditableDocument, ModelEdit } from './cursor-doc/model';
+import * as model from './cursor-doc/model';
 import * as select from './select';
 import * as printer from './printer';
 import * as paredit from './cursor-doc/paredit';
 import * as format from './calva-fmt/src/format';
-import { calculateCommentPrefixRemovalEnd, findCommentPrefixStart } from './comment-prefix';
+import * as commentPrefix from './comment-prefix';
 
 type CandidatesMap = Map<number, number[]>;
 
@@ -97,7 +97,10 @@ function areAllNonEmptyTargetLinesCommented(
     nonEmptyLines.length > 0 &&
     nonEmptyLines.every((lineNum) => {
       const candidates = candidatesMap.get(lineNum) ?? [];
-      return findCommentPrefixStart(document.lineAt(lineNum).text, candidates) !== undefined;
+      return (
+        commentPrefix.findCommentPrefixStart(document.lineAt(lineNum).text, candidates) !==
+        undefined
+      );
     })
   );
 }
@@ -311,7 +314,7 @@ async function applyStructuralCommentsToSingleSelectionLines(
  * - `false` when the break can be skipped entirely.
  */
 function resolveStructuralBreakOffset(
-  mirrorDoc: EditableDocument,
+  mirrorDoc: model.EditableDocument,
   wouldBreakWhere: number,
   affectedLineSet: Set<number>,
   partialSelectionStartOffset?: number,
@@ -455,11 +458,14 @@ async function updateLineComments(
         const lineText = line.text;
 
         if (shouldUncomment) {
-          const removalStart = findCommentPrefixStart(lineText, candidatesMap.get(lineNum) ?? []);
+          const removalStart = commentPrefix.findCommentPrefixStart(
+            lineText,
+            candidatesMap.get(lineNum) ?? []
+          );
           if (removalStart === undefined) {
             continue;
           }
-          const removalEnd = calculateCommentPrefixRemovalEnd(lineText, removalStart);
+          const removalEnd = commentPrefix.calculateCommentPrefixRemovalEnd(lineText, removalStart);
           if (removalEnd === undefined) {
             continue;
           }
@@ -613,10 +619,10 @@ export function replace(
   options = {}
 ) {
   const document = editor.document;
-  const mirrorDoc: EditableDocument = docMirror.getDocument(document);
+  const mirrorDoc: model.EditableDocument = docMirror.getDocument(document);
   return mirrorDoc.model.edit(
     [
-      new ModelEdit('changeRange', [
+      new model.ModelEdit('changeRange', [
         document.offsetAt(range.start),
         document.offsetAt(range.end),
         newText,

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -3,27 +3,27 @@ import * as state from './state';
 import annotations from './providers/annotations';
 import * as path from 'path';
 import * as util from './utilities';
-import { NReplSession, NReplEvaluation } from './nrepl';
+import * as nrepl from './nrepl';
 import statusbar from './statusbar';
-import { PrettyPrintingOptions } from './printer';
+import type * as printerTypes from './printer';
 import * as replWindow from './repl-window/repl-window-doc';
 import * as namespace from './namespace';
 import * as replHistory from './repl-window/repl-history';
-import { formatAsLineComments } from './results-output/util';
-import { getStateValue, appendStackTraceToReplOutputWebview } from '../out/cljs-lib/cljs-lib';
-import { getConfig } from './config';
+import * as resultsOutputUtil from './results-output/util';
+import * as cljsLib from '../out/cljs-lib/cljs-lib';
+import * as calvaConfig from './config';
 import * as replSession from './nrepl/repl-session';
 import * as sessionRegistry from './nrepl/session-registry';
 import * as getText from './util/get-text';
 import * as customSnippets from './custom-snippets';
 import * as output from './results-output/output';
 import * as inspector from './providers/inspector';
-import { resultAsComment } from './util/string-result';
-import { highlight } from './highlight/src/extension';
+import * as stringResult from './util/string-result';
+import * as highlightExtension from './highlight/src/extension';
 import * as flareHandler from './flare-handler';
-import { normalizeEvaluateAsCommentArgs } from './evaluate-utils';
+import * as evaluateUtils from './evaluate-utils';
 import * as whoTracking from './api/who-tracking';
-import { normalizeDestinations } from './results-output/output-destinations';
+import * as outputDestinations from './results-output/output-destinations';
 
 let inspectorDataProvider: inspector.InspectorDataProvider;
 
@@ -32,7 +32,7 @@ function initInspectorDataProvider() {
   return inspectorDataProvider;
 }
 
-async function getJavaVersion(session: NReplSession): Promise<number | null> {
+async function getJavaVersion(session: nrepl.NReplSession): Promise<number | null> {
   try {
     const result = await session.eval('(System/getProperty "java.version")', 'user').value;
     // Parse version like "21.0.1", "17.0.2", "1.8.0_292"
@@ -44,7 +44,7 @@ async function getJavaVersion(session: NReplSession): Promise<number | null> {
   }
 }
 
-async function checkJvmAttachSelfSupport(session: NReplSession): Promise<boolean> {
+async function checkJvmAttachSelfSupport(session: nrepl.NReplSession): Promise<boolean> {
   try {
     const result = await session.eval('(System/getProperty "jdk.attach.allowAttachSelf")', 'user')
       .value;
@@ -62,7 +62,7 @@ async function interruptAllEvaluations() {
     return;
   }
 
-  const firstSession = NReplSession.getInstances()?.[0];
+  const firstSession = nrepl.NReplSession.getInstances()?.[0];
   if (!firstSession?.supports('interrupt')) {
     void vscode.window.showInformationMessage(
       'The nREPL server does not support interruption of evaluations.'
@@ -82,14 +82,14 @@ async function interruptAllEvaluations() {
   }
 
   const msgs: string[] = [];
-  const nums = NReplEvaluation.interruptAll((msg) => {
+  const nums = nrepl.NReplEvaluation.interruptAll((msg) => {
     msgs.push(msg);
   });
   if (msgs.length) {
     output.appendLineOtherOut(msgs.join('\n'), { who: 'ui' });
   }
   try {
-    NReplSession.getInstances().forEach((session, _index) => {
+    nrepl.NReplSession.getInstances().forEach((session, _index) => {
       session.interruptAll();
     });
   } catch (error) {
@@ -112,12 +112,16 @@ async function addAsComment(
   commentStyle: string
 ) {
   const endOfLinePosition = editor.document.lineAt(codeSelection.end.line).range.end;
-  const commentText = resultAsComment(codeSelection.start.character, result, commentStyle);
+  const commentText = stringResult.resultAsComment(
+    codeSelection.start.character,
+    result,
+    commentStyle
+  );
   await editor.edit((editBuilder) => {
     editBuilder.insert(endOfLinePosition, commentText);
   });
   editor.selections = [selection];
-  highlight(editor);
+  highlightExtension.highlight(editor);
 }
 
 // TODO: Clean up this mess
@@ -126,12 +130,12 @@ async function evaluateCodeUpdatingUI(
   options,
   selection?: vscode.Selection
 ): Promise<string | null> {
-  const pprintOptions = options.pprintOptions || getConfig().prettyPrintingOptions;
+  const pprintOptions = options.pprintOptions || calvaConfig.getConfig().prettyPrintingOptions;
   // passed options overwrite config options
   const evaluationSendCodeToOutputWindow =
     (options.evaluationSendCodeToOutputWindow === undefined ||
       options.evaluationSendCodeToOutputWindow === true) &&
-    getConfig().evaluationSendCodeToOutputWindow;
+    calvaConfig.getConfig().evaluationSendCodeToOutputWindow;
   const addToHistory =
     (options.addToHistory === undefined || options.addToHistory === true) &&
     (evaluationSendCodeToOutputWindow ||
@@ -142,7 +146,7 @@ async function evaluateCodeUpdatingUI(
   const line = options.line;
   const column = options.column;
   const filePath = options.filePath;
-  const session: NReplSession = options.session;
+  const session: nrepl.NReplSession = options.session;
   const sessionKey = sessionRegistry.resolveSessionKey(session);
   const ns = options.ns;
   let editor: vscode.TextEditor;
@@ -165,7 +169,7 @@ async function evaluateCodeUpdatingUI(
       await session.evaluateInNs(options.nsForm, replWindow.getNs());
     }
 
-    const context: NReplEvaluation = session.eval(code, ns, {
+    const context: nrepl.NReplEvaluation = session.eval(code, ns, {
       file: filePath,
       line: line + 1,
       column: column + 1,
@@ -189,7 +193,7 @@ async function evaluateCodeUpdatingUI(
         destination: shouldWriteVisibleEvaluatedCode ? 'repl-window' : evalResultsDestination,
         additionalDestinations:
           shouldWriteVisibleEvaluatedCode &&
-          !normalizeDestinations(evalResultsDestination).includes('repl-window')
+          !outputDestinations.normalizeDestinations(evalResultsDestination).includes('repl-window')
             ? [evalResultsDestination]
             : [],
         sinkDestination: evalResultsDestination,
@@ -255,13 +259,16 @@ async function evaluateCodeUpdatingUI(
           const errMsg = err.join('\n');
           if (context.stacktrace) {
             replWindow.saveStacktrace(context.stacktrace);
-            replWindow.appendLine(formatAsLineComments(errMsg), (_, afterResultLocation) => {
-              replWindow.markLastStacktraceRange(afterResultLocation);
-            });
+            replWindow.appendLine(
+              resultsOutputUtil.formatAsLineComments(errMsg),
+              (_, afterResultLocation) => {
+                replWindow.markLastStacktraceRange(afterResultLocation);
+              }
+            );
             if (
-              !normalizeDestinations(output.getDestinationConfiguration().evalOutput).includes(
-                'repl-window'
-              )
+              !outputDestinations
+                .normalizeDestinations(output.getDestinationConfiguration().evalOutput)
+                .includes('repl-window')
             ) {
               output.appendEvalErr(errMsg, { ns, replSessionType: sessionKey, who: 'ui' });
             }
@@ -273,8 +280,8 @@ async function evaluateCodeUpdatingUI(
     } catch (e) {
       if (showErrorMessage) {
         const outputWindowError = err.length
-          ? formatAsLineComments(err.join('\n'))
-          : formatAsLineComments(e);
+          ? resultsOutputUtil.formatAsLineComments(err.join('\n'))
+          : resultsOutputUtil.formatAsLineComments(e);
         replWindow.appendLine(outputWindowError, async (resultLocation, afterResultLocation) => {
           if (selection) {
             const editorError = util.stripAnsi(err.length ? err.join('\n') : e);
@@ -314,9 +321,9 @@ async function evaluateCodeUpdatingUI(
             });
         });
         if (
-          !normalizeDestinations(output.getDestinationConfiguration().evalOutput).includes(
-            'repl-window'
-          )
+          !outputDestinations
+            .normalizeDestinations(output.getDestinationConfiguration().evalOutput)
+            .includes('repl-window')
         ) {
           output.appendEvalErr(err.length ? err.join('\n') : e, {
             ns,
@@ -324,15 +331,15 @@ async function evaluateCodeUpdatingUI(
             who: 'ui',
           });
           if (
-            normalizeDestinations(output.getDestinationConfiguration().evalOutput).includes(
-              'output-view'
-            )
+            outputDestinations
+              .normalizeDestinations(output.getDestinationConfiguration().evalOutput)
+              .includes('output-view')
           ) {
             session
               .stacktrace()
               .then((stacktrace) => {
                 if (stacktrace && stacktrace.stacktrace) {
-                  appendStackTraceToReplOutputWebview(stacktrace.stacktrace);
+                  cljsLib.appendStackTraceToReplOutputWebview(stacktrace.stacktrace);
                 }
               })
               .catch((e) => {
@@ -355,7 +362,7 @@ async function evaluateSelection(document = {}, options) {
   const selectionFn: (editor: vscode.TextEditor) => [vscode.Selection, string] =
     options.selectionFn;
 
-  if (getStateValue('connected')) {
+  if (cljsLib.getStateValue('connected')) {
     const editor = util.getActiveTextEditor();
     const selection = selectionFn(editor);
     const codeSelection: vscode.Selection = selection[0];
@@ -433,7 +440,7 @@ function evaluateSelectionReplace(document = {}, options = {}) {
       document,
       Object.assign({}, options, {
         replace: true,
-        pprintOptions: getConfig().prettyPrintingOptions,
+        pprintOptions: calvaConfig.getConfig().prettyPrintingOptions,
         selectionFn: _currentSelectionElseCurrentForm,
       })
     ).catch(printWarningForError);
@@ -451,14 +458,14 @@ function validateCommentStyle(commentStyle: string) {
 }
 
 function evaluateSelectionAsComment(options = { commentStyle: 'line' }, document = {}) {
-  const normalized = normalizeEvaluateAsCommentArgs(document, options);
+  const normalized = evaluateUtils.normalizeEvaluateAsCommentArgs(document, options);
   validateCommentStyle(normalized.options.commentStyle);
   if (util.getConnectedState()) {
     evaluateSelection(
       normalized.document,
       Object.assign({}, normalized.options, {
         comment: true,
-        pprintOptions: getConfig().prettyPrintingOptions,
+        pprintOptions: calvaConfig.getConfig().prettyPrintingOptions,
         selectionFn: _currentSelectionElseCurrentForm,
       })
     ).catch(printWarningForError);
@@ -468,14 +475,14 @@ function evaluateSelectionAsComment(options = { commentStyle: 'line' }, document
 }
 
 function evaluateTopLevelFormAsComment(options = { commentStyle: 'line' }, document = {}) {
-  const normalized = normalizeEvaluateAsCommentArgs(document, options);
+  const normalized = evaluateUtils.normalizeEvaluateAsCommentArgs(document, options);
   validateCommentStyle(normalized.options.commentStyle);
   if (util.getConnectedState()) {
     evaluateSelection(
       normalized.document,
       Object.assign({}, normalized.options, {
         comment: true,
-        pprintOptions: getConfig().prettyPrintingOptions,
+        pprintOptions: calvaConfig.getConfig().prettyPrintingOptions,
         selectionFn: _currentTopLevelFormText,
       })
     ).catch(printWarningForError);
@@ -504,7 +511,7 @@ function evaluateTopLevelForm(document = {}, options = {}) {
     evaluateSelection(
       document,
       Object.assign({}, options, {
-        pprintOptions: getConfig().prettyPrintingOptions,
+        pprintOptions: calvaConfig.getConfig().prettyPrintingOptions,
         selectionFn: _currentTopLevelFormText,
       })
     ).catch(printWarningForError);
@@ -518,7 +525,7 @@ function evaluateReplWindowForm(document = {}, options = {}) {
     evaluateSelection(
       document,
       Object.assign({}, options, {
-        pprintOptions: getConfig().prettyPrintingOptions,
+        pprintOptions: calvaConfig.getConfig().prettyPrintingOptions,
         selectionFn: _currentTopLevelFormText,
         evaluationSendCodeToOutputWindow: false,
         addToHistory: true,
@@ -534,7 +541,7 @@ function evaluateCurrentForm(document = {}, options = {}) {
     evaluateSelection(
       document,
       Object.assign({}, options, {
-        pprintOptions: getConfig().prettyPrintingOptions,
+        pprintOptions: calvaConfig.getConfig().prettyPrintingOptions,
         selectionFn: _currentSelectionElseCurrentForm,
       })
     ).catch(printWarningForError);
@@ -548,7 +555,7 @@ function evaluateEnclosingForm(document = {}, options = {}) {
     evaluateSelection(
       document,
       Object.assign({}, options, {
-        pprintOptions: getConfig().prettyPrintingOptions,
+        pprintOptions: calvaConfig.getConfig().prettyPrintingOptions,
         selectionFn: _currentEnclosingFormText,
       })
     ).catch(printWarningForError);
@@ -566,7 +573,7 @@ function evaluateUsingTextAndSelectionGetter(
   evaluateSelection(
     document,
     Object.assign({}, options, {
-      pprintOptions: getConfig().prettyPrintingOptions,
+      pprintOptions: calvaConfig.getConfig().prettyPrintingOptions,
       selectionFn: (editor: vscode.TextEditor) => {
         const [selection, code] = getter(editor?.document, editor?.selections[0].active);
         return [selection, formatter(code)];
@@ -618,7 +625,7 @@ function evaluateStartOfFileToCursor(document = {}, options = {}) {
 
 async function loadDocument(
   document: vscode.TextDocument | Record<string, never> | undefined,
-  pprintOptions: PrettyPrintingOptions,
+  pprintOptions: printerTypes.PrettyPrintingOptions,
   shouldResetPreview: boolean = false,
   silent: boolean = false,
   sessionKey?: string,
@@ -638,7 +645,12 @@ async function loadDocument(
   const [ns, nsForm] = namespace.getNamespace(doc, doc.positionAt(0));
   const session = sessionKey ? sessionRegistry.getSession(sessionKey) : replSession.getSession();
 
-  if (doc && doc.languageId == 'clojure' && fileType != 'edn' && getStateValue('connected')) {
+  if (
+    doc &&
+    doc.languageId == 'clojure' &&
+    fileType != 'edn' &&
+    cljsLib.getStateValue('connected')
+  ) {
     const docUri = replWindow.isReplWindowDoc(doc)
       ? await namespace.getUriForNamespace(session, ns)
       : doc.uri;
@@ -658,7 +670,7 @@ async function loadFileCommand(fileArg?: unknown) {
     }
     const result = await loadDocument(
       document,
-      getConfig().prettyPrintingOptions,
+      calvaConfig.getConfig().prettyPrintingOptions,
       true,
       silent,
       sessionKey,
@@ -698,7 +710,7 @@ async function loadFile(
   filePath: string,
   ns: string,
   nsForm: string,
-  pprintOptions: PrettyPrintingOptions,
+  pprintOptions: printerTypes.PrettyPrintingOptions,
   fileType: string,
   silent: boolean = false,
   targetSessionKey?: string,
@@ -746,9 +758,9 @@ async function loadFile(
       }
     );
     if (
-      !normalizeDestinations(output.getDestinationConfiguration().evalOutput).includes(
-        'repl-window'
-      )
+      !outputDestinations
+        .normalizeDestinations(output.getDestinationConfiguration().evalOutput)
+        .includes('repl-window')
     ) {
       output.appendLineOtherErr(`Evaluation of file ${fileName} failed: ${e}`, { who });
     }
@@ -774,7 +786,7 @@ async function loadFile(
   } finally {
     replWindow.setSession(session, ns);
     replSession.updateReplSessionType();
-    if (getConfig().autoEvaluateCode.onFileLoaded[fileType]) {
+    if (calvaConfig.getConfig().autoEvaluateCode.onFileLoaded[fileType]) {
       output.appendLineOtherOut(`Evaluating \`autoEvaluateCode.onFileLoaded.${fileType}\``, {
         who,
       });
@@ -787,7 +799,7 @@ async function loadFile(
       );
       await customSnippets.evaluateSnippet(
         util.getActiveTextEditor(),
-        getConfig().autoEvaluateCode.onFileLoaded[fileType],
+        calvaConfig.getConfig().autoEvaluateCode.onFileLoaded[fileType],
         context,
         {}
       );
@@ -845,7 +857,7 @@ async function copyLastResultCommand() {
 async function togglePrettyPrint() {
   const config = vscode.workspace.getConfiguration('calva'),
     pprintConfigKey = 'prettyPrintingOptions',
-    pprintOptions = config.get<PrettyPrintingOptions>(pprintConfigKey);
+    pprintOptions = config.get<printerTypes.PrettyPrintingOptions>(pprintConfigKey);
   pprintOptions.enabled = !pprintOptions.enabled;
   if (pprintOptions.enabled && !(pprintOptions.printEngine || pprintOptions.printFn)) {
     pprintOptions.printEngine = 'pprint';
@@ -869,7 +881,7 @@ function instrumentTopLevelForm() {
     evaluateSelection(
       {},
       {
-        pprintOptions: getConfig().prettyPrintingOptions,
+        pprintOptions: calvaConfig.getConfig().prettyPrintingOptions,
         debug: true,
         selectionFn: _currentTopLevelFormText,
       }

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
 import * as state from './state';
-import * as annotationsModule from './providers/annotations';
+import * as annotations from './providers/annotations';
 import * as path from 'path';
 import * as util from './utilities';
 import * as nrepl from './nrepl';
-import * as statusbarModule from './statusbar';
+import * as statusbar from './statusbar';
 import type * as printerTypes from './printer';
 import * as replWindow from './repl-window/repl-window-doc';
 import * as namespace from './namespace';
@@ -24,9 +24,6 @@ import * as flareHandler from './flare-handler';
 import * as evaluateUtils from './evaluate-utils';
 import * as whoTracking from './api/who-tracking';
 import * as outputDestinations from './results-output/output-destinations';
-
-const annotations = annotationsModule.default;
-const statusbar = statusbarModule.default;
 
 let inspectorDataProvider: inspector.InspectorDataProvider;
 
@@ -956,7 +953,7 @@ async function evaluateInCurrentEditor(
   }
 }
 
-export default {
+export {
   interruptAllEvaluations,
   loadDocument,
   loadFileCommand,

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
 import * as state from './state';
-import annotations from './providers/annotations';
+import * as annotationsModule from './providers/annotations';
 import * as path from 'path';
 import * as util from './utilities';
 import * as nrepl from './nrepl';
-import statusbar from './statusbar';
+import * as statusbarModule from './statusbar';
 import type * as printerTypes from './printer';
 import * as replWindow from './repl-window/repl-window-doc';
 import * as namespace from './namespace';
@@ -24,6 +24,9 @@ import * as flareHandler from './flare-handler';
 import * as evaluateUtils from './evaluate-utils';
 import * as whoTracking from './api/who-tracking';
 import * as outputDestinations from './results-output/output-destinations';
+
+const annotations = annotationsModule.default;
+const statusbar = statusbarModule.default;
 
 let inspectorDataProvider: inspector.InspectorDataProvider;
 

--- a/src/extension-test/integration/integration-text-notation.ts
+++ b/src/extension-test/integration/integration-text-notation.ts
@@ -1,5 +1,5 @@
 // Adapted from unit test text-notation.ts
-import { clone, entries, first, last, orderBy, toInteger } from 'lodash';
+import * as _ from 'lodash';
 
 // textNotationToTextAndSelection duplicated and adapted from text-notation.ts
 /**
@@ -17,7 +17,7 @@ import { clone, entries, first, last, orderBy, toInteger } from 'lodash';
 export function textNotationToTextAndSelection(content: string): [string, [number, number][]] {
   const cursorSymbolRegExPattern =
     /(?<cursorType>(?:(?<selectionDirection><|>(?=\d{1})))|(?:\|))(?<cursorNumber>\d{1})?/g;
-  const text = clone(content).replace(/•/g, '\n').replace(cursorSymbolRegExPattern, '');
+  const text = _.clone(content).replace(/•/g, '\n').replace(cursorSymbolRegExPattern, '');
 
   /**
    * 3 capture groups:
@@ -48,9 +48,9 @@ export function textNotationToTextAndSelection(content: string): [string, [numbe
 
   const selections: [number, number][] = [].fill(0, matches.length, undefined);
 
-  entries(cursorMatchInstances).forEach(([_, matches]) => {
-    const firstMatch = first(matches);
-    const secondMatch = last(matches) ?? firstMatch;
+  _.entries(cursorMatchInstances).forEach(([_cursorKey, matches]) => {
+    const firstMatch = _.first(matches);
+    const secondMatch = _.last(matches) ?? firstMatch;
 
     const isReversed =
       (firstMatch.groups['selectionDirection'] ?? firstMatch[2] ?? '') === '<' ? true : false;
@@ -61,7 +61,7 @@ export function textNotationToTextAndSelection(content: string): [string, [numbe
     const anchor = isReversed ? end : start;
     const active = isReversed ? start : end;
 
-    const cursorNumber = toInteger(firstMatch.groups['cursorNumber'] ?? firstMatch[3] ?? '0');
+    const cursorNumber = _.toInteger(firstMatch.groups['cursorNumber'] ?? firstMatch[3] ?? '0');
 
     selections[cursorNumber] = [anchor, active]; //new model.ModelEditSelection(anchor, active, start, end, isReversed);
   });
@@ -93,14 +93,14 @@ export function textNotationFromTextAndSelections(
     }
   });
 
-  cursorSymbols = orderBy(cursorSymbols, (c) => c[0]);
+  cursorSymbols = _.orderBy(cursorSymbols, (c) => c[0]);
 
   // split the text into chunks separated by where they'd have had cursor symbols, and append cursor symbols after each chunk, before joining back together
   // this way we can insert the cursor symbols in the right place without having to worry about the cumulative offsets created by appending the cursor symbols
   const textSegments = cursorSymbols
     .reduce(
       (acc, [offset, symbol], index) => {
-        const lastSection = last(acc)[1];
+        const lastSection = _.last(acc)[1];
         const sections = acc.slice(0, -1);
 
         const lastSectionOffset =

--- a/src/extension-test/integration/runTests.ts
+++ b/src/extension-test/integration/runTests.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { glob } from 'glob';
+import * as globLib from 'glob';
 
-import { runTests } from '@vscode/test-electron';
+import * as testElectron from '@vscode/test-electron';
 
 async function main() {
   try {
@@ -40,7 +40,7 @@ async function main() {
     // Check if filter matches any files before launching VS Code
     if (testFilters.length > 0) {
       const testsRoot = path.resolve(__dirname, 'suite');
-      const allFiles = await glob('**/**-test.js', { cwd: testsRoot });
+      const allFiles = await globLib.glob('**/**-test.js', { cwd: testsRoot });
       const matchingFiles = allFiles.filter((filePath) =>
         testFilters.some((filterToken) =>
           filePath.toLowerCase().includes(filterToken.toLowerCase())
@@ -73,7 +73,7 @@ async function main() {
     const launchArgs = [testWorkspace, '--disable-extensions', '--disable-workspace-trust'];
 
     // Download VS Code, unzip it and run the integration test
-    await runTests({
+    await testElectron.runTests({
       version: 'insiders',
       extensionDevelopmentPath,
       extensionTestsPath,

--- a/src/extension-test/integration/suite/annotations-test.ts
+++ b/src/extension-test/integration/suite/annotations-test.ts
@@ -5,10 +5,8 @@ import * as vscode from 'vscode';
 import * as mocha from 'mocha';
 import * as sinon from 'sinon';
 
-import * as annotationsModule from '../../../providers/annotations';
+import * as annotations from '../../../providers/annotations';
 import * as testUtil from './util';
-
-const annotations = annotationsModule.default;
 
 suite('Annotations suite', () => {
   const suite = 'Annotations';

--- a/src/extension-test/integration/suite/annotations-test.ts
+++ b/src/extension-test/integration/suite/annotations-test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { before, after, afterEach } from 'mocha';
+import * as mocha from 'mocha';
 import * as sinon from 'sinon';
 
 import annotations from '../../../providers/annotations';
@@ -11,16 +11,16 @@ import * as testUtil from './util';
 suite('Annotations suite', () => {
   const suite = 'Annotations';
 
-  before(async () => {
+  mocha.before(async () => {
     testUtil.showMessage(suite, `suite starting!`);
     await testUtil.ensureOutputDir(testUtil.testDataDir);
   });
 
-  after(() => {
+  mocha.after(() => {
     testUtil.showMessage(suite, `suite done!`);
   });
 
-  afterEach(function () {
+  mocha.afterEach(function () {
     sinon.restore(); // Restore original methods
   });
 

--- a/src/extension-test/integration/suite/annotations-test.ts
+++ b/src/extension-test/integration/suite/annotations-test.ts
@@ -5,8 +5,10 @@ import * as vscode from 'vscode';
 import * as mocha from 'mocha';
 import * as sinon from 'sinon';
 
-import annotations from '../../../providers/annotations';
+import * as annotationsModule from '../../../providers/annotations';
 import * as testUtil from './util';
+
+const annotations = annotationsModule.default;
 
 suite('Annotations suite', () => {
   const suite = 'Annotations';

--- a/src/extension-test/integration/suite/cljc-routing-test.ts
+++ b/src/extension-test/integration/suite/cljc-routing-test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { before, after, beforeEach } from 'mocha';
+import * as mocha from 'mocha';
 import * as path from 'path';
 import * as testUtil from './util';
 import * as clientRegistry from '../../../nrepl/client-registry';
@@ -7,7 +7,6 @@ import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as replSession from '../../../nrepl/repl-session';
 import * as jackIn from '../../../nrepl/jack-in';
 import * as vscode from 'vscode';
-import { commands } from 'vscode';
 import connector from '../../../connector';
 
 const suiteName = 'CLJC Routing';
@@ -43,7 +42,7 @@ suite('CLJC Routing suite', function () {
 
   let clientKey: string;
 
-  before(async () => {
+  mocha.before(async () => {
     testUtil.showMessage(suiteName, `suite starting!`);
     await testUtil.ensureOutputDir(testUtil.testDataDir);
 
@@ -73,7 +72,7 @@ suite('CLJC Routing suite', function () {
     assert.ok(sessionKeys.includes('cljs'), 'Should have cljs session');
   });
 
-  after(async () => {
+  mocha.after(async () => {
     testUtil.showMessage(suiteName, `suite done!`);
 
     // Kill jack-in processes to prevent orphaned Java processes
@@ -92,7 +91,7 @@ suite('CLJC Routing suite', function () {
     }
   });
 
-  beforeEach(() => {
+  mocha.beforeEach(() => {
     // Reset cljc target to primary before each test
     clientRegistry.setCljcTargetForConnection(clientKey, 'primary');
   });
@@ -151,7 +150,7 @@ suite('CLJC Routing suite', function () {
     assert.strictEqual(initialRouting?.sessionKey, 'clj', 'Initial routing should be clj');
 
     // Toggle cljc target
-    await commands.executeCommand('calva.toggleCLJCSession');
+    await vscode.commands.executeCommand('calva.toggleCLJCSession');
     await waitForRouting('cljs', 'cljc-within-connection');
 
     // After toggle, should route to cljs (secondary)
@@ -170,7 +169,7 @@ suite('CLJC Routing suite', function () {
     );
 
     // Toggle again - should go back to clj
-    await commands.executeCommand('calva.toggleCLJCSession');
+    await vscode.commands.executeCommand('calva.toggleCLJCSession');
     await waitForRouting('clj', 'cljc-within-connection');
 
     const afterSecondToggleRouting = replSession.getRoutingInfo();
@@ -187,7 +186,7 @@ suite('CLJC Routing suite', function () {
     await testUtil.openFile(cljcFile);
 
     // Select secondary target directly
-    await commands.executeCommand('calva.selectCljcTarget', 'secondary');
+    await vscode.commands.executeCommand('calva.selectCljcTarget', 'secondary');
     await waitForRouting('cljs', 'cljc-within-connection');
 
     const afterSelectSecondary = replSession.getRoutingInfo();
@@ -205,7 +204,7 @@ suite('CLJC Routing suite', function () {
     );
 
     // Select primary target directly
-    await commands.executeCommand('calva.selectCljcTarget', 'primary');
+    await vscode.commands.executeCommand('calva.selectCljcTarget', 'primary');
     await waitForRouting('clj', 'cljc-within-connection');
 
     const afterSelectPrimary = replSession.getRoutingInfo();
@@ -237,7 +236,7 @@ suite('CLJC Routing suite', function () {
     );
 
     // Toggle and verify it changes
-    await commands.executeCommand('calva.toggleCLJCSession');
+    await vscode.commands.executeCommand('calva.toggleCLJCSession');
     await waitForRouting('cljs', 'cljc-within-connection');
 
     const afterToggleRouting = replSession.getRoutingInfo();
@@ -303,7 +302,7 @@ suite('CLJC Routing suite', function () {
     );
 
     // Toggle and verify it changes
-    await commands.executeCommand('calva.toggleCLJCSession');
+    await vscode.commands.executeCommand('calva.toggleCLJCSession');
     await waitForRouting('cljs', 'cljc-within-connection');
 
     const afterToggleRouting = replSession.getRoutingInfo();
@@ -336,7 +335,7 @@ suite('CLJC Routing suite', function () {
     );
 
     // Toggle and verify it changes
-    await commands.executeCommand('calva.toggleCLJCSession');
+    await vscode.commands.executeCommand('calva.toggleCLJCSession');
     await waitForRouting('cljs', 'cljc-within-connection');
 
     const afterToggleRouting = replSession.getRoutingInfo();
@@ -354,7 +353,7 @@ suite('CLJC Routing suite', function () {
 
     // Pass the full connect sequence object directly to bypass QuickPicks
     // and avoid modifying workspace settings
-    await commands.executeCommand('calva.jackIn', {
+    await vscode.commands.executeCommand('calva.jackIn', {
       connectSequence: {
         name: 'cljc-routing-test-cljs-node',
         projectType: 'deps.edn',

--- a/src/extension-test/integration/suite/cljc-routing-test.ts
+++ b/src/extension-test/integration/suite/cljc-routing-test.ts
@@ -7,7 +7,9 @@ import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as replSession from '../../../nrepl/repl-session';
 import * as jackIn from '../../../nrepl/jack-in';
 import * as vscode from 'vscode';
-import connector from '../../../connector';
+import * as connectorModule from '../../../connector';
+
+const connector = connectorModule.default;
 
 const suiteName = 'CLJC Routing';
 

--- a/src/extension-test/integration/suite/cljc-routing-test.ts
+++ b/src/extension-test/integration/suite/cljc-routing-test.ts
@@ -7,9 +7,7 @@ import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as replSession from '../../../nrepl/repl-session';
 import * as jackIn from '../../../nrepl/jack-in';
 import * as vscode from 'vscode';
-import * as connectorModule from '../../../connector';
-
-const connector = connectorModule.default;
+import * as connector from '../../../connector';
 
 const suiteName = 'CLJC Routing';
 

--- a/src/extension-test/integration/suite/connection-isolation-test.ts
+++ b/src/extension-test/integration/suite/connection-isolation-test.ts
@@ -4,14 +4,12 @@ import * as path from 'path';
 import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as clientRegistry from '../../../nrepl/client-registry';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
-import * as connectorModule from '../../../connector';
+import * as connector from '../../../connector';
 import * as cljsLib from '../../../../out/cljs-lib/cljs-lib';
 import type * as nrepl from '../../../nrepl';
 import * as sessionRouting from '../../../nrepl/session-routing';
 import * as sessionTeardown from '../../../nrepl/session-teardown';
 import * as testUtil from './util';
-
-const connector = connectorModule.default;
 
 const { describe, before, beforeEach, afterEach, it } = Mocha;
 

--- a/src/extension-test/integration/suite/connection-isolation-test.ts
+++ b/src/extension-test/integration/suite/connection-isolation-test.ts
@@ -6,7 +6,7 @@ import * as clientRegistry from '../../../nrepl/client-registry';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
 import connector from '../../../connector';
 import * as cljsLib from '../../../../out/cljs-lib/cljs-lib';
-import type { NReplSession, NReplClient } from '../../../nrepl';
+import type * as nrepl from '../../../nrepl';
 import * as sessionRouting from '../../../nrepl/session-routing';
 import * as sessionTeardown from '../../../nrepl/session-teardown';
 import * as testUtil from './util';
@@ -15,11 +15,11 @@ const { describe, before, beforeEach, afterEach, it } = Mocha;
 
 const suiteName = 'Connection isolation';
 
-const createSession = (replType: string, clientKey?: string): NReplSession =>
+const createSession = (replType: string, clientKey?: string): nrepl.NReplSession =>
   ({
     replType,
     client: clientKey ? { clientKey } : undefined,
-  } as NReplSession);
+  } as nrepl.NReplSession);
 
 const resetOutputWindowSession = (sessionType: string, ns: string): void => {
   outputWindow.setSession(createSession(sessionType), ns, sessionType);
@@ -72,7 +72,7 @@ describe(`${suiteName} suite`, () => {
       disconnect: () => undefined,
       addOnCloseHandler: () => undefined,
       removeOnCloseHandler: () => undefined,
-    } as unknown as NReplClient;
+    } as unknown as nrepl.NReplClient;
 
     const clientB = {
       clientKey: 'client-b',
@@ -80,7 +80,7 @@ describe(`${suiteName} suite`, () => {
       disconnect: () => undefined,
       addOnCloseHandler: () => undefined,
       removeOnCloseHandler: () => undefined,
-    } as unknown as NReplClient;
+    } as unknown as nrepl.NReplClient;
 
     clientRegistry.registerClient(clientA, {
       connectSequenceName: 'Connection A',
@@ -136,7 +136,7 @@ describe(`${suiteName} suite`, () => {
       disconnect: () => undefined,
       addOnCloseHandler: () => undefined,
       removeOnCloseHandler: () => undefined,
-    } as unknown as NReplClient;
+    } as unknown as nrepl.NReplClient;
 
     clientRegistry.registerClient(clientA, {
       connectSequenceName: 'Connection A',
@@ -179,7 +179,7 @@ describe(`${suiteName} suite`, () => {
       disconnect: () => undefined,
       addOnCloseHandler: () => undefined,
       removeOnCloseHandler: () => undefined,
-    })) as unknown as NReplClient[];
+    })) as unknown as nrepl.NReplClient[];
 
     clients.forEach((client, i) => {
       clientRegistry.registerClient(client, {
@@ -226,7 +226,7 @@ describe(`${suiteName} suite`, () => {
       disconnect: () => undefined,
       addOnCloseHandler: () => undefined,
       removeOnCloseHandler: () => undefined,
-    } as unknown as NReplClient;
+    } as unknown as nrepl.NReplClient;
 
     const clientB = {
       clientKey: 'client-b',
@@ -234,7 +234,7 @@ describe(`${suiteName} suite`, () => {
       disconnect: () => undefined,
       addOnCloseHandler: () => undefined,
       removeOnCloseHandler: () => undefined,
-    } as unknown as NReplClient;
+    } as unknown as nrepl.NReplClient;
 
     clientRegistry.registerClient(clientA, {
       connectSequenceName: 'Connection A',

--- a/src/extension-test/integration/suite/connection-isolation-test.ts
+++ b/src/extension-test/integration/suite/connection-isolation-test.ts
@@ -4,12 +4,14 @@ import * as path from 'path';
 import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as clientRegistry from '../../../nrepl/client-registry';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
-import connector from '../../../connector';
+import * as connectorModule from '../../../connector';
 import * as cljsLib from '../../../../out/cljs-lib/cljs-lib';
 import type * as nrepl from '../../../nrepl';
 import * as sessionRouting from '../../../nrepl/session-routing';
 import * as sessionTeardown from '../../../nrepl/session-teardown';
 import * as testUtil from './util';
+
+const connector = connectorModule.default;
 
 const { describe, before, beforeEach, afterEach, it } = Mocha;
 

--- a/src/extension-test/integration/suite/file-output-destination-test.ts
+++ b/src/extension-test/integration/suite/file-output-destination-test.ts
@@ -3,13 +3,9 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { before, after, beforeEach, afterEach } from 'mocha';
+import * as mocha from 'mocha';
 import * as jackIn from '../../../nrepl/jack-in';
-import {
-  ReplConnectSequence,
-  ProjectTypes,
-  CljsTypes,
-} from '../../../nrepl/connect-sequence-types';
+import * as connectSequenceTypes from '../../../nrepl/connect-sequence-types';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as testUtil from './util';
 
@@ -21,29 +17,29 @@ suite('File Output Destination Test', () => {
 
   const testFile = 'test.clj';
   const testFilePath = path.join(testUtil.testDataDir, testFile);
-  const connectSequence: ReplConnectSequence = {
-    projectType: ProjectTypes['deps.edn'],
+  const connectSequence: connectSequenceTypes.ReplConnectSequence = {
+    projectType: connectSequenceTypes.ProjectTypes['deps.edn'],
     name: 'deps.edn',
-    cljsType: CljsTypes.none,
+    cljsType: connectSequenceTypes.CljsTypes.none,
     projectRootPath: [path.join(testUtil.testDataDir, '..')],
     menuSelections: { cljAliases: [] },
   };
 
-  before(async () => {
+  mocha.before(async () => {
     testUtil.showMessage(suite, 'suite starting!');
     await testUtil.ensureOutputDir(testUtil.testDataDir);
     const config = vscode.workspace.getConfiguration('calva');
     originalDestinations = config.inspect('outputDestinations')?.globalValue;
   });
 
-  after(async () => {
+  mocha.after(async () => {
     testUtil.log(suite, 'Suite cleanup: killing all jack-in processes');
     await jackIn.calvaJackout({ force: true });
     await testUtil.waitForJackOutComplete(suite);
     testUtil.showMessage(suite, 'suite done!');
   });
 
-  beforeEach(async function () {
+  mocha.beforeEach(async function () {
     this.timeout(60_000);
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'calva-file-output-test-'));
     await outputWindow.clearReplWindowDoc();
@@ -51,7 +47,7 @@ suite('File Output Destination Test', () => {
     await jackInHarness.disconnectAllClients();
   });
 
-  afterEach(async () => {
+  mocha.afterEach(async () => {
     const config = vscode.workspace.getConfiguration('calva');
     await config.update(
       'outputDestinations',

--- a/src/extension-test/integration/suite/format-test.ts
+++ b/src/extension-test/integration/suite/format-test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { before, after, it } from 'mocha';
+import * as mocha from 'mocha';
 import * as path from 'path';
 import * as testUtil from './util';
 import * as vscode from 'vscode';
@@ -100,30 +100,30 @@ async function reformatUsingActiveEditor(textAndSelections: string) {
 }
 
 suite(suiteName, () => {
-  before(async () => {
+  mocha.before(async () => {
     testUtil.showMessage(suiteName, `suite starting`);
     await testUtil.openFile(testFilePath);
   });
 
-  after(async () => {
+  mocha.after(async () => {
     console.log('Finally, format suite is closing the active editor');
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     testUtil.showMessage(suiteName, `suite done!`);
   });
 
-  it('should add indenting spaces on lines where cursors are', async () => {
+  mocha.it('should add indenting spaces on lines where cursors are', async () => {
     assert.equal(await reformatUsingActiveEditor('(foo•|•|1 :a)'), '(foo•  |•|1  :a)');
   });
 
-  it('should advance indented cursors to proper indentation spot', async () => {
+  mocha.it('should advance indented cursors to proper indentation spot', async () => {
     assert.equal(await reformatUsingActiveEditor('(foo•|• |1:a)'), '(foo•  |•  |1:a)');
   });
 
-  it('should remove spaces and commas from an empty list', async () => {
+  mocha.it('should remove spaces and commas from an empty list', async () => {
     assert.equal(await reformatUsingActiveEditor('(•|•,)'), '(|)');
   });
 
-  it('should format deftype', async () => {
+  mocha.it('should format deftype', async () => {
     assert.equal(
       await reformatUsingActiveEditor(
         '(deftype MyType [arg1 arg2]•  IMyProto•  (method1 [this]•           |(smth)))'
@@ -132,35 +132,35 @@ suite(suiteName, () => {
     );
   });
 
-  it('should not remove a single blank line', async () => {
+  mocha.it('should not remove a single blank line', async () => {
     assert.equal(
       await reformatUsingActiveEditor('(defn bar• |   [x]••    baz)'),
       '(defn bar• | [x]••  baz)'
     );
   });
 
-  it('should collapse consecutive blank lines to a single line', async () => {
+  mocha.it('should collapse consecutive blank lines to a single line', async () => {
     assert.equal(
       await reformatUsingActiveEditor('(defn bar• |   [x]• •,••    baz)'),
       '(defn bar• | [x]••  baz)'
     );
   });
 
-  it('should close a rich comment form on a new line (1)', async () => {
+  mocha.it('should close a rich comment form on a new line (1)', async () => {
     assert.equal(
       await reformatUsingActiveEditor('(comment•  (def foo•:foo)|)'),
       '(comment•  (def foo•    :foo)•  |)'
     );
   });
 
-  it('should close a rich comment form on a new line (2)', async () => {
+  mocha.it('should close a rich comment form on a new line (2)', async () => {
     assert.equal(
       await reformatUsingActiveEditor('(comment•  |(def foo•:foo))'),
       '(comment•  |(def foo•    :foo)•  )'
     );
   });
 
-  it('should automatically reformat all paredited forms', async () => {
+  mocha.it('should automatically reformat all paredited forms', async () => {
     assert.equal(
       await reformat(
         vscode.window.activeTextEditor,
@@ -171,7 +171,7 @@ suite(suiteName, () => {
     );
   });
 
-  it('should format a ns form alone', async () => {
+  mocha.it('should format a ns form alone', async () => {
     assert.equal(await reformatUsingActiveEditor('(ns •       |foo)'), '(ns• |foo)');
   });
 });

--- a/src/extension-test/integration/suite/highlight-test.ts
+++ b/src/extension-test/integration/suite/highlight-test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { before, after } from 'mocha';
+import * as mocha from 'mocha';
 import * as path from 'path';
 import * as testUtil from './util';
 
@@ -9,11 +9,11 @@ import * as highlight from '../../../highlight/src/extension';
 suite('Highlight suite', () => {
   const suite = 'Highlight';
 
-  before(() => {
+  mocha.before(() => {
     testUtil.showMessage(suite, `suite starting!`);
   });
 
-  after(() => {
+  mocha.after(() => {
     testUtil.showMessage(suite, `suite done!`);
   });
 

--- a/src/extension-test/integration/suite/insert-semicolon-test.ts
+++ b/src/extension-test/integration/suite/insert-semicolon-test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { after, before, it } from 'mocha';
+import * as mocha from 'mocha';
 import * as path from 'path';
 import * as testUtil from './util';
 import * as vscode from 'vscode';
@@ -82,53 +82,59 @@ async function undoOnce(editor: vscode.TextEditor): Promise<void> {
 }
 
 suite(suiteName, () => {
-  before(async () => {
+  mocha.before(async () => {
     testUtil.showMessage(suiteName, 'suite starting');
     await testUtil.openFile(testFilePath);
   });
 
-  after(async () => {
+  mocha.after(async () => {
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     testUtil.showMessage(suiteName, 'suite done!');
   });
 
-  it('undo once restores pre-command state for structure-preserving insertSemiColon', async () => {
-    const editor = vscode.window.activeTextEditor;
-    const initialState = '(defn foo []•  |(println "test"))';
-    const expectedAfterInsert = '(defn foo []•  ;|(println "test")•  )';
+  mocha.it(
+    'undo once restores pre-command state for structure-preserving insertSemiColon',
+    async () => {
+      const editor = vscode.window.activeTextEditor;
+      const initialState = '(defn foo []•  |(println "test"))';
+      const expectedAfterInsert = '(defn foo []•  ;|(println "test")•  )';
 
-    await resetEditor(editor, initialState);
+      await resetEditor(editor, initialState);
 
-    await vscode.commands.executeCommand('paredit.insertSemiColon');
-    await waitForNotation(editor, expectedAfterInsert);
+      await vscode.commands.executeCommand('paredit.insertSemiColon');
+      await waitForNotation(editor, expectedAfterInsert);
 
-    assert.equal(
-      textNotationFromDocAndSelections(editor.document, editor.selections),
-      expectedAfterInsert
-    );
+      assert.equal(
+        textNotationFromDocAndSelections(editor.document, editor.selections),
+        expectedAfterInsert
+      );
 
-    await undoOnce(editor);
-    await waitForNotation(editor, initialState);
+      await undoOnce(editor);
+      await waitForNotation(editor, initialState);
 
-    assert.equal(
-      textNotationFromDocAndSelections(editor.document, editor.selections),
-      initialState
-    );
-  });
+      assert.equal(
+        textNotationFromDocAndSelections(editor.document, editor.selections),
+        initialState
+      );
+    }
+  );
 
-  it('keeps closing delimiter outside the inserted comment when cursor is before close', async () => {
-    const editor = vscode.window.activeTextEditor;
-    const initialState = '(bar 24 |)';
-    const expectedAfterInsert = '(bar 24 ;|•     )';
+  mocha.it(
+    'keeps closing delimiter outside the inserted comment when cursor is before close',
+    async () => {
+      const editor = vscode.window.activeTextEditor;
+      const initialState = '(bar 24 |)';
+      const expectedAfterInsert = '(bar 24 ;|•     )';
 
-    await resetEditor(editor, initialState);
+      await resetEditor(editor, initialState);
 
-    await vscode.commands.executeCommand('paredit.insertSemiColon');
-    await waitForNotation(editor, expectedAfterInsert);
+      await vscode.commands.executeCommand('paredit.insertSemiColon');
+      await waitForNotation(editor, expectedAfterInsert);
 
-    assert.equal(
-      textNotationFromDocAndSelections(editor.document, editor.selections),
-      expectedAfterInsert
-    );
-  });
+      assert.equal(
+        textNotationFromDocAndSelections(editor.document, editor.selections),
+        expectedAfterInsert
+      );
+    }
+  );
 });

--- a/src/extension-test/integration/suite/jack-in-and-connect-test.ts
+++ b/src/extension-test/integration/suite/jack-in-and-connect-test.ts
@@ -11,7 +11,7 @@ import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as docMirror from '../../../doc-mirror';
 import * as projectRoot from '../../../project-root';
 import * as state from '../../../state';
-import * as connectorModule from '../../../connector';
+import * as connector from '../../../connector';
 import * as connectTypes from '../../../nrepl/connect-types';
 import * as connectSequence from '../../../nrepl/connectSequence';
 import * as connectSequenceTypes from '../../../nrepl/connect-sequence-types';
@@ -19,8 +19,6 @@ import * as projectTypes from '../../../nrepl/project-types';
 import * as config from '../../../config';
 import * as output from '../../../results-output/output';
 import * as outputDestinations from '../../../results-output/output-destinations';
-
-const connector = connectorModule.default;
 
 suite('Jack-in and Connect suite', () => {
   const suite = 'Jack-in and Connect';
@@ -365,12 +363,7 @@ suite('Jack-in and Connect suite', () => {
     await state.initProjectDir(connectTypes.ConnectType.Connect, reconnectSequence, true);
 
     // Connect directly using the same sequence, host, and port as the first jack-in
-    await connectorModule.connect(
-      reconnectSequence,
-      true,
-      firstClientHost,
-      String(firstClientPort)
-    );
+    await connector.connect(reconnectSequence, true, firstClientHost, String(firstClientPort));
     const reconnectedClientKey = await waitForNextClient(suite);
     await waitForSessionsReady(suite, reconnectedClientKey);
 
@@ -545,7 +538,7 @@ async function reconnectAndAssert(
     connectSequenceOverride
   );
 
-  await connectorModule.connect(connectSequence, true);
+  await connector.connect(connectSequence, true);
 
   await loadAndAssert(suite, testFilePath, needle, { waitForJackInOutput: false });
   await vscode.commands.executeCommand('workbench.action.closeActiveEditor');

--- a/src/extension-test/integration/suite/jack-in-and-connect-test.ts
+++ b/src/extension-test/integration/suite/jack-in-and-connect-test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { before, after, beforeEach, afterEach } from 'mocha';
+import * as mocha from 'mocha';
 import * as path from 'path';
 import * as testUtil from './util';
 import * as util from '../../../utilities';
@@ -8,35 +8,31 @@ import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as jackIn from '../../../nrepl/jack-in';
 import * as vscode from 'vscode';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
-import { commands } from 'vscode';
-import { getDocument } from '../../../doc-mirror';
+import * as docMirror from '../../../doc-mirror';
 import * as projectRoot from '../../../project-root';
 import * as state from '../../../state';
-import connector, { connect as connectDirect } from '../../../connector';
-import { ConnectType } from '../../../nrepl/connect-types';
-import { getConnectSequences } from '../../../nrepl/connectSequence';
-import {
-  CljsTypes,
-  ProjectTypes,
-  ReplConnectSequence,
-} from '../../../nrepl/connect-sequence-types';
+import connector from '../../../connector';
+import * as connectorModule from '../../../connector';
+import * as connectTypes from '../../../nrepl/connect-types';
+import * as connectSequence from '../../../nrepl/connectSequence';
+import * as connectSequenceTypes from '../../../nrepl/connect-sequence-types';
 import * as projectTypes from '../../../nrepl/project-types';
-import { getConfig } from '../../../config';
+import * as config from '../../../config';
 import * as output from '../../../results-output/output';
-import { normalizeDestinations } from '../../../results-output/output-destinations';
+import * as outputDestinations from '../../../results-output/output-destinations';
 
 suite('Jack-in and Connect suite', () => {
   const suite = 'Jack-in and Connect';
   let originalDestinations: any;
 
-  before(async () => {
+  mocha.before(async () => {
     testUtil.showMessage(suite, 'suite starting!');
     await testUtil.ensureOutputDir(testUtil.testDataDir);
     const config = vscode.workspace.getConfiguration('calva');
     originalDestinations = config.inspect('outputDestinations')?.globalValue;
   });
 
-  after(async () => {
+  mocha.after(async () => {
     // Ensure all REPL processes are killed at suite end to prevent orphaned Java processes
     // Use force=true because test harness shutdown is similar to VS Code deactivation
     testUtil.log(suite, 'Suite cleanup: killing all jack-in processes');
@@ -45,14 +41,14 @@ suite('Jack-in and Connect suite', () => {
     testUtil.showMessage(suite, 'suite done!');
   });
 
-  beforeEach(async () => {
+  mocha.beforeEach(async () => {
     await setOutputDestinations('repl-window');
     await outputWindow.clearReplWindowDoc();
     resetConnectionTracking();
     await disconnectExistingClients();
   });
 
-  afterEach(async () => {
+  mocha.afterEach(async () => {
     const config = vscode.workspace.getConfiguration('calva');
     await config.update(
       'outputDestinations',
@@ -74,7 +70,7 @@ suite('Jack-in and Connect suite', () => {
 
   test('start repl and connect (jack-in) to Basilisp', async function () {
     testUtil.log(suite, 'start repl and connect (jack-in) to Basilisp');
-    const basilispPath = getConfig().basilispPath;
+    const basilispPath = config.getConfig().basilispPath;
     const executablePath = testUtil.getExecutablePath(basilispPath);
 
     if (executablePath === null && !testUtil.isCircleCI) {
@@ -99,12 +95,12 @@ suite('Jack-in and Connect suite', () => {
 
   test('Jack-in afterPrimaryReplConnectedCode can be a string', async () => {
     testUtil.log(suite, 'Reconnect: afterPrimaryReplConnectedCode (string)');
-    const connectSequence: ReplConnectSequence = {
-      projectType: ProjectTypes['deps.edn'],
+    const connectSequence: connectSequenceTypes.ReplConnectSequence = {
+      projectType: connectSequenceTypes.ProjectTypes['deps.edn'],
       name: 'string-afterPrimaryReplConnectedCode',
       autoSelectForJackIn: true,
       afterPrimaryReplConnectedCode: '(println :hello :world!)',
-      cljsType: CljsTypes.none,
+      cljsType: connectSequenceTypes.CljsTypes.none,
     };
     await reconnectAndAssert(
       suite,
@@ -117,12 +113,12 @@ suite('Jack-in and Connect suite', () => {
 
   test('Jack-in afterPrimaryReplConnectedCode can be an array', async () => {
     testUtil.log(suite, 'Reconnect: afterPrimaryReplConnectedCode (array)');
-    const connectSequence: ReplConnectSequence = {
-      projectType: ProjectTypes['deps.edn'],
+    const connectSequence: connectSequenceTypes.ReplConnectSequence = {
+      projectType: connectSequenceTypes.ProjectTypes['deps.edn'],
       name: 'array-afterPrimaryReplConnectedCode',
       autoSelectForJackIn: true,
       afterPrimaryReplConnectedCode: ['(println :hello)', '(println :world!)'].join('\n'),
-      cljsType: CljsTypes.none,
+      cljsType: connectSequenceTypes.CljsTypes.none,
     };
     await reconnectAndAssert(
       suite,
@@ -135,12 +131,12 @@ suite('Jack-in and Connect suite', () => {
 
   test('Jack-in still accepts afterCLJReplJackInCode', async () => {
     testUtil.log(suite, 'Reconnect: afterCLJReplJackInCode');
-    const connectSequence: ReplConnectSequence = {
-      projectType: ProjectTypes['deps.edn'],
+    const connectSequence: connectSequenceTypes.ReplConnectSequence = {
+      projectType: connectSequenceTypes.ProjectTypes['deps.edn'],
       name: 'legacy-afterCLJReplJackInCode',
       autoSelectForJackIn: true,
       afterCLJReplJackInCode: '(println :legacy :hook!)',
-      cljsType: CljsTypes.none,
+      cljsType: connectSequenceTypes.CljsTypes.none,
     };
     await reconnectAndAssert(
       suite,
@@ -154,11 +150,11 @@ suite('Jack-in and Connect suite', () => {
   test('Jack-in works with auto-selected project type', async () => {
     testUtil.log(suite, 'Reconnect: auto-selected project type');
 
-    const connectSequence: ReplConnectSequence = {
-      projectType: ProjectTypes['deps.edn'],
+    const connectSequence: connectSequenceTypes.ReplConnectSequence = {
+      projectType: connectSequenceTypes.ProjectTypes['deps.edn'],
       name: 'auto-select',
       autoSelectForJackIn: true,
-      cljsType: CljsTypes.none,
+      cljsType: connectSequenceTypes.CljsTypes.none,
     };
     await reconnectAndAssert(
       suite,
@@ -196,17 +192,17 @@ suite('Jack-in and Connect suite', () => {
     await testUtil.openFile(testFilePath);
     testUtil.log(suite, 'projectless test.clj opened');
 
-    const connectSequence: ReplConnectSequence = {
+    const connectSequence: connectSequenceTypes.ReplConnectSequence = {
       name: 'Clojure (projectless)',
-      projectType: ProjectTypes['clj-projectless'],
-      cljsType: CljsTypes.none,
+      projectType: connectSequenceTypes.ProjectTypes['clj-projectless'],
+      cljsType: connectSequenceTypes.CljsTypes.none,
       projectRootPath: [projectlessDir],
     };
 
     // Clear clipboard so we can detect if command generation failed
     await vscode.env.clipboard.writeText('');
 
-    await commands.executeCommand('calva.copyJackInCommandToClipboard', {
+    await vscode.commands.executeCommand('calva.copyJackInCommandToClipboard', {
       connectSequence,
       disableAutoSelect: true,
     });
@@ -233,10 +229,10 @@ suite('Jack-in and Connect suite', () => {
     testUtil.log(suite, 'Reconnection: different sequence name, same session names');
 
     // First jack-in with Babashka (fast, lightweight)
-    const sequence1: ReplConnectSequence = {
-      projectType: ProjectTypes['babashka'],
+    const sequence1: connectSequenceTypes.ReplConnectSequence = {
+      projectType: connectSequenceTypes.ProjectTypes['babashka'],
       name: 'First Babashka Sequence',
-      cljsType: CljsTypes.none,
+      cljsType: connectSequenceTypes.CljsTypes.none,
       afterPrimaryReplConnectedCode: '(println "First connection")',
     };
 
@@ -254,10 +250,10 @@ suite('Jack-in and Connect suite', () => {
     testUtil.log(suite, `First client key: ${firstClientKey}`);
 
     // Second jack-in with different sequence name but same base session name (bb)
-    const sequence2: ReplConnectSequence = {
-      projectType: ProjectTypes['babashka'],
+    const sequence2: connectSequenceTypes.ReplConnectSequence = {
+      projectType: connectSequenceTypes.ProjectTypes['babashka'],
       name: 'Second Babashka Sequence', // Different name!
-      cljsType: CljsTypes.none,
+      cljsType: connectSequenceTypes.CljsTypes.none,
       afterPrimaryReplConnectedCode: '(println "Second connection")',
     };
 
@@ -301,10 +297,10 @@ suite('Jack-in and Connect suite', () => {
     testUtil.log(suite, 'Manual reconnect: two jack-ins, then reconnect first');
 
     // First jack-in with Babashka (fast, lightweight)
-    const sequence1: ReplConnectSequence = {
-      projectType: ProjectTypes['babashka'],
+    const sequence1: connectSequenceTypes.ReplConnectSequence = {
+      projectType: connectSequenceTypes.ProjectTypes['babashka'],
       name: 'First Manual Reconnect Test',
-      cljsType: CljsTypes.none,
+      cljsType: connectSequenceTypes.CljsTypes.none,
     };
 
     const testFile1 = 'bb-mini/test.clj';
@@ -335,10 +331,10 @@ suite('Jack-in and Connect suite', () => {
     );
 
     // Second jack-in to bb-mini2 (different project root to avoid reconnection during jack-in)
-    const sequence2: ReplConnectSequence = {
-      projectType: ProjectTypes['babashka'],
+    const sequence2: connectSequenceTypes.ReplConnectSequence = {
+      projectType: connectSequenceTypes.ProjectTypes['babashka'],
       name: 'Second Manual Reconnect Test',
-      cljsType: CljsTypes.none,
+      cljsType: connectSequenceTypes.CljsTypes.none,
     };
 
     const testFile2 = 'bb-mini2/test.clj';
@@ -365,10 +361,15 @@ suite('Jack-in and Connect suite', () => {
       ...sequence1,
       projectRootPath: [firstProjectRootPath],
     };
-    await state.initProjectDir(ConnectType.Connect, reconnectSequence, true);
+    await state.initProjectDir(connectTypes.ConnectType.Connect, reconnectSequence, true);
 
     // Connect directly using the same sequence, host, and port as the first jack-in
-    await connectDirect(reconnectSequence, true, firstClientHost, String(firstClientPort));
+    await connectorModule.connect(
+      reconnectSequence,
+      true,
+      firstClientHost,
+      String(firstClientPort)
+    );
     const reconnectedClientKey = await waitForNextClient(suite);
     await waitForSessionsReady(suite, reconnectedClientKey);
 
@@ -438,12 +439,12 @@ async function loadAndAssert(
   );
   testUtil.log(suite, 'opened test.clj document again');
 
-  await commands.executeCommand('calva.loadFile');
+  await vscode.commands.executeCommand('calva.loadFile');
   let haystack: string[] = [];
   await testUtil.waitForCondition(
     async () => {
       const replWindowDoc = await outputWindow.openReplWindowDoc();
-      haystack = getDocument(replWindowDoc).document.getText().split(/\r?\n/);
+      haystack = docMirror.getDocument(replWindowDoc).document.getText().split(/\r?\n/);
       return appearInOrder(needle, haystack);
     },
     10_000,
@@ -466,7 +467,7 @@ async function waitForResult(suite: string, options?: { waitForJackInOutput?: bo
   await waitForSessionsReady(suite, clientKey);
   testUtil.log(suite, 'connected to repl');
 
-  return getDocument(await outputWindow.openReplWindowDoc());
+  return docMirror.getDocument(await outputWindow.openReplWindowDoc());
 }
 
 async function waitForNextClient(suite: string): Promise<string> {
@@ -477,7 +478,9 @@ async function waitForNextClient(suite: string): Promise<string> {
 
 async function waitForJackInCompletion(suite: string) {
   if (
-    !normalizeDestinations(output.getDestinationConfiguration().otherOutput).includes('repl-window')
+    !outputDestinations
+      .normalizeDestinations(output.getDestinationConfiguration().otherOutput)
+      .includes('repl-window')
   ) {
     testUtil.log(
       suite,
@@ -506,7 +509,7 @@ async function startJackInProcedure(
   cmdId: string,
   projectType: string | undefined,
   testFile: string,
-  connectSequenceOverride?: ReplConnectSequence
+  connectSequenceOverride?: connectSequenceTypes.ReplConnectSequence
 ) {
   const { testFilePath, connectSequence } = await openTestFileAndBuildSequence(
     suite,
@@ -516,9 +519,9 @@ async function startJackInProcedure(
   );
 
   if (cmdId === 'calva.jackIn' || cmdId === 'calva.copyJackInCommandToClipboard') {
-    await commands.executeCommand(cmdId, { connectSequence, disableAutoSelect: true });
+    await vscode.commands.executeCommand(cmdId, { connectSequence, disableAutoSelect: true });
   } else {
-    await commands.executeCommand(cmdId);
+    await vscode.commands.executeCommand(cmdId);
   }
 
   return testFilePath;
@@ -529,7 +532,7 @@ async function reconnectAndAssert(
   projectType: string | undefined,
   testFile: string,
   needle: string[],
-  connectSequenceOverride?: ReplConnectSequence
+  connectSequenceOverride?: connectSequenceTypes.ReplConnectSequence
 ) {
   await disconnectExistingClients();
   resetConnectionTracking();
@@ -541,7 +544,7 @@ async function reconnectAndAssert(
     connectSequenceOverride
   );
 
-  await connectDirect(connectSequence, true);
+  await connectorModule.connect(connectSequence, true);
 
   await loadAndAssert(suite, testFilePath, needle, { waitForJackInOutput: false });
   await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
@@ -552,7 +555,7 @@ async function openTestFileAndBuildSequence(
   suite: string,
   projectType: string | undefined,
   testFile: string,
-  connectSequenceOverride?: ReplConnectSequence
+  connectSequenceOverride?: connectSequenceTypes.ReplConnectSequence
 ) {
   const testFilePath = path.join(testUtil.testDataDir, testFile);
   await testUtil.openFile(testFilePath);
@@ -575,9 +578,9 @@ async function openTestFileAndBuildSequence(
 function buildConnectSequence(
   projectType: string | undefined,
   projectRootUri: vscode.Uri
-): ReplConnectSequence {
-  const configuredSequences = getConfig().replConnectSequences ?? [];
-  const defaultSequences = getConnectSequences(projectTypes.getAllProjectTypes());
+): connectSequenceTypes.ReplConnectSequence {
+  const configuredSequences = config.getConfig().replConnectSequences ?? [];
+  const defaultSequences = connectSequence.getConnectSequences(projectTypes.getAllProjectTypes());
   const sequences = configuredSequences.concat(defaultSequences);
 
   const sequenceFromProjectType = projectType
@@ -588,19 +591,19 @@ function buildConnectSequence(
 
   const effectiveProjectType = (projectType ??
     sequenceFromProjectType?.projectType ??
-    'deps.edn') as ReplConnectSequence['projectType'];
+    'deps.edn') as connectSequenceTypes.ReplConnectSequence['projectType'];
   const baseSequence =
     sequenceFromProjectType ??
     ({
       name: effectiveProjectType,
       projectType: effectiveProjectType,
-      cljsType: CljsTypes.none,
-    } as ReplConnectSequence);
+      cljsType: connectSequenceTypes.CljsTypes.none,
+    } as connectSequenceTypes.ReplConnectSequence);
 
   return {
     ...baseSequence,
     projectRootPath: [projectRootUri.fsPath],
-    cljsType: baseSequence.cljsType ?? CljsTypes.none,
+    cljsType: baseSequence.cljsType ?? connectSequenceTypes.CljsTypes.none,
   };
 }
 

--- a/src/extension-test/integration/suite/jack-in-and-connect-test.ts
+++ b/src/extension-test/integration/suite/jack-in-and-connect-test.ts
@@ -11,7 +11,6 @@ import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as docMirror from '../../../doc-mirror';
 import * as projectRoot from '../../../project-root';
 import * as state from '../../../state';
-import connector from '../../../connector';
 import * as connectorModule from '../../../connector';
 import * as connectTypes from '../../../nrepl/connect-types';
 import * as connectSequence from '../../../nrepl/connectSequence';
@@ -20,6 +19,8 @@ import * as projectTypes from '../../../nrepl/project-types';
 import * as config from '../../../config';
 import * as output from '../../../results-output/output';
 import * as outputDestinations from '../../../results-output/output-destinations';
+
+const connector = connectorModule.default;
 
 suite('Jack-in and Connect suite', () => {
   const suite = 'Jack-in and Connect';

--- a/src/extension-test/integration/suite/jack-in-dependency-versions-test.ts
+++ b/src/extension-test/integration/suite/jack-in-dependency-versions-test.ts
@@ -1,17 +1,14 @@
 import * as assert from 'assert';
-import { before, after, suite, test } from 'mocha';
+import * as mocha from 'mocha';
 import * as vscode from 'vscode';
 import * as state from '../../../state';
 import * as testUtil from './util';
-import {
-  getEffectiveJackInDependencyVersions,
-  JackInDependencyKey,
-} from '../../../nrepl/jack-in-dependency-versions';
+import * as jackInDependencyVersions from '../../../nrepl/jack-in-dependency-versions';
 
 const SUITE = 'Jack-in dependency versions';
 const GLOBAL_STATE_KEY = 'calva.jackIn.latestDependencyVersions';
 
-type Versions = Partial<Record<JackInDependencyKey, string>>;
+type Versions = Partial<Record<jackInDependencyVersions.JackInDependencyKey, string>>;
 
 let prevWorkspaceValue: Versions | undefined;
 let originalGlobalState: vscode.Memento | undefined;
@@ -48,8 +45,8 @@ class InMemoryMemento implements vscode.Memento {
   }
 }
 
-suite(SUITE, () => {
-  before(async () => {
+mocha.suite(SUITE, () => {
+  mocha.before(async () => {
     const ext = vscode.extensions.getExtension('betterthantomorrow.calva');
     await ext?.activate();
 
@@ -73,7 +70,7 @@ suite(SUITE, () => {
     prevWorkspaceValue = inspected?.workspaceValue;
   });
 
-  after(async () => {
+  mocha.after(async () => {
     await vscode.workspace
       .getConfiguration('calva')
       .update('jackInDependencyVersions', prevWorkspaceValue, vscode.ConfigurationTarget.Workspace);
@@ -86,8 +83,8 @@ suite(SUITE, () => {
     }
   });
 
-  test('happy path: uses configured versions when set at workspace level', async () => {
-    const configured: Record<JackInDependencyKey, string> = {
+  mocha.test('happy path: uses configured versions when set at workspace level', async () => {
+    const configured: Record<jackInDependencyVersions.JackInDependencyKey, string> = {
       nrepl: 'TEST-NREPL-1',
       'cider-nrepl': 'TEST-CIDER-NREPL-2',
       'cider/piggieback': 'TEST-PIGGIEBACK-3',
@@ -97,7 +94,7 @@ suite(SUITE, () => {
       .getConfiguration('calva')
       .update('jackInDependencyVersions', configured, vscode.ConfigurationTarget.Workspace);
 
-    const effective = getEffectiveJackInDependencyVersions();
+    const effective = jackInDependencyVersions.getEffectiveJackInDependencyVersions();
 
     assert.deepStrictEqual(
       effective,
@@ -106,56 +103,69 @@ suite(SUITE, () => {
     );
   });
 
-  test('partial configuration: missing keys fall back while set keys are respected', async () => {
-    // Clear global state to avoid influencing this test
-    await state.extensionContext?.globalState.update(GLOBAL_STATE_KEY, {});
+  mocha.test(
+    'partial configuration: missing keys fall back while set keys are respected',
+    async () => {
+      // Clear global state to avoid influencing this test
+      await state.extensionContext?.globalState.update(GLOBAL_STATE_KEY, {});
 
-    const inspectedDefaults = vscode.workspace
-      .getConfiguration('calva')
-      .inspect<Record<JackInDependencyKey, string>>('jackInDependencyVersions');
-    const defaults = (inspectedDefaults?.defaultValue ?? {}) as Record<JackInDependencyKey, string>;
-
-    const configured: Versions = {
-      nrepl: 'PARTIAL-NREPL-1',
-    };
-
-    await vscode.workspace
-      .getConfiguration('calva')
-      .update('jackInDependencyVersions', configured, vscode.ConfigurationTarget.Workspace);
-
-    await testUtil.waitForCondition(
-      () => {
-        const effective = getEffectiveJackInDependencyVersions();
-        return (
-          effective.nrepl === 'PARTIAL-NREPL-1' &&
-          effective['cider-nrepl'] === defaults['cider-nrepl'] &&
-          effective['cider/piggieback'] === defaults['cider/piggieback']
+      const inspectedDefaults = vscode.workspace
+        .getConfiguration('calva')
+        .inspect<Record<jackInDependencyVersions.JackInDependencyKey, string>>(
+          'jackInDependencyVersions'
         );
-      },
-      1000,
-      20,
-      'Timed out waiting for partial jack-in dependency version configuration'
-    );
-    const effective = getEffectiveJackInDependencyVersions();
+      const defaults = (inspectedDefaults?.defaultValue ?? {}) as Record<
+        jackInDependencyVersions.JackInDependencyKey,
+        string
+      >;
 
-    assert.strictEqual(effective.nrepl, 'PARTIAL-NREPL-1', 'nrepl should use configured value');
-    assert.strictEqual(
-      effective['cider-nrepl'],
-      defaults['cider-nrepl'],
-      'cider-nrepl should fall back to default'
-    );
-    assert.strictEqual(
-      effective['cider/piggieback'],
-      defaults['cider/piggieback'],
-      'cider/piggieback should fall back to default'
-    );
-  });
+      const configured: Versions = {
+        nrepl: 'PARTIAL-NREPL-1',
+      };
 
-  test('precedence: default is used when nothing is configured', async () => {
+      await vscode.workspace
+        .getConfiguration('calva')
+        .update('jackInDependencyVersions', configured, vscode.ConfigurationTarget.Workspace);
+
+      await testUtil.waitForCondition(
+        () => {
+          const effective = jackInDependencyVersions.getEffectiveJackInDependencyVersions();
+          return (
+            effective.nrepl === 'PARTIAL-NREPL-1' &&
+            effective['cider-nrepl'] === defaults['cider-nrepl'] &&
+            effective['cider/piggieback'] === defaults['cider/piggieback']
+          );
+        },
+        1000,
+        20,
+        'Timed out waiting for partial jack-in dependency version configuration'
+      );
+      const effective = jackInDependencyVersions.getEffectiveJackInDependencyVersions();
+
+      assert.strictEqual(effective.nrepl, 'PARTIAL-NREPL-1', 'nrepl should use configured value');
+      assert.strictEqual(
+        effective['cider-nrepl'],
+        defaults['cider-nrepl'],
+        'cider-nrepl should fall back to default'
+      );
+      assert.strictEqual(
+        effective['cider/piggieback'],
+        defaults['cider/piggieback'],
+        'cider/piggieback should fall back to default'
+      );
+    }
+  );
+
+  mocha.test('precedence: default is used when nothing is configured', async () => {
     const inspectedDefaults = vscode.workspace
       .getConfiguration('calva')
-      .inspect<Record<JackInDependencyKey, string>>('jackInDependencyVersions');
-    const defaults = (inspectedDefaults?.defaultValue ?? {}) as Record<JackInDependencyKey, string>;
+      .inspect<Record<jackInDependencyVersions.JackInDependencyKey, string>>(
+        'jackInDependencyVersions'
+      );
+    const defaults = (inspectedDefaults?.defaultValue ?? {}) as Record<
+      jackInDependencyVersions.JackInDependencyKey,
+      string
+    >;
 
     const ctx = state.extensionContext;
     if (ctx) {
@@ -167,13 +177,15 @@ suite(SUITE, () => {
 
     const defaultsJson = JSON.stringify(defaults);
     await testUtil.waitForCondition(
-      () => JSON.stringify(getEffectiveJackInDependencyVersions()) === defaultsJson,
+      () =>
+        JSON.stringify(jackInDependencyVersions.getEffectiveJackInDependencyVersions()) ===
+        defaultsJson,
       1000,
       20,
       'Timed out waiting for default jack-in dependency versions'
     );
 
-    const effective = getEffectiveJackInDependencyVersions();
+    const effective = jackInDependencyVersions.getEffectiveJackInDependencyVersions();
 
     assert.deepStrictEqual(
       effective,

--- a/src/extension-test/integration/suite/load-file-test.ts
+++ b/src/extension-test/integration/suite/load-file-test.ts
@@ -1,14 +1,10 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
 import * as path from 'path';
-import { before, after, beforeEach, afterEach } from 'mocha';
-import { getDocument } from '../../../doc-mirror';
+import * as mocha from 'mocha';
+import * as docMirror from '../../../doc-mirror';
 import * as jackIn from '../../../nrepl/jack-in';
-import {
-  ReplConnectSequence,
-  ProjectTypes,
-  CljsTypes,
-} from '../../../nrepl/connect-sequence-types';
+import * as connectSequenceTypes from '../../../nrepl/connect-sequence-types';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as testUtil from './util';
 
@@ -19,36 +15,36 @@ suite('Load File Command Test', () => {
 
   const testFile = 'test.clj';
   const testFilePath = path.join(testUtil.testDataDir, testFile);
-  const connectSequence: ReplConnectSequence = {
-    projectType: ProjectTypes['deps.edn'],
+  const connectSequence: connectSequenceTypes.ReplConnectSequence = {
+    projectType: connectSequenceTypes.ProjectTypes['deps.edn'],
     name: 'deps.edn',
-    cljsType: CljsTypes.none,
+    cljsType: connectSequenceTypes.CljsTypes.none,
     projectRootPath: [path.join(testUtil.testDataDir, '..')],
     menuSelections: { cljAliases: [] },
   };
 
-  before(async () => {
+  mocha.before(async () => {
     testUtil.showMessage(suite, 'suite starting!');
     await testUtil.ensureOutputDir(testUtil.testDataDir);
     const config = vscode.workspace.getConfiguration('calva');
     originalDestinations = config.inspect('outputDestinations')?.globalValue;
   });
 
-  after(async () => {
+  mocha.after(async () => {
     testUtil.log(suite, 'Suite cleanup: killing all jack-in processes');
     await jackIn.calvaJackout({ force: true });
     await testUtil.waitForJackOutComplete(suite);
     testUtil.showMessage(suite, 'suite done!');
   });
 
-  beforeEach(async function () {
+  mocha.beforeEach(async function () {
     this.timeout(60_000);
     await outputWindow.clearReplWindowDoc();
     jackInHarness.reset();
     await jackInHarness.disconnectAllClients();
   });
 
-  afterEach(async () => {
+  mocha.afterEach(async () => {
     const config = vscode.workspace.getConfiguration('calva');
     await config.update(
       'outputDestinations',
@@ -88,7 +84,7 @@ suite('Load File Command Test', () => {
 
   async function getReplWindowText() {
     const replWindowDoc = await outputWindow.openReplWindowDoc();
-    return getDocument(replWindowDoc).document.getText();
+    return docMirror.getDocument(replWindowDoc).document.getText();
   }
 
   test('execute calva.loadFile with repl-window output and verify results', async function () {

--- a/src/extension-test/integration/suite/multi-project-routing-test.ts
+++ b/src/extension-test/integration/suite/multi-project-routing-test.ts
@@ -5,24 +5,20 @@ import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as replSession from '../../../nrepl/repl-session';
 import * as cljsLib from '../../../../out/cljs-lib/cljs-lib';
-import type { NReplSession } from '../../../nrepl';
+import type * as nrepl from '../../../nrepl';
 import * as testUtil from './util';
 import * as sessionRouting from '../../../nrepl/session-routing';
 import * as clientRegistry from '../../../nrepl/client-registry';
-import {
-  constructGlobsFromFilePatterns,
-  createCatchAllGlobSpec,
-  SessionGlobSpec,
-} from '../../../nrepl/globs';
+import * as globs from '../../../nrepl/globs';
 
 const { describe, before, beforeEach, afterEach, it } = Mocha;
 
 const suiteName = 'Multi-project routing';
 
-const createSession = (replType: string): NReplSession =>
+const createSession = (replType: string): nrepl.NReplSession =>
   ({
     replType,
-  } as NReplSession);
+  } as nrepl.NReplSession);
 
 const resetOutputWindowSession = (sessionType: string, ns: string): void => {
   outputWindow.setSession(createSession(sessionType), ns, sessionType);
@@ -32,10 +28,10 @@ const resetOutputWindowSession = (sessionType: string, ns: string): void => {
  * Helper to build glob specs for a project, mimicking what connector.ts does
  * for a deps.edn/clj connect sequence.
  */
-function buildProjectGlobSpecs(projectRoot: string): SessionGlobSpec[] {
+function buildProjectGlobSpecs(projectRoot: string): globs.SessionGlobSpec[] {
   // Typical deps.edn always-claim patterns
   const alwaysClaimPatterns = ['*.clj', '*.edn'];
-  const alwaysClaim = constructGlobsFromFilePatterns(
+  const alwaysClaim = globs.constructGlobsFromFilePatterns(
     projectRoot,
     alwaysClaimPatterns,
     'always-claim'
@@ -43,14 +39,14 @@ function buildProjectGlobSpecs(projectRoot: string): SessionGlobSpec[] {
 
   // Typical deps.edn is-fallback-for patterns
   const fallbackPatterns = ['*.cljc'];
-  const isFallbackFor = constructGlobsFromFilePatterns(
+  const isFallbackFor = globs.constructGlobsFromFilePatterns(
     projectRoot,
     fallbackPatterns,
     'is-fallback-for'
   );
 
   // Add the catch-all for the project
-  const catchAll = createCatchAllGlobSpec(projectRoot);
+  const catchAll = globs.createCatchAllGlobSpec(projectRoot);
 
   return [...alwaysClaim, ...isFallbackFor, catchAll];
 }
@@ -142,10 +138,10 @@ describe(`${suiteName} suite`, () => {
       const sessionB = createSession('clj');
 
       // Session A: has workspace-wide is-fallback-for patterns
-      const sessionASpecs: SessionGlobSpec[] = [
-        ...constructGlobsFromFilePatterns(projectARoot, ['*.clj', '*.edn'], 'always-claim'),
-        ...constructGlobsFromFilePatterns(projectARoot, ['**/*.cljc'], 'is-fallback-for'), // workspace-wide!
-        createCatchAllGlobSpec(projectARoot),
+      const sessionASpecs: globs.SessionGlobSpec[] = [
+        ...globs.constructGlobsFromFilePatterns(projectARoot, ['*.clj', '*.edn'], 'always-claim'),
+        ...globs.constructGlobsFromFilePatterns(projectARoot, ['**/*.cljc'], 'is-fallback-for'), // workspace-wide!
+        globs.createCatchAllGlobSpec(projectARoot),
       ];
 
       sessionRegistry.registerSession('project-a-clj', sessionA, {
@@ -155,9 +151,9 @@ describe(`${suiteName} suite`, () => {
       });
 
       // Session B: only has project-scoped catch-all (no is-fallback-for)
-      const sessionBSpecs: SessionGlobSpec[] = [
-        ...constructGlobsFromFilePatterns(projectBRoot, ['*.clj', '*.edn'], 'always-claim'),
-        createCatchAllGlobSpec(projectBRoot),
+      const sessionBSpecs: globs.SessionGlobSpec[] = [
+        ...globs.constructGlobsFromFilePatterns(projectBRoot, ['*.clj', '*.edn'], 'always-claim'),
+        globs.createCatchAllGlobSpec(projectBRoot),
       ];
 
       sessionRegistry.registerSession('project-b-clj', sessionB, {
@@ -194,8 +190,8 @@ describe(`${suiteName} suite`, () => {
       sessionRegistry.registerSession('project-a-clj', sessionA, {
         projectRoot: `file://${projectARoot}`,
         globSpecs: [
-          ...constructGlobsFromFilePatterns(projectARoot, ['*.clj'], 'always-claim'),
-          createCatchAllGlobSpec(projectARoot),
+          ...globs.constructGlobsFromFilePatterns(projectARoot, ['*.clj'], 'always-claim'),
+          globs.createCatchAllGlobSpec(projectARoot),
         ],
         globs: ['*.clj', '**/*'],
       });
@@ -205,8 +201,8 @@ describe(`${suiteName} suite`, () => {
       sessionRegistry.registerSession('joyride', joyrideSession, {
         projectRoot: `file://${deepProjectRoot}`,
         globSpecs: [
-          ...constructGlobsFromFilePatterns(deepProjectRoot, ['*.cljs'], 'always-claim'),
-          createCatchAllGlobSpec(deepProjectRoot),
+          ...globs.constructGlobsFromFilePatterns(deepProjectRoot, ['*.cljs'], 'always-claim'),
+          globs.createCatchAllGlobSpec(deepProjectRoot),
         ],
         globs: ['*.cljs', '**/*'],
       });
@@ -266,19 +262,19 @@ describe(`${suiteName} suite`, () => {
       sessionRegistry.registerSession('project-a-clj', cljSession, {
         projectRoot: `file://${projectARoot}`,
         globSpecs: [
-          ...constructGlobsFromFilePatterns(projectARoot, ['*.clj', '*.edn'], 'always-claim'),
-          createCatchAllGlobSpec(projectARoot),
+          ...globs.constructGlobsFromFilePatterns(projectARoot, ['*.clj', '*.edn'], 'always-claim'),
+          globs.createCatchAllGlobSpec(projectARoot),
         ],
         globs: ['*.clj', '*.edn', '**/*'],
       });
 
       // BB session: workspace-wide fallback for .clj (like bb project type)
       // This simulates: is-fallback-for: ['**/*.clj']
-      const bbSpecs: SessionGlobSpec[] = [
-        ...constructGlobsFromFilePatterns(projectBRoot, ['*.bb'], 'always-claim'),
+      const bbSpecs: globs.SessionGlobSpec[] = [
+        ...globs.constructGlobsFromFilePatterns(projectBRoot, ['*.bb'], 'always-claim'),
         // Workspace-wide fallback - note the **/ prefix
-        ...constructGlobsFromFilePatterns(projectBRoot, ['**/*.clj'], 'is-fallback-for'),
-        createCatchAllGlobSpec(projectBRoot),
+        ...globs.constructGlobsFromFilePatterns(projectBRoot, ['**/*.clj'], 'is-fallback-for'),
+        globs.createCatchAllGlobSpec(projectBRoot),
       ];
 
       sessionRegistry.registerSession('bb', bbSession, {
@@ -311,8 +307,8 @@ describe(`${suiteName} suite`, () => {
       sessionRegistry.registerSession('project-a-clj', sessionA, {
         projectRoot: `file://${projectARoot}`,
         globSpecs: [
-          ...constructGlobsFromFilePatterns(projectARoot, ['*.edn'], 'always-claim'),
-          createCatchAllGlobSpec(projectARoot),
+          ...globs.constructGlobsFromFilePatterns(projectARoot, ['*.edn'], 'always-claim'),
+          globs.createCatchAllGlobSpec(projectARoot),
         ],
         globs: ['*.edn', '**/*'],
       });
@@ -321,9 +317,9 @@ describe(`${suiteName} suite`, () => {
       sessionRegistry.registerSession('project-b-clj', sessionB, {
         projectRoot: `file://${projectBRoot}`,
         globSpecs: [
-          ...constructGlobsFromFilePatterns(projectBRoot, ['*.edn'], 'always-claim'),
-          ...constructGlobsFromFilePatterns(projectBRoot, ['**/*.clj'], 'is-fallback-for'),
-          createCatchAllGlobSpec(projectBRoot),
+          ...globs.constructGlobsFromFilePatterns(projectBRoot, ['*.edn'], 'always-claim'),
+          ...globs.constructGlobsFromFilePatterns(projectBRoot, ['**/*.clj'], 'is-fallback-for'),
+          globs.createCatchAllGlobSpec(projectBRoot),
         ],
         globs: ['*.edn', '**/*.clj', '**/*'],
       });

--- a/src/extension-test/integration/suite/name-suffix-test.ts
+++ b/src/extension-test/integration/suite/name-suffix-test.ts
@@ -6,10 +6,8 @@ import * as clientRegistry from '../../../nrepl/client-registry';
 import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as nameSuffix from '../../../nrepl/session-name-suffix';
 import * as jackIn from '../../../nrepl/jack-in';
-import * as connectorModule from '../../../connector';
+import * as connector from '../../../connector';
 import * as testUtil from './util';
-
-const connector = connectorModule.default;
 
 const suiteName = 'Name Suffix';
 

--- a/src/extension-test/integration/suite/name-suffix-test.ts
+++ b/src/extension-test/integration/suite/name-suffix-test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { before, after, beforeEach } from 'mocha';
+import * as mocha from 'mocha';
 import * as path from 'path';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as clientRegistry from '../../../nrepl/client-registry';
@@ -19,21 +19,21 @@ suite('Name Suffix suite', () => {
   let baseClientKey: string | undefined;
   let secondClientKey: string | undefined;
 
-  before(async () => {
+  mocha.before(async () => {
     testUtil.showMessage(suiteName, `suite starting!`);
     await testUtil.ensureOutputDir(testUtil.testDataDir);
     await jackInHarness.disconnectAllClients();
     nameSuffix.resetPool();
   });
 
-  after(async () => {
+  mocha.after(async () => {
     testUtil.showMessage(suiteName, `suite done!`);
     await jackIn.calvaJackout({ force: true });
     await testUtil.waitForJackOutComplete(suiteName);
     nameSuffix.resetPool();
   });
 
-  beforeEach(async () => {
+  mocha.beforeEach(async () => {
     await outputWindow.clearReplWindowDoc();
     jackInHarness.reset();
     await ensureBaseConnection();

--- a/src/extension-test/integration/suite/name-suffix-test.ts
+++ b/src/extension-test/integration/suite/name-suffix-test.ts
@@ -6,8 +6,10 @@ import * as clientRegistry from '../../../nrepl/client-registry';
 import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as nameSuffix from '../../../nrepl/session-name-suffix';
 import * as jackIn from '../../../nrepl/jack-in';
-import connector from '../../../connector';
+import * as connectorModule from '../../../connector';
 import * as testUtil from './util';
+
+const connector = connectorModule.default;
 
 const suiteName = 'Name Suffix';
 

--- a/src/extension-test/integration/suite/project-utils-test.ts
+++ b/src/extension-test/integration/suite/project-utils-test.ts
@@ -1,28 +1,28 @@
 import * as project_utils from '../../../project-root';
-import { describe, it } from 'mocha';
-import { expect } from 'expect';
+import * as mocha from 'mocha';
+import * as expectLib from 'expect';
 import * as vscode from 'vscode';
 
-describe('project root utils', () => {
-  it('should return the furthest parent', () => {
+mocha.describe('project root utils', () => {
+  mocha.it('should return the furthest parent', () => {
     const furthest = project_utils.findFurthestParent(vscode.Uri.parse('/a/b/c/d'), [
       vscode.Uri.parse('/a/b/c'),
       vscode.Uri.parse('/a/b'),
     ]);
 
-    expect(furthest.path).toBe('/a/b');
+    expectLib.expect(furthest.path).toBe('/a/b');
   });
 
-  it('should return the closest parent', () => {
+  mocha.it('should return the closest parent', () => {
     const furthest = project_utils.findClosestParent(vscode.Uri.parse('/a/b/c/d'), [
       vscode.Uri.parse('/a/b/c'),
       vscode.Uri.parse('/a/b'),
     ]);
 
-    expect(furthest.path).toBe('/a/b/c');
+    expectLib.expect(furthest.path).toBe('/a/b/c');
   });
 
-  it('should return a filtered set of shortest, distinct paths', () => {
+  mocha.it('should return a filtered set of shortest, distinct paths', () => {
     try {
       const distinct = project_utils.filterShortestDistinctPaths([
         vscode.Uri.parse('/a/b/c'),
@@ -32,7 +32,7 @@ describe('project root utils', () => {
         vscode.Uri.parse('/a/b/d/c'),
       ]);
 
-      expect(distinct.map((uri) => uri.path)).toEqual(['/a/b/c', '/a/b/d']);
+      expectLib.expect(distinct.map((uri) => uri.path)).toEqual(['/a/b/c', '/a/b/d']);
     } catch (err) {
       console.log('err', err);
     }

--- a/src/extension-test/integration/suite/repl-history-test.ts
+++ b/src/extension-test/integration/suite/repl-history-test.ts
@@ -5,7 +5,7 @@ import * as testUtil from './util';
 import * as state from '../../../state';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as replHistory from '../../../repl-window/repl-history';
-import type { NReplSession } from '../../../nrepl';
+import type * as nrepl from '../../../nrepl';
 
 const suiteName = 'REPL history';
 const serverSessionKey = 'app.server';
@@ -23,7 +23,7 @@ async function clearHistoryForSessions() {
 }
 
 function setSessionKey(sessionKey: string) {
-  const fakeSession = undefined as unknown as NReplSession;
+  const fakeSession = undefined as unknown as nrepl.NReplSession;
   outputWindow.setSession(fakeSession, 'user', sessionKey);
 }
 

--- a/src/extension-test/integration/suite/repl-window-targeting-test.ts
+++ b/src/extension-test/integration/suite/repl-window-targeting-test.ts
@@ -9,7 +9,9 @@ import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as replSessionsMenu from '../../../repl-sessions-menu';
 import * as jackIn from '../../../nrepl/jack-in';
 import * as vscode from 'vscode';
-import connector from '../../../connector';
+import * as connectorModule from '../../../connector';
+
+const connector = connectorModule.default;
 
 const suiteName = 'REPL Window Targeting';
 

--- a/src/extension-test/integration/suite/repl-window-targeting-test.ts
+++ b/src/extension-test/integration/suite/repl-window-targeting-test.ts
@@ -9,9 +9,7 @@ import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as replSessionsMenu from '../../../repl-sessions-menu';
 import * as jackIn from '../../../nrepl/jack-in';
 import * as vscode from 'vscode';
-import * as connectorModule from '../../../connector';
-
-const connector = connectorModule.default;
+import * as connector from '../../../connector';
 
 const suiteName = 'REPL Window Targeting';
 

--- a/src/extension-test/integration/suite/repl-window-targeting-test.ts
+++ b/src/extension-test/integration/suite/repl-window-targeting-test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { before, after, beforeEach } from 'mocha';
+import * as mocha from 'mocha';
 import * as path from 'path';
 import * as testUtil from './util';
 import * as clientRegistry from '../../../nrepl/client-registry';
@@ -9,7 +9,6 @@ import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as replSessionsMenu from '../../../repl-sessions-menu';
 import * as jackIn from '../../../nrepl/jack-in';
 import * as vscode from 'vscode';
-import { commands } from 'vscode';
 import connector from '../../../connector';
 
 const suiteName = 'REPL Window Targeting';
@@ -42,7 +41,7 @@ suite('REPL Window Targeting suite', function () {
 
   let clientKey: string;
 
-  before(async () => {
+  mocha.before(async () => {
     testUtil.showMessage(suiteName, `suite starting!`);
     await testUtil.ensureOutputDir(testUtil.testDataDir);
 
@@ -72,7 +71,7 @@ suite('REPL Window Targeting suite', function () {
     assert.ok(sessionKeys.includes('cljs'), 'Should have cljs session');
   });
 
-  after(async () => {
+  mocha.after(async () => {
     testUtil.showMessage(suiteName, `suite done!`);
 
     // Kill jack-in processes to prevent orphaned Java processes
@@ -91,7 +90,7 @@ suite('REPL Window Targeting suite', function () {
     }
   });
 
-  beforeEach(async () => {
+  mocha.beforeEach(async () => {
     // Reset REPL window to clj session before each test
     replSessionsMenu.setReplWindowSession('clj');
     await testUtil.waitForCondition(
@@ -123,7 +122,7 @@ suite('REPL Window Targeting suite', function () {
     assert.strictEqual(outputWindow.getSessionType(), 'clj', 'Initial session should be clj');
 
     // Change to cljs via command
-    await commands.executeCommand('calva.selectReplWindowSession', 'cljs');
+    await vscode.commands.executeCommand('calva.selectReplWindowSession', 'cljs');
     await testUtil.waitForCondition(() => outputWindow.getSessionType() === 'cljs', 2000, 10);
 
     assert.strictEqual(
@@ -133,7 +132,7 @@ suite('REPL Window Targeting suite', function () {
     );
 
     // Change back to clj
-    await commands.executeCommand('calva.selectReplWindowSession', 'clj');
+    await vscode.commands.executeCommand('calva.selectReplWindowSession', 'clj');
     await testUtil.waitForCondition(() => outputWindow.getSessionType() === 'clj', 2000, 10);
 
     assert.strictEqual(
@@ -257,7 +256,7 @@ suite('REPL Window Targeting suite', function () {
       async () => {
         await testUtil.openFile(cljsFile);
         testUtil.log(suiteName, `Opened file for jack-in: ${cljsFile}`);
-        await commands.executeCommand('calva.jackIn', {
+        await vscode.commands.executeCommand('calva.jackIn', {
           connectSequence: {
             name: 'repl-window-targeting-test-cljs-node',
             projectType: 'deps.edn',

--- a/src/extension-test/integration/suite/serialization-test.ts
+++ b/src/extension-test/integration/suite/serialization-test.ts
@@ -2,12 +2,12 @@ import assert = require('assert');
 import * as fsPromises from 'fs/promises';
 import path = require('path');
 import * as testUtil from './util';
-import { NotebookProvider } from '../../../NotebookProvider';
-import { before, after } from 'mocha';
-import { serialize } from 'v8';
+import * as notebookProvider from '../../../NotebookProvider';
+import * as mocha from 'mocha';
+import * as v8 from 'v8';
 import _ = require('lodash');
 
-const tester = new NotebookProvider();
+const tester = new notebookProvider.NotebookProvider();
 const suiteName = 'notebook';
 const decoder = new TextDecoder();
 
@@ -27,11 +27,11 @@ async function absoluteFileNamesIn(directoryName, results: string[] = []) {
 }
 
 suite('serialization', () => {
-  before(() => {
+  mocha.before(() => {
     testUtil.showMessage(suiteName, `suite starting!`);
   });
 
-  after(() => {
+  mocha.after(() => {
     testUtil.showMessage(suiteName, `suite done!`);
   });
 

--- a/src/extension-test/integration/suite/session-management-test.ts
+++ b/src/extension-test/integration/suite/session-management-test.ts
@@ -9,12 +9,12 @@ import * as replApi from '../../../api/repl-v1';
 import * as replSession from '../../../nrepl/repl-session';
 import evaluate from '../../../evaluate';
 import * as cljsLib from '../../../../out/cljs-lib/cljs-lib';
-import type { NReplSession, NReplClient } from '../../../nrepl';
+import type * as nrepl from '../../../nrepl';
 import * as testUtil from './util';
 import * as sessionRouting from '../../../nrepl/session-routing';
 import * as clientRegistry from '../../../nrepl/client-registry';
-import { buildGlobSpecsFromTiers } from '../../../nrepl/globs';
-import { getDocument } from '../../../doc-mirror';
+import * as globs from '../../../nrepl/globs';
+import * as docMirror from '../../../doc-mirror';
 
 const { describe, before, beforeEach, afterEach, it } = Mocha;
 
@@ -22,13 +22,13 @@ const suiteName = 'Session management';
 const serverSessionKey = 'session-management/server';
 const uiSessionKey = 'session-management/ui';
 
-const createSession = (replType: string, clientKey?: string): NReplSession =>
+const createSession = (replType: string, clientKey?: string): nrepl.NReplSession =>
   ({
     replType,
     client: clientKey ? { clientKey } : undefined,
-  } as NReplSession);
+  } as nrepl.NReplSession);
 
-const createEvaluatingSession = (result: string, clientKey?: string): NReplSession =>
+const createEvaluatingSession = (result: string, clientKey?: string): nrepl.NReplSession =>
   ({
     replType: 'clj',
     sessionId: 'session-management/evaluate-session-id',
@@ -40,7 +40,7 @@ const createEvaluatingSession = (result: string, clientKey?: string): NReplSessi
       errorOutput: '',
     }),
     stacktrace: () => Promise.resolve(undefined),
-  } as unknown as NReplSession);
+  } as unknown as nrepl.NReplSession);
 
 const resetOutputWindowSession = (sessionType: string, ns: string): void => {
   outputWindow.setSession(createSession(sessionType), ns, sessionType);
@@ -48,7 +48,7 @@ const resetOutputWindowSession = (sessionType: string, ns: string): void => {
 
 const getReplWindowText = async (): Promise<string> => {
   const replWindowDoc = await outputWindow.openReplWindowDoc();
-  return getDocument(replWindowDoc).document.getText();
+  return docMirror.getDocument(replWindowDoc).document.getText();
 };
 
 describe(`${suiteName} suite`, () => {
@@ -173,7 +173,7 @@ describe(`${suiteName} suite`, () => {
         let lastReplText = '';
         await testUtil.waitForCondition(async () => {
           const replWindowDoc = await outputWindow.openReplWindowDoc();
-          lastReplText = getDocument(replWindowDoc).document.getText();
+          lastReplText = docMirror.getDocument(replWindowDoc).document.getText();
           return lastReplText.includes(code);
         });
 
@@ -190,7 +190,7 @@ describe(`${suiteName} suite`, () => {
         assert.strictEqual(evaluatedCodeEvents[0].replSessionKey, sessionKey);
 
         const replWindowDoc = await outputWindow.openReplWindowDoc();
-        const replText = getDocument(replWindowDoc).document.getText();
+        const replText = docMirror.getDocument(replWindowDoc).document.getText();
         const codeOccurrences = (replText.match(/\(inc 1\)/g) || []).length;
 
         assert.strictEqual(
@@ -398,7 +398,7 @@ describe(`${suiteName} suite`, () => {
       disconnect: () => undefined,
       addOnCloseHandler: () => undefined,
       removeOnCloseHandler: () => undefined,
-    } as unknown as NReplClient;
+    } as unknown as nrepl.NReplClient;
 
     clientRegistry.registerClient(stubClient, {
       connectSequenceName: 'Test Connection',
@@ -497,7 +497,7 @@ describe(`${suiteName} suite`, () => {
       disconnect: () => undefined,
       addOnCloseHandler: () => undefined,
       removeOnCloseHandler: () => undefined,
-    } as unknown as NReplClient;
+    } as unknown as nrepl.NReplClient;
 
     clientRegistry.registerClient(stubClient, {
       connectSequenceName: 'Test Connection',
@@ -519,12 +519,15 @@ describe(`${suiteName} suite`, () => {
 
     sessionRegistry.registerSession('general-cljs', generalCljs, {
       globs: ['**/*.cljs'],
-      globSpecs: buildGlobSpecsFromTiers({ 'always-claim': ['**/*.cljs'], 'is-fallback-for': [] }),
+      globSpecs: globs.buildGlobSpecsFromTiers({
+        'always-claim': ['**/*.cljs'],
+        'is-fallback-for': [],
+      }),
     });
 
     sessionRegistry.registerSession('joyride', joyrideCljs, {
       globs: ['**/.joyride/**/*.cljs'],
-      globSpecs: buildGlobSpecsFromTiers({
+      globSpecs: globs.buildGlobSpecsFromTiers({
         'always-claim': ['**/.joyride/**/*.cljs'],
         'is-fallback-for': [],
       }),
@@ -543,7 +546,7 @@ describe(`${suiteName} suite`, () => {
 
     sessionRegistry.registerSession('bb', bbSession, {
       globs: ['**/*.bb', '**/*.clj', '**/*.cljc'],
-      globSpecs: buildGlobSpecsFromTiers({
+      globSpecs: globs.buildGlobSpecsFromTiers({
         'always-claim': ['**/*.bb'],
         'is-fallback-for': ['**/*.clj', '**/*.cljc'],
       }),
@@ -551,7 +554,10 @@ describe(`${suiteName} suite`, () => {
 
     sessionRegistry.registerSession('clj', cljSession, {
       globs: ['**/*.clj'],
-      globSpecs: buildGlobSpecsFromTiers({ 'always-claim': ['**/*.clj'], 'is-fallback-for': [] }),
+      globSpecs: globs.buildGlobSpecsFromTiers({
+        'always-claim': ['**/*.clj'],
+        'is-fallback-for': [],
+      }),
     });
 
     const cljFilePath = path.join(testUtil.testDataDir, 'test.clj');

--- a/src/extension-test/integration/suite/session-management-test.ts
+++ b/src/extension-test/integration/suite/session-management-test.ts
@@ -4,10 +4,10 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
-import * as connectorModule from '../../../connector';
+import * as connector from '../../../connector';
 import * as replApi from '../../../api/repl-v1';
 import * as replSession from '../../../nrepl/repl-session';
-import * as evaluateModule from '../../../evaluate';
+import * as evaluate from '../../../evaluate';
 import * as cljsLib from '../../../../out/cljs-lib/cljs-lib';
 import type * as nrepl from '../../../nrepl';
 import * as testUtil from './util';
@@ -15,9 +15,6 @@ import * as sessionRouting from '../../../nrepl/session-routing';
 import * as clientRegistry from '../../../nrepl/client-registry';
 import * as globs from '../../../nrepl/globs';
 import * as docMirror from '../../../doc-mirror';
-
-const connector = connectorModule.default;
-const evaluate = evaluateModule.default;
 
 const { describe, before, beforeEach, afterEach, it } = Mocha;
 

--- a/src/extension-test/integration/suite/session-management-test.ts
+++ b/src/extension-test/integration/suite/session-management-test.ts
@@ -4,10 +4,10 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
-import connector from '../../../connector';
+import * as connectorModule from '../../../connector';
 import * as replApi from '../../../api/repl-v1';
 import * as replSession from '../../../nrepl/repl-session';
-import evaluate from '../../../evaluate';
+import * as evaluateModule from '../../../evaluate';
 import * as cljsLib from '../../../../out/cljs-lib/cljs-lib';
 import type * as nrepl from '../../../nrepl';
 import * as testUtil from './util';
@@ -15,6 +15,9 @@ import * as sessionRouting from '../../../nrepl/session-routing';
 import * as clientRegistry from '../../../nrepl/client-registry';
 import * as globs from '../../../nrepl/globs';
 import * as docMirror from '../../../doc-mirror';
+
+const connector = connectorModule.default;
+const evaluate = evaluateModule.default;
 
 const { describe, before, beforeEach, afterEach, it } = Mocha;
 

--- a/src/extension-test/integration/suite/toggle-comment-test.ts
+++ b/src/extension-test/integration/suite/toggle-comment-test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { suite, describe, before, after, it } from 'mocha';
+import * as mocha from 'mocha';
 import * as path from 'path';
 import * as testUtil from './util';
 import * as vscode from 'vscode';
@@ -154,15 +154,15 @@ async function setToggleCommentBehavior(behavior: string | undefined) {
     .update('toggleCommentBehavior', behavior, vscode.ConfigurationTarget.Global);
 }
 
-suite(suiteName, () => {
-  before(async () => {
+mocha.suite(suiteName, () => {
+  mocha.before(async () => {
     testUtil.showMessage(suiteName, `suite starting`);
     // Set commentCurrentLine so existing ;; tests continue to work as before
     await setToggleCommentBehavior('commentCurrentLine');
     await testUtil.openFile(testFilePath);
   });
 
-  after(async () => {
+  mocha.after(async () => {
     // Restore default setting
     await setToggleCommentBehavior(undefined);
     console.log('Finally, toggle comment suite is closing the active editor');
@@ -170,215 +170,272 @@ suite(suiteName, () => {
     testUtil.showMessage(suiteName, `suite done!`);
   });
 
-  it('should comment a code line inside defn with correct indent', async () => {
+  mocha.it('should comment a code line inside defn with correct indent', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(defn foo []•  |(println "test"))'),
       '(defn foo []•  ;; |(println "test")•  )'
     );
   });
 
-  it('should uncomment a line and restore correct indentation', async () => {
+  mocha.it('should uncomment a line and restore correct indentation', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(defn foo []•  ;; |(println "test"))'),
       '(defn foo []•  |(println "test"))'
     );
   });
 
-  it('should uncomment a line with single semicolon prefix', async () => {
+  mocha.it('should uncomment a line with single semicolon prefix', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(defn foo []•  ; |(println "test"))'),
       '(defn foo []•  |(println "test"))'
     );
   });
 
-  it('should uncomment a line with triple semicolon prefix', async () => {
+  mocha.it('should uncomment a line with triple semicolon prefix', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(defn foo []•  ;;; |header)'),
       '(defn foo []•  |header)'
     );
   });
 
-  it('should treat triple semicolon lines as commented when toggling', async () => {
+  mocha.it('should treat triple semicolon lines as commented when toggling', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(defn foo []•  |;;; header)'),
       '(defn foo []•  |header)'
     );
   });
 
-  it('should uncomment mixed semicolon prefixes across selected lines and preserve selection', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(defn foo []•  |; a•  ;; b|)'),
-      '(defn foo []•  |a•  b|)'
-    );
-  });
+  mocha.it(
+    'should uncomment mixed semicolon prefixes across selected lines and preserve selection',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(defn foo []•  |; a•  ;; b|)'),
+        '(defn foo []•  |a•  b|)'
+      );
+    }
+  );
 
-  it('should preserve nested indentation when uncommenting selected multiline block (issue #3078)', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor(
-        '|;; (a (b c•;;       (d e•;;          f)•;;       g•;;       h)•;;    i•;;    j)|'
-      ),
-      '|(a (b c•      (d e•         f)•      g•      h)•   i•   j)|'
-    );
-  });
+  mocha.it(
+    'should preserve nested indentation when uncommenting selected multiline block (issue #3078)',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor(
+          '|;; (a (b c•;;       (d e•;;          f)•;;       g•;;       h)•;;    i•;;    j)|'
+        ),
+        '|(a (b c•      (d e•         f)•      g•      h)•   i•   j)|'
+      );
+    }
+  );
 
-  it('should preserve nested indentation when uncommenting selected multiline block inside defn (issue #3078)', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor(
-        '(defn foo []•  |;; (a (b c•  ;;       (d e•  ;;          f)•  ;;       g•  ;;       h)•  ;;    i•  ;;    j)|•     )'
-      ),
-      '(defn foo []•  |(a (b c•        (d e•           f)•        g•        h)•     i•     j)|)'
-    );
-  });
+  mocha.it(
+    'should preserve nested indentation when uncommenting selected multiline block inside defn (issue #3078)',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor(
+          '(defn foo []•  |;; (a (b c•  ;;       (d e•  ;;          f)•  ;;       g•  ;;       h)•  ;;    i•  ;;    j)|•     )'
+        ),
+        '(defn foo []•  |(a (b c•        (d e•           f)•        g•        h)•     i•     j)|)'
+      );
+    }
+  );
 
-  it('should comment an empty line inside assoc with alignment indent (issue #2872)', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(assoc m•       :key :val•|)'),
-      '(assoc m•       :key :val•       ;; |•       )'
-    );
-  });
+  mocha.it(
+    'should comment an empty line inside assoc with alignment indent (issue #2872)',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(assoc m•       :key :val•|)'),
+        '(assoc m•       :key :val•       ;; |•       )'
+      );
+    }
+  );
 
-  it('should comment a line in aligned position with correct indent', async () => {
+  mocha.it('should comment a line in aligned position with correct indent', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(assoc m•       :key :val•       |(+ 1 2))'),
       '(assoc m•       :key :val•       ;; |(+ 1 2)•       )'
     );
   });
 
-  it('should uncomment an aligned line and restore alignment', async () => {
+  mocha.it('should uncomment an aligned line and restore alignment', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(assoc m•       :key :val•       ;;  |(+ 1 2))'),
       '(assoc m•       :key :val•       |(+ 1 2))'
     );
   });
 
-  it('should handle multiple cursors on different lines and preserve cursor positions', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(defn foo []•  |(println "a")•  |1(println "b"))'),
-      '(defn foo []•  ;; |(println "a")•  ;; |1(println "b"))'
-    );
-  });
-
-  it('should uncomment multiple lines with correct indentation and preserve selections', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor(
+  mocha.it(
+    'should handle multiple cursors on different lines and preserve cursor positions',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(defn foo []•  |(println "a")•  |1(println "b"))'),
         '(defn foo []•  ;; |(println "a")•  ;; |1(println "b"))'
-      ),
-      '(defn foo []•  |(println "a")•  |1(println "b"))'
-    );
-  });
+      );
+    }
+  );
 
-  it('should comment at top level with zero indent', async () => {
+  mocha.it(
+    'should uncomment multiple lines with correct indentation and preserve selections',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor(
+          '(defn foo []•  ;; |(println "a")•  ;; |1(println "b"))'
+        ),
+        '(defn foo []•  |(println "a")•  |1(println "b"))'
+      );
+    }
+  );
+
+  mocha.it('should comment at top level with zero indent', async () => {
     assert.equal(await toggleCommentUsingActiveEditor('|(defn foo [])'), ';; |(defn foo [])');
   });
 
-  it('should comment inside let binding vector with alignment', async () => {
+  mocha.it('should comment inside let binding vector with alignment', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(let [x 1•      |y 2]•  x)'),
       '(let [x 1•      ;; |y 2•      ]•  x)'
     );
   });
 
-  it('should handle nested forms with correct indent', async () => {
+  mocha.it('should handle nested forms with correct indent', async () => {
     assert.equal(
       await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    |(+ 1 2)))'),
       '(defn foo []•  (when true•    ;; |(+ 1 2)•    ))'
     );
   });
 
-  it('should comment a complete multi-line top-level form without structural breaks and preserve selection', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('|(defn foo []•  (prn "hi"))|'),
-      '|;; (defn foo []•;;   (prn "hi"))|'
-    );
-  });
+  mocha.it(
+    'should comment a complete multi-line top-level form without structural breaks and preserve selection',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('|(defn foo []•  (prn "hi"))|'),
+        '|;; (defn foo []•;;   (prn "hi"))|'
+      );
+    }
+  );
 
-  it('should comment selected lines inside a containing form, preserving outside closers and selection', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(do•  |(prn "a")•  (prn "b")|)'),
-      '(do•  |;; (prn "a")•  ;; (prn "b")|•  )'
-    );
-  });
+  mocha.it(
+    'should comment selected lines inside a containing form, preserving outside closers and selection',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(do•  |(prn "a")•  (prn "b")|)'),
+        '(do•  |;; (prn "a")•  ;; (prn "b")|•  )'
+      );
+    }
+  );
 
-  it('should comment multi-line nested forms when all lines selected and preserve selection', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('|(do•  (prn "a")•  (prn "b"))|'),
-      '|;; (do•;;   (prn "a")•;;   (prn "b"))|'
-    );
-  });
+  mocha.it(
+    'should comment multi-line nested forms when all lines selected and preserve selection',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('|(do•  (prn "a")•  (prn "b"))|'),
+        '|;; (do•;;   (prn "a")•;;   (prn "b"))|'
+      );
+    }
+  );
 
-  it('should comment complete multi-line let binding without displacing bracket and preserve selection', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('|(let [a 1•        b 2])|'),
-      '|;; (let [a 1•;;         b 2])|'
-    );
-  });
+  mocha.it(
+    'should comment complete multi-line let binding without displacing bracket and preserve selection',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('|(let [a 1•        b 2])|'),
+        '|;; (let [a 1•;;         b 2])|'
+      );
+    }
+  );
 
-  it('should structurally comment two selected lines and preserve closing delimiter and selection', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(assoc {}•         |:a•         :b|)'),
-      '(assoc {}•         |;; :a•         ;; :b|•         )'
-    );
-  });
+  mocha.it(
+    'should structurally comment two selected lines and preserve closing delimiter and selection',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(assoc {}•         |:a•         :b|)'),
+        '(assoc {}•         |;; :a•         ;; :b|•         )'
+      );
+    }
+  );
 
-  it('should preserve indentation and structure for selected multiline expression in with-open', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor(
-        '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    |(mod (->> #(.read r)•              repeatedly•              (filter #(not (>= % 200)))•              (take 1)•              doall•              first)•         100)|)•  :rcf)'
-      ),
-      '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    |;; (mod (->> #(.read r)•    ;;           repeatedly•    ;;           (filter #(not (>= % 200)))•    ;;           (take 1)•    ;;           doall•    ;;           first)•    ;;      100)|•         )•  :rcf)'
-    );
-  });
+  mocha.it(
+    'should preserve indentation and structure for selected multiline expression in with-open',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor(
+          '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    |(mod (->> #(.read r)•              repeatedly•              (filter #(not (>= % 200)))•              (take 1)•              doall•              first)•         100)|)•  :rcf)'
+        ),
+        '(ns main.server•  #_(:require [babashka.fs :as fs])•  (:gen-class))••(defn -main•  "I don\'t do a whole lot ... yet."•  [& _args]•  (println "Hello, World!"))••(comment•  (-main)•  (System/getProperty "user.dir")•  (rand-int 100)•  (with-open [r (java.io.FileInputStream. "/dev/urandom")]•    |;; (mod (->> #(.read r)•    ;;           repeatedly•    ;;           (filter #(not (>= % 200)))•    ;;           (take 1)•    ;;           doall•    ;;           first)•    ;;      100)|•         )•  :rcf)'
+      );
+    }
+  );
 
-  it('should structurally comment multiline partial selection and keep full selection over commented text', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(a |(b c•      d)|•   e)'),
-      '(a |;; (b c•   ;;    d)|•   e)'
-    );
-  });
+  mocha.it(
+    'should structurally comment multiline partial selection and keep full selection over commented text',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(a |(b c•      d)|•   e)'),
+        '(a |;; (b c•   ;;    d)|•   e)'
+      );
+    }
+  );
 
-  it('should structurally comment unformatted multiline partial selection in a defn body', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(defn foo []•(a |(b c•d•e)|•f))'),
-      '(defn foo []•(a |;; (b c•;; d•;; e)|•f))'
-    );
-  });
+  mocha.it(
+    'should structurally comment unformatted multiline partial selection in a defn body',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(defn foo []•(a |(b c•d•e)|•f))'),
+        '(defn foo []•(a |;; (b c•;; d•;; e)|•f))'
+      );
+    }
+  );
 
-  it('should structurally comment unformatted nested multiline partial selection without breaking structure', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(defn foo []•(a |(b c•(d e•f)•g•h)|•i•j))'),
-      '(defn foo []•(a |;; (b c•;; (d e•;; f)•;; g•;; h)|•i•j))'
-    );
-  });
+  mocha.it(
+    'should structurally comment unformatted nested multiline partial selection without breaking structure',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(defn foo []•(a |(b c•(d e•f)•g•h)|•i•j))'),
+        '(defn foo []•(a |;; (b c•;; (d e•;; f)•;; g•;; h)|•i•j))'
+      );
+    }
+  );
 
-  it('should structurally comment multiline selection starting inside a nested form (issue #3096)', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(a (|b•    c|))'),
-      '(a (|;; b•    ;; c|•    ))'
-    );
-  });
+  mocha.it(
+    'should structurally comment multiline selection starting inside a nested form (issue #3096)',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(a (|b•    c|))'),
+        '(a (|;; b•    ;; c|•    ))'
+      );
+    }
+  );
 
-  it('should structurally comment multiline selection nested in parent form and preserve full selected range', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(x•  (y |(a b•        c)|)•  z)'),
-      '(x•  (y |;; (a b•     ;;    c)|•        )•  z)'
-    );
-  });
+  mocha.it(
+    'should structurally comment multiline selection nested in parent form and preserve full selected range',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(x•  (y |(a b•        c)|)•  z)'),
+        '(x•  (y |;; (a b•     ;;    c)|•        )•  z)'
+      );
+    }
+  );
 
-  it('should structurally comment multiline selection nested in j/y forms and keep full selected range', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(x• (j |(y •     (a b c))|)• z)'),
-      '(x• (j |;; (y •    ;;  (a b c))|•     )• z)'
-    );
-  });
+  mocha.it(
+    'should structurally comment multiline selection nested in j/y forms and keep full selected range',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(x• (j |(y •     (a b c))|)• z)'),
+        '(x• (j |;; (y •    ;;  (a b c))|•     )• z)'
+      );
+    }
+  );
 
-  it('should insert structural comment at selection start for single-line nested selection', async () => {
-    assert.equal(
-      await toggleCommentUsingActiveEditor('(x• (j (y |(a b c)|))• z)'),
-      '(x• (j (y |;; (a b c)|•     ))• z)'
-    );
-  });
+  mocha.it(
+    'should insert structural comment at selection start for single-line nested selection',
+    async () => {
+      assert.equal(
+        await toggleCommentUsingActiveEditor('(x• (j (y |(a b c)|))• z)'),
+        '(x• (j (y |;; (a b c)|•     ))• z)'
+      );
+    }
+  );
 
-  it('should uncomment partial-selection comments round-trip (issue #3081)', async () => {
+  mocha.it('should uncomment partial-selection comments round-trip (issue #3081)', async () => {
     const editor = vscode.window.activeTextEditor;
 
     // Simple partial selection
@@ -402,29 +459,41 @@ suite(suiteName, () => {
     assert.equal(nestedUncommented, nested);
   });
 
-  it('should toggle comments inside bracketed form and properly handle structure (issue #3096)', async () => {
-    assert.equal(await toggleCommentUsingActiveEditor('(|a•  b|)'), '(|;; a• ;;  b|•  )');
-  });
+  mocha.it(
+    'should toggle comments inside bracketed form and properly handle structure (issue #3096)',
+    async () => {
+      assert.equal(await toggleCommentUsingActiveEditor('(|a•  b|)'), '(|;; a• ;;  b|•  )');
+    }
+  );
 
-  it('should toggle comments inside bracketed form and keep structure with trailing code (issue #3096)', async () => {
-    assert.equal(await toggleCommentUsingActiveEditor('(|a•  b|)•(c)'), '(|;; a• ;;  b|•  )•(c)');
-  });
+  mocha.it(
+    'should toggle comments inside bracketed form and keep structure with trailing code (issue #3096)',
+    async () => {
+      assert.equal(await toggleCommentUsingActiveEditor('(|a•  b|)•(c)'), '(|;; a• ;;  b|•  )•(c)');
+    }
+  );
 
-  describe('ignoreCurrentForm and ignoreParentForm behavior', () => {
-    it('should remove #_ when cursor is between #_ and form on next line (ignoreCurrentForm)', async () => {
-      await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(await toggleCommentUsingActiveEditor('#_|•(defn foo [])'), '|(defn foo [])');
-    });
+  mocha.describe('ignoreCurrentForm and ignoreParentForm behavior', () => {
+    mocha.it(
+      'should remove #_ when cursor is between #_ and form on next line (ignoreCurrentForm)',
+      async () => {
+        await setToggleCommentBehavior('ignoreCurrentForm');
+        assert.equal(await toggleCommentUsingActiveEditor('#_|•(defn foo [])'), '|(defn foo [])');
+      }
+    );
 
-    it('should remove #_ when cursor is between #_ and form with many spaces (ignoreCurrentForm)', async () => {
-      await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(
-        await toggleCommentUsingActiveEditor('#_     |     (defn foo [])'),
-        '|(defn foo [])'
-      );
-    });
+    mocha.it(
+      'should remove #_ when cursor is between #_ and form with many spaces (ignoreCurrentForm)',
+      async () => {
+        await setToggleCommentBehavior('ignoreCurrentForm');
+        assert.equal(
+          await toggleCommentUsingActiveEditor('#_     |     (defn foo [])'),
+          '|(defn foo [])'
+        );
+      }
+    );
 
-    it('should add #_ to parent form when using ignoreParentForm', async () => {
+    mocha.it('should add #_ to parent form when using ignoreParentForm', async () => {
       await setToggleCommentBehavior('ignoreParentForm');
       assert.equal(
         await toggleCommentUsingActiveEditor('(defn foo []•  (when true•    (+ |-5 2)))'),
@@ -432,28 +501,34 @@ suite(suiteName, () => {
       );
     });
 
-    it('should fall back to ;; when text is selected even with ignoreCurrentForm', async () => {
-      await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(
-        await toggleCommentUsingActiveEditor('|(defn foo []•  (prn "hi"))|'),
-        '|;; (defn foo []•;;   (prn "hi"))|'
-      );
-    });
+    mocha.it(
+      'should fall back to ;; when text is selected even with ignoreCurrentForm',
+      async () => {
+        await setToggleCommentBehavior('ignoreCurrentForm');
+        assert.equal(
+          await toggleCommentUsingActiveEditor('|(defn foo []•  (prn "hi"))|'),
+          '|;; (defn foo []•;;   (prn "hi"))|'
+        );
+      }
+    );
 
-    it('should fall back to ;; uncomment when cursor is in comment with ignoreCurrentForm', async () => {
-      await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(
-        await toggleCommentUsingActiveEditor('(defn foo []•  ;; |(println "test"))'),
-        '(defn foo []•  |(println "test"))'
-      );
-    });
+    mocha.it(
+      'should fall back to ;; uncomment when cursor is in comment with ignoreCurrentForm',
+      async () => {
+        await setToggleCommentBehavior('ignoreCurrentForm');
+        assert.equal(
+          await toggleCommentUsingActiveEditor('(defn foo []•  ;; |(println "test"))'),
+          '(defn foo []•  |(println "test"))'
+        );
+      }
+    );
 
-    it('should add #_ to top-level form with ignoreCurrentForm', async () => {
+    mocha.it('should add #_ to top-level form with ignoreCurrentForm', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(await toggleCommentUsingActiveEditor('|(defn foo [])'), '#_|(defn foo [])');
     });
 
-    it('should format unformatted code when adding #_ (ignoreCurrentForm)', async () => {
+    mocha.it('should format unformatted code when adding #_ (ignoreCurrentForm)', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(
         await toggleCommentUsingActiveEditor('|(when true•(println "Hello, World!"))'),
@@ -461,7 +536,7 @@ suite(suiteName, () => {
       );
     });
 
-    it('should format unformatted code when removing #_ (ignoreCurrentForm)', async () => {
+    mocha.it('should format unformatted code when removing #_ (ignoreCurrentForm)', async () => {
       await setToggleCommentBehavior('ignoreCurrentForm');
       assert.equal(
         await toggleCommentUsingActiveEditor('#_|(when true•(println "Hello, World!"))'),
@@ -470,45 +545,60 @@ suite(suiteName, () => {
     });
   });
 
-  describe('args.behavior overrides setting', () => {
-    it('should use ignoreCurrentForm arg even when setting is commentCurrentLine', async () => {
-      await setToggleCommentBehavior('commentCurrentLine');
-      assert.equal(
-        await toggleCommentUsingActiveEditorWithArgs('(defn foo []•  |(println "test"))', {
-          behavior: 'ignoreCurrentForm',
-        }),
-        '(defn foo []•  #_|(println "test"))'
-      );
-    });
+  mocha.describe('args.behavior overrides setting', () => {
+    mocha.it(
+      'should use ignoreCurrentForm arg even when setting is commentCurrentLine',
+      async () => {
+        await setToggleCommentBehavior('commentCurrentLine');
+        assert.equal(
+          await toggleCommentUsingActiveEditorWithArgs('(defn foo []•  |(println "test"))', {
+            behavior: 'ignoreCurrentForm',
+          }),
+          '(defn foo []•  #_|(println "test"))'
+        );
+      }
+    );
 
-    it('should use ignoreParentForm arg even when setting is commentCurrentLine', async () => {
-      await setToggleCommentBehavior('commentCurrentLine');
-      assert.equal(
-        await toggleCommentUsingActiveEditorWithArgs('(defn foo []•  (when true•    (+ |-5 2)))', {
-          behavior: 'ignoreParentForm',
-        }),
-        '(defn foo []•  (when true•    #_(+ |-5 2)))'
-      );
-    });
+    mocha.it(
+      'should use ignoreParentForm arg even when setting is commentCurrentLine',
+      async () => {
+        await setToggleCommentBehavior('commentCurrentLine');
+        assert.equal(
+          await toggleCommentUsingActiveEditorWithArgs(
+            '(defn foo []•  (when true•    (+ |-5 2)))',
+            {
+              behavior: 'ignoreParentForm',
+            }
+          ),
+          '(defn foo []•  (when true•    #_(+ |-5 2)))'
+        );
+      }
+    );
 
-    it('should use commentCurrentLine arg even when setting is ignoreCurrentForm', async () => {
-      await setToggleCommentBehavior('ignoreCurrentForm');
-      assert.equal(
-        await toggleCommentUsingActiveEditorWithArgs('(defn foo []•  |(println "test"))', {
-          behavior: 'commentCurrentLine',
-        }),
-        '(defn foo []•  ;; |(println "test")•  )'
-      );
-    });
+    mocha.it(
+      'should use commentCurrentLine arg even when setting is ignoreCurrentForm',
+      async () => {
+        await setToggleCommentBehavior('ignoreCurrentForm');
+        assert.equal(
+          await toggleCommentUsingActiveEditorWithArgs('(defn foo []•  |(println "test"))', {
+            behavior: 'commentCurrentLine',
+          }),
+          '(defn foo []•  ;; |(println "test")•  )'
+        );
+      }
+    );
 
-    it('should remove #_ using ignoreCurrentForm arg even when setting is commentCurrentLine', async () => {
-      await setToggleCommentBehavior('commentCurrentLine');
-      assert.equal(
-        await toggleCommentUsingActiveEditorWithArgs('(defn foo []•  #_|(println "test"))', {
-          behavior: 'ignoreCurrentForm',
-        }),
-        '(defn foo []•  |(println "test"))'
-      );
-    });
+    mocha.it(
+      'should remove #_ using ignoreCurrentForm arg even when setting is commentCurrentLine',
+      async () => {
+        await setToggleCommentBehavior('commentCurrentLine');
+        assert.equal(
+          await toggleCommentUsingActiveEditorWithArgs('(defn foo []•  #_|(println "test"))', {
+            behavior: 'ignoreCurrentForm',
+          }),
+          '(defn foo []•  |(println "test"))'
+        );
+      }
+    );
   });
 });

--- a/src/extension-test/integration/suite/util.ts
+++ b/src/extension-test/integration/suite/util.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as which from 'which';
-import * as screenshot from 'screenshot-desktop';
+import screenshot = require('screenshot-desktop');
 import * as state from '../../../state';
 import * as projectRoot from '../../../project-root';
 import * as clientRegistry from '../../../nrepl/client-registry';
@@ -12,7 +12,9 @@ import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as output from '../../../results-output/output';
 import * as outputDestinations from '../../../results-output/output-destinations';
 import * as docMirror from '../../../doc-mirror';
-import connector from '../../../connector';
+import * as connectorModule from '../../../connector';
+
+const connector = connectorModule.default;
 
 export const testDataDir = path.join(
   __dirname,

--- a/src/extension-test/integration/suite/util.ts
+++ b/src/extension-test/integration/suite/util.ts
@@ -10,8 +10,8 @@ import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as jackIn from '../../../nrepl/jack-in';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as output from '../../../results-output/output';
-import { normalizeDestinations } from '../../../results-output/output-destinations';
-import { getDocument } from '../../../doc-mirror';
+import * as outputDestinations from '../../../results-output/output-destinations';
+import * as docMirror from '../../../doc-mirror';
 import connector from '../../../connector';
 
 export const testDataDir = path.join(
@@ -246,7 +246,7 @@ export async function waitForJackInCompletionCount(
   const currentCount = await waitForValue(
     async () => {
       const resultsEditor = await outputWindow.openReplWindowDoc();
-      const text = getDocument(resultsEditor).document.getText();
+      const text = docMirror.getDocument(resultsEditor).document.getText();
       const matchCount = (text.match(/Jack-in done\./g) || []).length;
       return matchCount > previousCount ? matchCount : undefined;
     },
@@ -437,9 +437,9 @@ export class JackInHarness {
 
   async waitForJackInCompletion(timeoutMs = 60_000): Promise<void> {
     if (
-      !normalizeDestinations(output.getDestinationConfiguration().otherOutput).includes(
-        'repl-window'
-      )
+      !outputDestinations
+        .normalizeDestinations(output.getDestinationConfiguration().otherOutput)
+        .includes('repl-window')
     ) {
       log(
         this.suiteName,

--- a/src/extension-test/integration/suite/util.ts
+++ b/src/extension-test/integration/suite/util.ts
@@ -12,9 +12,7 @@ import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as output from '../../../results-output/output';
 import * as outputDestinations from '../../../results-output/output-destinations';
 import * as docMirror from '../../../doc-mirror';
-import * as connectorModule from '../../../connector';
-
-const connector = connectorModule.default;
+import * as connector from '../../../connector';
 
 export const testDataDir = path.join(
   __dirname,

--- a/src/extension-test/unit/calva-fmt/healer-test.ts
+++ b/src/extension-test/unit/calva-fmt/healer-test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as healer from '../../../calva-fmt/src/healer';
 import * as model from '../../../cursor-doc/model';
 
@@ -10,27 +10,27 @@ describe('calva-fmt', () => {
     //                         \----------/
     const originalFrag = originalDoc.substring(6);
     const healing = healer.bandage(originalFrag, 6, '\n');
-    expect(healing.healedText).toEqual('([:x :y :z ])');
+    expectLib.expect(healing.healedText).toEqual('([:x :y :z ])');
     const formattedHealed = '([:x :y :z])';
     const replacement = healer.unbandage(healing, formattedHealed);
-    expect(replacement).toEqual('[:x :y :z])');
+    expectLib.expect(replacement).toEqual('[:x :y :z])');
   });
   it('Heals unclosed vector', () => {
     const originalDoc = '(def a[:x :y :z ]) ';
     //                         \--------/
     const originalFrag = originalDoc.substring(6, 16);
     const healing = healer.bandage(originalFrag, 6, '\n');
-    expect(healing.healedText).toEqual('[:x :y :z]');
+    expectLib.expect(healing.healedText).toEqual('[:x :y :z]');
     const formattedHealed = '[:x :y :z]';
     const replacement = healer.unbandage(healing, formattedHealed);
-    expect(replacement).toEqual('[:x :y :z ');
+    expectLib.expect(replacement).toEqual('[:x :y :z ');
   });
   it('Indents subsequent lines relative to first-line indent', () => {
     const originalFrag = '(def a\n42)';
     const healing = healer.bandage(originalFrag, 4, '\n');
-    expect(healing.healedText).toEqual('(def a\n42)');
+    expectLib.expect(healing.healedText).toEqual('(def a\n42)');
     const formattedHealed = '(def a\n  42)';
     const replacement = healer.unbandage(healing, formattedHealed);
-    expect(replacement).toEqual('(def a\n      42)');
+    expectLib.expect(replacement).toEqual('(def a\n      42)');
   });
 });

--- a/src/extension-test/unit/calva-fmt/respacer-test.ts
+++ b/src/extension-test/unit/calva-fmt/respacer-test.ts
@@ -1,117 +1,181 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as respacer from '../../../calva-fmt/src/respacer';
 import * as model from '../../../cursor-doc/model';
-import {
-  docFromTextNotation,
-  textNotationFromDoc,
-  textAndSelection,
-  getText,
-  textAndSelections,
-} from '../common/text-notation';
+import * as textNotation from '../common/text-notation';
 
 model.initScanner(20000);
 
 describe('respacer', () => {
   it('Inserts formatting space at the beginning', () => {
-    const actual = docFromTextNotation('(def| foo 42)');
-    const expected = docFromTextNotation('  (def| foo 42)');
-    const spaceEdits = respacer.whitespaceEdits('\n', 0, getText(actual), getText(expected));
+    const actual = textNotation.docFromTextNotation('(def| foo 42)');
+    const expected = textNotation.docFromTextNotation('  (def| foo 42)');
+    const spaceEdits = respacer.whitespaceEdits(
+      '\n',
+      0,
+      textNotation.getText(actual),
+      textNotation.getText(expected)
+    );
     actual.model.editNow(
       spaceEdits.map((se) => new model.ModelEdit('changeRange', [se.start, se.end, se.text])),
       { skipFormat: true }
     );
-    expect(textNotationFromDoc(actual)).toEqual(textNotationFromDoc(expected));
+    expectLib
+      .expect(textNotation.textNotationFromDoc(actual))
+      .toEqual(textNotation.textNotationFromDoc(expected));
   });
   it('Inserts formatting space at the middle', () => {
-    const actual = docFromTextNotation('(def foo|[42])');
-    const expected = docFromTextNotation('  (def foo |[42])');
-    const spaceEdits = respacer.whitespaceEdits('\n', 0, getText(actual), getText(expected));
+    const actual = textNotation.docFromTextNotation('(def foo|[42])');
+    const expected = textNotation.docFromTextNotation('  (def foo |[42])');
+    const spaceEdits = respacer.whitespaceEdits(
+      '\n',
+      0,
+      textNotation.getText(actual),
+      textNotation.getText(expected)
+    );
     actual.model.editNow(
       spaceEdits.map((se) => new model.ModelEdit('changeRange', [se.start, se.end, se.text])),
       { skipFormat: true }
     );
-    expect(textNotationFromDoc(actual)).toEqual(textNotationFromDoc(expected));
+    expectLib
+      .expect(textNotation.textNotationFromDoc(actual))
+      .toEqual(textNotation.textNotationFromDoc(expected));
   });
   it('Inserts formatting space at the end', () => {
-    const actual = docFromTextNotation('(def foo| [42])');
-    const expected = docFromTextNotation('(def foo| [42])  ');
-    const spaceEdits = respacer.whitespaceEdits('\n', 0, getText(actual), getText(expected));
+    const actual = textNotation.docFromTextNotation('(def foo| [42])');
+    const expected = textNotation.docFromTextNotation('(def foo| [42])  ');
+    const spaceEdits = respacer.whitespaceEdits(
+      '\n',
+      0,
+      textNotation.getText(actual),
+      textNotation.getText(expected)
+    );
     actual.model.editNow(
       spaceEdits.map((se) => new model.ModelEdit('changeRange', [se.start, se.end, se.text])),
       { skipFormat: true }
     );
-    expect(textNotationFromDoc(actual)).toEqual(textNotationFromDoc(expected));
+    expectLib
+      .expect(textNotation.textNotationFromDoc(actual))
+      .toEqual(textNotation.textNotationFromDoc(expected));
   });
   it('Removes formatting space from the beginning', () => {
-    const actual = docFromTextNotation('  (def foo| 42)');
-    const expected = docFromTextNotation('(def foo| 42)');
-    const spaceEdits = respacer.whitespaceEdits('\n', 0, getText(actual), getText(expected));
+    const actual = textNotation.docFromTextNotation('  (def foo| 42)');
+    const expected = textNotation.docFromTextNotation('(def foo| 42)');
+    const spaceEdits = respacer.whitespaceEdits(
+      '\n',
+      0,
+      textNotation.getText(actual),
+      textNotation.getText(expected)
+    );
     actual.model.editNow(
       spaceEdits.map((se) => new model.ModelEdit('changeRange', [se.start, se.end, se.text])),
       { skipFormat: true }
     );
-    expect(textNotationFromDoc(actual)).toEqual(textNotationFromDoc(expected));
+    expectLib
+      .expect(textNotation.textNotationFromDoc(actual))
+      .toEqual(textNotation.textNotationFromDoc(expected));
   });
   it('Removes formatting space from the middle', () => {
-    const actual = docFromTextNotation('(def foo|  42)');
-    const expected = docFromTextNotation('(def foo| 42)');
-    const spaceEdits = respacer.whitespaceEdits('\n', 0, getText(actual), getText(expected));
+    const actual = textNotation.docFromTextNotation('(def foo|  42)');
+    const expected = textNotation.docFromTextNotation('(def foo| 42)');
+    const spaceEdits = respacer.whitespaceEdits(
+      '\n',
+      0,
+      textNotation.getText(actual),
+      textNotation.getText(expected)
+    );
     actual.model.editNow(
       spaceEdits.map((se) => new model.ModelEdit('changeRange', [se.start, se.end, se.text])),
       { skipFormat: true }
     );
-    expect(textNotationFromDoc(actual)).toEqual(textNotationFromDoc(expected));
+    expectLib
+      .expect(textNotation.textNotationFromDoc(actual))
+      .toEqual(textNotation.textNotationFromDoc(expected));
   });
   it('Resizes formatting space in the middle', () => {
-    const actual = docFromTextNotation('(def•foo| 42)');
-    const expected = docFromTextNotation('(def•  foo| 42)');
-    const spaceEdits = respacer.whitespaceEdits('\n', 0, getText(actual), getText(expected));
+    const actual = textNotation.docFromTextNotation('(def•foo| 42)');
+    const expected = textNotation.docFromTextNotation('(def•  foo| 42)');
+    const spaceEdits = respacer.whitespaceEdits(
+      '\n',
+      0,
+      textNotation.getText(actual),
+      textNotation.getText(expected)
+    );
     actual.model.editNow(
       spaceEdits.map((se) => new model.ModelEdit('changeRange', [se.start, se.end, se.text])),
       { skipFormat: true }
     );
-    expect(textNotationFromDoc(actual)).toEqual(textNotationFromDoc(expected));
+    expectLib
+      .expect(textNotation.textNotationFromDoc(actual))
+      .toEqual(textNotation.textNotationFromDoc(expected));
   });
   it('Inserts, deletes, and resizes formatting space throughout', () => {
-    const actual = docFromTextNotation('  (def•foo|  42)');
-    const expected = docFromTextNotation('(def•  foo| 42)  ');
-    const spaceEdits = respacer.whitespaceEdits('\n', 0, getText(actual), getText(expected));
+    const actual = textNotation.docFromTextNotation('  (def•foo|  42)');
+    const expected = textNotation.docFromTextNotation('(def•  foo| 42)  ');
+    const spaceEdits = respacer.whitespaceEdits(
+      '\n',
+      0,
+      textNotation.getText(actual),
+      textNotation.getText(expected)
+    );
     actual.model.editNow(
       spaceEdits.map((se) => new model.ModelEdit('changeRange', [se.start, se.end, se.text])),
       { skipFormat: true }
     );
-    expect(textNotationFromDoc(actual)).toEqual(textNotationFromDoc(expected));
+    expectLib
+      .expect(textNotation.textNotationFromDoc(actual))
+      .toEqual(textNotation.textNotationFromDoc(expected));
   });
   it('Preserves multiple cursors amidst formatting-space alterations', () => {
-    const actual = docFromTextNotation('  |(def•f|2oo|3  42)');
-    const expected = docFromTextNotation('|(def•  f|2oo|3 42  )');
-    const spaceEdits = respacer.whitespaceEdits('\n', 0, getText(actual), getText(expected));
+    const actual = textNotation.docFromTextNotation('  |(def•f|2oo|3  42)');
+    const expected = textNotation.docFromTextNotation('|(def•  f|2oo|3 42  )');
+    const spaceEdits = respacer.whitespaceEdits(
+      '\n',
+      0,
+      textNotation.getText(actual),
+      textNotation.getText(expected)
+    );
     actual.model.editNow(
       spaceEdits.map((se) => new model.ModelEdit('changeRange', [se.start, se.end, se.text])),
       { skipFormat: true }
     );
-    expect(textNotationFromDoc(actual)).toEqual(textNotationFromDoc(expected));
+    expectLib
+      .expect(textNotation.textNotationFromDoc(actual))
+      .toEqual(textNotation.textNotationFromDoc(expected));
   });
   it('Keeps the cursor on the same line when adjusting whitespace', () => {
-    const actual = docFromTextNotation('(foo•|•:a)');
-    const expected = docFromTextNotation('(foo•  |•:a)');
+    const actual = textNotation.docFromTextNotation('(foo•|•:a)');
+    const expected = textNotation.docFromTextNotation('(foo•  |•:a)');
     const eol = actual.model.lineEnding;
-    const spaceEdits = respacer.whitespaceEdits(eol, 0, getText(actual), getText(expected));
+    const spaceEdits = respacer.whitespaceEdits(
+      eol,
+      0,
+      textNotation.getText(actual),
+      textNotation.getText(expected)
+    );
     actual.model.editNow(
       spaceEdits.map((se) => new model.ModelEdit('changeRange', [se.start, se.end, se.text])),
       { skipFormat: true }
     );
-    expect(textNotationFromDoc(actual)).toEqual(textNotationFromDoc(expected));
+    expectLib
+      .expect(textNotation.textNotationFromDoc(actual))
+      .toEqual(textNotation.textNotationFromDoc(expected));
   });
   it('Reformats but may lose cursors if document text changes', () => {
-    const actual = docFromTextNotation(';;a•(foo••:a)');
-    const expected = docFromTextNotation(';;bbb•(foo•  •:a)');
+    const actual = textNotation.docFromTextNotation(';;a•(foo••:a)');
+    const expected = textNotation.docFromTextNotation(';;bbb•(foo•  •:a)');
     const eol = actual.model.lineEnding;
-    const spaceEdits = respacer.whitespaceEdits(eol, 0, getText(actual), getText(expected));
+    const spaceEdits = respacer.whitespaceEdits(
+      eol,
+      0,
+      textNotation.getText(actual),
+      textNotation.getText(expected)
+    );
     actual.model.editNow(
       spaceEdits.map((se) => new model.ModelEdit('changeRange', [se.start, se.end, se.text])),
       { skipFormat: true }
     );
-    expect(textNotationFromDoc(actual)).toEqual(textNotationFromDoc(expected));
+    expectLib
+      .expect(textNotation.textNotationFromDoc(actual))
+      .toEqual(textNotation.textNotationFromDoc(expected));
   });
 });

--- a/src/extension-test/unit/client-teardown-test.ts
+++ b/src/extension-test/unit/client-teardown-test.ts
@@ -1,18 +1,18 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as clientRegistry from '../../nrepl/client-registry';
 import * as sessionRegistry from '../../nrepl/session-registry';
 import * as nameSuffix from '../../nrepl/session-name-suffix';
 import * as clientTeardown from '../../nrepl/client-teardown';
-import type { NReplClient, NReplSession } from '../../nrepl';
+import type * as nrepl from '../../nrepl';
 
-const createMockClient = (clientKey: string): NReplClient =>
+const createMockClient = (clientKey: string): nrepl.NReplClient =>
   ({
     clientKey,
     close: () => Promise.resolve(undefined),
     disconnect: () => undefined,
     addOnCloseHandler: () => undefined,
     removeOnCloseHandler: () => undefined,
-  } as unknown as NReplClient);
+  } as unknown as nrepl.NReplClient);
 
 describe('client-teardown', () => {
   beforeEach(() => {
@@ -32,7 +32,7 @@ describe('client-teardown', () => {
       // Setup: Register a client with a suffix
       const client = createMockClient('client-a');
       const suffix = nameSuffix.acquireNextAvailableSuffix();
-      expect(suffix).toBeDefined();
+      expectLib.expect(suffix).toBeDefined();
 
       clientRegistry.registerClient(client, {
         connectSequenceName: 'Test Connection',
@@ -50,15 +50,15 @@ describe('client-teardown', () => {
       });
 
       // Verify suffix is in use
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
 
       // Call the teardown helper that releases the suffix
       clientTeardown.releaseClientSuffix('client-a');
       clientRegistry.unregisterClient('client-a');
 
       // Verify suffix is released
-      expect(nameSuffix.getUsedSuffixes()).not.toContain(suffix);
-      expect(nameSuffix.getAvailableSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).not.toContain(suffix);
+      expectLib.expect(nameSuffix.getAvailableSuffixes()).toContain(suffix);
     });
 
     it('handles teardown of client without suffix (no-op for suffix release)', () => {
@@ -85,14 +85,14 @@ describe('client-teardown', () => {
       clientRegistry.unregisterClient('client-b');
 
       // Verify no suffixes are used
-      expect(nameSuffix.getUsedSuffixes()).toEqual([]);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toEqual([]);
     });
 
     it('does not release suffix when teardown is called with undefined clientKey', () => {
       // Setup: Register a client with a suffix
       const client = createMockClient('client-a');
       const suffix = nameSuffix.acquireNextAvailableSuffix();
-      expect(suffix).toBeDefined();
+      expectLib.expect(suffix).toBeDefined();
 
       clientRegistry.registerClient(client, {
         connectSequenceName: 'Test Connection',
@@ -113,21 +113,21 @@ describe('client-teardown', () => {
       clientTeardown.releaseClientSuffix(undefined as unknown as string);
 
       // Suffix should still be in use because we didn't tear down client-a
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
     });
 
     it('releases suffix even when client has already been unregistered', () => {
       // This tests the scenario where we need to track suffix separately
       // because the client might be gone but we still have the suffix stored
       const suffix = nameSuffix.acquireNextAvailableSuffix();
-      expect(suffix).toBeDefined();
+      expectLib.expect(suffix).toBeDefined();
 
       // Store suffix separately (simulating what happens if we track it before client registration)
       // Then release it
       nameSuffix.releaseSuffix(suffix);
 
-      expect(nameSuffix.getUsedSuffixes()).not.toContain(suffix);
-      expect(nameSuffix.getAvailableSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).not.toContain(suffix);
+      expectLib.expect(nameSuffix.getAvailableSuffixes()).toContain(suffix);
     });
   });
 
@@ -135,7 +135,7 @@ describe('client-teardown', () => {
     it('releases suffix when client has nameSuffix in connectionState', () => {
       const client = createMockClient('client-x');
       const suffix = nameSuffix.acquireNextAvailableSuffix();
-      expect(suffix).toBeDefined();
+      expectLib.expect(suffix).toBeDefined();
 
       clientRegistry.registerClient(client, {
         connectSequenceName: 'Test',
@@ -152,12 +152,12 @@ describe('client-teardown', () => {
         },
       });
 
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
 
       const released = clientTeardown.releaseClientSuffix('client-x');
 
-      expect(released).toBe(suffix);
-      expect(nameSuffix.getUsedSuffixes()).not.toContain(suffix);
+      expectLib.expect(released).toBe(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).not.toContain(suffix);
     });
 
     it('returns undefined when connectionState is undefined', () => {
@@ -165,8 +165,8 @@ describe('client-teardown', () => {
 
       const released = clientTeardown.releaseClientSuffix('nonexistent-client');
 
-      expect(released).toBeUndefined();
-      expect(nameSuffix.getUsedSuffixes()).toEqual(initialUsed);
+      expectLib.expect(released).toBeUndefined();
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toEqual(initialUsed);
     });
 
     it('returns undefined when connectionState has no nameSuffix', () => {
@@ -189,36 +189,36 @@ describe('client-teardown', () => {
 
       const released = clientTeardown.releaseClientSuffix('client-no-suffix');
 
-      expect(released).toBeUndefined();
+      expectLib.expect(released).toBeUndefined();
     });
 
     it('returns undefined when clientKey is undefined', () => {
       const released = clientTeardown.releaseClientSuffix(undefined);
 
-      expect(released).toBeUndefined();
+      expectLib.expect(released).toBeUndefined();
     });
   });
 
   describe('releaseSuffixDirectly', () => {
     it('releases suffix when provided', () => {
       const suffix = nameSuffix.acquireNextAvailableSuffix();
-      expect(suffix).toBeDefined();
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(suffix).toBeDefined();
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
 
       clientTeardown.releaseSuffixDirectly(suffix);
 
-      expect(nameSuffix.getUsedSuffixes()).not.toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).not.toContain(suffix);
     });
 
     it('does nothing when suffix is undefined', () => {
       const suffix = nameSuffix.acquireNextAvailableSuffix();
-      expect(suffix).toBeDefined();
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(suffix).toBeDefined();
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
 
       clientTeardown.releaseSuffixDirectly(undefined);
 
       // Original suffix should still be in use
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
     });
   });
 
@@ -229,8 +229,8 @@ describe('client-teardown', () => {
       const clientB = createMockClient('client-b');
       const suffixA = nameSuffix.acquireNextAvailableSuffix();
       const suffixB = nameSuffix.acquireNextAvailableSuffix();
-      expect(suffixA).toBeDefined();
-      expect(suffixB).toBeDefined();
+      expectLib.expect(suffixA).toBeDefined();
+      expectLib.expect(suffixB).toBeDefined();
 
       clientRegistry.registerClient(clientA, {
         connectSequenceName: 'Connection A',
@@ -263,16 +263,16 @@ describe('client-teardown', () => {
       });
 
       // Verify both suffixes are in use
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffixA);
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffixB);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffixA);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffixB);
 
       // Tear down only client A using the helper
       clientTeardown.releaseClientSuffix('client-a');
       clientRegistry.unregisterClient('client-a');
 
       // Only the suffix for client A should be released
-      expect(nameSuffix.getUsedSuffixes()).not.toContain(suffixA);
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffixB);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).not.toContain(suffixA);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffixB);
     });
   });
 
@@ -304,7 +304,7 @@ describe('client-teardown', () => {
         },
       });
 
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
 
       // Simulate reconnection: resolver has already reserved the suffix again
       // (this happens before teardown in real code)
@@ -316,7 +316,7 @@ describe('client-teardown', () => {
       clientRegistry.unregisterClient('client-a');
 
       // Suffix should STILL be reserved (not released)
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
 
       // Now a new client can be registered with the same suffix
       const clientB = createMockClient('client-b');
@@ -336,7 +336,7 @@ describe('client-teardown', () => {
       });
 
       // Suffix remains in use with new client
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
     });
 
     it('suffix would be stolen without preservation (demonstrates the bug fix)', () => {
@@ -362,19 +362,19 @@ describe('client-teardown', () => {
         },
       });
 
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
 
       // If we DO release the suffix during teardown (the old buggy behavior)
       clientTeardown.releaseClientSuffix('client-a');
       clientRegistry.unregisterClient('client-a');
 
       // Suffix is now available - another connection could grab it!
-      expect(nameSuffix.getUsedSuffixes()).not.toContain(suffix);
-      expect(nameSuffix.getAvailableSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).not.toContain(suffix);
+      expectLib.expect(nameSuffix.getAvailableSuffixes()).toContain(suffix);
 
       // Reserve the suffix again (simulating what another project might do)
       const wasReserved = nameSuffix.reserveSuffix(suffix);
-      expect(wasReserved).toBe(true); // Demonstrates the vulnerability - suffix was available to steal
+      expectLib.expect(wasReserved).toBe(true); // Demonstrates the vulnerability - suffix was available to steal
     });
 
     it('markSuffixPreserved prevents release by releaseClientSuffix', () => {
@@ -402,7 +402,7 @@ describe('client-teardown', () => {
         },
       });
 
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
 
       // Mark suffix as preserved (simulating what disconnectClientByKey does with preserveSuffix: true)
       clientTeardown.markSuffixPreserved('client-a');
@@ -412,8 +412,8 @@ describe('client-teardown', () => {
       const released = clientTeardown.releaseClientSuffix('client-a');
 
       // Suffix should NOT have been released
-      expect(released).toBeUndefined();
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(released).toBeUndefined();
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
     });
 
     it('clearSuffixPreserved allows subsequent release', () => {
@@ -444,8 +444,8 @@ describe('client-teardown', () => {
 
       // Now release should work
       const released = clientTeardown.releaseClientSuffix('client-a');
-      expect(released).toBe(suffix);
-      expect(nameSuffix.getUsedSuffixes()).not.toContain(suffix);
+      expectLib.expect(released).toBe(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).not.toContain(suffix);
     });
 
     it('simulates full reconnection flow with on-close handler', () => {
@@ -478,7 +478,7 @@ describe('client-teardown', () => {
         },
       });
 
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
 
       // Step 2: resolveSessionNames would reserve the suffix again (already reserved, but stays in set)
       // In real code, this happens before disconnectClientByKey
@@ -491,15 +491,15 @@ describe('client-teardown', () => {
       clientRegistry.unregisterClient('client-a');
 
       // At this point, getConnectionState('client-a') would return undefined
-      expect(clientRegistry.getConnectionState('client-a')).toBeUndefined();
+      expectLib.expect(clientRegistry.getConnectionState('client-a')).toBeUndefined();
 
       // Step 4: on-close handler fires and calls releaseClientSuffix
       // This should NOT release the suffix because it's marked as preserved
       const released = clientTeardown.releaseClientSuffix('client-a');
 
       // Suffix should NOT have been released
-      expect(released).toBeUndefined();
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(released).toBeUndefined();
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
 
       // Step 5: New client can now be registered with the same suffix
       const clientB = createMockClient('client-b');
@@ -519,7 +519,7 @@ describe('client-teardown', () => {
       });
 
       // Suffix remains in use with new client
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
     });
   });
 });

--- a/src/extension-test/unit/common/text-notation-test.ts
+++ b/src/extension-test/unit/common/text-notation-test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as textNotation from '../common/text-notation';
 
 describe('text-notation test utils', () => {
@@ -6,23 +6,23 @@ describe('text-notation test utils', () => {
     it('returns the same input text to textNotationFromDoc', () => {
       const inputText = '(a b|1) (a b|) (a <2(b)<2)';
       const doc = textNotation.docFromTextNotation(inputText);
-      expect(textNotation.textNotationFromDoc(doc)).toEqual(inputText);
+      expectLib.expect(textNotation.textNotationFromDoc(doc)).toEqual(inputText);
     });
     it('returns the normalized version of the input text to textNotationFromDoc', () => {
       const inputText = '<0e<0 f >1g>1';
       const normalized = '<e< f |1g|1';
       const doc = textNotation.docFromTextNotation(inputText);
-      expect(textNotation.textNotationFromDoc(doc)).toEqual(normalized);
+      expectLib.expect(textNotation.textNotationFromDoc(doc)).toEqual(normalized);
 
       const inputText1 = '|3a|3 <1b<1 >2c>2 d•>0e>0 f |4g<5<5';
       const normalized1 = '|3a|3 <1b<1 |2c|2 d•|e| f |4g|5';
       const doc1 = textNotation.docFromTextNotation(inputText1);
-      expect(textNotation.textNotationFromDoc(doc1)).toEqual(normalized1);
+      expectLib.expect(textNotation.textNotationFromDoc(doc1)).toEqual(normalized1);
     });
     it('has cursor at end when no trailing newline', () => {
       const inputText = '()|';
       const doc = textNotation.docFromTextNotation(inputText);
-      expect(textNotation.textNotationFromDoc(doc)).toEqual(inputText);
+      expectLib.expect(textNotation.textNotationFromDoc(doc)).toEqual(inputText);
     });
   });
   describe('docFromTextNotation', () => {
@@ -32,49 +32,49 @@ describe('text-notation test utils', () => {
         const text = '(a b)';
         const selection = [4, 4];
         const doc = textNotation.docFromTextNotation(tn);
-        expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
+        expectLib.expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
       });
       it('creates single cursor position from multiple selections', () => {
         const tn = '(|1a |2b|)';
         const text = '(a b)';
         const selection = [4, 4];
         const doc = textNotation.docFromTextNotation(tn);
-        expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
+        expectLib.expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
       });
       it('creates single range/selection', () => {
         const tn = '(a |b|)';
         const text = '(a b)';
         const selection = [3, 4];
         const doc = textNotation.docFromTextNotation(tn);
-        expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
+        expectLib.expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
       });
       it('creates single range/selection from multiple selections', () => {
         const tn = '|1(|1|2a|2 |b|)';
         const text = '(a b)';
         const selection = [3, 4];
         const doc = textNotation.docFromTextNotation(tn);
-        expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
+        expectLib.expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
       });
       it('creates single directed r->l range/selection', () => {
         const tn = '(a <b<)';
         const text = '(a b)';
         const selection = [4, 3];
         const doc = textNotation.docFromTextNotation(tn);
-        expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
+        expectLib.expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
       });
       it('creates a single directed r->l range/selection from the primary cursor amongst multiple', () => {
         const tn = '(<1a<1 <b<)';
         const text = '(a b)';
         const selection = [4, 3];
         const doc = textNotation.docFromTextNotation(tn);
-        expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
+        expectLib.expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
       });
       it('creates a single cursor from the primary cursor amongst a variety of multi-cursor positions and selections', () => {
         const tn = '|3a|3 <1b<1 >2c>2 d•>0e>0 f |4g<5<5';
         const text = 'a b c d•e f g'.replace(/•/g, '\n');
         const selection = [8, 9];
         const doc = textNotation.docFromTextNotation(tn);
-        expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
+        expectLib.expect(textNotation.textAndSelection(doc)).toEqual([text, selection]);
       });
     });
     describe('textAndSelections - multiple cursors', () => {
@@ -83,7 +83,7 @@ describe('text-notation test utils', () => {
         const text = '(a b)';
         const selections = [[4, 4]];
         const doc = textNotation.docFromTextNotation(tn);
-        expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
+        expectLib.expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
       });
       it('creates multiple cursor positions', () => {
         const tn = '(|1a |2b|)';
@@ -94,14 +94,14 @@ describe('text-notation test utils', () => {
           [3, 3],
         ];
         const doc = textNotation.docFromTextNotation(tn);
-        expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
+        expectLib.expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
       });
       it('creates single range/selection', () => {
         const tn = '(a |b|)';
         const text = '(a b)';
         const selections = [[3, 4]];
         const doc = textNotation.docFromTextNotation(tn);
-        expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
+        expectLib.expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
       });
       it('creates multiple ranges/selections', () => {
         const tn = '|1(|1|2a|2 |b|)';
@@ -112,14 +112,14 @@ describe('text-notation test utils', () => {
           [1, 2],
         ];
         const doc = textNotation.docFromTextNotation(tn);
-        expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
+        expectLib.expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
       });
       it('creates single directed r->l range/selection', () => {
         const tn = '(a <b<)';
         const text = '(a b)';
         const selections = [[4, 3]];
         const doc = textNotation.docFromTextNotation(tn);
-        expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
+        expectLib.expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
       });
       it('creates a variety directed r->l range/selection', () => {
         const tn = '(<1a<1 <b<)';
@@ -129,7 +129,7 @@ describe('text-notation test utils', () => {
           [2, 1],
         ];
         const doc = textNotation.docFromTextNotation(tn);
-        expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
+        expectLib.expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
       });
       it('creates a variety of multi-cursor positions and selections', () => {
         const tn = '|3a|3 <1b<1 >2c>2 d•>0e>0 f |4g<5<5';
@@ -143,7 +143,7 @@ describe('text-notation test utils', () => {
           [13, 13],
         ];
         const doc = textNotation.docFromTextNotation(tn);
-        expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
+        expectLib.expect(textNotation.textAndSelections(doc)).toEqual([text, selections]);
       });
     });
   });

--- a/src/extension-test/unit/common/text-notation.ts
+++ b/src/extension-test/unit/common/text-notation.ts
@@ -1,4 +1,4 @@
-import { clone, entries, first, last, orderBy, partialRight, toInteger } from 'lodash';
+import * as _ from 'lodash';
 import * as model from '../../../cursor-doc/model';
 
 /**
@@ -16,7 +16,7 @@ import * as model from '../../../cursor-doc/model';
 function textNotationToTextAndSelection(content: string): [string, model.ModelEditSelection[]] {
   const cursorSymbolRegExPattern =
     /(?<cursorType>(?:(?<selectionDirection><|>(?=\d{1})))|(?:\|))(?<cursorNumber>\d{1})?/g;
-  const text = clone(content).replace(/•/g, '\n').replace(cursorSymbolRegExPattern, '');
+  const text = _.clone(content).replace(/•/g, '\n').replace(cursorSymbolRegExPattern, '');
 
   /**
    * 3 capt groups:
@@ -48,9 +48,9 @@ function textNotationToTextAndSelection(content: string): [string, model.ModelEd
 
   const selections = [].fill(0, matches.length, undefined);
 
-  entries(cursorMatchInstances).forEach(([_, matches]) => {
-    const firstMatch = first(matches);
-    const secondMatch = last(matches) ?? firstMatch;
+  _.entries(cursorMatchInstances).forEach(([_cursorKey, matches]) => {
+    const firstMatch = _.first(matches);
+    const secondMatch = _.last(matches) ?? firstMatch;
 
     const isReversed =
       (firstMatch.groups['selectionDirection'] ?? firstMatch[2] ?? '') === '<' ? true : false;
@@ -61,7 +61,7 @@ function textNotationToTextAndSelection(content: string): [string, model.ModelEd
     const anchor = isReversed ? end : start;
     const active = isReversed ? start : end;
 
-    const cursorNumber = toInteger(firstMatch.groups['cursorNumber'] ?? firstMatch[3] ?? '0');
+    const cursorNumber = _.toInteger(firstMatch.groups['cursorNumber'] ?? firstMatch[3] ?? '0');
 
     selections[cursorNumber] = new model.ModelEditSelection(anchor, active, start, end, isReversed);
   });
@@ -108,14 +108,14 @@ export function textNotationFromTextAndSelections(
     }
   });
 
-  cursorSymbols = orderBy(cursorSymbols, (c) => c[0]);
+  cursorSymbols = _.orderBy(cursorSymbols, (c) => c[0]);
 
   // basically split up the text into chunks separated by where they'd have had cursor symbols, and append cursor symbols after each chunk, before joining back together
   // this way we can insert the cursor symbols in the right place without having to worry about the cumulative offsets created by appending the cursor symbols
   const textSegments = cursorSymbols
     .reduce(
       (acc, [offset, symbol], index) => {
-        const lastSection = last(acc)[1];
+        const lastSection = _.last(acc)[1];
         const sections = acc.slice(0, -1);
 
         const lastSectionOffset =
@@ -139,8 +139,8 @@ export function textNotationFromTextAndSelections(
   return prettyPrint ? textNotation.replace(/•/g, '\n') : textNotation;
 }
 
-textNotationFromDoc.pretty = partialRight(textNotationFromDoc, true);
-textNotationFromTextAndSelections.pretty = partialRight(textNotationFromTextAndSelections, true);
+textNotationFromDoc.pretty = _.partialRight(textNotationFromDoc, true);
+textNotationFromTextAndSelections.pretty = _.partialRight(textNotationFromTextAndSelections, true);
 
 /**
  * Utility function to get the text from a document.

--- a/src/extension-test/unit/completion-test.ts
+++ b/src/extension-test/unit/completion-test.ts
@@ -1,23 +1,23 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as completionUtil from '../../../src/providers/completion-util';
 
 describe('Merging completion arrays', () => {
   it('it merges two empty arrays or completions', function () {
-    expect(completionUtil.mergeCompletions([], [])).toStrictEqual([]);
+    expectLib.expect(completionUtil.mergeCompletions([], [])).toStrictEqual([]);
   });
   it('it merges an empty and a populated array or completions', function () {
     const completions = [
       { label: 'a', kind: 1 },
       { label: 'b', kind: 2 },
     ];
-    expect(completionUtil.mergeCompletions([], completions)).toStrictEqual(completions);
+    expectLib.expect(completionUtil.mergeCompletions([], completions)).toStrictEqual(completions);
   });
   it('it merges a populated and empty array or completions', function () {
     const completions = [
       { label: 'a', kind: 1 },
       { label: 'b', kind: 2 },
     ];
-    expect(completionUtil.mergeCompletions(completions, [])).toStrictEqual(completions);
+    expectLib.expect(completionUtil.mergeCompletions(completions, [])).toStrictEqual(completions);
   });
   it('it merges two populated arrays or completions, the second array wins with equal scores', function () {
     const completions1 = [
@@ -33,9 +33,9 @@ describe('Merging completion arrays', () => {
       { label: 'b', kind: 2 },
       { label: 'c', kind: 3 },
     ];
-    expect(completionUtil.mergeCompletions(completions1, completions2)).toStrictEqual(
-      mergedCompletions
-    );
+    expectLib
+      .expect(completionUtil.mergeCompletions(completions1, completions2))
+      .toStrictEqual(mergedCompletions);
   });
   it('it merges two populated arrays or completions, the higher score wins', function () {
     const completions1 = [
@@ -54,8 +54,8 @@ describe('Merging completion arrays', () => {
       { label: 'd', kind: 4 },
       { label: 'c', kind: 3 },
     ];
-    expect(completionUtil.mergeCompletions(completions1, completions2)).toStrictEqual(
-      mergedCompletions
-    );
+    expectLib
+      .expect(completionUtil.mergeCompletions(completions1, completions2))
+      .toStrictEqual(mergedCompletions);
   });
 });

--- a/src/extension-test/unit/connector-cljs-builds-test.ts
+++ b/src/extension-test/unit/connector-cljs-builds-test.ts
@@ -1,17 +1,23 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as cljsBuilds from '../../connector-cljs-builds';
 import * as connectSeq from '../../nrepl/connect-sequence-types';
 
 describe('connector-cljs-builds', () => {
   describe('isShadowCljsConnector', () => {
     it('returns true for shadow-cljs enum type', () => {
-      expect(cljsBuilds.isShadowCljsConnector(connectSeq.CljsTypes['shadow-cljs'])).toBe(true);
+      expectLib
+        .expect(cljsBuilds.isShadowCljsConnector(connectSeq.CljsTypes['shadow-cljs']))
+        .toBe(true);
     });
 
     it('returns false for other enum types', () => {
-      expect(cljsBuilds.isShadowCljsConnector(connectSeq.CljsTypes['Figwheel Main'])).toBe(false);
-      expect(cljsBuilds.isShadowCljsConnector(connectSeq.CljsTypes['lein-figwheel'])).toBe(false);
-      expect(cljsBuilds.isShadowCljsConnector(connectSeq.CljsTypes.none)).toBe(false);
+      expectLib
+        .expect(cljsBuilds.isShadowCljsConnector(connectSeq.CljsTypes['Figwheel Main']))
+        .toBe(false);
+      expectLib
+        .expect(cljsBuilds.isShadowCljsConnector(connectSeq.CljsTypes['lein-figwheel']))
+        .toBe(false);
+      expectLib.expect(cljsBuilds.isShadowCljsConnector(connectSeq.CljsTypes.none)).toBe(false);
     });
 
     it('returns true for config object with name shadow-cljs', () => {
@@ -20,7 +26,7 @@ describe('connector-cljs-builds', () => {
         isStarted: false,
         connectCode: '',
       };
-      expect(cljsBuilds.isShadowCljsConnector(config)).toBe(true);
+      expectLib.expect(cljsBuilds.isShadowCljsConnector(config)).toBe(true);
     });
 
     it('returns true for config object with dependsOn shadow-cljs', () => {
@@ -30,7 +36,7 @@ describe('connector-cljs-builds', () => {
         isStarted: false,
         connectCode: '',
       };
-      expect(cljsBuilds.isShadowCljsConnector(config)).toBe(true);
+      expectLib.expect(cljsBuilds.isShadowCljsConnector(config)).toBe(true);
     });
 
     it('returns false for config object without shadow-cljs reference', () => {
@@ -39,12 +45,12 @@ describe('connector-cljs-builds', () => {
         isStarted: false,
         connectCode: '',
       };
-      expect(cljsBuilds.isShadowCljsConnector(config)).toBe(false);
+      expectLib.expect(cljsBuilds.isShadowCljsConnector(config)).toBe(false);
     });
 
     it('handles null and undefined gracefully', () => {
-      expect(cljsBuilds.isShadowCljsConnector(null as any)).toBe(false);
-      expect(cljsBuilds.isShadowCljsConnector(undefined as any)).toBe(false);
+      expectLib.expect(cljsBuilds.isShadowCljsConnector(null as any)).toBe(false);
+      expectLib.expect(cljsBuilds.isShadowCljsConnector(undefined as any)).toBe(false);
     });
   });
 
@@ -56,21 +62,23 @@ describe('connector-cljs-builds', () => {
       };
 
       it('uses repl template for node-repl', () => {
-        expect(cljsBuilds.updateInitCode('node-repl', initCode)).toBe('(start-repl node-repl)');
+        expectLib
+          .expect(cljsBuilds.updateInitCode('node-repl', initCode))
+          .toBe('(start-repl node-repl)');
       });
 
       it('uses repl template for browser-repl', () => {
-        expect(cljsBuilds.updateInitCode('browser-repl', initCode)).toBe(
-          '(start-repl browser-repl)'
-        );
+        expectLib
+          .expect(cljsBuilds.updateInitCode('browser-repl', initCode))
+          .toBe('(start-repl browser-repl)');
       });
 
       it('uses build template for named builds, keywordizing the build', () => {
-        expect(cljsBuilds.updateInitCode('app', initCode)).toBe('(start-build :app)');
+        expectLib.expect(cljsBuilds.updateInitCode('app', initCode)).toBe('(start-build :app)');
       });
 
       it('handles builds that already have colons', () => {
-        expect(cljsBuilds.updateInitCode(':app', initCode)).toBe('(start-build :app)');
+        expectLib.expect(cljsBuilds.updateInitCode(':app', initCode)).toBe('(start-build :app)');
       });
     });
 
@@ -78,138 +86,138 @@ describe('connector-cljs-builds', () => {
       const initCode = '(connect %BUILD%)';
 
       it('replaces %BUILD% with quoted build name', () => {
-        expect(cljsBuilds.updateInitCode('app', initCode)).toBe('(connect "app")');
+        expectLib.expect(cljsBuilds.updateInitCode('app', initCode)).toBe('(connect "app")');
       });
 
       it('handles builds with colons', () => {
-        expect(cljsBuilds.updateInitCode(':app', initCode)).toBe('(connect ":app")');
+        expectLib.expect(cljsBuilds.updateInitCode(':app', initCode)).toBe('(connect ":app")');
       });
     });
 
     it('returns undefined when build is empty', () => {
-      expect(cljsBuilds.updateInitCode('', { repl: 'x', build: 'y' })).toBeUndefined();
+      expectLib.expect(cljsBuilds.updateInitCode('', { repl: 'x', build: 'y' })).toBeUndefined();
     });
 
     it('returns undefined when build is falsy', () => {
-      expect(cljsBuilds.updateInitCode(null as any, 'code')).toBeUndefined();
+      expectLib.expect(cljsBuilds.updateInitCode(null as any, 'code')).toBeUndefined();
     });
   });
 
   describe('parseClojureVectorResult', () => {
     it('parses keyword vector', () => {
-      expect(cljsBuilds.parseClojureVectorResult('[:app :app-too]')).toEqual([':app', ':app-too']);
+      expectLib
+        .expect(cljsBuilds.parseClojureVectorResult('[:app :app-too]'))
+        .toEqual([':app', ':app-too']);
     });
 
     it('parses quoted string vector', () => {
-      expect(cljsBuilds.parseClojureVectorResult('[":app" ":app-too"]')).toEqual([
-        ':app',
-        ':app-too',
-      ]);
+      expectLib
+        .expect(cljsBuilds.parseClojureVectorResult('[":app" ":app-too"]'))
+        .toEqual([':app', ':app-too']);
     });
 
     it('handles empty vector', () => {
-      expect(cljsBuilds.parseClojureVectorResult('[]')).toEqual([]);
+      expectLib.expect(cljsBuilds.parseClojureVectorResult('[]')).toEqual([]);
     });
 
     it('handles single element', () => {
-      expect(cljsBuilds.parseClojureVectorResult('[:app]')).toEqual([':app']);
+      expectLib.expect(cljsBuilds.parseClojureVectorResult('[:app]')).toEqual([':app']);
     });
 
     it('handles empty string', () => {
-      expect(cljsBuilds.parseClojureVectorResult('')).toEqual([]);
+      expectLib.expect(cljsBuilds.parseClojureVectorResult('')).toEqual([]);
     });
 
     it('handles null/undefined', () => {
-      expect(cljsBuilds.parseClojureVectorResult(null as any)).toEqual([]);
-      expect(cljsBuilds.parseClojureVectorResult(undefined as any)).toEqual([]);
+      expectLib.expect(cljsBuilds.parseClojureVectorResult(null as any)).toEqual([]);
+      expectLib.expect(cljsBuilds.parseClojureVectorResult(undefined as any)).toEqual([]);
     });
 
     it('handles extra whitespace', () => {
-      expect(cljsBuilds.parseClojureVectorResult('[  :app   :app-too  ]')).toEqual([
-        ':app',
-        ':app-too',
-      ]);
+      expectLib
+        .expect(cljsBuilds.parseClojureVectorResult('[  :app   :app-too  ]'))
+        .toEqual([':app', ':app-too']);
     });
   });
 
   describe('getActiveBuildQueryCode', () => {
     it('returns shadow-cljs query for shadow-cljs type', () => {
       const code = cljsBuilds.getActiveBuildQueryCode('shadow-cljs');
-      expect(code).toContain('shadow.cljs.devtools.api/active-builds');
+      expectLib.expect(code).toContain('shadow.cljs.devtools.api/active-builds');
     });
 
     it('returns figwheel query for Figwheel Main type', () => {
       const code = cljsBuilds.getActiveBuildQueryCode('Figwheel Main');
-      expect(code).toContain('figwheel.main/build-registry');
+      expectLib.expect(code).toContain('figwheel.main/build-registry');
     });
 
     it('returns undefined for unsupported types', () => {
-      expect(cljsBuilds.getActiveBuildQueryCode('lein-figwheel')).toBeUndefined();
-      expect(cljsBuilds.getActiveBuildQueryCode('none')).toBeUndefined();
+      expectLib.expect(cljsBuilds.getActiveBuildQueryCode('lein-figwheel')).toBeUndefined();
+      expectLib.expect(cljsBuilds.getActiveBuildQueryCode('none')).toBeUndefined();
     });
   });
 
   describe('normalizeBuildKey', () => {
     it('removes leading colon', () => {
-      expect(cljsBuilds.normalizeBuildKey(':app')).toBe('app');
+      expectLib.expect(cljsBuilds.normalizeBuildKey(':app')).toBe('app');
     });
 
     it('leaves build without colon unchanged', () => {
-      expect(cljsBuilds.normalizeBuildKey('app')).toBe('app');
+      expectLib.expect(cljsBuilds.normalizeBuildKey('app')).toBe('app');
     });
 
     it('handles empty string', () => {
-      expect(cljsBuilds.normalizeBuildKey('')).toBe('');
+      expectLib.expect(cljsBuilds.normalizeBuildKey('')).toBe('');
     });
   });
 
   describe('buildRequiresWatcher', () => {
     it('returns false for node-repl', () => {
-      expect(cljsBuilds.buildRequiresWatcher('node-repl')).toBe(false);
-      expect(cljsBuilds.buildRequiresWatcher(':node-repl')).toBe(false);
+      expectLib.expect(cljsBuilds.buildRequiresWatcher('node-repl')).toBe(false);
+      expectLib.expect(cljsBuilds.buildRequiresWatcher(':node-repl')).toBe(false);
     });
 
     it('returns false for browser-repl', () => {
-      expect(cljsBuilds.buildRequiresWatcher('browser-repl')).toBe(false);
-      expect(cljsBuilds.buildRequiresWatcher(':browser-repl')).toBe(false);
+      expectLib.expect(cljsBuilds.buildRequiresWatcher('browser-repl')).toBe(false);
+      expectLib.expect(cljsBuilds.buildRequiresWatcher(':browser-repl')).toBe(false);
     });
 
     it('returns true for named builds', () => {
-      expect(cljsBuilds.buildRequiresWatcher('app')).toBe(true);
-      expect(cljsBuilds.buildRequiresWatcher(':app')).toBe(true);
-      expect(cljsBuilds.buildRequiresWatcher('frontend')).toBe(true);
+      expectLib.expect(cljsBuilds.buildRequiresWatcher('app')).toBe(true);
+      expectLib.expect(cljsBuilds.buildRequiresWatcher(':app')).toBe(true);
+      expectLib.expect(cljsBuilds.buildRequiresWatcher('frontend')).toBe(true);
     });
   });
 
   describe('isBuildActive', () => {
     it('returns true for node-repl regardless of active builds', () => {
-      expect(cljsBuilds.isBuildActive('node-repl', [])).toBe(true);
-      expect(cljsBuilds.isBuildActive('node-repl', [':app'])).toBe(true);
-      expect(cljsBuilds.isBuildActive('node-repl', undefined)).toBe(true);
+      expectLib.expect(cljsBuilds.isBuildActive('node-repl', [])).toBe(true);
+      expectLib.expect(cljsBuilds.isBuildActive('node-repl', [':app'])).toBe(true);
+      expectLib.expect(cljsBuilds.isBuildActive('node-repl', undefined)).toBe(true);
     });
 
     it('returns true for browser-repl regardless of active builds', () => {
-      expect(cljsBuilds.isBuildActive('browser-repl', [])).toBe(true);
-      expect(cljsBuilds.isBuildActive('browser-repl', [':app'])).toBe(true);
+      expectLib.expect(cljsBuilds.isBuildActive('browser-repl', [])).toBe(true);
+      expectLib.expect(cljsBuilds.isBuildActive('browser-repl', [':app'])).toBe(true);
     });
 
     it('returns true when activeBuilds is undefined (cannot determine)', () => {
-      expect(cljsBuilds.isBuildActive('app', undefined)).toBe(true);
+      expectLib.expect(cljsBuilds.isBuildActive('app', undefined)).toBe(true);
     });
 
     it('returns true when build is in active builds list', () => {
-      expect(cljsBuilds.isBuildActive('app', [':app', ':test'])).toBe(true);
-      expect(cljsBuilds.isBuildActive(':app', ['app', 'test'])).toBe(true);
+      expectLib.expect(cljsBuilds.isBuildActive('app', [':app', ':test'])).toBe(true);
+      expectLib.expect(cljsBuilds.isBuildActive(':app', ['app', 'test'])).toBe(true);
     });
 
     it('returns false when build is not in active builds list', () => {
-      expect(cljsBuilds.isBuildActive('app', [':test'])).toBe(false);
-      expect(cljsBuilds.isBuildActive(':app', [])).toBe(false);
+      expectLib.expect(cljsBuilds.isBuildActive('app', [':test'])).toBe(false);
+      expectLib.expect(cljsBuilds.isBuildActive(':app', [])).toBe(false);
     });
 
     it('handles colon normalization in comparison', () => {
-      expect(cljsBuilds.isBuildActive(':app', ['app'])).toBe(true);
-      expect(cljsBuilds.isBuildActive('app', [':app'])).toBe(true);
+      expectLib.expect(cljsBuilds.isBuildActive(':app', ['app'])).toBe(true);
+      expectLib.expect(cljsBuilds.isBuildActive('app', [':app'])).toBe(true);
     });
   });
 });

--- a/src/extension-test/unit/connector-utilities-test.ts
+++ b/src/extension-test/unit/connector-utilities-test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as connectorUtils from '../../connector-utilities';
 
 describe('connector-utilities', () => {
@@ -9,7 +9,7 @@ describe('connector-utilities', () => {
         connectSequenceName: 'My Project REPL',
         sessionKeys: [],
       };
-      expect(connectorUtils.buildDisconnectItemLabel(client)).toBe('My Project REPL');
+      expectLib.expect(connectorUtils.buildDisconnectItemLabel(client)).toBe('My Project REPL');
     });
 
     it('falls back to client key when no connectSequenceName', () => {
@@ -17,7 +17,7 @@ describe('connector-utilities', () => {
         key: 'client-abc',
         sessionKeys: [],
       };
-      expect(connectorUtils.buildDisconnectItemLabel(client)).toBe('client-abc');
+      expectLib.expect(connectorUtils.buildDisconnectItemLabel(client)).toBe('client-abc');
     });
 
     it('prefers connectSequenceName over key', () => {
@@ -26,57 +26,65 @@ describe('connector-utilities', () => {
         connectSequenceName: 'Descriptive Name',
         sessionKeys: ['clj', 'cljs'],
       };
-      expect(connectorUtils.buildDisconnectItemLabel(client)).toBe('Descriptive Name');
+      expectLib.expect(connectorUtils.buildDisconnectItemLabel(client)).toBe('Descriptive Name');
     });
   });
 
   describe('buildDisconnectItemDescription', () => {
     it('shows session summary only when no project root', () => {
-      expect(connectorUtils.buildDisconnectItemDescription(['clj', 'cljs'])).toBe('clj, cljs');
+      expectLib
+        .expect(connectorUtils.buildDisconnectItemDescription(['clj', 'cljs']))
+        .toBe('clj, cljs');
     });
 
     it('combines session summary and project root', () => {
-      expect(connectorUtils.buildDisconnectItemDescription(['clj'], 'my-project')).toBe(
-        'clj — my-project'
-      );
+      expectLib
+        .expect(connectorUtils.buildDisconnectItemDescription(['clj'], 'my-project'))
+        .toBe('clj — my-project');
     });
 
     it('handles multiple sessions', () => {
-      expect(connectorUtils.buildDisconnectItemDescription(['clj', 'cljs', 'cljc'], 'proj')).toBe(
-        'clj, cljs, cljc — proj'
-      );
+      expectLib
+        .expect(connectorUtils.buildDisconnectItemDescription(['clj', 'cljs', 'cljc'], 'proj'))
+        .toBe('clj, cljs, cljc — proj');
     });
 
     it('shows fallback message for empty sessions', () => {
-      expect(connectorUtils.buildDisconnectItemDescription([])).toBe('No sessions registered');
+      expectLib
+        .expect(connectorUtils.buildDisconnectItemDescription([]))
+        .toBe('No sessions registered');
     });
 
     it('shows fallback message with project root for empty sessions', () => {
-      expect(connectorUtils.buildDisconnectItemDescription([], 'my-project')).toBe(
-        'No sessions registered — my-project'
-      );
+      expectLib
+        .expect(connectorUtils.buildDisconnectItemDescription([], 'my-project'))
+        .toBe('No sessions registered — my-project');
     });
   });
 
   describe('buildDisconnectItemDetail', () => {
     it('returns undefined when no host', () => {
-      expect(connectorUtils.buildDisconnectItemDetail()).toBeUndefined();
+      expectLib.expect(connectorUtils.buildDisconnectItemDetail()).toBeUndefined();
     });
 
     it('returns undefined for empty host', () => {
-      expect(connectorUtils.buildDisconnectItemDetail('')).toBeUndefined();
+      expectLib.expect(connectorUtils.buildDisconnectItemDetail('')).toBeUndefined();
     });
 
     it('returns host only when no port', () => {
-      expect(connectorUtils.buildDisconnectItemDetail('localhost')).toBe('localhost');
+      expectLib.expect(connectorUtils.buildDisconnectItemDetail('localhost')).toBe('localhost');
     });
 
     it('returns host:port when both provided', () => {
-      expect(connectorUtils.buildDisconnectItemDetail('localhost', 12345)).toBe('localhost:12345');
+      expectLib
+        .expect(connectorUtils.buildDisconnectItemDetail('localhost', 12345))
+        .toBe('localhost:12345');
     });
 
     it('handles IP addresses', () => {
-      expect(connectorUtils.buildDisconnectItemDetail('127.0.0.1', 8080)).toBe('127.0.0.1:8080');
+      expectLib
+        .expect(connectorUtils.buildDisconnectItemDetail('127.0.0.1', 8080))
+        .toBe('127.0.0.1:8080');
     });
   });
 });

--- a/src/extension-test/unit/cursor-doc/clojure-lexer-test.ts
+++ b/src/extension-test/unit/cursor-doc/clojure-lexer-test.ts
@@ -1,6 +1,6 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as fc from 'fast-check';
-import { Scanner, toplevel, validPair } from '../../../cursor-doc/clojure-lexer';
+import * as clojureLexer from '../../../cursor-doc/clojure-lexer';
 
 const MAX_LINE_LENGTH = 100;
 
@@ -98,7 +98,7 @@ function list(): fc.Arbitrary<string> {
   return fc
     .tuple(open(), symbol(), close())
     .filter(([o, _s, c]) => {
-      return validPair(o[o.length - 1], c);
+      return clojureLexer.validPair(o[o.length - 1], c);
     })
     .map(([o, s, c]) => `${o}${s}${c}`);
 }
@@ -116,10 +116,10 @@ function testTokens(data) {
 }
 
 describe('Scanner', () => {
-  let scanner: Scanner;
+  let scanner: clojureLexer.Scanner;
 
   beforeEach(() => {
-    scanner = new Scanner(MAX_LINE_LENGTH);
+    scanner = new clojureLexer.Scanner(MAX_LINE_LENGTH);
   });
 
   describe('simple', () => {
@@ -128,8 +128,8 @@ describe('Scanner', () => {
         fc.assert(
           fc.property(symbol(), (data) => {
             const tokens = scanner.processLine(data);
-            expect(tokens[0].type).toBe('id');
-            expect(tokens[0].raw).toBe(data);
+            expectLib.expect(tokens[0].type).toBe('id');
+            expectLib.expect(tokens[0].raw).toBe(data);
           })
         );
       });
@@ -137,22 +137,22 @@ describe('Scanner', () => {
         fc.assert(
           fc.property(underscoreSymbol(), (data) => {
             const tokens = scanner.processLine(data);
-            expect(tokens[0].type).toBe('id');
-            expect(tokens[0].raw).toBe(data);
+            expectLib.expect(tokens[0].type).toBe('id');
+            expectLib.expect(tokens[0].raw).toBe(data);
           })
         );
       });
       it('tokenizes _ as a symbol', () => {
         const tokens = scanner.processLine('_');
-        expect(tokens[0].type).toBe('id');
-        expect(tokens[0].raw).toBe('_');
+        expectLib.expect(tokens[0].type).toBe('id');
+        expectLib.expect(tokens[0].raw).toBe('_');
       });
       it('does not tokenize something with leading digit as a symbol', () => {
         const tokens = scanner.processLine('1foo');
-        expect(tokens[0].type).toBe('lit');
-        expect(tokens[0].raw).toBe('1');
-        expect(tokens[1].type).toBe('id');
-        expect(tokens[1].raw).toBe('foo');
+        expectLib.expect(tokens[0].type).toBe('lit');
+        expectLib.expect(tokens[0].raw).toBe('1');
+        expectLib.expect(tokens[1].type).toBe('id');
+        expectLib.expect(tokens[1].raw).toBe('foo');
       });
     });
     it('tokenizes whitespace', () => {
@@ -160,15 +160,15 @@ describe('Scanner', () => {
         fc.property(ws(), (data) => {
           // Remove extra eol put in there by the scanner
           const tokens = scanner.processLine(data).slice(0, -1);
-          expect(tokens.map((t) => t.raw).join('')).toBe(data);
+          expectLib.expect(tokens.map((t) => t.raw).join('')).toBe(data);
           tokens.forEach((t) => {
-            expect(t.type).toBe('ws');
+            expectLib.expect(t.type).toBe('ws');
           });
         })
       );
       const tokens = scanner.processLine('foo   bar');
-      expect(tokens[1].type).toBe('ws');
-      expect(tokens[1].raw).toBe('   ');
+      expectLib.expect(tokens[1].type).toBe('ws');
+      expectLib.expect(tokens[1].raw).toBe('   ');
     });
     describe('numbers', () => {
       it('tokenizes ints', () => {
@@ -177,8 +177,8 @@ describe('Scanner', () => {
             fc.constantFrom(...['42', '0', '-007', '+42', '-0', '-42', '+3r11', '-25Rn', '00M']),
             (text) => {
               const tokens = scanner.processLine(text);
-              expect(tokens[0].type).toBe('lit');
-              expect(tokens[0].raw).toBe(text);
+              expectLib.expect(tokens[0].type).toBe('lit');
+              expectLib.expect(tokens[0].raw).toBe(text);
             }
           )
         );
@@ -201,8 +201,8 @@ describe('Scanner', () => {
             ),
             (text) => {
               const tokens = scanner.processLine(text);
-              expect(tokens[0].type).toBe('lit');
-              expect(tokens[0].raw).toBe(text);
+              expectLib.expect(tokens[0].type).toBe('lit');
+              expectLib.expect(tokens[0].raw).toBe(text);
             }
           )
         );
@@ -228,8 +228,8 @@ describe('Scanner', () => {
             ),
             (text) => {
               const tokens = scanner.processLine(text);
-              expect(tokens[0].type).toBe('lit');
-              expect(tokens[0].raw).toBe(text);
+              expectLib.expect(tokens[0].type).toBe('lit');
+              expectLib.expect(tokens[0].raw).toBe(text);
             }
           )
         );
@@ -253,8 +253,8 @@ describe('Scanner', () => {
             ),
             (text) => {
               const tokens = scanner.processLine(text);
-              expect(tokens[0].type).toBe('lit');
-              expect(tokens[0].raw).toBe(text);
+              expectLib.expect(tokens[0].type).toBe('lit');
+              expectLib.expect(tokens[0].raw).toBe(text);
             }
           )
         );
@@ -263,8 +263,8 @@ describe('Scanner', () => {
         fc.assert(
           fc.property(fc.constantFrom(...['1/2', '01/02', '-100/200', '+1/0']), (text) => {
             const tokens = scanner.processLine(text);
-            expect(tokens[0].type).toBe('lit');
-            expect(tokens[0].raw).toBe(text);
+            expectLib.expect(tokens[0].type).toBe('lit');
+            expectLib.expect(tokens[0].raw).toBe(text);
           })
         );
       });
@@ -276,8 +276,8 @@ describe('Scanner', () => {
             ),
             (text) => {
               const tokens = scanner.processLine(text);
-              expect(tokens[0].type).toBe('lit');
-              expect(tokens[0].raw).toBe(text);
+              expectLib.expect(tokens[0].type).toBe('lit');
+              expectLib.expect(tokens[0].raw).toBe(text);
             }
           )
         );
@@ -290,10 +290,10 @@ describe('Scanner', () => {
             ),
             (text) => {
               const tokens = scanner.processLine(text);
-              expect(tokens[0].type).toBe('lit');
-              expect(tokens[0].raw).toBe(text.substr(0, text.indexOf(';')));
-              expect(tokens[1].type).toBe('comment');
-              expect(tokens[1].raw).toBe(text.substr(text.indexOf(';')));
+              expectLib.expect(tokens[0].type).toBe('lit');
+              expectLib.expect(tokens[0].raw).toBe(text.substr(0, text.indexOf(';')));
+              expectLib.expect(tokens[1].type).toBe('comment');
+              expectLib.expect(tokens[1].raw).toBe(text.substr(text.indexOf(';')));
             }
           )
         );
@@ -306,8 +306,8 @@ describe('Scanner', () => {
             ),
             (text) => {
               const tokens = scanner.processLine(text);
-              expect(tokens[0].type).toBe('lit');
-              expect(tokens[0].raw).toBe(text.substr(0, text.indexOf('\\')));
+              expectLib.expect(tokens[0].type).toBe('lit');
+              expectLib.expect(tokens[0].raw).toBe(text.substr(0, text.indexOf('\\')));
             }
           )
         );
@@ -317,8 +317,8 @@ describe('Scanner', () => {
       fc.assert(
         fc.property(keyword(), (data) => {
           const tokens = scanner.processLine(data);
-          expect(tokens[0].type).toBe('kw');
-          expect(tokens[0].raw).toBe(data);
+          expectLib.expect(tokens[0].type).toBe('kw');
+          expectLib.expect(tokens[0].raw).toBe(data);
         })
       );
     });
@@ -327,8 +327,8 @@ describe('Scanner', () => {
         fc.assert(
           fc.property(quotedUnicode(), (data) => {
             const tokens = scanner.processLine(data);
-            expect(tokens[0].type).toBe('lit');
-            expect(tokens[0].raw).toBe(data);
+            expectLib.expect(tokens[0].type).toBe('lit');
+            expectLib.expect(tokens[0].raw).toBe(data);
           })
         );
       });
@@ -336,8 +336,8 @@ describe('Scanner', () => {
         fc.assert(
           fc.property(fc.constantFrom(...['\\']), (data) => {
             const tokens = scanner.processLine(data);
-            expect(tokens[0].type).toBe('lit');
-            expect(tokens[0].raw).toBe(data);
+            expectLib.expect(tokens[0].type).toBe('lit');
+            expectLib.expect(tokens[0].raw).toBe(data);
           })
         );
       });
@@ -349,15 +349,15 @@ describe('Scanner', () => {
             ),
             (data) => {
               const tokens = scanner.processLine(data);
-              expect(tokens[0].type).toBe('lit');
-              expect(tokens[0].raw).toBe(data);
+              expectLib.expect(tokens[0].type).toBe('lit');
+              expectLib.expect(tokens[0].raw).toBe(data);
             }
           )
         );
         const data = '\\\b';
         const tokens = scanner.processLine(data);
-        expect(tokens[0].type).toBe('lit');
-        expect(tokens[0].raw).toBe(data);
+        expectLib.expect(tokens[0].type).toBe('lit');
+        expectLib.expect(tokens[0].raw).toBe(data);
       });
       it('tokenizes named literals', () => {
         fc.assert(
@@ -365,8 +365,8 @@ describe('Scanner', () => {
             fc.constantFrom(...['\\space', '\\space,', '\\space;', '\\space ', '\\space\\newline']),
             (text) => {
               const tokens = scanner.processLine(text);
-              expect(tokens[0].type).toBe('lit');
-              expect(tokens[0].raw).toBe('\\space');
+              expectLib.expect(tokens[0].type).toBe('lit');
+              expectLib.expect(tokens[0].raw).toBe('\\space');
             }
           )
         );
@@ -377,10 +377,10 @@ describe('Scanner', () => {
             fc.constantFrom(...['\\newline;', '\\space;comment', '\\space; comment', '1;', '+1;']),
             (text) => {
               const tokens = scanner.processLine(text);
-              expect(tokens[0].type).toBe('lit');
-              expect(tokens[0].raw).toBe(text.substr(0, text.indexOf(';')));
-              expect(tokens[1].type).toBe('comment');
-              expect(tokens[1].raw).toBe(text.substr(text.indexOf(';')));
+              expectLib.expect(tokens[0].type).toBe('lit');
+              expectLib.expect(tokens[0].raw).toBe(text.substr(0, text.indexOf(';')));
+              expectLib.expect(tokens[1].type).toBe('comment');
+              expectLib.expect(tokens[1].raw).toBe(text.substr(text.indexOf(';')));
             }
           )
         );
@@ -389,7 +389,7 @@ describe('Scanner', () => {
         fc.assert(
           fc.property(fc.constantFrom(...['1#_', '+1#_', '-12#_', '4.2#_', '42.2#_']), (text) => {
             const tokens = scanner.processLine(text);
-            expect(selectKeysTypeRaw(tokens)).toEqual(
+            expectLib.expect(selectKeysTypeRaw(tokens)).toEqual(
               testTokens([
                 ['lit', text.substr(0, text.indexOf('#_'))],
                 ['ignore', '#_'],
@@ -401,95 +401,95 @@ describe('Scanner', () => {
     });
     it('tokenizes literal named character', () => {
       const tokens = scanner.processLine('\\space');
-      expect(tokens[0].type).toBe('lit');
-      expect(tokens[0].raw).toBe('\\space');
+      expectLib.expect(tokens[0].type).toBe('lit');
+      expectLib.expect(tokens[0].raw).toBe('\\space');
     });
     it('tokenizes line comments', () => {
       const tokens = scanner.processLine('; foo');
-      expect(tokens[0].type).toBe('comment');
-      expect(tokens[0].raw).toBe('; foo');
+      expectLib.expect(tokens[0].type).toBe('comment');
+      expectLib.expect(tokens[0].raw).toBe('; foo');
     });
     describe('tokenizes ignores', () => {
       it('sole, no ws', () => {
         const tokens = scanner.processLine('#_foo');
-        expect(tokens[0].type).toBe('ignore');
-        expect(tokens[0].raw).toBe('#_');
-        expect(tokens[1].type).toBe('id');
-        expect(tokens[1].raw).toBe('foo');
+        expectLib.expect(tokens[0].type).toBe('ignore');
+        expectLib.expect(tokens[0].raw).toBe('#_');
+        expectLib.expect(tokens[1].type).toBe('id');
+        expectLib.expect(tokens[1].raw).toBe('foo');
       });
       it('sole, trailing ws', () => {
         const tokens = scanner.processLine('#_ foo');
-        expect(tokens[0].type).toBe('ignore');
-        expect(tokens[0].raw).toBe('#_');
-        expect(tokens[1].type).toBe('ws');
-        expect(tokens[1].raw).toBe(' ');
-        expect(tokens[2].type).toBe('id');
-        expect(tokens[2].raw).toBe('foo');
+        expectLib.expect(tokens[0].type).toBe('ignore');
+        expectLib.expect(tokens[0].raw).toBe('#_');
+        expectLib.expect(tokens[1].type).toBe('ws');
+        expectLib.expect(tokens[1].raw).toBe(' ');
+        expectLib.expect(tokens[2].type).toBe('id');
+        expectLib.expect(tokens[2].raw).toBe('foo');
       });
       it('sole, leading symbol/id, no ws', () => {
         const tokens = scanner.processLine('foo#_bar');
-        expect(tokens[0].type).toBe('id');
-        expect(tokens[0].raw).toBe('foo#_bar');
+        expectLib.expect(tokens[0].type).toBe('id');
+        expectLib.expect(tokens[0].raw).toBe('foo#_bar');
       });
       it('sole, leading number, no ws', () => {
         const tokens = scanner.processLine('1.2#_foo');
-        expect(tokens[0].type).toBe('lit');
-        expect(tokens[0].raw).toBe('1.2');
-        expect(tokens[1].type).toBe('ignore');
-        expect(tokens[1].raw).toBe('#_');
-        expect(tokens[2].type).toBe('id');
-        expect(tokens[2].raw).toBe('foo');
+        expectLib.expect(tokens[0].type).toBe('lit');
+        expectLib.expect(tokens[0].raw).toBe('1.2');
+        expectLib.expect(tokens[1].type).toBe('ignore');
+        expectLib.expect(tokens[1].raw).toBe('#_');
+        expectLib.expect(tokens[2].type).toBe('id');
+        expectLib.expect(tokens[2].raw).toBe('foo');
       });
       it('many, no ws', () => {
         const tokens = scanner.processLine('#_#_#_foo');
-        expect(tokens[0].type).toBe('ignore');
-        expect(tokens[0].raw).toBe('#_');
-        expect(tokens[1].type).toBe('ignore');
-        expect(tokens[1].raw).toBe('#_');
-        expect(tokens[2].type).toBe('ignore');
-        expect(tokens[2].raw).toBe('#_');
-        expect(tokens[3].type).toBe('id');
-        expect(tokens[3].raw).toBe('foo');
+        expectLib.expect(tokens[0].type).toBe('ignore');
+        expectLib.expect(tokens[0].raw).toBe('#_');
+        expectLib.expect(tokens[1].type).toBe('ignore');
+        expectLib.expect(tokens[1].raw).toBe('#_');
+        expectLib.expect(tokens[2].type).toBe('ignore');
+        expectLib.expect(tokens[2].raw).toBe('#_');
+        expectLib.expect(tokens[3].type).toBe('id');
+        expectLib.expect(tokens[3].raw).toBe('foo');
       });
       it('adjacent after literals it is part of the token', () => {
         fc.assert(
           fc.property(fc.constantFrom(...['\\c#_']), (text) => {
             const tokens = scanner.processLine(text);
-            expect(tokens[0].raw).toBe(text);
+            expectLib.expect(tokens[0].raw).toBe(text);
           })
         );
       });
     });
     it('tokenizes the Calva repl prompt', () => {
       const tokens = scanner.processLine('foo꞉bar.baz꞉> ()');
-      expect(tokens[0].type).toBe('prompt');
-      expect(tokens[0].raw).toBe('foo꞉bar.baz꞉> ');
-      expect(tokens[1].type).toBe('open');
-      expect(tokens[1].raw).toBe('(');
-      expect(tokens[2].type).toBe('close');
-      expect(tokens[2].raw).toBe(')');
+      expectLib.expect(tokens[0].type).toBe('prompt');
+      expectLib.expect(tokens[0].raw).toBe('foo꞉bar.baz꞉> ');
+      expectLib.expect(tokens[1].type).toBe('open');
+      expectLib.expect(tokens[1].raw).toBe('(');
+      expectLib.expect(tokens[2].type).toBe('close');
+      expectLib.expect(tokens[2].raw).toBe(')');
     });
     it('only tokenizes the Calva repl prompt if it is at the start of a line', () => {
       const tokens = scanner.processLine(' foo꞉bar.baz꞉> ()');
-      expect(tokens[0].type).toBe('ws');
-      expect(tokens[0].raw).toBe(' ');
-      expect(tokens[1].type).toBe('id');
-      expect(tokens[1].raw).toBe('foo꞉bar.baz꞉>');
-      expect(tokens[2].type).toBe('junk');
-      expect(tokens[2].raw).toBe(' ');
-      expect(tokens[3].type).toBe('open');
-      expect(tokens[3].raw).toBe('(');
-      expect(tokens[4].type).toBe('close');
-      expect(tokens[4].raw).toBe(')');
+      expectLib.expect(tokens[0].type).toBe('ws');
+      expectLib.expect(tokens[0].raw).toBe(' ');
+      expectLib.expect(tokens[1].type).toBe('id');
+      expectLib.expect(tokens[1].raw).toBe('foo꞉bar.baz꞉>');
+      expectLib.expect(tokens[2].type).toBe('junk');
+      expectLib.expect(tokens[2].raw).toBe(' ');
+      expectLib.expect(tokens[3].type).toBe('open');
+      expectLib.expect(tokens[3].raw).toBe('(');
+      expectLib.expect(tokens[4].type).toBe('close');
+      expectLib.expect(tokens[4].raw).toBe(')');
     });
     it('only tokenizes the Calva repl prompt if it ends with a space', () => {
       const tokens = scanner.processLine('foo꞉bar.baz꞉>()');
-      expect(tokens[0].type).toBe('id');
-      expect(tokens[0].raw).toBe('foo꞉bar.baz꞉>');
-      expect(tokens[1].type).toBe('open');
-      expect(tokens[1].raw).toBe('(');
-      expect(tokens[2].type).toBe('close');
-      expect(tokens[2].raw).toBe(')');
+      expectLib.expect(tokens[0].type).toBe('id');
+      expectLib.expect(tokens[0].raw).toBe('foo꞉bar.baz꞉>');
+      expectLib.expect(tokens[1].type).toBe('open');
+      expectLib.expect(tokens[1].raw).toBe('(');
+      expectLib.expect(tokens[2].type).toBe('close');
+      expectLib.expect(tokens[2].raw).toBe(')');
     });
   });
   describe('lists', () => {
@@ -498,161 +498,161 @@ describe('Scanner', () => {
         fc.property(list(), (data) => {
           const tokens = scanner.processLine(data);
           const numTokens = tokens.length;
-          expect(tokens[numTokens - 4].type).toBe('open');
-          expect(tokens[numTokens - 2].type).toBe('close');
+          expectLib.expect(tokens[numTokens - 4].type).toBe('open');
+          expectLib.expect(tokens[numTokens - 2].type).toBe('close');
         })
       );
     });
     it('tokenizes list', () => {
       const tokens = scanner.processLine('(foo)');
-      expect(tokens[0].type).toBe('open');
-      expect(tokens[0].raw).toBe('(');
-      expect(tokens[1].type).toBe('id');
-      expect(tokens[1].raw).toBe('foo');
-      expect(tokens[2].type).toBe('close');
-      expect(tokens[2].raw).toBe(')');
+      expectLib.expect(tokens[0].type).toBe('open');
+      expectLib.expect(tokens[0].raw).toBe('(');
+      expectLib.expect(tokens[1].type).toBe('id');
+      expectLib.expect(tokens[1].raw).toBe('foo');
+      expectLib.expect(tokens[2].type).toBe('close');
+      expectLib.expect(tokens[2].raw).toBe(')');
     });
     it('tokenizes vector', () => {
       const tokens = scanner.processLine('[foo]');
-      expect(tokens[0].type).toBe('open');
-      expect(tokens[0].raw).toBe('[');
-      expect(tokens[1].type).toBe('id');
-      expect(tokens[1].raw).toBe('foo');
-      expect(tokens[2].type).toBe('close');
-      expect(tokens[2].raw).toBe(']');
+      expectLib.expect(tokens[0].type).toBe('open');
+      expectLib.expect(tokens[0].raw).toBe('[');
+      expectLib.expect(tokens[1].type).toBe('id');
+      expectLib.expect(tokens[1].raw).toBe('foo');
+      expectLib.expect(tokens[2].type).toBe('close');
+      expectLib.expect(tokens[2].raw).toBe(']');
     });
     it('tokenizes map', () => {
       const tokens = scanner.processLine('{:foo bar}');
-      expect(tokens[0].type).toBe('open');
-      expect(tokens[0].raw).toBe('{');
-      expect(tokens[1].type).toBe('kw');
-      expect(tokens[1].raw).toBe(':foo');
-      expect(tokens[2].type).toBe('ws');
-      expect(tokens[2].raw).toBe(' ');
-      expect(tokens[3].type).toBe('id');
-      expect(tokens[3].raw).toBe('bar');
-      expect(tokens[4].type).toBe('close');
-      expect(tokens[4].raw).toBe('}');
+      expectLib.expect(tokens[0].type).toBe('open');
+      expectLib.expect(tokens[0].raw).toBe('{');
+      expectLib.expect(tokens[1].type).toBe('kw');
+      expectLib.expect(tokens[1].raw).toBe(':foo');
+      expectLib.expect(tokens[2].type).toBe('ws');
+      expectLib.expect(tokens[2].raw).toBe(' ');
+      expectLib.expect(tokens[3].type).toBe('id');
+      expectLib.expect(tokens[3].raw).toBe('bar');
+      expectLib.expect(tokens[4].type).toBe('close');
+      expectLib.expect(tokens[4].raw).toBe('}');
     });
     it('tokenizes shorthand lambda', () => {
       const tokens = scanner.processLine('#(foo bar)');
-      expect(tokens[0].type).toBe('open');
-      expect(tokens[0].raw).toBe('#(');
-      expect(tokens[1].type).toBe('id');
-      expect(tokens[1].raw).toBe('foo');
-      expect(tokens[2].type).toBe('ws');
-      expect(tokens[2].raw).toBe(' ');
-      expect(tokens[3].type).toBe('id');
-      expect(tokens[3].raw).toBe('bar');
-      expect(tokens[4].type).toBe('close');
-      expect(tokens[4].raw).toBe(')');
+      expectLib.expect(tokens[0].type).toBe('open');
+      expectLib.expect(tokens[0].raw).toBe('#(');
+      expectLib.expect(tokens[1].type).toBe('id');
+      expectLib.expect(tokens[1].raw).toBe('foo');
+      expectLib.expect(tokens[2].type).toBe('ws');
+      expectLib.expect(tokens[2].raw).toBe(' ');
+      expectLib.expect(tokens[3].type).toBe('id');
+      expectLib.expect(tokens[3].raw).toBe('bar');
+      expectLib.expect(tokens[4].type).toBe('close');
+      expectLib.expect(tokens[4].raw).toBe(')');
     });
     it('tokenizes set', () => {
       const tokens = scanner.processLine('#{:foo :bar}');
-      expect(tokens[0].type).toBe('open');
-      expect(tokens[0].raw).toBe('#{');
-      expect(tokens[1].type).toBe('kw');
-      expect(tokens[1].raw).toBe(':foo');
-      expect(tokens[2].type).toBe('ws');
-      expect(tokens[2].raw).toBe(' ');
-      expect(tokens[3].type).toBe('kw');
-      expect(tokens[3].raw).toBe(':bar');
-      expect(tokens[4].type).toBe('close');
-      expect(tokens[4].raw).toBe('}');
+      expectLib.expect(tokens[0].type).toBe('open');
+      expectLib.expect(tokens[0].raw).toBe('#{');
+      expectLib.expect(tokens[1].type).toBe('kw');
+      expectLib.expect(tokens[1].raw).toBe(':foo');
+      expectLib.expect(tokens[2].type).toBe('ws');
+      expectLib.expect(tokens[2].raw).toBe(' ');
+      expectLib.expect(tokens[3].type).toBe('kw');
+      expectLib.expect(tokens[3].raw).toBe(':bar');
+      expectLib.expect(tokens[4].type).toBe('close');
+      expectLib.expect(tokens[4].raw).toBe('}');
     });
     it('tokenizes string', () => {
       const tokens = scanner.processLine('"foo"');
-      expect(tokens[0].type).toBe('open');
-      expect(tokens[0].raw).toBe('"');
-      expect(tokens[1].type).toBe('str-inside');
-      expect(tokens[1].raw).toBe('foo');
-      expect(tokens[2].type).toBe('close');
-      expect(tokens[2].raw).toBe('"');
+      expectLib.expect(tokens[0].type).toBe('open');
+      expectLib.expect(tokens[0].raw).toBe('"');
+      expectLib.expect(tokens[1].type).toBe('str-inside');
+      expectLib.expect(tokens[1].raw).toBe('foo');
+      expectLib.expect(tokens[2].type).toBe('close');
+      expectLib.expect(tokens[2].raw).toBe('"');
     });
     it('tokenizes regex', () => {
       const tokens = scanner.processLine('#"foo"');
-      expect(tokens[0].type).toBe('open');
-      expect(tokens[0].raw).toBe('#"');
-      expect(tokens[1].type).toBe('str-inside');
-      expect(tokens[1].raw).toBe('foo');
-      expect(tokens[2].type).toBe('close');
-      expect(tokens[2].raw).toBe('"');
+      expectLib.expect(tokens[0].type).toBe('open');
+      expectLib.expect(tokens[0].raw).toBe('#"');
+      expectLib.expect(tokens[1].type).toBe('str-inside');
+      expectLib.expect(tokens[1].raw).toBe('foo');
+      expectLib.expect(tokens[2].type).toBe('close');
+      expectLib.expect(tokens[2].raw).toBe('"');
     });
     it('tokenizes the `#` in `#[]` separately', () => {
       const tokens = scanner.processLine('#[foo bar]');
-      expect(tokens[0].type).toBe('junk');
-      expect(tokens[0].raw).toBe('#');
-      expect(tokens[1].type).toBe('open');
-      expect(tokens[1].raw).toBe('[');
-      expect(tokens[2].type).toBe('id');
-      expect(tokens[2].raw).toBe('foo');
-      expect(tokens[3].type).toBe('ws');
-      expect(tokens[3].raw).toBe(' ');
-      expect(tokens[4].type).toBe('id');
-      expect(tokens[4].raw).toBe('bar');
-      expect(tokens[5].type).toBe('close');
-      expect(tokens[5].raw).toBe(']');
+      expectLib.expect(tokens[0].type).toBe('junk');
+      expectLib.expect(tokens[0].raw).toBe('#');
+      expectLib.expect(tokens[1].type).toBe('open');
+      expectLib.expect(tokens[1].raw).toBe('[');
+      expectLib.expect(tokens[2].type).toBe('id');
+      expectLib.expect(tokens[2].raw).toBe('foo');
+      expectLib.expect(tokens[3].type).toBe('ws');
+      expectLib.expect(tokens[3].raw).toBe(' ');
+      expectLib.expect(tokens[4].type).toBe('id');
+      expectLib.expect(tokens[4].raw).toBe('bar');
+      expectLib.expect(tokens[5].type).toBe('close');
+      expectLib.expect(tokens[5].raw).toBe(']');
     });
   });
   describe('data reader tags', () => {
     it('tokenizes tag, separate line', () => {
       const tokens = scanner.processLine('#foo');
-      expect(tokens[0].type).toBe('reader');
-      expect(tokens[0].raw).toBe('#foo');
+      expectLib.expect(tokens[0].type).toBe('reader');
+      expectLib.expect(tokens[0].raw).toBe('#foo');
     });
     it('tokenizes tag, with underscores', () => {
       const tokens = scanner.processLine('#foo_bar');
-      expect(tokens[0].type).toBe('reader');
-      expect(tokens[0].raw).toBe('#foo_bar');
+      expectLib.expect(tokens[0].type).toBe('reader');
+      expectLib.expect(tokens[0].raw).toBe('#foo_bar');
     });
     it('does not treat var quote plus open token as reader tag plus open token', () => {
       const tokens = scanner.processLine("#'foo []");
-      expect(tokens[0].type).toBe('id');
-      expect(tokens[0].raw).toBe("#'foo");
-      expect(tokens[1].type).toBe('ws');
-      expect(tokens[1].raw).toBe(' ');
-      expect(tokens[2].type).toBe('open');
-      expect(tokens[2].raw).toBe('[');
-      expect(tokens[3].type).toBe('close');
-      expect(tokens[3].raw).toBe(']');
+      expectLib.expect(tokens[0].type).toBe('id');
+      expectLib.expect(tokens[0].raw).toBe("#'foo");
+      expectLib.expect(tokens[1].type).toBe('ws');
+      expectLib.expect(tokens[1].raw).toBe(' ');
+      expectLib.expect(tokens[2].type).toBe('open');
+      expectLib.expect(tokens[2].raw).toBe('[');
+      expectLib.expect(tokens[3].type).toBe('close');
+      expectLib.expect(tokens[3].raw).toBe(']');
     });
   });
   describe('strings', () => {
     it('tokenizes words in strings', () => {
       const tokens = scanner.processLine('"(foo :bar)"');
-      expect(tokens[0].type).toBe('open');
-      expect(tokens[0].raw).toBe('"');
-      expect(tokens[1].type).toBe('str-inside');
-      expect(tokens[1].raw).toBe('(foo');
-      expect(tokens[2].type).toBe('ws');
-      expect(tokens[2].raw).toBe(' ');
-      expect(tokens[3].type).toBe('str-inside');
-      expect(tokens[3].raw).toBe(':bar)');
-      expect(tokens[4].type).toBe('close');
-      expect(tokens[4].raw).toBe('"');
+      expectLib.expect(tokens[0].type).toBe('open');
+      expectLib.expect(tokens[0].raw).toBe('"');
+      expectLib.expect(tokens[1].type).toBe('str-inside');
+      expectLib.expect(tokens[1].raw).toBe('(foo');
+      expectLib.expect(tokens[2].type).toBe('ws');
+      expectLib.expect(tokens[2].raw).toBe(' ');
+      expectLib.expect(tokens[3].type).toBe('str-inside');
+      expectLib.expect(tokens[3].raw).toBe(':bar)');
+      expectLib.expect(tokens[4].type).toBe('close');
+      expectLib.expect(tokens[4].raw).toBe('"');
     });
     it('tokenizes newlines in strings', () => {
       const tokens = scanner.processLine('"foo\nbar"');
-      expect(tokens[0].type).toBe('open');
-      expect(tokens[0].raw).toBe('"');
-      expect(tokens[1].type).toBe('str-inside');
-      expect(tokens[1].raw).toBe('foo');
-      expect(tokens[2].type).toBe('ws');
-      expect(tokens[2].raw).toBe('\n');
-      expect(tokens[3].type).toBe('str-inside');
-      expect(tokens[3].raw).toBe('bar');
-      expect(tokens[4].type).toBe('close');
-      expect(tokens[4].raw).toBe('"');
+      expectLib.expect(tokens[0].type).toBe('open');
+      expectLib.expect(tokens[0].raw).toBe('"');
+      expectLib.expect(tokens[1].type).toBe('str-inside');
+      expectLib.expect(tokens[1].raw).toBe('foo');
+      expectLib.expect(tokens[2].type).toBe('ws');
+      expectLib.expect(tokens[2].raw).toBe('\n');
+      expectLib.expect(tokens[3].type).toBe('str-inside');
+      expectLib.expect(tokens[3].raw).toBe('bar');
+      expectLib.expect(tokens[4].type).toBe('close');
+      expectLib.expect(tokens[4].raw).toBe('"');
     });
     it('tokenizes quoted quotes in strings', () => {
       let tokens = scanner.processLine('"\\""');
-      expect(tokens[0].type).toBe('open');
-      expect(tokens[0].raw).toBe('"');
-      expect(tokens[1].type).toBe('str-inside');
-      expect(tokens[1].raw).toBe('\\"');
+      expectLib.expect(tokens[0].type).toBe('open');
+      expectLib.expect(tokens[0].raw).toBe('"');
+      expectLib.expect(tokens[1].type).toBe('str-inside');
+      expectLib.expect(tokens[1].raw).toBe('\\"');
       tokens = scanner.processLine('"foo\\"bar"');
-      expect(tokens[1].type).toBe('str-inside');
-      expect(tokens[1].raw).toBe('foo\\"bar');
+      expectLib.expect(tokens[1].type).toBe('str-inside');
+      expectLib.expect(tokens[1].raw).toBe('foo\\"bar');
     });
   });
   describe('Reported issues', () => {
@@ -660,57 +660,57 @@ describe('Scanner', () => {
       // https://github.com/BetterThanTomorrow/calva/issues/556
       const longLine = 'foo '.repeat(26),
         tokens = scanner.processLine(longLine);
-      expect(tokens[0].type).toBe('too-long-line');
-      expect(tokens[0].raw).toBe(longLine);
+      expectLib.expect(tokens[0].type).toBe('too-long-line');
+      expectLib.expect(tokens[0].raw).toBe(longLine);
     });
     it('handles literal quotes - #566', () => {
       // https://github.com/BetterThanTomorrow/calva/issues/566
       const tokens = scanner.processLine("\\' foo");
-      expect(tokens[0].type).toBe('lit');
-      expect(tokens[0].raw).toBe("\\'");
-      expect(tokens[1].type).toBe('ws');
-      expect(tokens[1].raw).toBe(' ');
-      expect(tokens[2].type).toBe('id');
-      expect(tokens[2].raw).toBe('foo');
+      expectLib.expect(tokens[0].type).toBe('lit');
+      expectLib.expect(tokens[0].raw).toBe("\\'");
+      expectLib.expect(tokens[1].type).toBe('ws');
+      expectLib.expect(tokens[1].raw).toBe(' ');
+      expectLib.expect(tokens[2].type).toBe('id');
+      expectLib.expect(tokens[2].raw).toBe('foo');
     });
     it('handles symbols ending in =? - #566', () => {
       // https://github.com/BetterThanTomorrow/calva/issues/566
       const tokens = scanner.processLine('foo=? foo');
-      expect(tokens[0].type).toBe('id');
-      expect(tokens[0].raw).toBe('foo=?');
-      expect(tokens[1].type).toBe('ws');
-      expect(tokens[1].raw).toBe(' ');
-      expect(tokens[2].type).toBe('id');
-      expect(tokens[2].raw).toBe('foo');
+      expectLib.expect(tokens[0].type).toBe('id');
+      expectLib.expect(tokens[0].raw).toBe('foo=?');
+      expectLib.expect(tokens[1].type).toBe('ws');
+      expectLib.expect(tokens[1].raw).toBe(' ');
+      expectLib.expect(tokens[2].type).toBe('id');
+      expectLib.expect(tokens[2].raw).toBe('foo');
     });
     it('does not treat var quoted symbols as reader tags - #584', () => {
       // https://github.com/BetterThanTomorrow/calva/issues/584
       const tokens = scanner.processLine("#'foo");
-      expect(tokens[0].type).toBe('id');
-      expect(tokens[0].raw).toBe("#'foo");
+      expectLib.expect(tokens[0].type).toBe('id');
+      expectLib.expect(tokens[0].raw).toBe("#'foo");
     });
     it('does not croak on funny data in strings - #659', () => {
       // https://github.com/BetterThanTomorrow/calva/issues/659
       const tokens = scanner.processLine('" "'); // <- That's not a regular space
-      expect(tokens[0].type).toBe('open');
-      expect(tokens[0].raw).toBe('"');
-      expect(tokens[1].type).toBe('junk');
-      expect(tokens[1].raw).toBe(' ');
-      expect(tokens[2].type).toBe('close');
-      expect(tokens[2].raw).toBe('"');
+      expectLib.expect(tokens[0].type).toBe('open');
+      expectLib.expect(tokens[0].raw).toBe('"');
+      expectLib.expect(tokens[1].type).toBe('junk');
+      expectLib.expect(tokens[1].raw).toBe(' ');
+      expectLib.expect(tokens[2].type).toBe('close');
+      expectLib.expect(tokens[2].raw).toBe('"');
     });
     it('does not hang on matching token rule regexes against a string of hashes', () => {
       // https://github.com/BetterThanTomorrow/calva/issues/667
       const text = '#################################################';
-      const rule = toplevel.rules.find((rule) => rule.name === 'open');
-      toplevel.rules.forEach((rule) => {
+      const rule = clojureLexer.toplevel.rules.find((rule) => rule.name === 'open');
+      clojureLexer.toplevel.rules.forEach((rule) => {
         console.log(`Testing rule: ${rule.name}`);
         const x = rule.r.exec(text);
         console.log(`Tested rule: ${rule.name}`);
         if (!['reader', 'junk'].includes(rule.name)) {
-          expect(x).toBeNull();
+          expectLib.expect(x).toBeNull();
         } else {
-          expect(x.length).toBe(1);
+          expectLib.expect(x.length).toBe(1);
         }
       });
     });
@@ -718,9 +718,9 @@ describe('Scanner', () => {
       // https://github.com/BetterThanTomorrow/calva/issues/659
       const text = ';; ################################################# FRONTEND';
       const tokens = scanner.processLine(text);
-      expect(tokens.length).toBe(2);
-      expect(tokens[0].type).toBe('comment');
-      expect(tokens[0].raw === text);
+      expectLib.expect(tokens.length).toBe(2);
+      expectLib.expect(tokens[0].type).toBe('comment');
+      expectLib.expect(tokens[0].raw === text);
     });
   });
 });

--- a/src/extension-test/unit/cursor-doc/cursor-context-test.ts
+++ b/src/extension-test/unit/cursor-doc/cursor-context-test.ts
@@ -1,394 +1,524 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as context from '../../../cursor-doc/cursor-context';
-import { docFromTextNotation, textAndSelection } from '../common/text-notation';
+import * as textNotation from '../common/text-notation';
 
 describe('Cursor Contexts', () => {
   describe('cursorInString', () => {
     it('is true in string', () => {
-      const contexts = context.determineContexts(docFromTextNotation('foo•   "bar•  |baz"•gaz'));
-      expect(contexts.includes('calva:cursorInString')).toBe(true);
+      const contexts = context.determineContexts(
+        textNotation.docFromTextNotation('foo•   "bar•  |baz"•gaz')
+      );
+      expectLib.expect(contexts.includes('calva:cursorInString')).toBe(true);
     });
     it('is false outside after string', () => {
-      const contexts = context.determineContexts(docFromTextNotation('foo•   "bar•  baz"|•gaz'));
-      expect(contexts.includes('calva:cursorInString')).toBe(false);
+      const contexts = context.determineContexts(
+        textNotation.docFromTextNotation('foo•   "bar•  baz"|•gaz')
+      );
+      expectLib.expect(contexts.includes('calva:cursorInString')).toBe(false);
     });
     it('is true in regexp', () => {
-      const contexts = context.determineContexts(docFromTextNotation('foo•   #"bar•  ba|z"•gaz'));
-      expect(contexts.includes('calva:cursorInString')).toBe(true);
+      const contexts = context.determineContexts(
+        textNotation.docFromTextNotation('foo•   #"bar•  ba|z"•gaz')
+      );
+      expectLib.expect(contexts.includes('calva:cursorInString')).toBe(true);
     });
     it('is false in regexp open token', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation('foo•   #|"bat bar•  baz"•gaz')
+        textNotation.docFromTextNotation('foo•   #|"bat bar•  baz"•gaz')
       );
-      expect(contexts.includes('calva:cursorInString')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorInString')).toBe(false);
     });
   });
   describe('cursorInComment', () => {
     it('is true in comment', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; f|oo•   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation(';; f|oo•   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorInComment')).toBe(true);
+      expectLib.expect(contexts.includes('calva:cursorInComment')).toBe(true);
     });
     it('is true adjacent before comment', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation('|;; foo•   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation('|;; foo•   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorInComment')).toBe(true);
+      expectLib.expect(contexts.includes('calva:cursorInComment')).toBe(true);
     });
     it('is true in whitespace between SOL and comment', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo•|   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation(';; foo•|   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorInComment')).toBe(true);
+      expectLib.expect(contexts.includes('calva:cursorInComment')).toBe(true);
     });
     it('is true adjacent after comment', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo |•   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation(';; foo |•   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorInComment')).toBe(true);
+      expectLib.expect(contexts.includes('calva:cursorInComment')).toBe(true);
     });
     it('is false in symbol', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  •g|az   ;;  ')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  •g|az   ;;  ')
       );
-      expect(contexts.includes('calva:cursorInComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorInComment')).toBe(false);
     });
     it('is false adjacent after symbol', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz|   ;;  ')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz|   ;;  ')
       );
-      expect(contexts.includes('calva:cursorInComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorInComment')).toBe(false);
     });
     it('is false in whitespace after symbol', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz |  ;;  ')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz |  ;;  ')
       );
-      expect(contexts.includes('calva:cursorInComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorInComment')).toBe(false);
     });
     it('is true after symbol adjacent before comment', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz   |;;  ')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz   |;;  ')
       );
-      expect(contexts.includes('calva:cursorInComment')).toBe(true);
+      expectLib.expect(contexts.includes('calva:cursorInComment')).toBe(true);
     });
     it('is false in leading ws on line after comment', () => {
-      const contexts = context.determineContexts(docFromTextNotation('(+• ;foo• | 2)'));
-      expect(contexts.includes('calva:cursorInComment')).toBe(false);
+      const contexts = context.determineContexts(
+        textNotation.docFromTextNotation('(+• ;foo• | 2)')
+      );
+      expectLib.expect(contexts.includes('calva:cursorInComment')).toBe(false);
     });
   });
   describe('cursorBeforeComment', () => {
     it('is false in comment', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; fo|o•   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation(';; fo|o•   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
     });
     it('is true adjacent before comment starting a line', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation('|;; foo•   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation('|;; foo•   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorBeforeComment')).toBe(true);
+      expectLib.expect(contexts.includes('calva:cursorBeforeComment')).toBe(true);
     });
     it('is true adjacent before comment with space before', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(' |;; foo•   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation(' |;; foo•   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorBeforeComment')).toBe(true);
+      expectLib.expect(contexts.includes('calva:cursorBeforeComment')).toBe(true);
     });
     it('is false before comment with space between', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation('| ;; foo•   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation('| ;; foo•   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorBeforeComment')).toBe(true);
+      expectLib.expect(contexts.includes('calva:cursorBeforeComment')).toBe(true);
     });
     it('is false adjacent before comment on line with leading witespace and preceding comment line', () => {
-      const contexts = context.determineContexts(docFromTextNotation(' ;; foo• |;; bar'));
-      expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
+      const contexts = context.determineContexts(
+        textNotation.docFromTextNotation(' ;; foo• |;; bar')
+      );
+      expectLib.expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
     });
     it('is true after symbol in whitespace between SOL and comment', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(' foo•|   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation(' foo•|   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorBeforeComment')).toBe(true);
+      expectLib.expect(contexts.includes('calva:cursorBeforeComment')).toBe(true);
     });
     it('is false at SOL on a comment line with more comment lines following', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •|   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation(';; foo •|   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
     });
     it('is false at empty line squeezed in along comments lines', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   •|•   •   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation(';; foo •   •|•   •   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
     });
     it('is false after comment lines before symbol', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  |•gaz   ;;  ')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  |•gaz   ;;  ')
       );
-      expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
     });
     it('is false in symbol', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  •g|az   ;;  ')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  •g|az   ;;  ')
       );
-      expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
     });
     it('is false adjacent after symbol after comment lines', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz|   ;;  ')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz|   ;;  ')
       );
-      expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
     });
     it('is false in whitespace after symbol', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz |  ;;  ')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz |  ;;  ')
       );
-      expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
     });
     it('is true adjacent before comment after symbol', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz   |;;  ')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz   |;;  ')
       );
-      expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
     });
     it('is false at EOT after comment', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz   ;;  |')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz   ;;  |')
       );
-      expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorBeforeComment')).toBe(false);
     });
   });
   describe('cursorAfterComment', () => {
     it('is false in comment', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; fo|o•   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation(';; fo|o•   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
     });
     it('is false adjacent before comment', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation('|;; foo•   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation('|;; foo•   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
     });
     it('is false in whitespace between SOL and comment', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo•|   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation(';; foo•|   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
     });
     it('is false at EOL on a comment line with more comment lines following', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo |•   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation(';; foo |•   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
     });
     it('is false at empty line squeezed in along comments lines', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   •|•   •   ;; bar•  ;; baz  •gaz')
+        textNotation.docFromTextNotation(';; foo •   •|•   •   ;; bar•  ;; baz  •gaz')
       );
-      expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
     });
     it('is true after comment lines before symbol', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  |•gaz   ;;  ')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  |•gaz   ;;  ')
       );
-      expect(contexts.includes('calva:cursorAfterComment')).toBe(true);
+      expectLib.expect(contexts.includes('calva:cursorAfterComment')).toBe(true);
     });
     it('is false in symbol', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  •g|az   ;;  ')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  •g|az   ;;  ')
       );
-      expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
     });
     it('is false adjacent after symbol after comment lines', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz|   ;;  ')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz|   ;;  ')
       );
-      expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
     });
     it('is false in whitespace after symbol', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz |  ;;  ')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz |  ;;  ')
       );
-      expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
+      expectLib.expect(contexts.includes('calva:cursorAfterComment')).toBe(false);
     });
     it('is true at EOT after comment', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz   ;;  |')
+        textNotation.docFromTextNotation(';; foo •   ;; bar•  ;; baz  •gaz   ;;  |')
       );
-      expect(contexts.includes('calva:cursorAfterComment')).toBe(true);
+      expectLib.expect(contexts.includes('calva:cursorAfterComment')).toBe(true);
     });
   });
   describe('isAtLineStartInclWS', () => {
     it('returns true at the start of a line', () => {
-      expect(
-        context.isAtLineStartInclWS(docFromTextNotation('|;; foo•   ;; bar•  ;; baz  •gaz'))
-      ).toBe(true);
-      expect(
-        context.isAtLineStartInclWS(docFromTextNotation(';; foo•   ;; bar•  ;; baz  •|gaz'))
-      ).toBe(true);
+      expectLib
+        .expect(
+          context.isAtLineStartInclWS(
+            textNotation.docFromTextNotation('|;; foo•   ;; bar•  ;; baz  •gaz')
+          )
+        )
+        .toBe(true);
+      expectLib
+        .expect(
+          context.isAtLineStartInclWS(
+            textNotation.docFromTextNotation(';; foo•   ;; bar•  ;; baz  •|gaz')
+          )
+        )
+        .toBe(true);
     });
     it('returns true at line start with leading whitespace', () => {
-      expect(
-        context.isAtLineStartInclWS(docFromTextNotation(';; foo•   |;; bar•  ;; baz  •gaz'))
-      ).toBe(true);
-      expect(
-        context.isAtLineStartInclWS(docFromTextNotation(';; foo• |  ;; bar•  ;; baz  •gaz'))
-      ).toBe(true);
-      expect(
-        context.isAtLineStartInclWS(docFromTextNotation(';; foo•|   ;; bar•  ;; baz  •gaz'))
-      ).toBe(true);
+      expectLib
+        .expect(
+          context.isAtLineStartInclWS(
+            textNotation.docFromTextNotation(';; foo•   |;; bar•  ;; baz  •gaz')
+          )
+        )
+        .toBe(true);
+      expectLib
+        .expect(
+          context.isAtLineStartInclWS(
+            textNotation.docFromTextNotation(';; foo• |  ;; bar•  ;; baz  •gaz')
+          )
+        )
+        .toBe(true);
+      expectLib
+        .expect(
+          context.isAtLineStartInclWS(
+            textNotation.docFromTextNotation(';; foo•|   ;; bar•  ;; baz  •gaz')
+          )
+        )
+        .toBe(true);
     });
     it('returns true at end of line with only whitespace', () => {
-      expect(context.isAtLineStartInclWS(docFromTextNotation(';; foo•    |•  ;; baz  •gaz'))).toBe(
-        true
-      );
+      expectLib
+        .expect(
+          context.isAtLineStartInclWS(
+            textNotation.docFromTextNotation(';; foo•    |•  ;; baz  •gaz')
+          )
+        )
+        .toBe(true);
     });
     it('returns true at start of line with only whitespace', () => {
-      expect(context.isAtLineStartInclWS(docFromTextNotation(';; foo•|    •  ;; baz  •gaz'))).toBe(
-        true
-      );
+      expectLib
+        .expect(
+          context.isAtLineStartInclWS(
+            textNotation.docFromTextNotation(';; foo•|    •  ;; baz  •gaz')
+          )
+        )
+        .toBe(true);
     });
     it('returns true in middle of line with only whitespace', () => {
-      expect(context.isAtLineStartInclWS(docFromTextNotation(';; foo•  |  •  ;; baz  •gaz'))).toBe(
-        true
-      );
+      expectLib
+        .expect(
+          context.isAtLineStartInclWS(
+            textNotation.docFromTextNotation(';; foo•  |  •  ;; baz  •gaz')
+          )
+        )
+        .toBe(true);
     });
     it('returns true at empty line', () => {
-      expect(context.isAtLineStartInclWS(docFromTextNotation(';; foo•|•  ;; baz  •gaz'))).toBe(
-        true
-      );
+      expectLib
+        .expect(
+          context.isAtLineStartInclWS(textNotation.docFromTextNotation(';; foo•|•  ;; baz  •gaz'))
+        )
+        .toBe(true);
     });
     it('returns true at line start with leading & trailing whitespace', () => {
-      expect(
-        context.isAtLineStartInclWS(docFromTextNotation(';; foo•   ;; bar• | ;; baz  •gaz'))
-      ).toBe(true);
+      expectLib
+        .expect(
+          context.isAtLineStartInclWS(
+            textNotation.docFromTextNotation(';; foo•   ;; bar• | ;; baz  •gaz')
+          )
+        )
+        .toBe(true);
     });
     it('returns false within a line (non-whitespace)', () => {
-      expect(
-        context.isAtLineStartInclWS(docFromTextNotation(';|; foo•   ;; bar•  ;; baz  •gaz'))
-      ).toBe(false);
+      expectLib
+        .expect(
+          context.isAtLineStartInclWS(
+            textNotation.docFromTextNotation(';|; foo•   ;; bar•  ;; baz  •gaz')
+          )
+        )
+        .toBe(false);
     });
     it('returns false within a line with leading whitespace', () => {
-      expect(
-        context.isAtLineStartInclWS(docFromTextNotation(';; foo•   ;; |bar•  ;; baz  •gaz'))
-      ).toBe(false);
+      expectLib
+        .expect(
+          context.isAtLineStartInclWS(
+            textNotation.docFromTextNotation(';; foo•   ;; |bar•  ;; baz  •gaz')
+          )
+        )
+        .toBe(false);
     });
     it('returns false at the end of a line', () => {
-      expect(
-        context.isAtLineStartInclWS(docFromTextNotation(';; foo|•   ;; bar•  ;; baz  •gaz'))
-      ).toBe(false);
+      expectLib
+        .expect(
+          context.isAtLineStartInclWS(
+            textNotation.docFromTextNotation(';; foo|•   ;; bar•  ;; baz  •gaz')
+          )
+        )
+        .toBe(false);
     });
     it('returns false at the end of document', () => {
-      expect(
-        context.isAtLineStartInclWS(docFromTextNotation(';; foo•   ;; bar•  ;; baz  •gaz|'))
-      ).toBe(false);
+      expectLib
+        .expect(
+          context.isAtLineStartInclWS(
+            textNotation.docFromTextNotation(';; foo•   ;; bar•  ;; baz  •gaz|')
+          )
+        )
+        .toBe(false);
     });
   });
   describe('isAtLineEndInclWS', () => {
     it('returns true at the end of a line', () => {
-      expect(
-        context.isAtLineEndInclWS(docFromTextNotation(';; foo•   ;; bar   •  ;; baz  •gaz|'))
-      ).toBe(true);
-      expect(
-        context.isAtLineEndInclWS(docFromTextNotation(';; foo|•   ;; bar   •  ;; baz  •gaz'))
-      ).toBe(true);
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(
+            textNotation.docFromTextNotation(';; foo•   ;; bar   •  ;; baz  •gaz|')
+          )
+        )
+        .toBe(true);
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(
+            textNotation.docFromTextNotation(';; foo|•   ;; bar   •  ;; baz  •gaz')
+          )
+        )
+        .toBe(true);
     });
     it('returns true at line end with trailing whitespace', () => {
-      expect(
-        context.isAtLineEndInclWS(docFromTextNotation(';; foo•   ;; bar|  •  ;; baz  •gaz'))
-      ).toBe(true);
-      expect(
-        context.isAtLineEndInclWS(docFromTextNotation(';; foo•   ;; bar  |•  ;; baz  •gaz'))
-      ).toBe(true);
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(
+            textNotation.docFromTextNotation(';; foo•   ;; bar|  •  ;; baz  •gaz')
+          )
+        )
+        .toBe(true);
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(
+            textNotation.docFromTextNotation(';; foo•   ;; bar  |•  ;; baz  •gaz')
+          )
+        )
+        .toBe(true);
     });
     it('returns true at line end with leading & trailing whitespace', () => {
-      expect(
-        context.isAtLineEndInclWS(docFromTextNotation(';; foo•   ;; bar | •  ;; baz  •gaz'))
-      ).toBe(true);
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(
+            textNotation.docFromTextNotation(';; foo•   ;; bar | •  ;; baz  •gaz')
+          )
+        )
+        .toBe(true);
     });
     it('returns true at end of line with only whitespace', () => {
-      expect(context.isAtLineEndInclWS(docFromTextNotation(';; foo•    |•  ;; baz  •gaz'))).toBe(
-        true
-      );
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(textNotation.docFromTextNotation(';; foo•    |•  ;; baz  •gaz'))
+        )
+        .toBe(true);
     });
     it('returns true at start of line with only whitespace', () => {
-      expect(context.isAtLineEndInclWS(docFromTextNotation(';; foo•|    •  ;; baz  •gaz'))).toBe(
-        true
-      );
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(textNotation.docFromTextNotation(';; foo•|    •  ;; baz  •gaz'))
+        )
+        .toBe(true);
     });
     it('returns true in middle of line with only whitespace', () => {
-      expect(context.isAtLineEndInclWS(docFromTextNotation(';; foo•  |  •  ;; baz  •gaz'))).toBe(
-        true
-      );
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(textNotation.docFromTextNotation(';; foo•  |  •  ;; baz  •gaz'))
+        )
+        .toBe(true);
     });
     it('returns true at empty line', () => {
-      expect(context.isAtLineEndInclWS(docFromTextNotation(';; foo•|•  ;; baz  •gaz'))).toBe(true);
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(textNotation.docFromTextNotation(';; foo•|•  ;; baz  •gaz'))
+        )
+        .toBe(true);
     });
     it('returns true at line start with only leading & trailing whitespace', () => {
-      expect(
-        context.isAtLineEndInclWS(docFromTextNotation(';; foo•   ;; bar | •  ;; baz  •gaz'))
-      ).toBe(true);
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(
+            textNotation.docFromTextNotation(';; foo•   ;; bar | •  ;; baz  •gaz')
+          )
+        )
+        .toBe(true);
     });
     it('returns false within a line (non-whitespace)', () => {
-      expect(
-        context.isAtLineEndInclWS(docFromTextNotation(';; foo•   ;; bar•  ;; ba|z  •gaz'))
-      ).toBe(false);
-      expect(
-        context.isAtLineEndInclWS(docFromTextNotation(';; foo•   ;; bar•  ;; ba|z  •gaz ;|;'))
-      ).toBe(false);
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(
+            textNotation.docFromTextNotation(';; foo•   ;; bar•  ;; ba|z  •gaz')
+          )
+        )
+        .toBe(false);
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(
+            textNotation.docFromTextNotation(';; foo•   ;; bar•  ;; ba|z  •gaz ;|;')
+          )
+        )
+        .toBe(false);
     });
     it('returns false within a line with trailing whitespace', () => {
-      expect(
-        context.isAtLineEndInclWS(docFromTextNotation(';; foo•   ;; bar•  ;|; baz  •gaz'))
-      ).toBe(false);
-      expect(
-        context.isAtLineEndInclWS(docFromTextNotation(';; foo•   ;; bar•  ;; b|az  •gaz'))
-      ).toBe(false);
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(
+            textNotation.docFromTextNotation(';; foo•   ;; bar•  ;|; baz  •gaz')
+          )
+        )
+        .toBe(false);
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(
+            textNotation.docFromTextNotation(';; foo•   ;; bar•  ;; b|az  •gaz')
+          )
+        )
+        .toBe(false);
     });
     it('returns false at the start of a line', () => {
-      expect(
-        context.isAtLineEndInclWS(docFromTextNotation(';; foo•   ;; bar•|  ;; baz  •gaz'))
-      ).toBe(false);
-      expect(
-        context.isAtLineEndInclWS(docFromTextNotation('|;; foo•   ;; bar•  ;; baz  •gaz'))
-      ).toBe(false);
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(
+            textNotation.docFromTextNotation(';; foo•   ;; bar•|  ;; baz  •gaz')
+          )
+        )
+        .toBe(false);
+      expectLib
+        .expect(
+          context.isAtLineEndInclWS(
+            textNotation.docFromTextNotation('|;; foo•   ;; bar•  ;; baz  •gaz')
+          )
+        )
+        .toBe(false);
     });
   });
   describe('cursorInWhitespaceAfterComment', () => {
     it('is false in whitespace directly after comment; the parser considers this part of a comment', () => {
-      const contexts = context.determineContexts(docFromTextNotation(';; comment line | '));
-      expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
+      const contexts = context.determineContexts(
+        textNotation.docFromTextNotation(';; comment line | ')
+      );
+      expectLib.expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
     });
     it('is true after newline after comment', () => {
-      const contexts = context.determineContexts(docFromTextNotation(';; comment line•| '));
-      expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(true);
+      const contexts = context.determineContexts(
+        textNotation.docFromTextNotation(';; comment line•| ')
+      );
+      expectLib.expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(true);
     });
     it('is true in whitespace after newlines after comment', () => {
       const contexts = context.determineContexts(
-        docFromTextNotation(':foo ;; comment line•• •  | ')
+        textNotation.docFromTextNotation(':foo ;; comment line•• •  | ')
       );
-      expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(true);
+      expectLib.expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(true);
     });
     it('is false after a symbol', () => {
-      const contexts = context.determineContexts(docFromTextNotation(':foo | '));
-      expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
+      const contexts = context.determineContexts(textNotation.docFromTextNotation(':foo | '));
+      expectLib.expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
     });
     it('is false after symbol, newlines, and whitespace', () => {
-      const contexts = context.determineContexts(docFromTextNotation('{:foo :bar}•• •  | '));
-      expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
+      const contexts = context.determineContexts(
+        textNotation.docFromTextNotation('{:foo :bar}•• •  | ')
+      );
+      expectLib.expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
     });
     it('is false inside a comment', () => {
-      const contexts = context.determineContexts(docFromTextNotation(';; comment| line'));
-      expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
+      const contexts = context.determineContexts(
+        textNotation.docFromTextNotation(';; comment| line')
+      );
+      expectLib.expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
     });
     it('is false at the beginning of a document', () => {
-      const contexts = context.determineContexts(docFromTextNotation('| '));
-      expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
+      const contexts = context.determineContexts(textNotation.docFromTextNotation('| '));
+      expectLib.expect(contexts.includes('calva:cursorInWhitespaceAfterComment')).toBe(false);
     });
   });
 });

--- a/src/extension-test/unit/cursor-doc/indent-test.ts
+++ b/src/extension-test/unit/cursor-doc/indent-test.ts
@@ -1,7 +1,7 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as model from '../../../cursor-doc/model';
 import * as indent from '../../../cursor-doc/indent';
-import { docFromTextNotation, textAndSelection } from '../common/text-notation';
+import * as textNotation from '../common/text-notation';
 
 model.initScanner(20000);
 
@@ -9,255 +9,297 @@ describe('indent', () => {
   describe('getIndent', () => {
     describe('lists', () => {
       it('calculates indents for cursor in empty list', () => {
-        const doc = docFromTextNotation('(|)');
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(1);
+        const doc = textNotation.docFromTextNotation('(|)');
+        expectLib
+          .expect(indent.getIndent(doc.model, textNotation.textAndSelection(doc)[1][0]))
+          .toEqual(1);
       });
       it('calculates indents for cursor in empty list prepended by text', () => {
-        const doc = docFromTextNotation('  a b (|)');
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(7);
+        const doc = textNotation.docFromTextNotation('  a b (|)');
+        expectLib
+          .expect(indent.getIndent(doc.model, textNotation.textAndSelection(doc)[1][0]))
+          .toEqual(7);
       });
       it('calculates indents for empty list inside vector', () => {
-        const doc = docFromTextNotation('[(|)]');
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(2);
+        const doc = textNotation.docFromTextNotation('[(|)]');
+        expectLib
+          .expect(indent.getIndent(doc.model, textNotation.textAndSelection(doc)[1][0]))
+          .toEqual(2);
       });
       it("calculates indents for cursor in at arg 0 in `[['inner' 0]]`", () => {
-        const doc = docFromTextNotation('(foo|)');
-        expect(
-          indent.getIndent(
-            doc.model,
-            textAndSelection(doc)[1][0],
-            mkConfig({
-              '#"^\\w"': [['inner', 0]],
-            })
+        const doc = textNotation.docFromTextNotation('(foo|)');
+        expectLib
+          .expect(
+            indent.getIndent(
+              doc.model,
+              textNotation.textAndSelection(doc)[1][0],
+              mkConfig({
+                '#"^\\w"': [['inner', 0]],
+              })
+            )
           )
-        ).toEqual(2);
+          .toEqual(2);
       });
       it("calculates indents for arg 1 in `[['inner' 0]]`", () => {
-        const doc = docFromTextNotation('(foo x|)');
-        expect(
-          indent.getIndent(
-            doc.model,
-            textAndSelection(doc)[1][0],
-            mkConfig({
-              '#"^\\w"': [['inner', 0]],
-            })
+        const doc = textNotation.docFromTextNotation('(foo x|)');
+        expectLib
+          .expect(
+            indent.getIndent(
+              doc.model,
+              textNotation.textAndSelection(doc)[1][0],
+              mkConfig({
+                '#"^\\w"': [['inner', 0]],
+              })
+            )
           )
-        ).toEqual(2);
+          .toEqual(2);
       });
       it("calculates indents for cursor at arg 0 in `[['block' 1]]`", () => {
-        const doc = docFromTextNotation('(foo|)');
-        expect(
-          indent.getIndent(
-            doc.model,
-            textAndSelection(doc)[1][0],
-            mkConfig({
-              '#"^\\w"': [['block', 1]],
-            })
+        const doc = textNotation.docFromTextNotation('(foo|)');
+        expectLib
+          .expect(
+            indent.getIndent(
+              doc.model,
+              textNotation.textAndSelection(doc)[1][0],
+              mkConfig({
+                '#"^\\w"': [['block', 1]],
+              })
+            )
           )
-        ).toEqual(1);
+          .toEqual(1);
       });
       it("calculates indents for cursor at arg 1 in `[['block' 1]]`", () => {
-        const doc = docFromTextNotation('(foo x|)');
-        expect(
-          indent.getIndent(
-            doc.model,
-            textAndSelection(doc)[1][0],
-            mkConfig({
-              '#"^\\w"': [['block', 1]],
-            })
+        const doc = textNotation.docFromTextNotation('(foo x|)');
+        expectLib
+          .expect(
+            indent.getIndent(
+              doc.model,
+              textNotation.textAndSelection(doc)[1][0],
+              mkConfig({
+                '#"^\\w"': [['block', 1]],
+              })
+            )
           )
-        ).toEqual(2);
+          .toEqual(2);
       });
       it('calculates indents for `foo` given different rules for `fo` and `foo`', () => {
-        const doc = docFromTextNotation('(foo [] |x)');
-        expect(
-          indent.getIndent(
-            doc.model,
-            textAndSelection(doc)[1][0],
-            mkConfig({
-              fo: [['block', 0]],
-              foo: [['block', 1]],
-            })
+        const doc = textNotation.docFromTextNotation('(foo [] |x)');
+        expectLib
+          .expect(
+            indent.getIndent(
+              doc.model,
+              textNotation.textAndSelection(doc)[1][0],
+              mkConfig({
+                fo: [['block', 0]],
+                foo: [['block', 1]],
+              })
+            )
           )
-        ).toEqual(2);
+          .toEqual(2);
       });
       it('custom config does not override indents for default `defn`', () => {
-        const doc = docFromTextNotation('(defn foo [] |x)');
-        expect(
-          indent.getIndent(
-            doc.model,
-            textAndSelection(doc)[1][0],
-            mkConfig({
-              foo: [['block', 0]],
-            })
+        const doc = textNotation.docFromTextNotation('(defn foo [] |x)');
+        expectLib
+          .expect(
+            indent.getIndent(
+              doc.model,
+              textNotation.textAndSelection(doc)[1][0],
+              mkConfig({
+                foo: [['block', 0]],
+              })
+            )
           )
-        ).toEqual(2);
+          .toEqual(2);
       });
     });
 
     describe('vectors', () => {
       it('calculates indents for cursor in empty vector', () => {
-        const doc = docFromTextNotation('[|]');
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(1);
+        const doc = textNotation.docFromTextNotation('[|]');
+        expectLib
+          .expect(indent.getIndent(doc.model, textNotation.textAndSelection(doc)[1][0]))
+          .toEqual(1);
       });
       it('calculates indents for cursor in empty vector inside list', () => {
-        const doc = docFromTextNotation('([|])');
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(2);
+        const doc = textNotation.docFromTextNotation('([|])');
+        expectLib
+          .expect(indent.getIndent(doc.model, textNotation.textAndSelection(doc)[1][0]))
+          .toEqual(2);
       });
       it('does not use indent rules for vectors with symbols at ”call” position', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1622
-        const doc = docFromTextNotation('[foo|]');
-        expect(
-          indent.getIndent(
-            doc.model,
-            textAndSelection(doc)[1][0],
-            mkConfig({
-              '#"^\\w"': [['inner', 0]],
-            })
+        const doc = textNotation.docFromTextNotation('[foo|]');
+        expectLib
+          .expect(
+            indent.getIndent(
+              doc.model,
+              textNotation.textAndSelection(doc)[1][0],
+              mkConfig({
+                '#"^\\w"': [['inner', 0]],
+              })
+            )
           )
-        ).toEqual(1);
+          .toEqual(1);
       });
     });
 
     describe('maps', () => {
       it('calculates indents for cursor in empty map', () => {
-        const doc = docFromTextNotation('{|}');
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(1);
+        const doc = textNotation.docFromTextNotation('{|}');
+        expectLib
+          .expect(indent.getIndent(doc.model, textNotation.textAndSelection(doc)[1][0]))
+          .toEqual(1);
       });
       it('calculates indents for cursor in empty map inside list inside a vector', () => {
-        const doc = docFromTextNotation('([{|}])');
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(3);
+        const doc = textNotation.docFromTextNotation('([{|}])');
+        expectLib
+          .expect(indent.getIndent(doc.model, textNotation.textAndSelection(doc)[1][0]))
+          .toEqual(3);
       });
       it('does not use indent rules for maps with symbols at ”call” position', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1622
-        const doc = docFromTextNotation('{foo|}');
-        expect(
-          indent.getIndent(
-            doc.model,
-            textAndSelection(doc)[1][0],
-            mkConfig({
-              '#"^\\w"': [['inner', 0]],
-            })
+        const doc = textNotation.docFromTextNotation('{foo|}');
+        expectLib
+          .expect(
+            indent.getIndent(
+              doc.model,
+              textNotation.textAndSelection(doc)[1][0],
+              mkConfig({
+                '#"^\\w"': [['inner', 0]],
+              })
+            )
           )
-        ).toEqual(1);
+          .toEqual(1);
       });
     });
 
     describe('sets', () => {
       it('calculates indents for cursor in empty set', () => {
-        const doc = docFromTextNotation('#{|}');
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(2);
+        const doc = textNotation.docFromTextNotation('#{|}');
+        expectLib
+          .expect(indent.getIndent(doc.model, textNotation.textAndSelection(doc)[1][0]))
+          .toEqual(2);
       });
       it('calculates indents for cursor in empty set inside list inside a vector', () => {
-        const doc = docFromTextNotation('([#{|}])');
-        expect(indent.getIndent(doc.model, textAndSelection(doc)[1][0])).toEqual(4);
+        const doc = textNotation.docFromTextNotation('([#{|}])');
+        expectLib
+          .expect(indent.getIndent(doc.model, textNotation.textAndSelection(doc)[1][0]))
+          .toEqual(4);
       });
       it('does not use indent rules for maps with symbols at ”call” position', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1622
-        const doc = docFromTextNotation('#{foo|}');
-        expect(
-          indent.getIndent(
-            doc.model,
-            textAndSelection(doc)[1][0],
-            mkConfig({
-              '#"^\\w"': [['inner', 0]],
-            })
+        const doc = textNotation.docFromTextNotation('#{foo|}');
+        expectLib
+          .expect(
+            indent.getIndent(
+              doc.model,
+              textNotation.textAndSelection(doc)[1][0],
+              mkConfig({
+                '#"^\\w"': [['inner', 0]],
+              })
+            )
           )
-        ).toEqual(2);
+          .toEqual(2);
       });
     });
 
     describe('deftype', () => {
       it('calculates indents for cursor on the new line of a method implementation', () => {
-        const doc = docFromTextNotation(`
+        const doc = textNotation.docFromTextNotation(`
 (deftype MyType [arg1 arg2]
   IMyProto
   (method1 [this]
 |(print "hello")))`);
 
-        expect(
-          indent.getIndent(
-            doc.model,
-            textAndSelection(doc)[1][0],
-            mkConfig({
-              deftype: [
-                ['block', 2],
-                ['inner', 1],
-              ],
-              '#"^def(?!ault)(?!late)(?!er)"': [['inner', 0]],
-            })
+        expectLib
+          .expect(
+            indent.getIndent(
+              doc.model,
+              textNotation.textAndSelection(doc)[1][0],
+              mkConfig({
+                deftype: [
+                  ['block', 2],
+                  ['inner', 1],
+                ],
+                '#"^def(?!ault)(?!late)(?!er)"': [['inner', 0]],
+              })
+            )
           )
-        ).toEqual(4);
+          .toEqual(4);
       });
     });
     describe('and', () => {
       it('calculates indents for cursor on the new line before the second argument with clojure regex config', () => {
-        const doc = docFromTextNotation(`
+        const doc = textNotation.docFromTextNotation(`
 (and x
 |y)`);
-        expect(
-          indent.getIndent(
-            doc.model,
-            textAndSelection(doc)[1][0],
-            mkConfig({
-              '#"\\S+"': [['inner', 0]],
-            })
+        expectLib
+          .expect(
+            indent.getIndent(
+              doc.model,
+              textNotation.textAndSelection(doc)[1][0],
+              mkConfig({
+                '#"\\S+"': [['inner', 0]],
+              })
+            )
           )
-        ).toEqual(2);
+          .toEqual(2);
       });
       it('calculates indents for cursor on the new line before the second argument with js regex config', () => {
-        const doc = docFromTextNotation(`
+        const doc = textNotation.docFromTextNotation(`
 (and x
 |y)`);
-        expect(
-          indent.getIndent(
-            doc.model,
-            textAndSelection(doc)[1][0],
-            mkConfig({
-              '/\\S+/': [['inner', 0]],
-            })
+        expectLib
+          .expect(
+            indent.getIndent(
+              doc.model,
+              textNotation.textAndSelection(doc)[1][0],
+              mkConfig({
+                '/\\S+/': [['inner', 0]],
+              })
+            )
           )
-        ).toEqual(2);
+          .toEqual(2);
       });
     });
     describe('cljfmt defaults', () => {
-      const doc = docFromTextNotation('(let []\n|x)');
-      const defndoc = docFromTextNotation('(defn []\n|x)');
-      const p = textAndSelection(doc)[1][0];
+      const doc = textNotation.docFromTextNotation('(let []\n|x)');
+      const defndoc = textNotation.docFromTextNotation('(defn []\n|x)');
+      const p = textNotation.textAndSelection(doc)[1][0];
       const emptyConfig = mkConfig({});
       it('with empty config, uses the built-in rule for the `let` body', () => {
-        expect(indent.getIndent(doc.model, p, emptyConfig)).toEqual(2);
+        expectLib.expect(indent.getIndent(doc.model, p, emptyConfig)).toEqual(2);
       });
       const someConfig = mkConfig({
         '/foo+/': [['inner', 0]],
       });
       it('with some config, still uses the built-in rule for the `let` body', () => {
-        expect(indent.getIndent(doc.model, p, someConfig)).toEqual(2);
+        expectLib.expect(indent.getIndent(doc.model, p, someConfig)).toEqual(2);
       });
       const blockConfig = mkConfig({
         '/\\S+/': [['block', 0]],
       });
       it('catch-all does not override the built-in rule for the `let` body', () => {
-        expect(indent.getIndent(doc.model, p, blockConfig)).toEqual(2);
+        expectLib.expect(indent.getIndent(doc.model, p, blockConfig)).toEqual(2);
       });
       const letBlockConfig = mkConfig({
         let: [['block', 0]],
       });
       it('symbol let overrides the built-in rule for the `let` body', () => {
-        expect(indent.getIndent(doc.model, p, letBlockConfig)).toEqual(5);
+        expectLib.expect(indent.getIndent(doc.model, p, letBlockConfig)).toEqual(5);
       });
       it('does not overrides the built-in rule for the `defn` body', () => {
-        expect(indent.getIndent(defndoc.model, p, letBlockConfig)).toEqual(2);
+        expectLib.expect(indent.getIndent(defndoc.model, p, letBlockConfig)).toEqual(2);
       });
     });
     describe('replacing cljfmt defaults', () => {
       // TODO: We probably need more test cases here
-      const doc = docFromTextNotation('(let []\n|x)');
-      const defndoc = docFromTextNotation('(defn []\n|x)');
-      const p = textAndSelection(doc)[1][0];
+      const doc = textNotation.docFromTextNotation('(let []\n|x)');
+      const defndoc = textNotation.docFromTextNotation('(defn []\n|x)');
+      const p = textNotation.textAndSelection(doc)[1][0];
       const emptyConfig = mkConfig({}, {});
       it('with empty replace config, does not use the built-in rule for the `let` body', () => {
-        expect(indent.getIndent(doc.model, p, emptyConfig)).toEqual(5);
+        expectLib.expect(indent.getIndent(doc.model, p, emptyConfig)).toEqual(5);
       });
       const someConfig = mkConfig(
         {
@@ -266,7 +308,7 @@ describe('indent', () => {
         {}
       );
       it('with some config, still uses the built-in the built-in rule for the `let` body', () => {
-        expect(indent.getIndent(doc.model, p, someConfig)).toEqual(5);
+        expectLib.expect(indent.getIndent(doc.model, p, someConfig)).toEqual(5);
       });
     });
   });
@@ -274,33 +316,33 @@ describe('indent', () => {
   describe('collectIndents', () => {
     describe('lists', () => {
       it('collects indents for cursor in empty list', () => {
-        const doc = docFromTextNotation('(|)');
+        const doc = textNotation.docFromTextNotation('(|)');
         const rules: indent.IndentRules = {
           '#"^\\w"': [['inner', 0]],
         };
         const state: indent.IndentInformation[] = indent.collectIndents(
           doc.model,
-          textAndSelection(doc)[1][0],
+          textNotation.textAndSelection(doc)[1][0],
           mkConfig(rules)
         );
-        expect(state.length).toEqual(1);
-        expect(state[0].rules).toEqual([]);
+        expectLib.expect(state.length).toEqual(1);
+        expectLib.expect(state[0].rules).toEqual([]);
       });
       it('collects indents for cursor in empty list with structure around', () => {
-        const doc = docFromTextNotation('[](|)(foo)');
+        const doc = textNotation.docFromTextNotation('[](|)(foo)');
         const rules: indent.IndentRules = {
           '#"^\\w"': [['inner', 0]],
         };
         const state: indent.IndentInformation[] = indent.collectIndents(
           doc.model,
-          textAndSelection(doc)[1][0],
+          textNotation.textAndSelection(doc)[1][0],
           mkConfig(rules)
         );
-        expect(state.length).toEqual(1);
-        expect(state[0].rules).toEqual([]);
+        expectLib.expect(state.length).toEqual(1);
+        expectLib.expect(state[0].rules).toEqual([]);
       });
       it('collects indents for cursor in nested structure', () => {
-        const doc = docFromTextNotation('[]•(aa []•(bb•(cc :dd|)))•[]');
+        const doc = textNotation.docFromTextNotation('[]•(aa []•(bb•(cc :dd|)))•[]');
         const rule1: indent.IndentRule[] = [
           ['inner', 0],
           ['block', 1],
@@ -310,41 +352,41 @@ describe('indent', () => {
         };
         const state: indent.IndentInformation[] = indent.collectIndents(
           doc.model,
-          textAndSelection(doc)[1][0],
+          textNotation.textAndSelection(doc)[1][0],
           mkConfig(rules)
         );
-        expect(state.length).toEqual(1);
-        expect(state[0].rules).toEqual(rule1);
+        expectLib.expect(state.length).toEqual(1);
+        expectLib.expect(state[0].rules).toEqual(rule1);
       });
       it('collects indents for empty list inside vector', () => {
-        const doc = docFromTextNotation('[(|)]');
+        const doc = textNotation.docFromTextNotation('[(|)]');
         const rules: indent.IndentRules = {
           '#"^\\w"': [['inner', 0]],
         };
         const state: indent.IndentInformation[] = indent.collectIndents(
           doc.model,
-          textAndSelection(doc)[1][0],
+          textNotation.textAndSelection(doc)[1][0],
           mkConfig(rules)
         );
-        expect(state.length).toEqual(1);
-        expect(state[0].rules).toEqual([]);
+        expectLib.expect(state.length).toEqual(1);
+        expectLib.expect(state[0].rules).toEqual([]);
       });
       it('collects indents for arg 0', () => {
-        const doc = docFromTextNotation('(foo|)');
+        const doc = textNotation.docFromTextNotation('(foo|)');
         const rule1: indent.IndentRule[] = [['inner', 0]];
         const rules: indent.IndentRules = {
           '#"^\\w"': rule1,
         };
         const state: indent.IndentInformation[] = indent.collectIndents(
           doc.model,
-          textAndSelection(doc)[1][0],
+          textNotation.textAndSelection(doc)[1][0],
           mkConfig(rules)
         );
-        expect(state.length).toEqual(1);
-        expect(state[0].rules).toEqual(rule1);
+        expectLib.expect(state.length).toEqual(1);
+        expectLib.expect(state[0].rules).toEqual(rule1);
       });
       it('collects indents for `foo` given different rules for `fo` and `foo`', () => {
-        const doc = docFromTextNotation('(foo|)');
+        const doc = textNotation.docFromTextNotation('(foo|)');
         const rule1: indent.IndentRule[] = [['inner', 0]];
         const rule2: indent.IndentRule[] = [['block', 0]];
         const rules: indent.IndentRules = {
@@ -353,47 +395,47 @@ describe('indent', () => {
         };
         const state: indent.IndentInformation[] = indent.collectIndents(
           doc.model,
-          textAndSelection(doc)[1][0],
+          textNotation.textAndSelection(doc)[1][0],
           mkConfig(rules)
         );
-        expect(state.length).toEqual(1);
-        expect(state[0].rules).toEqual(rule2);
+        expectLib.expect(state.length).toEqual(1);
+        expectLib.expect(state[0].rules).toEqual(rule2);
       });
     });
 
     describe('vectors', () => {
       it('ignores rule arg 0', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1622
-        const doc = docFromTextNotation('[foo|]');
+        const doc = textNotation.docFromTextNotation('[foo|]');
         const rule1: indent.IndentRule[] = [['inner', 0]];
         const rules: indent.IndentRules = {
           '#"^\\w"': rule1,
         };
         const state: indent.IndentInformation[] = indent.collectIndents(
           doc.model,
-          textAndSelection(doc)[1][0],
+          textNotation.textAndSelection(doc)[1][0],
           mkConfig(rules)
         );
-        expect(state.length).toEqual(1);
-        expect(state[0].rules).toEqual([]);
+        expectLib.expect(state.length).toEqual(1);
+        expectLib.expect(state[0].rules).toEqual([]);
       });
     });
 
     describe('maps', () => {
       it('ignores rule arg 0', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1622
-        const doc = docFromTextNotation('{foo|}');
+        const doc = textNotation.docFromTextNotation('{foo|}');
         const rule1: indent.IndentRule[] = [['inner', 0]];
         const rules: indent.IndentRules = {
           '#"^\\w"': rule1,
         };
         const state: indent.IndentInformation[] = indent.collectIndents(
           doc.model,
-          textAndSelection(doc)[1][0],
+          textNotation.textAndSelection(doc)[1][0],
           mkConfig(rules)
         );
-        expect(state.length).toEqual(1);
-        expect(state[0].rules).toEqual([]);
+        expectLib.expect(state.length).toEqual(1);
+        expectLib.expect(state[0].rules).toEqual([]);
       });
     });
   });

--- a/src/extension-test/unit/cursor-doc/paredit-config-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-config-test.ts
@@ -1,8 +1,8 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as paredit from '../../../cursor-doc/paredit';
 import * as pareditConfig from '../../../cursor-doc/paredit-config';
 import * as model from '../../../cursor-doc/model';
-import { docFromTextNotation, getText, textAndSelection } from '../common/text-notation';
+import * as textNotation from '../common/text-notation';
 
 model.initScanner(20000);
 
@@ -10,11 +10,11 @@ describe('paredit-config', () => {
   describe('createPareditConfig', () => {
     it('returns default config when no custom forms provided', () => {
       const config = pareditConfig.createPareditConfig();
-      expect(config.pairForms['vector-binding'].length).toBeGreaterThan(0);
-      expect(config.pairForms.keyword.length).toBeGreaterThan(0);
-      expect(config.pairForms.flat.length).toBeGreaterThan(0);
-      expect(config.threadingMacros.firstArg).toContain('->');
-      expect(config.threadingMacros.lastArg).toContain('->>');
+      expectLib.expect(config.pairForms['vector-binding'].length).toBeGreaterThan(0);
+      expectLib.expect(config.pairForms.keyword.length).toBeGreaterThan(0);
+      expectLib.expect(config.pairForms.flat.length).toBeGreaterThan(0);
+      expectLib.expect(config.threadingMacros.firstArg).toContain('->');
+      expectLib.expect(config.threadingMacros.lastArg).toContain('->>');
     });
 
     it('appends custom vector-binding forms to defaults', () => {
@@ -23,8 +23,8 @@ describe('paredit-config', () => {
       ];
       const config = pareditConfig.createPareditConfig(customForms);
       const names = config.pairForms['vector-binding'].map((f) => f.name);
-      expect(names).toContain('my.ns/custom-let');
-      expect(names).toContain('let'); // default still present
+      expectLib.expect(names).toContain('my.ns/custom-let');
+      expectLib.expect(names).toContain('let'); // default still present
     });
 
     it('appends custom flat forms to defaults', () => {
@@ -33,8 +33,8 @@ describe('paredit-config', () => {
       ];
       const config = pareditConfig.createPareditConfig(customForms);
       const names = config.pairForms.flat.map((f) => f.name);
-      expect(names).toContain('match');
-      expect(names).toContain('cond'); // default still present
+      expectLib.expect(names).toContain('match');
+      expectLib.expect(names).toContain('cond'); // default still present
     });
 
     it('filters out duplicate custom forms that match defaults', () => {
@@ -43,8 +43,8 @@ describe('paredit-config', () => {
       ];
       const config = pareditConfig.createPareditConfig(customForms);
       const condForms = config.pairForms.flat.filter((f) => f.name === 'cond');
-      expect(condForms.length).toBe(1); // only default present, no duplicate
-      expect(condForms[0].offset).toBe(1); // default offset preserved
+      expectLib.expect(condForms.length).toBe(1); // only default present, no duplicate
+      expectLib.expect(condForms[0].offset).toBe(1); // default offset preserved
     });
 
     it('appends custom keyword forms to defaults', () => {
@@ -53,8 +53,8 @@ describe('paredit-config', () => {
       ];
       const config = pareditConfig.createPareditConfig(customForms);
       const keywords = config.pairForms.keyword.map((f) => f.keyword);
-      expect(keywords).toContain(':when');
-      expect(keywords).toContain(':let'); // default still present
+      expectLib.expect(keywords).toContain(':when');
+      expectLib.expect(keywords).toContain(':let'); // default still present
     });
 
     it('appends custom threading macros to defaults', () => {
@@ -62,9 +62,9 @@ describe('paredit-config', () => {
         firstArg: ['as->', 'my-custom->'],
       };
       const config = pareditConfig.createPareditConfig([], customThreading);
-      expect(config.threadingMacros.firstArg).toContain('as->');
-      expect(config.threadingMacros.firstArg).toContain('my-custom->');
-      expect(config.threadingMacros.firstArg).toContain('->'); // default still present
+      expectLib.expect(config.threadingMacros.firstArg).toContain('as->');
+      expectLib.expect(config.threadingMacros.firstArg).toContain('my-custom->');
+      expectLib.expect(config.threadingMacros.firstArg).toContain('->'); // default still present
     });
 
     it('handles forms with tripleMarker', () => {
@@ -73,7 +73,7 @@ describe('paredit-config', () => {
       ];
       const config = pareditConfig.createPareditConfig(customForms);
       const form = config.pairForms.flat.find((f) => f.name === 'my-condp');
-      expect(form?.tripleMarker).toBe(':custom');
+      expectLib.expect(form?.tripleMarker).toBe(':custom');
     });
   });
 
@@ -85,115 +85,115 @@ describe('paredit-config', () => {
         { type: 'keyword', keyword: ':let' },
       ];
       const grouped = pareditConfig.groupPairForms(forms);
-      expect(grouped['vector-binding'].length).toBe(1);
-      expect(grouped.flat.length).toBe(1);
-      expect(grouped.keyword.length).toBe(1);
+      expectLib.expect(grouped['vector-binding'].length).toBe(1);
+      expectLib.expect(grouped.flat.length).toBe(1);
+      expectLib.expect(grouped.keyword.length).toBe(1);
     });
 
     it('handles empty array', () => {
       const grouped = pareditConfig.groupPairForms([]);
-      expect(grouped['vector-binding'].length).toBe(0);
-      expect(grouped.flat.length).toBe(0);
-      expect(grouped.keyword.length).toBe(0);
+      expectLib.expect(grouped['vector-binding'].length).toBe(0);
+      expectLib.expect(grouped.flat.length).toBe(0);
+      expectLib.expect(grouped.keyword.length).toBe(0);
     });
   });
 
   describe('Custom pair forms in paredit operations', () => {
     it('growSelection works with custom vector-binding form', () => {
-      const a = docFromTextNotation('(my-ns/let [x| 1])');
-      const b = docFromTextNotation('(my-ns/let [|x 1|])');
+      const a = textNotation.docFromTextNotation('(my-ns/let [x| 1])');
+      const b = textNotation.docFromTextNotation('(my-ns/let [|x 1|])');
       const customForms: pareditConfig.PairFormConfig[] = [
         { type: 'vector-binding', name: 'my-ns/let' },
       ];
       const config = pareditConfig.createPareditConfig(customForms);
       paredit.growSelection(a, a.selections, config);
-      expect(getText(a)).toBe(getText(b));
+      expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
     });
 
     it('growSelection works with custom flat form', () => {
-      const a = docFromTextNotation('(match x| 1 :one 2 :two)');
-      const b = docFromTextNotation('(match |x 1| :one 2 :two)');
+      const a = textNotation.docFromTextNotation('(match x| 1 :one 2 :two)');
+      const b = textNotation.docFromTextNotation('(match |x 1| :one 2 :two)');
       const customForms: pareditConfig.PairFormConfig[] = [
         { type: 'flat', name: 'match', offset: 1 },
       ];
       const config = pareditConfig.createPareditConfig(customForms);
       paredit.growSelection(a, a.selections, config);
-      expect(getText(a)).toBe(getText(b));
+      expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
     });
 
     it('growSelection works with custom keyword form', () => {
-      const a = docFromTextNotation('(for [x xs :when| true] x)');
-      const b = docFromTextNotation('(for [x xs |:when true|] x)');
+      const a = textNotation.docFromTextNotation('(for [x xs :when| true] x)');
+      const b = textNotation.docFromTextNotation('(for [x xs |:when true|] x)');
       const customForms: pareditConfig.PairFormConfig[] = [
         { type: 'keyword', keyword: ':when', validParents: ['for'] },
       ];
       const config = pareditConfig.createPareditConfig(customForms);
       paredit.growSelection(a, a.selections, config);
-      expect(getText(a)).toBe(getText(b));
+      expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
     });
 
     it('dragSexprForward works with custom flat form', async () => {
-      const a = docFromTextNotation('(match |x 1 :a 2)');
-      const b = docFromTextNotation('(match :a 2 |x 1)');
+      const a = textNotation.docFromTextNotation('(match |x 1 :a 2)');
+      const b = textNotation.docFromTextNotation('(match :a 2 |x 1)');
       const customForms: pareditConfig.PairFormConfig[] = [
         { type: 'flat', name: 'match', offset: 1 },
       ];
       const config = pareditConfig.createPareditConfig(customForms);
       await paredit.dragSexprForward(a, a.selections[0].anchor, a.selections[0].active, config);
-      expect(getText(a)).toBe(getText(b));
+      expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
     });
 
     it('dragSexprBackward works with custom flat form', async () => {
-      const a = docFromTextNotation('(match x 1 |:a 2)');
-      const b = docFromTextNotation('(match |:a 2 x 1)');
+      const a = textNotation.docFromTextNotation('(match x 1 |:a 2)');
+      const b = textNotation.docFromTextNotation('(match |:a 2 x 1)');
       const customForms: pareditConfig.PairFormConfig[] = [
         { type: 'flat', name: 'match', offset: 1 },
       ];
       const config = pareditConfig.createPareditConfig(customForms);
       await paredit.dragSexprBackward(a, a.selections[0].anchor, a.selections[0].active, config);
-      expect(getText(a)).toBe(getText(b));
+      expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
     });
   });
 
   describe('Custom threading macros', () => {
     it('detects custom firstArg threading macro', () => {
-      const a = docFromTextNotation('(as-> x $ (|assoc :a 1 :b 2))');
-      const b = docFromTextNotation('(as-> x $ (|assoc :a 1| :b 2))');
+      const a = textNotation.docFromTextNotation('(as-> x $ (|assoc :a 1 :b 2))');
+      const b = textNotation.docFromTextNotation('(as-> x $ (|assoc :a 1| :b 2))');
       const customThreading: Partial<pareditConfig.ThreadingMacrosConfig> = {
         firstArg: ['as->'],
       };
       const config = pareditConfig.createPareditConfig([], customThreading);
       paredit.growSelection(a, a.selections, config);
-      expect(getText(a)).toBe(getText(b));
+      expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
     });
 
     it('detects custom lastArg threading macro', () => {
-      const a = docFromTextNotation('(my->> x (|assoc {} :a 1 :b))');
-      const b = docFromTextNotation('(my->> x (|assoc {} :a 1| :b))');
+      const a = textNotation.docFromTextNotation('(my->> x (|assoc {} :a 1 :b))');
+      const b = textNotation.docFromTextNotation('(my->> x (|assoc {} :a 1| :b))');
       const customThreading: Partial<pareditConfig.ThreadingMacrosConfig> = {
         lastArg: ['my->>'],
       };
       const config = pareditConfig.createPareditConfig([], customThreading);
       paredit.growSelection(a, a.selections, config);
-      expect(getText(a)).toBe(getText(b));
+      expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
     });
 
     it('applies offset reduction in -> style custom macro', () => {
-      const a = docFromTextNotation('(my-> {} (|assoc :a 1 :b 2))');
-      const b = docFromTextNotation('(my-> {} (|assoc :a 1| :b 2))');
+      const a = textNotation.docFromTextNotation('(my-> {} (|assoc :a 1 :b 2))');
+      const b = textNotation.docFromTextNotation('(my-> {} (|assoc :a 1| :b 2))');
       const customThreading: Partial<pareditConfig.ThreadingMacrosConfig> = {
         firstArg: ['my->'],
       };
       const config = pareditConfig.createPareditConfig([], customThreading);
       paredit.growSelection(a, a.selections, config);
-      expect(getText(a)).toBe(getText(b));
+      expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
     });
   });
 
   describe('Combined custom forms and threading', () => {
     it('works with custom form inside custom threading macro', () => {
-      const a = docFromTextNotation('(my-> x (match |1 :one 2 :two))');
-      const b = docFromTextNotation('(my-> x (match |1 :one| 2 :two))');
+      const a = textNotation.docFromTextNotation('(my-> x (match |1 :one 2 :two))');
+      const b = textNotation.docFromTextNotation('(my-> x (match |1 :one| 2 :two))');
       const customForms: pareditConfig.PairFormConfig[] = [
         { type: 'flat', name: 'match', offset: 1 },
       ];
@@ -202,24 +202,24 @@ describe('paredit-config', () => {
       };
       const config = pareditConfig.createPareditConfig(customForms, customThreading);
       paredit.growSelection(a, a.selections, config);
-      expect(getText(a)).toBe(getText(b));
+      expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
     });
 
     it('respects namespace-qualified custom binding form', () => {
-      const a = docFromTextNotation('(my.ns/let [x| 1 y 2] (+ x y))');
-      const b = docFromTextNotation('(my.ns/let [|x 1| y 2] (+ x y))');
+      const a = textNotation.docFromTextNotation('(my.ns/let [x| 1 y 2] (+ x y))');
+      const b = textNotation.docFromTextNotation('(my.ns/let [|x 1| y 2] (+ x y))');
       const customForms: pareditConfig.PairFormConfig[] = [
         { type: 'vector-binding', name: 'my.ns/let' },
       ];
       const config = pareditConfig.createPareditConfig(customForms);
       paredit.growSelection(a, a.selections, config);
-      expect(getText(a)).toBe(getText(b));
+      expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
     });
   });
 
   it('drags individual sexp when pair behavior is disabled for assoc', async () => {
-    const a = docFromTextNotation('(assoc m |:a "one" :b "two")');
-    const b = docFromTextNotation('(assoc m "one" |:a :b "two")');
+    const a = textNotation.docFromTextNotation('(assoc m |:a "one" :b "two")');
+    const b = textNotation.docFromTextNotation('(assoc m "one" |:a :b "two")');
     // Create config without assoc in flat pair forms
     const customConfig = {
       pairForms: {
@@ -234,92 +234,98 @@ describe('paredit-config', () => {
       aliasMap: {},
     };
     await paredit.dragSexprForward(a, undefined, undefined, customConfig);
-    expect(textAndSelection(a)).toEqual(textAndSelection(b));
+    expectLib.expect(textNotation.textAndSelection(a)).toEqual(textNotation.textAndSelection(b));
   });
 
   describe('Alias resolution', () => {
     describe('resolveAliasedSymbol', () => {
       it('resolves aliased namespace', () => {
-        expect(pareditConfig.resolveAliasedSymbol('p/let', { p: 'promesa.core' })).toBe(
-          'promesa.core/let'
-        );
+        expectLib
+          .expect(pareditConfig.resolveAliasedSymbol('p/let', { p: 'promesa.core' }))
+          .toBe('promesa.core/let');
       });
 
       it('resolves multiple aliases', () => {
         const aliasMap = { p: 'promesa.core', r: 'reagent.core' };
-        expect(pareditConfig.resolveAliasedSymbol('p/let', aliasMap)).toBe('promesa.core/let');
-        expect(pareditConfig.resolveAliasedSymbol('r/with-let', aliasMap)).toBe(
-          'reagent.core/with-let'
-        );
+        expectLib
+          .expect(pareditConfig.resolveAliasedSymbol('p/let', aliasMap))
+          .toBe('promesa.core/let');
+        expectLib
+          .expect(pareditConfig.resolveAliasedSymbol('r/with-let', aliasMap))
+          .toBe('reagent.core/with-let');
       });
 
       it('preserves unaliased symbols', () => {
-        expect(pareditConfig.resolveAliasedSymbol('let', { p: 'promesa.core' })).toBe('let');
+        expectLib
+          .expect(pareditConfig.resolveAliasedSymbol('let', { p: 'promesa.core' }))
+          .toBe('let');
       });
 
       it('preserves fully qualified symbols when no alias match', () => {
-        expect(pareditConfig.resolveAliasedSymbol('promesa.core/let', { p: 'other.ns' })).toBe(
-          'promesa.core/let'
-        );
+        expectLib
+          .expect(pareditConfig.resolveAliasedSymbol('promesa.core/let', { p: 'other.ns' }))
+          .toBe('promesa.core/let');
       });
 
       it('returns original symbol when alias not in map', () => {
-        expect(pareditConfig.resolveAliasedSymbol('x/let', { p: 'promesa.core' })).toBe('x/let');
+        expectLib
+          .expect(pareditConfig.resolveAliasedSymbol('x/let', { p: 'promesa.core' }))
+          .toBe('x/let');
       });
 
       it('handles empty alias map', () => {
-        expect(pareditConfig.resolveAliasedSymbol('p/let', {})).toBe('p/let');
+        expectLib.expect(pareditConfig.resolveAliasedSymbol('p/let', {})).toBe('p/let');
       });
     });
 
     describe('Aliased pair forms in paredit operations', () => {
       it('growSelection works with aliased vector-binding form', () => {
-        const a = docFromTextNotation('(p/let [x| 1 y 2])');
-        const b = docFromTextNotation('(p/let [|x 1| y 2])');
+        const a = textNotation.docFromTextNotation('(p/let [x| 1 y 2])');
+        const b = textNotation.docFromTextNotation('(p/let [|x 1| y 2])');
         const customForms: pareditConfig.PairFormConfig[] = [
           { type: 'vector-binding', name: 'promesa.core/let' },
         ];
         const config = pareditConfig.createPareditConfig(customForms, {}, { p: 'promesa.core' });
         paredit.growSelection(a, a.selections, config);
-        expect(getText(a)).toBe(getText(b));
+        expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
       });
 
       it('growSelection works with aliased flat form', () => {
-        const a = docFromTextNotation('(m/match x| 1 :one 2 :two)');
-        const b = docFromTextNotation('(m/match |x 1| :one 2 :two)');
+        const a = textNotation.docFromTextNotation('(m/match x| 1 :one 2 :two)');
+        const b = textNotation.docFromTextNotation('(m/match |x 1| :one 2 :two)');
         const customForms: pareditConfig.PairFormConfig[] = [
           { type: 'flat', name: 'my.ns/match', offset: 1 },
         ];
         const config = pareditConfig.createPareditConfig(customForms, {}, { m: 'my.ns' });
         paredit.growSelection(a, a.selections, config);
-        expect(getText(a)).toBe(getText(b));
+        expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
       });
 
       it('dragSexprForward works with aliased flat form', async () => {
-        const a = docFromTextNotation('(m/match |x 1 :a 2)');
-        const b = docFromTextNotation('(m/match :a 2 |x 1)');
+        const a = textNotation.docFromTextNotation('(m/match |x 1 :a 2)');
+        const b = textNotation.docFromTextNotation('(m/match :a 2 |x 1)');
         const customForms: pareditConfig.PairFormConfig[] = [
           { type: 'flat', name: 'my.ns/match', offset: 1 },
         ];
         const config = pareditConfig.createPareditConfig(customForms, {}, { m: 'my.ns' });
         await paredit.dragSexprForward(a, a.selections[0].anchor, a.selections[0].active, config);
-        expect(getText(a)).toBe(getText(b));
+        expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
       });
 
       it('dragSexprBackward works with aliased flat form', async () => {
-        const a = docFromTextNotation('(m/match x 1 |:a 2)');
-        const b = docFromTextNotation('(m/match |:a 2 x 1)');
+        const a = textNotation.docFromTextNotation('(m/match x 1 |:a 2)');
+        const b = textNotation.docFromTextNotation('(m/match |:a 2 x 1)');
         const customForms: pareditConfig.PairFormConfig[] = [
           { type: 'flat', name: 'my.ns/match', offset: 1 },
         ];
         const config = pareditConfig.createPareditConfig(customForms, {}, { m: 'my.ns' });
         await paredit.dragSexprBackward(a, a.selections[0].anchor, a.selections[0].active, config);
-        expect(getText(a)).toBe(getText(b));
+        expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
       });
 
       it('works with multiple aliases', () => {
-        const a = docFromTextNotation('(p/let [x 1] (r/with-let [y| 2] y))');
-        const b = docFromTextNotation('(p/let [x 1] (r/with-let [|y 2|] y))');
+        const a = textNotation.docFromTextNotation('(p/let [x 1] (r/with-let [y| 2] y))');
+        const b = textNotation.docFromTextNotation('(p/let [x 1] (r/with-let [|y 2|] y))');
         const customForms: pareditConfig.PairFormConfig[] = [
           { type: 'vector-binding', name: 'promesa.core/let' },
           { type: 'vector-binding', name: 'reagent.core/with-let' },
@@ -330,75 +336,83 @@ describe('paredit-config', () => {
           { p: 'promesa.core', r: 'reagent.core' }
         );
         paredit.growSelection(a, a.selections, config);
-        expect(getText(a)).toBe(getText(b));
+        expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
       });
 
       it('still works with fully qualified names when alias map provided', () => {
-        const a = docFromTextNotation('(promesa.core/let [x| 1])');
-        const b = docFromTextNotation('(promesa.core/let [|x 1|])');
+        const a = textNotation.docFromTextNotation('(promesa.core/let [x| 1])');
+        const b = textNotation.docFromTextNotation('(promesa.core/let [|x 1|])');
         const customForms: pareditConfig.PairFormConfig[] = [
           { type: 'vector-binding', name: 'promesa.core/let' },
         ];
         const config = pareditConfig.createPareditConfig(customForms, {}, { p: 'promesa.core' });
         paredit.growSelection(a, a.selections, config);
-        expect(getText(a)).toBe(getText(b));
+        expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
       });
 
       it('works with aliased form inside threading macro', () => {
-        const a = docFromTextNotation('(-> x (m/match |1 :one 2 :two))');
-        const b = docFromTextNotation('(-> x (m/match |1 :one| 2 :two))');
+        const a = textNotation.docFromTextNotation('(-> x (m/match |1 :one 2 :two))');
+        const b = textNotation.docFromTextNotation('(-> x (m/match |1 :one| 2 :two))');
         const customForms: pareditConfig.PairFormConfig[] = [
           { type: 'flat', name: 'my.ns/match', offset: 1 },
         ];
         const config = pareditConfig.createPareditConfig(customForms, {}, { m: 'my.ns' });
         paredit.growSelection(a, a.selections, config);
-        expect(getText(a)).toBe(getText(b));
+        expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
       });
     });
 
     describe('js-interop/let vector-binding form', () => {
       it('applied-science.js-interop/let - grows selection to binding pairs', () => {
-        const a = docFromTextNotation('(applied-science.js-interop/let [a b |c| d])');
+        const a = textNotation.docFromTextNotation('(applied-science.js-interop/let [a b |c| d])');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(applied-science.js-interop/let [a b |c d|])');
+        const b = textNotation.docFromTextNotation('(applied-science.js-interop/let [a b |c d|])');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
     });
 
     describe('js-interop flat pair forms', () => {
       it('applied-science.js-interop/assoc! - grows selection to key-value pairs', () => {
-        const a = docFromTextNotation('(applied-science.js-interop/assoc! obj :a 1 |:b| 2)');
+        const a = textNotation.docFromTextNotation(
+          '(applied-science.js-interop/assoc! obj :a 1 |:b| 2)'
+        );
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(applied-science.js-interop/assoc! obj :a 1 |:b 2|)');
+        const b = textNotation.docFromTextNotation(
+          '(applied-science.js-interop/assoc! obj :a 1 |:b 2|)'
+        );
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
 
       it('applied-science.js-interop/obj - grows selection to key-value pairs starting at offset 1', () => {
-        const a = docFromTextNotation('(applied-science.js-interop/obj |:a| 1 :b 2)');
+        const a = textNotation.docFromTextNotation('(applied-science.js-interop/obj |:a| 1 :b 2)');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(applied-science.js-interop/obj |:a 1| :b 2)');
+        const b = textNotation.docFromTextNotation('(applied-science.js-interop/obj |:a 1| :b 2)');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
 
       it('applied-science.js-interop/assoc! - does not treat object argument as part of pair', () => {
-        const a = docFromTextNotation('(applied-science.js-interop/assoc! |obj| :a 1 :b 2)');
+        const a = textNotation.docFromTextNotation(
+          '(applied-science.js-interop/assoc! |obj| :a 1 :b 2)'
+        );
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(|applied-science.js-interop/assoc! obj :a 1 :b 2|)');
+        const b = textNotation.docFromTextNotation(
+          '(|applied-science.js-interop/assoc! obj :a 1 :b 2|)'
+        );
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
 
       it('j/assoc! - works with alias map configuration', () => {
-        const a = docFromTextNotation('(j/assoc! obj :a 1 |:b| 2)');
+        const a = textNotation.docFromTextNotation('(j/assoc! obj :a 1 |:b| 2)');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(j/assoc! obj :a 1 |:b 2|)');
+        const b = textNotation.docFromTextNotation('(j/assoc! obj :a 1 |:b 2|)');
         const bSelection = b.selections[0];
         const config = pareditConfig.createPareditConfig(
           [],
@@ -406,14 +420,14 @@ describe('paredit-config', () => {
           { j: 'applied-science.js-interop' }
         );
         paredit.growSelection(a, a.selections, config);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
     });
 
     describe('Aliased threading macros', () => {
       it('applies offset reduction for aliased thread-first macro', () => {
-        const a = docFromTextNotation('(m/-> {} (assoc :a 1| :b 2))');
-        const b = docFromTextNotation('(m/-> {} (assoc |:a 1| :b 2))');
+        const a = textNotation.docFromTextNotation('(m/-> {} (assoc :a 1| :b 2))');
+        const b = textNotation.docFromTextNotation('(m/-> {} (assoc |:a 1| :b 2))');
         const customThreading = {
           firstArg: ['my.lib/thread-through'],
         };
@@ -421,20 +435,24 @@ describe('paredit-config', () => {
           m: 'my.lib',
         });
         paredit.growSelection(a, a.selections, config);
-        expect(getText(a)).toBe(getText(b));
+        expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
       });
 
       it('works with default promesa thread-first using alias', () => {
-        const a = docFromTextNotation('(p/-> {} (|assoc :a 1 :b 2))');
-        const b = docFromTextNotation('(p/-> {} (|assoc :a 1| :b 2))');
+        const a = textNotation.docFromTextNotation('(p/-> {} (|assoc :a 1 :b 2))');
+        const b = textNotation.docFromTextNotation('(p/-> {} (|assoc :a 1| :b 2))');
         const config = pareditConfig.createPareditConfig([], {}, { p: 'promesa.core' });
         paredit.growSelection(a, a.selections, config);
-        expect(getText(a)).toBe(getText(b));
+        expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
       });
 
       it('works with multiple aliased threading macros', () => {
-        const a = docFromTextNotation('(p/-> x (m/thread-through (assoc |:a 1 :b 2)))');
-        const b = docFromTextNotation('(p/-> x (m/thread-through (assoc |:a 1| :b 2)))');
+        const a = textNotation.docFromTextNotation(
+          '(p/-> x (m/thread-through (assoc |:a 1 :b 2)))'
+        );
+        const b = textNotation.docFromTextNotation(
+          '(p/-> x (m/thread-through (assoc |:a 1| :b 2)))'
+        );
         const customThreading = {
           firstArg: ['my.lib/thread-through'],
         };
@@ -443,12 +461,12 @@ describe('paredit-config', () => {
           m: 'my.lib',
         });
         paredit.growSelection(a, a.selections, config);
-        expect(getText(a)).toBe(getText(b));
+        expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
       });
 
       it('works with aliased threading macro containing aliased pair form', () => {
-        const a = docFromTextNotation('(p/-> x (m/match |1 :one 2 :two))');
-        const b = docFromTextNotation('(p/-> x (m/match |1 :one| 2 :two))');
+        const a = textNotation.docFromTextNotation('(p/-> x (m/match |1 :one 2 :two))');
+        const b = textNotation.docFromTextNotation('(p/-> x (m/match |1 :one| 2 :two))');
         const customForms: pareditConfig.PairFormConfig[] = [
           { type: 'flat', name: 'my.ns/match', offset: 1 },
         ];
@@ -461,12 +479,12 @@ describe('paredit-config', () => {
           }
         );
         paredit.growSelection(a, a.selections, config);
-        expect(getText(a)).toBe(getText(b));
+        expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
       });
 
       it('dragSexprForward works inside aliased threading macro', async () => {
-        const a = docFromTextNotation('(m/-> {} (assoc |:a 1 :b 2))');
-        const b = docFromTextNotation('(m/-> {} (assoc :b 2 |:a 1))');
+        const a = textNotation.docFromTextNotation('(m/-> {} (assoc |:a 1 :b 2))');
+        const b = textNotation.docFromTextNotation('(m/-> {} (assoc :b 2 |:a 1))');
         const config = pareditConfig.createPareditConfig(
           [],
           { firstArg: ['my-ns/->'] },
@@ -475,12 +493,12 @@ describe('paredit-config', () => {
           }
         );
         await paredit.dragSexprForward(a, a.selections[0].anchor, a.selections[0].active, config);
-        expect(getText(a)).toBe(getText(b));
+        expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
       });
 
       it('dragSexprBackward works inside aliased threading macro', async () => {
-        const a = docFromTextNotation('(m/-> {} (assoc :a 1 |:b 2))');
-        const b = docFromTextNotation('(m/-> {} (assoc |:b 2 :a 1))');
+        const a = textNotation.docFromTextNotation('(m/-> {} (assoc :a 1 |:b 2))');
+        const b = textNotation.docFromTextNotation('(m/-> {} (assoc |:b 2 :a 1))');
         const customThreading: Partial<pareditConfig.ThreadingMacrosConfig> = {
           firstArg: ['my-ns/->'],
         };
@@ -488,48 +506,48 @@ describe('paredit-config', () => {
           m: 'my-ns',
         });
         await paredit.dragSexprBackward(a, a.selections[0].anchor, a.selections[0].active, config);
-        expect(getText(a)).toBe(getText(b));
+        expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
       });
 
       it('works with default promesa thread-last using alias', () => {
-        const a = docFromTextNotation('(p/->> x (assoc {} :a 1 :b|))');
-        const b = docFromTextNotation('(p/->> x (|assoc {} :a 1 :b|))');
+        const a = textNotation.docFromTextNotation('(p/->> x (assoc {} :a 1 :b|))');
+        const b = textNotation.docFromTextNotation('(p/->> x (|assoc {} :a 1 :b|))');
         const config = pareditConfig.createPareditConfig([], {}, { p: 'promesa.core' });
         paredit.growSelection(a, a.selections, config);
-        expect(getText(a)).toBe(getText(b));
+        expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
       });
     });
   });
 
   describe('isCommentFormHead', () => {
     it('returns true for "comment"', () => {
-      expect(pareditConfig.isCommentFormHead('comment')).toBe(true);
+      expectLib.expect(pareditConfig.isCommentFormHead('comment')).toBe(true);
     });
 
     it('returns false for undefined', () => {
-      expect(pareditConfig.isCommentFormHead(undefined)).toBe(false);
+      expectLib.expect(pareditConfig.isCommentFormHead(undefined)).toBe(false);
     });
 
     it('returns false for null', () => {
-      expect(pareditConfig.isCommentFormHead(null)).toBe(false);
+      expectLib.expect(pareditConfig.isCommentFormHead(null)).toBe(false);
     });
 
     it('returns false for empty string', () => {
-      expect(pareditConfig.isCommentFormHead('')).toBe(false);
+      expectLib.expect(pareditConfig.isCommentFormHead('')).toBe(false);
     });
 
     it('returns false for non-comment symbol without config', () => {
-      expect(pareditConfig.isCommentFormHead('defn')).toBe(false);
+      expectLib.expect(pareditConfig.isCommentFormHead('defn')).toBe(false);
     });
 
     it('returns true for custom comment form', () => {
       const config = { customCommentForms: ['my-comment'], aliasMap: {} };
-      expect(pareditConfig.isCommentFormHead('my-comment', config)).toBe(true);
+      expectLib.expect(pareditConfig.isCommentFormHead('my-comment', config)).toBe(true);
     });
 
     it('returns false for non-matching symbol with config', () => {
       const config = { customCommentForms: ['my-comment'], aliasMap: {} };
-      expect(pareditConfig.isCommentFormHead('defn', config)).toBe(false);
+      expectLib.expect(pareditConfig.isCommentFormHead('defn', config)).toBe(false);
     });
 
     it('resolves aliased custom comment form', () => {
@@ -537,7 +555,7 @@ describe('paredit-config', () => {
         customCommentForms: ['my.ns/dev-comment'],
         aliasMap: { m: 'my.ns' },
       };
-      expect(pareditConfig.isCommentFormHead('m/dev-comment', config)).toBe(true);
+      expectLib.expect(pareditConfig.isCommentFormHead('m/dev-comment', config)).toBe(true);
     });
 
     it('returns false for aliased symbol that does not match custom forms', () => {
@@ -545,43 +563,43 @@ describe('paredit-config', () => {
         customCommentForms: ['my.ns/dev-comment'],
         aliasMap: { m: 'my.ns' },
       };
-      expect(pareditConfig.isCommentFormHead('m/other', config)).toBe(false);
+      expectLib.expect(pareditConfig.isCommentFormHead('m/other', config)).toBe(false);
     });
 
     it('still recognizes "comment" even with config provided', () => {
       const config = { customCommentForms: ['my-comment'], aliasMap: {} };
-      expect(pareditConfig.isCommentFormHead('comment', config)).toBe(true);
+      expectLib.expect(pareditConfig.isCommentFormHead('comment', config)).toBe(true);
     });
   });
 
   describe('atTopLevel with custom comment forms', () => {
     it('treats custom comment form as top level', () => {
-      const a = docFromTextNotation('(my-comment |(+ 1 2))');
+      const a = textNotation.docFromTextNotation('(my-comment |(+ 1 2))');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       const config = { customCommentForms: ['my-comment'], aliasMap: {} };
-      expect(cursor.atTopLevel(true, config)).toBe(true);
+      expectLib.expect(cursor.atTopLevel(true, config)).toBe(true);
     });
 
     it('does not treat custom comment form as top level without config', () => {
-      const a = docFromTextNotation('(my-comment |(+ 1 2))');
+      const a = textNotation.docFromTextNotation('(my-comment |(+ 1 2))');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.atTopLevel(true)).toBe(false);
+      expectLib.expect(cursor.atTopLevel(true)).toBe(false);
     });
 
     it('treats aliased custom comment form as top level', () => {
-      const a = docFromTextNotation('(m/dev-comment |(+ 1 2))');
+      const a = textNotation.docFromTextNotation('(m/dev-comment |(+ 1 2))');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       const config = {
         customCommentForms: ['my.ns/dev-comment'],
         aliasMap: { m: 'my.ns' },
       };
-      expect(cursor.atTopLevel(true, config)).toBe(true);
+      expectLib.expect(cursor.atTopLevel(true, config)).toBe(true);
     });
 
     it('still treats built-in comment as top level', () => {
-      const a = docFromTextNotation('(comment |(+ 1 2))');
+      const a = textNotation.docFromTextNotation('(comment |(+ 1 2))');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.atTopLevel(true)).toBe(true);
+      expectLib.expect(cursor.atTopLevel(true)).toBe(true);
     });
   });
 });

--- a/src/extension-test/unit/cursor-doc/paredit-test.ts
+++ b/src/extension-test/unit/cursor-doc/paredit-test.ts
@@ -1,14 +1,8 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as paredit from '../../../cursor-doc/paredit';
 import * as model from '../../../cursor-doc/model';
-import {
-  docFromTextNotation,
-  textAndSelection,
-  getText,
-  textAndSelections,
-} from '../common/text-notation';
-import { ModelEditRange, ModelEditSelection } from '../../../cursor-doc/model';
-import { last } from 'lodash';
+import * as textNotation from '../common/text-notation';
+import * as _ from 'lodash';
 
 model.initScanner(20000);
 
@@ -19,7 +13,7 @@ model.initScanner(20000);
 describe('paredit', () => {
   const docText = '(def foo [:foo :bar :baz])';
   let doc: model.StringDocument;
-  const startSelection = new ModelEditSelection(0, 0);
+  const startSelection = new model.ModelEditSelection(0, 0);
 
   beforeEach(() => {
     doc = new model.StringDocument(docText);
@@ -29,1153 +23,1420 @@ describe('paredit', () => {
   describe('movement', () => {
     describe('rangeToSexprForward/forwardSexpRange', () => {
       it('Finds the list in front', () => {
-        const a = docFromTextNotation('|(def foo [vec])');
-        const b = docFromTextNotation('|(def foo [vec])|');
-        expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('|(def foo [vec])');
+        const b = textNotation.docFromTextNotation('|(def foo [vec])|');
+        expectLib.expect(paredit.forwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the list in front through metadata', () => {
-        const a = docFromTextNotation('|^:foo (def foo [vec])');
-        const b = docFromTextNotation('|^:foo (def foo [vec])|');
-        expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('|^:foo (def foo [vec])');
+        const b = textNotation.docFromTextNotation('|^:foo (def foo [vec])|');
+        expectLib.expect(paredit.forwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the list in front through metadata and readers', () => {
-        const a = docFromTextNotation('|^:f #a #b (def foo [vec])');
-        const b = docFromTextNotation('|^:f #a #b (def foo [vec])|');
-        expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('|^:f #a #b (def foo [vec])');
+        const b = textNotation.docFromTextNotation('|^:f #a #b (def foo [vec])|');
+        expectLib.expect(paredit.forwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the list in front through reader metadata reader', () => {
-        const a = docFromTextNotation('|#c ^:f #a #b (def foo [vec])');
-        const b = docFromTextNotation('|#c ^:f #a #b (def foo [vec])|');
-        expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('|#c ^:f #a #b (def foo [vec])');
+        const b = textNotation.docFromTextNotation('|#c ^:f #a #b (def foo [vec])|');
+        expectLib.expect(paredit.forwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the symbol in front', () => {
-        const a = docFromTextNotation('(|def foo [vec])');
-        const b = docFromTextNotation('(|def| foo [vec])');
-        expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(|def foo [vec])');
+        const b = textNotation.docFromTextNotation('(|def| foo [vec])');
+        expectLib.expect(paredit.forwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the rest of the symbol', () => {
-        const a = docFromTextNotation('(d|ef foo [vec])');
-        const b = docFromTextNotation('(d|ef| foo [vec])');
-        expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(d|ef foo [vec])');
+        const b = textNotation.docFromTextNotation('(d|ef| foo [vec])');
+        expectLib.expect(paredit.forwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the rest of the keyword', () => {
-        const a = docFromTextNotation('(def foo [:foo :bar :ba|z])');
-        const b = docFromTextNotation('(def foo [:foo :bar :ba|z|])');
-        expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def foo [:foo :bar :ba|z])');
+        const b = textNotation.docFromTextNotation('(def foo [:foo :bar :ba|z|])');
+        expectLib.expect(paredit.forwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Includes space between the cursor and the symbol', () => {
-        const a = docFromTextNotation('(def| foo [vec])');
-        const b = docFromTextNotation('(def| foo| [vec])');
-        expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def| foo [vec])');
+        const b = textNotation.docFromTextNotation('(def| foo| [vec])');
+        expectLib.expect(paredit.forwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the vector in front', () => {
-        const a = docFromTextNotation('(def foo |[vec])');
-        const b = docFromTextNotation('(def foo |[vec]|)');
-        expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def foo |[vec])');
+        const b = textNotation.docFromTextNotation('(def foo |[vec]|)');
+        expectLib.expect(paredit.forwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the keyword in front', () => {
-        const a = docFromTextNotation('(def foo [:foo :bar |:baz])');
-        const b = docFromTextNotation('(def foo [:foo :bar |:baz|])');
-        expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def foo [:foo :bar |:baz])');
+        const b = textNotation.docFromTextNotation('(def foo [:foo :bar |:baz|])');
+        expectLib.expect(paredit.forwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Returns empty range when no forward sexp', () => {
-        const a = docFromTextNotation('(def foo [:foo :bar :baz|])');
-        const b = docFromTextNotation('(def foo [:foo :bar :baz|])');
-        expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def foo [:foo :bar :baz|])');
+        const b = textNotation.docFromTextNotation('(def foo [:foo :bar :baz|])');
+        expectLib.expect(paredit.forwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds next symbol, including leading space', () => {
-        const a = docFromTextNotation('(>0def>0 foo [vec])');
-        const b = docFromTextNotation('(def>0 foo>0 [vec])');
-        expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(>0def>0 foo [vec])');
+        const b = textNotation.docFromTextNotation('(def>0 foo>0 [vec])');
+        expectLib.expect(paredit.forwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds following vector including leading space', () => {
-        const a = docFromTextNotation('(>0def foo>0 [vec])');
-        const b = docFromTextNotation('(def foo>0 [vec]>0)');
-        expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(>0def foo>0 [vec])');
+        const b = textNotation.docFromTextNotation('(def foo>0 [vec]>0)');
+        expectLib.expect(paredit.forwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Reverses direction of selection and finds next sexp', () => {
-        const a = docFromTextNotation('(<0def foo<0 [vec])');
-        const b = docFromTextNotation('(def foo>0 [vec]>0)');
-        expect(paredit.forwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(<0def foo<0 [vec])');
+        const b = textNotation.docFromTextNotation('(def foo>0 [vec]>0)');
+        expectLib.expect(paredit.forwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
     });
 
     describe('rangeToSexprBackward/backwardSexpRange', () => {
       it('Finds the list preceding', () => {
-        const a = docFromTextNotation('(def foo [vec])|');
-        const b = docFromTextNotation('|(def foo [vec])|');
-        expect(paredit.backwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def foo [vec])|');
+        const b = textNotation.docFromTextNotation('|(def foo [vec])|');
+        expectLib.expect(paredit.backwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the list preceding through metadata', () => {
-        const a = docFromTextNotation('^:foo (def foo [vec])|');
-        const b = docFromTextNotation('|^:foo (def foo [vec])|');
-        expect(paredit.backwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('^:foo (def foo [vec])|');
+        const b = textNotation.docFromTextNotation('|^:foo (def foo [vec])|');
+        expectLib.expect(paredit.backwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the list preceding through metadata and readers', () => {
-        const a = docFromTextNotation('^:f #a #b (def foo [vec])|');
-        const b = docFromTextNotation('|^:f #a #b (def foo [vec])|');
-        expect(paredit.backwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('^:f #a #b (def foo [vec])|');
+        const b = textNotation.docFromTextNotation('|^:f #a #b (def foo [vec])|');
+        expectLib.expect(paredit.backwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the list preceding through reader metadata reader', () => {
-        const a = docFromTextNotation('#c ^:f #a #b (def foo [vec])|');
-        const b = docFromTextNotation('|#c ^:f #a #b (def foo [vec])|');
-        expect(paredit.backwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('#c ^:f #a #b (def foo [vec])|');
+        const b = textNotation.docFromTextNotation('|#c ^:f #a #b (def foo [vec])|');
+        expectLib.expect(paredit.backwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds previous form, including space, and reverses direction', () => {
         // TODO: Should we really be reversing the direction here?
-        const a = docFromTextNotation('(def <0foo [vec]<0)');
-        const b = docFromTextNotation('(>0def >0foo [vec])');
-        expect(paredit.backwardSexpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def <0foo [vec]<0)');
+        const b = textNotation.docFromTextNotation('(>0def >0foo [vec])');
+        expectLib.expect(paredit.backwardSexpRange(a)).toEqual(textNotation.textAndSelection(b)[1]);
       });
     });
 
     describe('forwardHybridSexpRange (for killRight)', () => {
       it('Finds end of string', () => {
-        const a = docFromTextNotation('"This |needs to find the end of the string."');
-        const b = docFromTextNotation('"This |needs to find the end of the string.|"');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('"This |needs to find the end of the string."');
+        const b = textNotation.docFromTextNotation('"This |needs to find the end of the string.|"');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds newline in multi line string', () => {
-        const a = docFromTextNotation('"This |needs to find the end\n of the string."');
-        const b = docFromTextNotation('"This |needs to find the end|\n of the string."');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation(
+          '"This |needs to find the end\n of the string."'
+        );
+        const b = textNotation.docFromTextNotation(
+          '"This |needs to find the end|\n of the string."'
+        );
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds newline in multi line string (Windows)', () => {
-        const a = docFromTextNotation('"This |needs to find the end\r\n of the string."');
-        const b = docFromTextNotation('"This |needs to find the end|\r\n of the string."');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation(
+          '"This |needs to find the end\r\n of the string."'
+        );
+        const b = textNotation.docFromTextNotation(
+          '"This |needs to find the end|\r\n of the string."'
+        );
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds end of comment', () => {
-        const a = docFromTextNotation('(a |;; foo\n e)');
-        const b = docFromTextNotation('(a |;; foo|\n e)');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(a |;; foo\n e)');
+        const b = textNotation.docFromTextNotation('(a |;; foo|\n e)');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds end of comment (Windows)', () => {
-        const a = docFromTextNotation('(a |;; foo\r\n e)');
-        const b = docFromTextNotation('(a |;; foo|\r\n e)');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(a |;; foo\r\n e)');
+        const b = textNotation.docFromTextNotation('(a |;; foo|\r\n e)');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Maintains balanced delimiters 1', () => {
-        const a = docFromTextNotation('(a| b (c\n d) e)');
-        const b = docFromTextNotation('(a| b (c\n d)| e)');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(a| b (c\n d) e)');
+        const b = textNotation.docFromTextNotation('(a| b (c\n d)| e)');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Maintains balanced delimiters 1 (Windows)', () => {
-        const a = docFromTextNotation('(a| b (c\r\n d) e)');
-        const b = docFromTextNotation('(a| b (c\r\n d)| e)');
-        const [start, end] = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(a| b (c\r\n d) e)');
+        const b = textNotation.docFromTextNotation('(a| b (c\r\n d)| e)');
+        const [start, end] = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual([start, end]);
+        expectLib.expect(actual).toEqual([start, end]);
       });
 
       it('Maintains balanced delimiters 2', () => {
-        const a = docFromTextNotation('(aa| (c (e\nf)) g)');
-        const b = docFromTextNotation('(aa| (c (e\nf))|g)');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(aa| (c (e\nf)) g)');
+        const b = textNotation.docFromTextNotation('(aa| (c (e\nf))|g)');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Maintains balanced delimiters 2 (Windows)', () => {
-        const a = docFromTextNotation('(aa| (c (e\r\nf)) g)');
-        const b = docFromTextNotation('(aa| (c (e\r\nf))|g)');
-        const [start, end] = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(aa| (c (e\r\nf)) g)');
+        const b = textNotation.docFromTextNotation('(aa| (c (e\r\nf))|g)');
+        const [start, end] = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual([start, end]);
+        expectLib.expect(actual).toEqual([start, end]);
       });
 
       it('Maintains balanced delimiters 3', () => {
-        const a = docFromTextNotation('(aa| (  c (e\nf)) g)');
-        const b = docFromTextNotation('(aa| (  c (e\nf))|g)');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(aa| (  c (e\nf)) g)');
+        const b = textNotation.docFromTextNotation('(aa| (  c (e\nf))|g)');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Maintains balanced delimiters 3 (Windows)', () => {
-        const a = docFromTextNotation('(aa| (  c (e\r\nf)) g)');
-        const b = docFromTextNotation('(aa| (  c (e\r\nf))|g)');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(aa| (  c (e\r\nf)) g)');
+        const b = textNotation.docFromTextNotation('(aa| (  c (e\r\nf))|g)');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Advances past newline when invoked on newline', () => {
-        const a = docFromTextNotation('(a|\n e) g)');
-        const b = docFromTextNotation('(a|\n| e)');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(a|\n e) g)');
+        const b = textNotation.docFromTextNotation('(a|\n| e)');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Advances past newline when invoked on newline (Windows)', () => {
-        const a = docFromTextNotation('(a|\r\n e) g)');
-        const b = docFromTextNotation('(a|\r\n| e) g)');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(a|\r\n e) g)');
+        const b = textNotation.docFromTextNotation('(a|\r\n| e) g)');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Advances past newline, preserving leading whitepace when invoked on newline with squash off', () => {
-        const a = docFromTextNotation('(a|\n   e) g)');
-        const b = docFromTextNotation('(a|\n|   e)');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(a|\n   e) g)');
+        const b = textNotation.docFromTextNotation('(a|\n|   e)');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a, a.selections[0].active, false);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Advances past newline, preserving leading whitepace when invoked on newline with squash off (Windows)', () => {
-        const a = docFromTextNotation('(a|\r\n   e) g)');
-        const b = docFromTextNotation('(a|\r\n|   e) g)');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(a|\r\n   e) g)');
+        const b = textNotation.docFromTextNotation('(a|\r\n|   e) g)');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a, a.selections[0].active, false);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Advances past newline, squashing leading whitepace when invoked on newline', () => {
-        const a = docFromTextNotation('(a|\n   e) g)');
-        const b = docFromTextNotation('(a|\n  | e) g)');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(a|\n   e) g)');
+        const b = textNotation.docFromTextNotation('(a|\n  | e) g)');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Advances past newline, squashing leading whitepace when invoked on newline (Windows)', () => {
-        const a = docFromTextNotation('(a|\r\n   e) g)');
-        const b = docFromTextNotation('(a|\r\n  | e) g)');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(a|\r\n   e) g)');
+        const b = textNotation.docFromTextNotation('(a|\r\n  | e) g)');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds end of vectors', () => {
-        const a = docFromTextNotation('[a [b |c d e f] g h]');
-        const b = docFromTextNotation('[a [b |c d e f|] g h]');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('[a [b |c d e f] g h]');
+        const b = textNotation.docFromTextNotation('[a [b |c d e f|] g h]');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds end of lists', () => {
-        const a = docFromTextNotation('(foo |bar)\n');
-        const b = docFromTextNotation('(foo |bar|)\n');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(foo |bar)\n');
+        const b = textNotation.docFromTextNotation('(foo |bar|)\n');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds end of maps', () => {
-        const a = docFromTextNotation('{:a 1 |:b 2 :c 3}');
-        const b = docFromTextNotation('{:a 1 |:b 2 :c 3|}');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('{:a 1 |:b 2 :c 3}');
+        const b = textNotation.docFromTextNotation('{:a 1 |:b 2 :c 3|}');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds end of line in multiline maps', () => {
-        const a = docFromTextNotation('{:a 1 |:b 2\n:c 3}');
-        const b = docFromTextNotation('{:a 1 |:b 2|:c 3}');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('{:a 1 |:b 2\n:c 3}');
+        const b = textNotation.docFromTextNotation('{:a 1 |:b 2|:c 3}');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds end of expr in multiline maps', () => {
-        const a = docFromTextNotation('{:a 1 |:b (+\n 0\n 2\n) :c 3}');
-        const b = docFromTextNotation('{:a 1 |:b (+\n 0\n 2\n)| :c 3}');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('{:a 1 |:b (+\n 0\n 2\n) :c 3}');
+        const b = textNotation.docFromTextNotation('{:a 1 |:b (+\n 0\n 2\n)| :c 3}');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds end of expr in multiline maps (Windows)', () => {
-        const a = docFromTextNotation('{:a 1 |:b (+\r\n 0\r\n 2\r\n) :c 3}');
-        const b = docFromTextNotation('{:a 1 |:b (+\r\n 0\r\n 2\r\n)| :c 3}');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('{:a 1 |:b (+\r\n 0\r\n 2\r\n) :c 3}');
+        const b = textNotation.docFromTextNotation('{:a 1 |:b (+\r\n 0\r\n 2\r\n)| :c 3}');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds end of line in bindings', () => {
-        const a = docFromTextNotation('(let [|a (+ 1 2)\n b (+ 2 3)] (+ a b))');
-        const b = docFromTextNotation('(let [|a (+ 1 2)|\n b (+ 2 3)] (+ a b))');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(let [|a (+ 1 2)\n b (+ 2 3)] (+ a b))');
+        const b = textNotation.docFromTextNotation('(let [|a (+ 1 2)|\n b (+ 2 3)] (+ a b))');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds end of expr in multiline bindings', () => {
-        const a = docFromTextNotation('(let [|a (+\n 1 \n 2)\n b (+ 2 3)] (+ a b))');
-        const b = docFromTextNotation('(let [|a (+\n 1 \n 2)|\n b (+ 2 3)] (+ a b))');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(let [|a (+\n 1 \n 2)\n b (+ 2 3)] (+ a b))');
+        const b = textNotation.docFromTextNotation('(let [|a (+\n 1 \n 2)|\n b (+ 2 3)] (+ a b))');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds end of expr in multiline bindings (Windows)', () => {
-        const a = docFromTextNotation('(let [|a (+\r\n 1 \r\n 2)\r\n b (+ 2 3)] (+ a b))');
-        const b = docFromTextNotation('(let [|a (+\r\n 1 \r\n 2)|\r\n b (+ 2 3)] (+ a b))');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation(
+          '(let [|a (+\r\n 1 \r\n 2)\r\n b (+ 2 3)] (+ a b))'
+        );
+        const b = textNotation.docFromTextNotation(
+          '(let [|a (+\r\n 1 \r\n 2)|\r\n b (+ 2 3)] (+ a b))'
+        );
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds range in line of tokens', () => {
-        const a = docFromTextNotation(' | 2 "hello" :hello/world\nbye');
-        const b = docFromTextNotation(' | 2 "hello" :hello/world|\nbye');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation(' | 2 "hello" :hello/world\nbye');
+        const b = textNotation.docFromTextNotation(' | 2 "hello" :hello/world|\nbye');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds range in token with form over multiple lines', () => {
-        const a = docFromTextNotation(' | 2 [\n 1 \n]');
-        const b = docFromTextNotation(' | 2 [\n 1 \n]|');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation(' | 2 [\n 1 \n]');
+        const b = textNotation.docFromTextNotation(' | 2 [\n 1 \n]|');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds range in token with form over multiple lines 2', () => {
-        const a = docFromTextNotation('|a [\n 1 \n]');
-        const b = docFromTextNotation('|a [\n 1 \n]|');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('|a [\n 1 \n]');
+        const b = textNotation.docFromTextNotation('|a [\n 1 \n]|');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds range in token with form over multiple lines 2 (Windows)', () => {
-        const a = docFromTextNotation('|a [\r\n 1 \r\n]');
-        const b = docFromTextNotation('|a [\r\n 1 \r\n]|');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('|a [\r\n 1 \r\n]');
+        const b = textNotation.docFromTextNotation('|a [\r\n 1 \r\n]|');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds range in token with form over multiple lines (Windows)', () => {
-        const a = docFromTextNotation(' | 2 [\r\n 1 \r\n]');
-        const b = docFromTextNotation(' | 2 [\r\n 1 \r\n]|');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation(' | 2 [\r\n 1 \r\n]');
+        const b = textNotation.docFromTextNotation(' | 2 [\r\n 1 \r\n]|');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Deals with comments start of line', () => {
-        const a = docFromTextNotation('|;;  hi\n');
-        const b = docFromTextNotation('|;;  hi|\n');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('|;;  hi\n');
+        const b = textNotation.docFromTextNotation('|;;  hi|\n');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Deals with comments middle of line', () => {
-        const a = docFromTextNotation(';; |hi\n');
-        const b = docFromTextNotation(';; |hi|\n');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation(';; |hi\n');
+        const b = textNotation.docFromTextNotation(';; |hi|\n');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Deals with empty lines', () => {
-        const a = docFromTextNotation('|\n');
-        const b = docFromTextNotation('|\n|');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('|\n');
+        const b = textNotation.docFromTextNotation('|\n|');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Deals with empty lines (Windows)', () => {
-        const a = docFromTextNotation('|\r\n');
-        const b = docFromTextNotation('|\r\n|');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('|\r\n');
+        const b = textNotation.docFromTextNotation('|\r\n|');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Deals with comments with empty line', () => {
-        const a = docFromTextNotation(';; |\n');
-        const b = docFromTextNotation(';; |\n|');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation(';; |\n');
+        const b = textNotation.docFromTextNotation(';; |\n|');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Deals with comments with empty line (Windows)', () => {
-        const a = docFromTextNotation(';; |\r\n');
-        const b = docFromTextNotation(';; |\r\n|');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation(';; |\r\n');
+        const b = textNotation.docFromTextNotation(';; |\r\n|');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Does not advance when on closing token type ', () => {
-        const a = docFromTextNotation('(a e|)\n');
-        const b = docFromTextNotation('(a e||)\n');
-        const expected = textAndSelection(b)[1];
+        const a = textNotation.docFromTextNotation('(a e|)\n');
+        const b = textNotation.docFromTextNotation('(a e||)\n');
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds the full form after an ignore marker', () => {
         // https://github.com/BetterThanTomorrow/calva/pull/1293#issuecomment-927123696
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(comment•  #_|[a b (c d•              e•              f) g]•  :a•)'
         );
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(comment•  #_|[a b (c d•              e•              f) g]|• :a•)'
         );
-        const expected = textAndSelection(b)[1];
+        const expected = textNotation.textAndSelection(b)[1];
         const actual = paredit.forwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
     });
 
     // TODO: backwardHybridSexpRange should probably be tested as a Directed range, not undirected
     describe('backwardHybridSexpRange (for killLeft)', () => {
       it('Finds whole string in list', () => {
-        const a = docFromTextNotation('("This needs to find the start of the string."|)');
-        const b = docFromTextNotation('(|"This needs to find the start of the string."|)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation(
+          '("This needs to find the start of the string."|)'
+        );
+        const b = textNotation.docFromTextNotation(
+          '(|"This needs to find the start of the string."|)'
+        );
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds whole string', () => {
-        const a = docFromTextNotation('"This needs to find the start of the string."|');
-        const b = docFromTextNotation('|"This needs to find the start of the string."|');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation(
+          '"This needs to find the start of the string."|'
+        );
+        const b = textNotation.docFromTextNotation(
+          '|"This needs to find the start of the string."|'
+        );
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of string', () => {
-        const a = docFromTextNotation('"This needs to find the |start of the string."');
-        const b = docFromTextNotation('"|This needs to find the |start of the string."');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation(
+          '"This needs to find the |start of the string."'
+        );
+        const b = textNotation.docFromTextNotation(
+          '"|This needs to find the |start of the string."'
+        );
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds newline in multi line string', () => {
-        const a = docFromTextNotation('"This needs to find the start\n of the |string."');
-        const b = docFromTextNotation('"This needs to find the start\n |of the |string."');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation(
+          '"This needs to find the start\n of the |string."'
+        );
+        const b = textNotation.docFromTextNotation(
+          '"This needs to find the start\n |of the |string."'
+        );
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds newline in multi line string (Windows)', () => {
-        const a = docFromTextNotation('"This needs to find the start\r\n of the |string."');
-        const b = docFromTextNotation('"This needs to find the start\r\n |of the |string."');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation(
+          '"This needs to find the start\r\n of the |string."'
+        );
+        const b = textNotation.docFromTextNotation(
+          '"This needs to find the start\r\n |of the |string."'
+        );
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of form from inside comment', () => {
-        const a = docFromTextNotation('(a ;; foo|\n e)');
-        const b = docFromTextNotation('(|a ;; foo|\n e)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('(a ;; foo|\n e)');
+        const b = textNotation.docFromTextNotation('(|a ;; foo|\n e)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of form from inside comment (Windows)', () => {
-        const a = docFromTextNotation('(a ;; foo|\r\n e)');
-        const b = docFromTextNotation('(|a ;; foo|\r\n e)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('(a ;; foo|\r\n e)');
+        const b = textNotation.docFromTextNotation('(|a ;; foo|\r\n e)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Maintains balanced delimiters 1', () => {
-        const a = docFromTextNotation('(a b (c\n d) e|)');
-        const b = docFromTextNotation('(a b |(c\n d) e|)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('(a b (c\n d) e|)');
+        const b = textNotation.docFromTextNotation('(a b |(c\n d) e|)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Maintains balanced delimiters 1 (Windows)', () => {
-        const a = docFromTextNotation('(a b (c\r\n d) e|)');
-        const b = docFromTextNotation('(a b |(c\r\n d) e|)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('(a b (c\r\n d) e|)');
+        const b = textNotation.docFromTextNotation('(a b |(c\r\n d) e|)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Maintains balanced delimiters 2', () => {
-        const a = docFromTextNotation('(aa (c (e\nf)) |g)');
-        const b = docFromTextNotation('(aa |(c (e\nf)) |g)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('(aa (c (e\nf)) |g)');
+        const b = textNotation.docFromTextNotation('(aa |(c (e\nf)) |g)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Maintains balanced delimiters 2 (Windows)', () => {
-        const a = docFromTextNotation('(aa (c (e\r\nf)) |g)');
-        const b = docFromTextNotation('(aa |(c (e\r\nf)) |g)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('(aa (c (e\r\nf)) |g)');
+        const b = textNotation.docFromTextNotation('(aa |(c (e\r\nf)) |g)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Maintains balanced delimiters 3', () => {
-        const a = docFromTextNotation('(aa (  c (e\nf)) |g)');
-        const b = docFromTextNotation('(aa |(  c (e\nf)) |g)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('(aa (  c (e\nf)) |g)');
+        const b = textNotation.docFromTextNotation('(aa |(  c (e\nf)) |g)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Maintains balanced delimiters 3 (Windows)', () => {
-        const a = docFromTextNotation('(aa (  c (e\r\nf)) |g)');
-        const b = docFromTextNotation('(aa |(  c (e\r\nf)) |g)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('(aa (  c (e\r\nf)) |g)');
+        const b = textNotation.docFromTextNotation('(aa |(  c (e\r\nf)) |g)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Squashes preceding whitespace, stopping at line start', () => {
-        const a = docFromTextNotation('(a\n |e) g)');
-        const b = docFromTextNotation('(a\n| |e) g)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('(a\n |e) g)');
+        const b = textNotation.docFromTextNotation('(a\n| |e) g)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Squashes preceding whitespace, stopping at line start (Windows)', () => {
-        const a = docFromTextNotation('(a\r\n |e) g)');
-        const b = docFromTextNotation('(a\r\n| |e) g)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('(a\r\n |e) g)');
+        const b = textNotation.docFromTextNotation('(a\r\n| |e) g)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Retreats past line start when invoked at line start', () => {
-        const a = docFromTextNotation('(a\n| e) g)');
-        const b = docFromTextNotation('(a|\n| e)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('(a\n| e) g)');
+        const b = textNotation.docFromTextNotation('(a|\n| e)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Retreats past line start when invoked at line start (Windows)', () => {
-        const a = docFromTextNotation('(a\r\n| e) g)');
-        const b = docFromTextNotation('(a|\r\n| e)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('(a\r\n| e) g)');
+        const b = textNotation.docFromTextNotation('(a|\r\n| e)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Retreats past line start, preserving leading whitepace when invoked at line start with squash off', () => {
-        const a = docFromTextNotation('(a  \n| e) g)');
-        const b = docFromTextNotation('(a  |\n| e)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('(a  \n| e) g)');
+        const b = textNotation.docFromTextNotation('(a  |\n| e)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a, a.selections[0].active, false);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Retreats past line start, preserving leading whitepace when invoked at line start with squash off (Windows)', () => {
-        const a = docFromTextNotation('(a  \r\n| e) g)');
-        const b = docFromTextNotation('(a  |\r\n| e)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('(a  \r\n| e) g)');
+        const b = textNotation.docFromTextNotation('(a  |\r\n| e)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a, a.selections[0].active, false);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Retreats past line start, squashing whitepace when invoked at line start', () => {
-        const a = docFromTextNotation('(a  \n| e) g)');
-        const b = docFromTextNotation('(a | \n| e)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('(a  \n| e) g)');
+        const b = textNotation.docFromTextNotation('(a | \n| e)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a, a.selections[0].active, true);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Retreats past line start, squashing whitepace when invoked at line start (Windows)', () => {
-        const a = docFromTextNotation('(a  \r\n| e) g)');
-        const b = docFromTextNotation('(a | \r\n| e)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('(a  \r\n| e) g)');
+        const b = textNotation.docFromTextNotation('(a | \r\n| e)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a, a.selections[0].active, true);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Retreats past line start, squashing only preceding whitepace when invoked at line start', () => {
-        const a = docFromTextNotation('(a  \n| e) g)');
-        const b = docFromTextNotation('(a | \n| e)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('(a  \n| e) g)');
+        const b = textNotation.docFromTextNotation('(a | \n| e)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a, a.selections[0].active, true);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Retreats past line start, squashing only preceding whitepace when invoked at line start (Windows)', () => {
-        const a = docFromTextNotation('(a  \r\n| e) g)');
-        const b = docFromTextNotation('(a | \r\n| e) g)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('(a  \r\n| e) g)');
+        const b = textNotation.docFromTextNotation('(a | \r\n| e) g)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a, a.selections[0].active, true);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       // https://github.com/BetterThanTomorrow/calva/pull/2427#issuecomment-1985910937
       it('Finds start of line after whitespace', () => {
-        const a = docFromTextNotation('(a\n |b)');
-        const b = docFromTextNotation('(a\n| |b)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('(a\n |b)');
+        const b = textNotation.docFromTextNotation('(a\n| |b)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a, a.selections[0].active, true);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of line after whitespace (Windows)', () => {
-        const a = docFromTextNotation('(a\r\n |b)');
-        const b = docFromTextNotation('(a\r\n| |b)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('(a\r\n |b)');
+        const b = textNotation.docFromTextNotation('(a\r\n| |b)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a, a.selections[0].active, true);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds newline when at line start', () => {
-        const a = docFromTextNotation('(a\n| b)');
-        const b = docFromTextNotation('(a|\n| b)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('(a\n| b)');
+        const b = textNotation.docFromTextNotation('(a|\n| b)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a, a.selections[0].active, true);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds newline when at line start (Windows)', () => {
-        const a = docFromTextNotation('(a\r\n| b)');
-        const b = docFromTextNotation('(a|\r\n| b)');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('(a\r\n| b)');
+        const b = textNotation.docFromTextNotation('(a|\r\n| b)');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a, a.selections[0].active, true);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of vectors', () => {
-        const a = docFromTextNotation('[a [b c d e| f] g h]');
-        const b = docFromTextNotation('[a [|b c d e| f] g h]');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('[a [b c d e| f] g h]');
+        const b = textNotation.docFromTextNotation('[a [|b c d e| f] g h]');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of lists', () => {
-        const a = docFromTextNotation('(foo |bar)\n');
-        const b = docFromTextNotation('(|foo |bar)\n');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('(foo |bar)\n');
+        const b = textNotation.docFromTextNotation('(|foo |bar)\n');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of maps', () => {
-        const a = docFromTextNotation('{:a 1 :b 2| :c 3}');
-        const b = docFromTextNotation('{|:a 1 :b 2| :c 3}');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('{:a 1 :b 2| :c 3}');
+        const b = textNotation.docFromTextNotation('{|:a 1 :b 2| :c 3}');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of line in multiline maps', () => {
-        const a = docFromTextNotation('{:a 1 \n:b 2| :c 3}');
-        const b = docFromTextNotation('{:a 1 \n|:b 2| :c 3}');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('{:a 1 \n:b 2| :c 3}');
+        const b = textNotation.docFromTextNotation('{:a 1 \n|:b 2| :c 3}');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of line in multiline maps (Windows)', () => {
-        const a = docFromTextNotation('{:a 1 \r\n:b 2| :c 3}');
-        const b = docFromTextNotation('{:a 1 \r\n|:b 2| :c 3}');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('{:a 1 \r\n:b 2| :c 3}');
+        const b = textNotation.docFromTextNotation('{:a 1 \r\n|:b 2| :c 3}');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of expr in multiline maps', () => {
-        const a = docFromTextNotation('{:a 1 :b 2 (+\n 0\n 2\n) 3| :c 4}');
-        const b = docFromTextNotation('{:a 1 :b 2 |(+\n 0\n 2\n) 3| :c 4}');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('{:a 1 :b 2 (+\n 0\n 2\n) 3| :c 4}');
+        const b = textNotation.docFromTextNotation('{:a 1 :b 2 |(+\n 0\n 2\n) 3| :c 4}');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of expr in multiline maps (Windows)', () => {
-        const a = docFromTextNotation('{:a 1 :b 2 (+\r\n 0\r\n 2\r\n) 3| :c 4}');
-        const b = docFromTextNotation('{:a 1 :b 2 |(+\r\n 0\r\n 2\r\n) 3| :c 4}');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('{:a 1 :b 2 (+\r\n 0\r\n 2\r\n) 3| :c 4}');
+        const b = textNotation.docFromTextNotation('{:a 1 :b 2 |(+\r\n 0\r\n 2\r\n) 3| :c 4}');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of immediate list even in bindings if at list close', () => {
-        const a = docFromTextNotation('(let [a (+ 1 2)\n b (+ 2 3)|] (+ a b))');
-        const b = docFromTextNotation('(let [a (+ 1 2)\n b |(+ 2 3)|] (+ a b))');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('(let [a (+ 1 2)\n b (+ 2 3)|] (+ a b))');
+        const b = textNotation.docFromTextNotation('(let [a (+ 1 2)\n b |(+ 2 3)|] (+ a b))');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of line in bindings if not at list close', () => {
-        const a = docFromTextNotation('(let [{a :a} c\n {b :b} d|] (+ a b))');
-        const b = docFromTextNotation('(let [{a :a} c\n |{b :b} d|] (+ a b))');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('(let [{a :a} c\n {b :b} d|] (+ a b))');
+        const b = textNotation.docFromTextNotation('(let [{a :a} c\n |{b :b} d|] (+ a b))');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of expr in multiline bindings', () => {
-        const a = docFromTextNotation('(let [{a :a\n b :b} d| c (+ 2 3)] (+ a b))');
-        const b = docFromTextNotation('(let [|{a :a\n b :b} d| c (+ 2 3)] (+ a b))');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('(let [{a :a\n b :b} d| c (+ 2 3)] (+ a b))');
+        const b = textNotation.docFromTextNotation('(let [|{a :a\n b :b} d| c (+ 2 3)] (+ a b))');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds start of expr in multiline bindings (Windows)', () => {
-        const a = docFromTextNotation('(let [{a :a\r\n b :b} d| c (+ 2 3)] (+ a b))');
-        const b = docFromTextNotation('(let [|{a :a\r\n b :b} d| c (+ 2 3)] (+ a b))');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('(let [{a :a\r\n b :b} d| c (+ 2 3)] (+ a b))');
+        const b = textNotation.docFromTextNotation('(let [|{a :a\r\n b :b} d| c (+ 2 3)] (+ a b))');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds range in line of tokens', () => {
-        const a = docFromTextNotation('2 \n"hello" :hello/world bye | ');
-        const b = docFromTextNotation('2 \n|"hello" :hello/world bye | ');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('2 \n"hello" :hello/world bye | ');
+        const b = textNotation.docFromTextNotation('2 \n|"hello" :hello/world bye | ');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds range in token with form over multiple lines', () => {
-        const a = docFromTextNotation('3 [\n 1 \n] a|');
-        const b = docFromTextNotation('3 |[\n 1 \n] a|');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('3 [\n 1 \n] a|');
+        const b = textNotation.docFromTextNotation('3 |[\n 1 \n] a|');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds range in token with form over multiple lines (Windows)', () => {
-        const a = docFromTextNotation('3 [\r\n 1 \r\n] a|');
-        const b = docFromTextNotation('3 |[\r\n 1 \r\n] a|');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('3 [\r\n 1 \r\n] a|');
+        const b = textNotation.docFromTextNotation('3 |[\r\n 1 \r\n] a|');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Deals with comments start of line', () => {
-        const a = docFromTextNotation('\n;;  hi|');
-        const b = docFromTextNotation('\n|;;  hi|');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('\n;;  hi|');
+        const b = textNotation.docFromTextNotation('\n|;;  hi|');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Deals with comments start of line (Windows)', () => {
-        const a = docFromTextNotation('\r\n;;  hi|');
-        const b = docFromTextNotation('\r\n|;;  hi|');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('\r\n;;  hi|');
+        const b = textNotation.docFromTextNotation('\r\n|;;  hi|');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Deals with comments middle of line', () => {
-        const a = docFromTextNotation('\n;; |hi');
-        const b = docFromTextNotation('\n|;; |hi');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('\n;; |hi');
+        const b = textNotation.docFromTextNotation('\n|;; |hi');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Deals with comments middle of line (Windows)', () => {
-        const a = docFromTextNotation('\r\n;; |hi');
-        const b = docFromTextNotation('\r\n|;; |hi');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('\r\n;; |hi');
+        const b = textNotation.docFromTextNotation('\r\n|;; |hi');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Deals with empty lines', () => {
-        const a = docFromTextNotation('\n|');
-        const b = docFromTextNotation('|\n|');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('\n|');
+        const b = textNotation.docFromTextNotation('|\n|');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Deals with empty lines (Windows)', () => {
-        const a = docFromTextNotation('\r\n|');
-        const b = docFromTextNotation('|\r\n|');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: true } };
+        const a = textNotation.docFromTextNotation('\r\n|');
+        const b = textNotation.docFromTextNotation('|\r\n|');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: true },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Deals with comments with empty line', () => {
-        const a = docFromTextNotation('\n;; |');
-        const b = docFromTextNotation('\n|;; |');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('\n;; |');
+        const b = textNotation.docFromTextNotation('\n|;; |');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Deals with comments with empty line (Windows)', () => {
-        const a = docFromTextNotation('\r\n;; |');
-        const b = docFromTextNotation('\r\n|;; |');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('\r\n;; |');
+        const b = textNotation.docFromTextNotation('\r\n|;; |');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Does not retreat when on closing token type ', () => {
-        const a = docFromTextNotation('\n(|a e)\n');
-        const b = docFromTextNotation('\n(||a e)\n');
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const a = textNotation.docFromTextNotation('\n(|a e)\n');
+        const b = textNotation.docFromTextNotation('\n(||a e)\n');
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Finds the full form after an ignore marker', () => {
         // https://github.com/BetterThanTomorrow/calva/pull/1293#issuecomment-927123696
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(comment•  #_[a b (c d•              e•              f) g]|•  :a•)'
         );
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           // '(comment•  #_<[a b (c d•              e•              f) g]<• :a•)'
           '(comment•  #_|[a b (c d•              e•              f) g]|• :a•)'
         );
-        const expected = { range: textAndSelection(b)[1], editOptions: { skipFormat: false } };
+        const expected = {
+          range: textNotation.textAndSelection(b)[1],
+          editOptions: { skipFormat: false },
+        };
         const actual = paredit.backwardHybridSexpRange(a);
-        expect(actual).toEqual(expected);
+        expectLib.expect(actual).toEqual(expected);
       });
 
       it('Takes 3 invocations to kill to first non-whitespace, preceding whitespace and then preceding newline', () => {
-        const firstBase = docFromTextNotation('(:a :b \n    :c :d|)');
-        const firstDoc = docFromTextNotation('(:a :b \n    |:c :d|)');
+        const firstBase = textNotation.docFromTextNotation('(:a :b \n    :c :d|)');
+        const firstDoc = textNotation.docFromTextNotation('(:a :b \n    |:c :d|)');
         const firstExpected = {
-          range: textAndSelection(firstDoc)[1],
+          range: textNotation.textAndSelection(firstDoc)[1],
           editOptions: { skipFormat: false },
         };
         const firstActual = paredit.backwardHybridSexpRange(firstBase);
-        expect(firstActual).toEqual(firstExpected);
+        expectLib.expect(firstActual).toEqual(firstExpected);
 
-        const secondBase = docFromTextNotation('(:a :b \n    |:c :d)');
-        const secondDoc = docFromTextNotation('(:a :b \n|    |:c :d)');
+        const secondBase = textNotation.docFromTextNotation('(:a :b \n    |:c :d)');
+        const secondDoc = textNotation.docFromTextNotation('(:a :b \n|    |:c :d)');
         const secondExpected = {
-          range: textAndSelection(secondDoc)[1],
+          range: textNotation.textAndSelection(secondDoc)[1],
           editOptions: { skipFormat: true },
         };
         const secondActual = paredit.backwardHybridSexpRange(secondBase);
-        expect(secondActual).toEqual(secondExpected);
+        expectLib.expect(secondActual).toEqual(secondExpected);
 
-        const thirdBase = docFromTextNotation('(:a :b \n|    :c :d)');
-        const thirdDoc = docFromTextNotation('(:a :b |\n|    :c :d)');
+        const thirdBase = textNotation.docFromTextNotation('(:a :b \n|    :c :d)');
+        const thirdDoc = textNotation.docFromTextNotation('(:a :b |\n|    :c :d)');
         const thirdExpected = {
-          range: textAndSelection(thirdDoc)[1],
+          range: textNotation.textAndSelection(thirdDoc)[1],
           editOptions: { skipFormat: true },
         };
         const thirdActual = paredit.backwardHybridSexpRange(thirdBase);
-        expect(thirdActual).toEqual(thirdExpected);
+        expectLib.expect(thirdActual).toEqual(thirdExpected);
       });
 
       it('Takes 3 invocations to kill to first non-whitespace, preceding whitespace and then preceding newline (Windows)', () => {
-        const firstBase = docFromTextNotation('(:a :b \r\n    :c :d|)');
-        const firstDoc = docFromTextNotation('(:a :b \r\n    |:c :d|)');
+        const firstBase = textNotation.docFromTextNotation('(:a :b \r\n    :c :d|)');
+        const firstDoc = textNotation.docFromTextNotation('(:a :b \r\n    |:c :d|)');
         const firstExpected = {
-          range: textAndSelection(firstDoc)[1],
+          range: textNotation.textAndSelection(firstDoc)[1],
           editOptions: { skipFormat: false },
         };
         const firstActual = paredit.backwardHybridSexpRange(firstBase);
-        expect(firstActual).toEqual(firstExpected);
+        expectLib.expect(firstActual).toEqual(firstExpected);
 
-        const secondBase = docFromTextNotation('(:a :b \r\n    |:c :d)');
-        const secondDoc = docFromTextNotation('(:a :b \r\n|    |:c :d)');
+        const secondBase = textNotation.docFromTextNotation('(:a :b \r\n    |:c :d)');
+        const secondDoc = textNotation.docFromTextNotation('(:a :b \r\n|    |:c :d)');
         const secondExpected = {
-          range: textAndSelection(secondDoc)[1],
+          range: textNotation.textAndSelection(secondDoc)[1],
           editOptions: { skipFormat: true },
         };
         const secondActual = paredit.backwardHybridSexpRange(secondBase);
-        expect(secondActual).toEqual(secondExpected);
+        expectLib.expect(secondActual).toEqual(secondExpected);
 
-        const thirdBase = docFromTextNotation('(:a :b \r\n|    :c :d)');
-        const thirdDoc = docFromTextNotation('(:a :b |\r\n|    :c :d)');
+        const thirdBase = textNotation.docFromTextNotation('(:a :b \r\n|    :c :d)');
+        const thirdDoc = textNotation.docFromTextNotation('(:a :b |\r\n|    :c :d)');
         const thirdExpected = {
-          range: textAndSelection(thirdDoc)[1],
+          range: textNotation.textAndSelection(thirdDoc)[1],
           editOptions: { skipFormat: true },
         };
         const thirdActual = paredit.backwardHybridSexpRange(thirdBase);
-        expect(thirdActual).toEqual(thirdExpected);
+        expectLib.expect(thirdActual).toEqual(thirdExpected);
       });
     });
 
     describe('forwardSexpOrUpRange', () => {
       it('Finds the list in front', () => {
-        const a = docFromTextNotation('|(def foo [vec])');
-        const b = docFromTextNotation('|(def foo [vec])|');
-        expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('|(def foo [vec])');
+        const b = textNotation.docFromTextNotation('|(def foo [vec])|');
+        expectLib
+          .expect(paredit.forwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the list in front through metadata', () => {
-        const a = docFromTextNotation('|^:foo (def foo [vec])');
-        const b = docFromTextNotation('|^:foo (def foo [vec])|');
-        expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('|^:foo (def foo [vec])');
+        const b = textNotation.docFromTextNotation('|^:foo (def foo [vec])|');
+        expectLib
+          .expect(paredit.forwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the list in front through metadata and readers', () => {
-        const a = docFromTextNotation('|^:f #a #b (def foo [vec])');
-        const b = docFromTextNotation('|^:f #a #b (def foo [vec])|');
-        expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('|^:f #a #b (def foo [vec])');
+        const b = textNotation.docFromTextNotation('|^:f #a #b (def foo [vec])|');
+        expectLib
+          .expect(paredit.forwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the list in front through reader metadata reader', () => {
-        const a = docFromTextNotation('|#c ^:f #a #b (def foo [vec])');
-        const b = docFromTextNotation('|#c ^:f #a #b (def foo [vec])|');
-        expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('|#c ^:f #a #b (def foo [vec])');
+        const b = textNotation.docFromTextNotation('|#c ^:f #a #b (def foo [vec])|');
+        expectLib
+          .expect(paredit.forwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the symbol in front', () => {
-        const a = docFromTextNotation('(|def foo [vec])');
-        const b = docFromTextNotation('(|def| foo [vec])');
-        expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(|def foo [vec])');
+        const b = textNotation.docFromTextNotation('(|def| foo [vec])');
+        expectLib
+          .expect(paredit.forwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the rest of the symbol', () => {
-        const a = docFromTextNotation('(d|ef foo [vec])');
-        const b = docFromTextNotation('(d|ef| foo [vec])');
-        expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(d|ef foo [vec])');
+        const b = textNotation.docFromTextNotation('(d|ef| foo [vec])');
+        expectLib
+          .expect(paredit.forwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the rest of the keyword', () => {
-        const a = docFromTextNotation('(def foo [:foo :bar :ba|z])');
-        const b = docFromTextNotation('(def foo [:foo :bar :ba|z|])');
-        expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def foo [:foo :bar :ba|z])');
+        const b = textNotation.docFromTextNotation('(def foo [:foo :bar :ba|z|])');
+        expectLib
+          .expect(paredit.forwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Includes space between the cursor and the symbol', () => {
-        const a = docFromTextNotation('(def| foo [vec])');
-        const b = docFromTextNotation('(def| foo| [vec])');
-        expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def| foo [vec])');
+        const b = textNotation.docFromTextNotation('(def| foo| [vec])');
+        expectLib
+          .expect(paredit.forwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the vector in front', () => {
-        const a = docFromTextNotation('(def foo |[vec])');
-        const b = docFromTextNotation('(def foo |[vec]|)');
-        expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def foo |[vec])');
+        const b = textNotation.docFromTextNotation('(def foo |[vec]|)');
+        expectLib
+          .expect(paredit.forwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the keyword in front', () => {
-        const a = docFromTextNotation('(def foo [:foo :bar |:baz])');
-        const b = docFromTextNotation('(def foo [:foo :bar |:baz|])');
-        expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def foo [:foo :bar |:baz])');
+        const b = textNotation.docFromTextNotation('(def foo [:foo :bar |:baz|])');
+        expectLib
+          .expect(paredit.forwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Leaves a sexp if at the end', () => {
-        const a = docFromTextNotation('(def foo [:foo :bar :baz|])');
-        const b = docFromTextNotation('(def foo [:foo :bar :baz|]|)');
-        expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def foo [:foo :bar :baz|])');
+        const b = textNotation.docFromTextNotation('(def foo [:foo :bar :baz|]|)');
+        expectLib
+          .expect(paredit.forwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds next symbol, including leading space', () => {
-        const a = docFromTextNotation('(>0def>0 foo [vec])');
-        const b = docFromTextNotation('(def>0 foo>0 [vec])');
-        expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(>0def>0 foo [vec])');
+        const b = textNotation.docFromTextNotation('(def>0 foo>0 [vec])');
+        expectLib
+          .expect(paredit.forwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds following vector including leading space', () => {
-        const a = docFromTextNotation('(>0def foo>0 [vec])');
-        const b = docFromTextNotation('(def foo>0 [vec]>0)');
-        expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(>0def foo>0 [vec])');
+        const b = textNotation.docFromTextNotation('(def foo>0 [vec]>0)');
+        expectLib
+          .expect(paredit.forwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Reverses direction of selection and finds next sexp', () => {
-        const a = docFromTextNotation('(<0def foo<0 [vec])');
-        const b = docFromTextNotation('(def foo>0 [vec]>0)');
-        expect(paredit.forwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(<0def foo<0 [vec])');
+        const b = textNotation.docFromTextNotation('(def foo>0 [vec]>0)');
+        expectLib
+          .expect(paredit.forwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
     });
 
     describe('backwardSexpOrUpRange', () => {
       it('Finds the list preceding', () => {
-        const a = docFromTextNotation('(def foo [vec])|');
-        const b = docFromTextNotation('|(def foo [vec])|');
-        expect(paredit.backwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def foo [vec])|');
+        const b = textNotation.docFromTextNotation('|(def foo [vec])|');
+        expectLib
+          .expect(paredit.backwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the list preceding through metadata', () => {
-        const a = docFromTextNotation('^:foo (def foo [vec])|');
-        const b = docFromTextNotation('|^:foo (def foo [vec])|');
-        expect(paredit.backwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('^:foo (def foo [vec])|');
+        const b = textNotation.docFromTextNotation('|^:foo (def foo [vec])|');
+        expectLib
+          .expect(paredit.backwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the list preceding through metadata and readers', () => {
-        const a = docFromTextNotation('^:f #a #b (def foo [vec])|');
-        const b = docFromTextNotation('|^:f #a #b (def foo [vec])|');
-        expect(paredit.backwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('^:f #a #b (def foo [vec])|');
+        const b = textNotation.docFromTextNotation('|^:f #a #b (def foo [vec])|');
+        expectLib
+          .expect(paredit.backwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the list preceding through reader metadata reader', () => {
-        const a = docFromTextNotation('#c ^:f #a #b (def foo [vec])|');
-        const b = docFromTextNotation('|#c ^:f #a #b (def foo [vec])|');
-        expect(paredit.backwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('#c ^:f #a #b (def foo [vec])|');
+        const b = textNotation.docFromTextNotation('|#c ^:f #a #b (def foo [vec])|');
+        expectLib
+          .expect(paredit.backwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds previous form, including space, and reverses direction', () => {
         // TODO: Should we really be reversing the direction here?
-        const a = docFromTextNotation('(def <0foo [vec]<0)');
-        const b = docFromTextNotation('(>0def >0foo [vec])');
-        expect(paredit.backwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def <0foo [vec]<0)');
+        const b = textNotation.docFromTextNotation('(>0def >0foo [vec])');
+        expectLib
+          .expect(paredit.backwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Goes up when at front bounds', () => {
-        const a = docFromTextNotation('(def x (|inc 1))');
-        const b = docFromTextNotation('(def x |(|inc 1))');
-        expect(paredit.backwardSexpOrUpRange(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(def x (|inc 1))');
+        const b = textNotation.docFromTextNotation('(def x |(|inc 1))');
+        expectLib
+          .expect(paredit.backwardSexpOrUpRange(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
     });
 
     describe('moveToRangeRight', () => {
       it('Places cursor at the right end of the selection', () => {
-        const a = docFromTextNotation('(def >0foo>0 [vec])');
-        const b = docFromTextNotation('(def foo| [vec])');
-        paredit.moveToRangeRight(a, textAndSelections(a)[1]);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        const a = textNotation.docFromTextNotation('(def >0foo>0 [vec])');
+        const b = textNotation.docFromTextNotation('(def foo| [vec])');
+        paredit.moveToRangeRight(a, textNotation.textAndSelections(a)[1]);
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Places cursor at the right end of the selection 2', () => {
-        const a = docFromTextNotation('(>0def foo>0 [vec])');
-        const b = docFromTextNotation('(def foo| [vec])');
-        paredit.moveToRangeRight(a, textAndSelections(a)[1]);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        const a = textNotation.docFromTextNotation('(>0def foo>0 [vec])');
+        const b = textNotation.docFromTextNotation('(def foo| [vec])');
+        paredit.moveToRangeRight(a, textNotation.textAndSelections(a)[1]);
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Move to right of given range, regardless of previous selection', () => {
-        const a = docFromTextNotation('(<0def<0 foo [vec])');
-        const b = docFromTextNotation('(def foo >0[vec]>0)');
-        const c = docFromTextNotation('(def foo [vec]|)');
-        paredit.moveToRangeRight(a, textAndSelections(b)[1]);
-        expect(textAndSelection(a)).toEqual(textAndSelection(c));
+        const a = textNotation.docFromTextNotation('(<0def<0 foo [vec])');
+        const b = textNotation.docFromTextNotation('(def foo >0[vec]>0)');
+        const c = textNotation.docFromTextNotation('(def foo [vec]|)');
+        paredit.moveToRangeRight(a, textNotation.textAndSelections(b)[1]);
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(c));
       });
     });
 
     describe('moveToRangeLeft', () => {
       it('Places cursor at the left end of the selection', () => {
-        const a = docFromTextNotation('(def >0foo>0 [vec])');
-        const b = docFromTextNotation('(def |foo [vec])');
-        paredit.moveToRangeLeft(a, textAndSelections(a)[1]);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        const a = textNotation.docFromTextNotation('(def >0foo>0 [vec])');
+        const b = textNotation.docFromTextNotation('(def |foo [vec])');
+        paredit.moveToRangeLeft(a, textNotation.textAndSelections(a)[1]);
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Places cursor at the left end of the selection 2', () => {
-        const a = docFromTextNotation('(>0def foo>0 [vec])');
-        const b = docFromTextNotation('(|def foo [vec])');
-        paredit.moveToRangeLeft(a, textAndSelections(a)[1]);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        const a = textNotation.docFromTextNotation('(>0def foo>0 [vec])');
+        const b = textNotation.docFromTextNotation('(|def foo [vec])');
+        paredit.moveToRangeLeft(a, textNotation.textAndSelections(a)[1]);
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Move to left of given range, regardless of previous selection', () => {
-        const a = docFromTextNotation('(<0def<0 foo [vec])');
-        const b = docFromTextNotation('(def foo >0[vec]>0)');
-        const c = docFromTextNotation('(def foo |[vec])');
-        paredit.moveToRangeLeft(a, textAndSelections(b)[1]);
-        expect(textAndSelection(a)).toEqual(textAndSelection(c));
+        const a = textNotation.docFromTextNotation('(<0def<0 foo [vec])');
+        const b = textNotation.docFromTextNotation('(def foo >0[vec]>0)');
+        const c = textNotation.docFromTextNotation('(def foo |[vec])');
+        paredit.moveToRangeLeft(a, textNotation.textAndSelections(b)[1]);
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(c));
       });
     });
 
     describe('Forward to end of list', () => {
       it('rangeToForwardList', () => {
-        const a = docFromTextNotation('(|c•(#b •[:f :b :z])•#z•1)');
-        const b = docFromTextNotation('(|c•(#b •[:f :b :z])•#z•1|)');
-        expect(paredit.rangeToForwardList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(|c•(#b •[:f :b :z])•#z•1)');
+        const b = textNotation.docFromTextNotation('(|c•(#b •[:f :b :z])•#z•1|)');
+        expectLib
+          .expect(paredit.rangeToForwardList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('rangeToForwardList through readers and meta', () => {
-        const a = docFromTextNotation('(|^e #a ^{:c d}•#b•[:f]•#z•1)');
-        const b = docFromTextNotation('(|^e #a ^{:c d}•#b•[:f]•#z•1|)');
-        expect(paredit.rangeToForwardList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(|^e #a ^{:c d}•#b•[:f]•#z•1)');
+        const b = textNotation.docFromTextNotation('(|^e #a ^{:c d}•#b•[:f]•#z•1|)');
+        expectLib
+          .expect(paredit.rangeToForwardList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
     });
 
     describe('Backward to start of list', () => {
       it('rangeToBackwardList', () => {
-        const a = docFromTextNotation('(c•(#b •[:f :b :z])•#z•1|)');
-        const b = docFromTextNotation('(|c•(#b •[:f :b :z])•#z•1|)');
-        expect(paredit.rangeToBackwardList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(c•(#b •[:f :b :z])•#z•1|)');
+        const b = textNotation.docFromTextNotation('(|c•(#b •[:f :b :z])•#z•1|)');
+        expectLib
+          .expect(paredit.rangeToBackwardList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('rangeToBackwardList through readers and meta', () => {
-        const a = docFromTextNotation('(^e #a ^{:c d}•#b•[:f]•#z•1|)');
-        const b = docFromTextNotation('(|^e #a ^{:c d}•#b•[:f]•#z•1|)');
-        expect(paredit.rangeToBackwardList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(^e #a ^{:c d}•#b•[:f]•#z•1|)');
+        const b = textNotation.docFromTextNotation('(|^e #a ^{:c d}•#b•[:f]•#z•1|)');
+        expectLib
+          .expect(paredit.rangeToBackwardList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
     });
 
     describe('Down list', () => {
       it('rangeToForwardDownList', () => {
-        const a = docFromTextNotation('(|c•(#b •[:f :b :z])•#z•1)');
-        const b = docFromTextNotation('(|c•(|#b •[:f :b :z])•#z•1)');
-        expect(paredit.rangeToForwardDownList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(|c•(#b •[:f :b :z])•#z•1)');
+        const b = textNotation.docFromTextNotation('(|c•(|#b •[:f :b :z])•#z•1)');
+        expectLib
+          .expect(paredit.rangeToForwardDownList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('rangeToForwardDownList through readers', () => {
-        const a = docFromTextNotation('(|c•#f•(#b •[:f :b :z])•#z•1)');
-        const b = docFromTextNotation('(|c•#f•(|#b •[:f :b :z])•#z•1)');
-        expect(paredit.rangeToForwardDownList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(|c•#f•(#b •[:f :b :z])•#z•1)');
+        const b = textNotation.docFromTextNotation('(|c•#f•(|#b •[:f :b :z])•#z•1)');
+        expectLib
+          .expect(paredit.rangeToForwardDownList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('rangeToForwardDownList through metadata', () => {
-        const a = docFromTextNotation('(|c•^f•(#b •[:f :b]))');
-        const b = docFromTextNotation('(|c•^f•(|#b •[:f :b]))');
-        expect(paredit.rangeToForwardDownList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(|c•^f•(#b •[:f :b]))');
+        const b = textNotation.docFromTextNotation('(|c•^f•(|#b •[:f :b]))');
+        expectLib
+          .expect(paredit.rangeToForwardDownList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('rangeToForwardDownList through metadata collection', () => {
-        const a = docFromTextNotation('(|c•^{:f 1}•(#b •[:f :b]))');
-        const b = docFromTextNotation('(|c•^{:f 1}•(|#b •[:f :b]))');
-        expect(paredit.rangeToForwardDownList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(|c•^{:f 1}•(#b •[:f :b]))');
+        const b = textNotation.docFromTextNotation('(|c•^{:f 1}•(|#b •[:f :b]))');
+        expectLib
+          .expect(paredit.rangeToForwardDownList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('rangeToForwardDownList through metadata and readers', () => {
-        const a = docFromTextNotation('(|c•^:a #f•(#b •[:f :b]))');
-        const b = docFromTextNotation('(|c•^:a #f•(|#b •[:f :b]))');
-        expect(paredit.rangeToForwardDownList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(|c•^:a #f•(#b •[:f :b]))');
+        const b = textNotation.docFromTextNotation('(|c•^:a #f•(|#b •[:f :b]))');
+        expectLib
+          .expect(paredit.rangeToForwardDownList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('rangeToForwardDownList through metadata collection and reader', () => {
-        const a = docFromTextNotation('(|c•^{:f 1}•#a •(#b •[:f :b]))');
-        const b = docFromTextNotation('(|c•^{:f 1}•#a •(|#b •[:f :b]))');
-        expect(paredit.rangeToForwardDownList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(|c•^{:f 1}•#a •(#b •[:f :b]))');
+        const b = textNotation.docFromTextNotation('(|c•^{:f 1}•#a •(|#b •[:f :b]))');
+        expectLib
+          .expect(paredit.rangeToForwardDownList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
     });
 
     describe('Backward Up list', () => {
       it('rangeToBackwardUpList', () => {
-        const a = docFromTextNotation('(c•(|#b •[:f :b :z])•#z•1)');
-        const b = docFromTextNotation('(c•|(|#b •[:f :b :z])•#z•1)');
-        expect(paredit.rangeToBackwardUpList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(c•(|#b •[:f :b :z])•#z•1)');
+        const b = textNotation.docFromTextNotation('(c•|(|#b •[:f :b :z])•#z•1)');
+        expectLib
+          .expect(paredit.rangeToBackwardUpList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('rangeToBackwardUpList through readers', () => {
-        const a = docFromTextNotation('(c•#f•(|#b •[:f :b :z])•#z•1)');
-        const b = docFromTextNotation('(c•|#f•(|#b •[:f :b :z])•#z•1)');
-        expect(paredit.rangeToBackwardUpList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(c•#f•(|#b •[:f :b :z])•#z•1)');
+        const b = textNotation.docFromTextNotation('(c•|#f•(|#b •[:f :b :z])•#z•1)');
+        expectLib
+          .expect(paredit.rangeToBackwardUpList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('rangeToBackwardUpList through metadata', () => {
-        const a = docFromTextNotation('(c•^f•(|#b •[:f :b]))');
-        const b = docFromTextNotation('(c•|^f•(|#b •[:f :b]))');
-        expect(paredit.rangeToBackwardUpList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(c•^f•(|#b •[:f :b]))');
+        const b = textNotation.docFromTextNotation('(c•|^f•(|#b •[:f :b]))');
+        expectLib
+          .expect(paredit.rangeToBackwardUpList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('rangeToBackwardUpList through metadata and readers', () => {
-        const a = docFromTextNotation('(c•^:a #f•(|#b •[:f :b]))');
-        const b = docFromTextNotation('(c•|^:a #f•(|#b •[:f :b]))');
-        expect(paredit.rangeToBackwardUpList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(c•^:a #f•(|#b •[:f :b]))');
+        const b = textNotation.docFromTextNotation('(c•|^:a #f•(|#b •[:f :b]))');
+        expectLib
+          .expect(paredit.rangeToBackwardUpList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('rangeToBackwardUpList 2', () => {
         // TODO: This is wrong! But real Paredit behaves as it should...
-        const a = docFromTextNotation('(a(b(c•#f•(#b •|[:f :b :z])•#z•1)))');
-        const b = docFromTextNotation('(a(b|(c•#f•(#b •|[:f :b :z])•#z•1)))');
-        expect(paredit.rangeToBackwardUpList(a)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(a(b(c•#f•(#b •|[:f :b :z])•#z•1)))');
+        const b = textNotation.docFromTextNotation('(a(b|(c•#f•(#b •|[:f :b :z])•#z•1)))');
+        expectLib
+          .expect(paredit.rangeToBackwardUpList(a))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
     });
   });
 
   describe('Reader tags', () => {
     it('dragSexprBackward', async () => {
-      const a = docFromTextNotation('(a(b(c•#f•|(#b •[:f :b :z])•#z•1)))');
-      const b = docFromTextNotation('(a(b(#f•|(#b •[:f :b :z])•c•#z•1)))');
+      const a = textNotation.docFromTextNotation('(a(b(c•#f•|(#b •[:f :b :z])•#z•1)))');
+      const b = textNotation.docFromTextNotation('(a(b(#f•|(#b •[:f :b :z])•c•#z•1)))');
       await paredit.dragSexprBackward(a);
-      expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      expectLib.expect(textNotation.textAndSelection(a)).toEqual(textNotation.textAndSelection(b));
     });
     it('dragSexprForward', async () => {
-      const a = docFromTextNotation('(a(b(c•#f•|(#b •[:f :b :z])•#z•1)))');
-      const b = docFromTextNotation('(a(b(c•#z•1•#f•|(#b •[:f :b :z]))))');
+      const a = textNotation.docFromTextNotation('(a(b(c•#f•|(#b •[:f :b :z])•#z•1)))');
+      const b = textNotation.docFromTextNotation('(a(b(c•#z•1•#f•|(#b •[:f :b :z]))))');
       await paredit.dragSexprForward(a);
-      expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      expectLib.expect(textNotation.textAndSelection(a)).toEqual(textNotation.textAndSelection(b));
     });
     describe('Stacked readers', () => {
       const docText = '(c\n#f\n(#b \n[:f :b :z])\n#x\n#y\n1)';
@@ -1185,16 +1446,20 @@ describe('paredit', () => {
         doc = new model.StringDocument(docText);
       });
       it('dragSexprBackward', async () => {
-        const a = docFromTextNotation('(c•#f•(#b •[:f :b :z])•#x•#y•|:a)');
-        const b = docFromTextNotation('(c•#x•#y•|:a•#f•(#b •[:f :b :z]))');
+        const a = textNotation.docFromTextNotation('(c•#f•(#b •[:f :b :z])•#x•#y•|:a)');
+        const b = textNotation.docFromTextNotation('(c•#x•#y•|:a•#f•(#b •[:f :b :z]))');
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('dragSexprForward', async () => {
-        const a = docFromTextNotation('(c•#f•|(#b •[:f :b :z])•#x•#y•1)');
-        const b = docFromTextNotation('(c•#x•#y•1•#f•|(#b •[:f :b :z]))');
+        const a = textNotation.docFromTextNotation('(c•#f•|(#b •[:f :b :z])•#x•#y•1)');
+        const b = textNotation.docFromTextNotation('(c•#x•#y•1•#f•|(#b •[:f :b :z]))');
         return paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
@@ -1206,21 +1471,27 @@ describe('paredit', () => {
         doc = new model.StringDocument(docText);
       });
       it('dragSexprBackward: #f•(#b •[:f :b :z])•#x•#y•|:a•#å#ä#ö => #x•#y•1•#f•(#b •[:f :b :z])•#å#ä#ö', async () => {
-        doc.selections = [new ModelEditSelection(26, 26)];
+        doc.selections = [new model.ModelEditSelection(26, 26)];
         await paredit.dragSexprBackward(doc);
-        expect(doc.model.getText(0, Infinity)).toBe('#x\n#y\n1\n#f\n(#b \n[:f :b :z])\n#å#ä#ö');
+        expectLib
+          .expect(doc.model.getText(0, Infinity))
+          .toBe('#x\n#y\n1\n#f\n(#b \n[:f :b :z])\n#å#ä#ö');
       });
       it('dragSexprForward: #f•|(#b •[:f :b :z])•#x•#y•1#å#ä#ö => #x•#y•1•#f•|(#b •[:f :b :z])•#å#ä#ö', async () => {
-        doc.selections = [new ModelEditSelection(3, 3)];
+        doc.selections = [new model.ModelEditSelection(3, 3)];
         await paredit.dragSexprForward(doc);
-        expect(doc.model.getText(0, Infinity)).toBe('#x\n#y\n1\n#f\n(#b \n[:f :b :z])\n#å#ä#ö');
-        expect(doc.selections).toEqual([new ModelEditSelection(11)]);
+        expectLib
+          .expect(doc.model.getText(0, Infinity))
+          .toBe('#x\n#y\n1\n#f\n(#b \n[:f :b :z])\n#å#ä#ö');
+        expectLib.expect(doc.selections).toEqual([new model.ModelEditSelection(11)]);
       });
       it('dragSexprForward: #f•(#b •[:f :b :z])•#x•#y•|:a•#å#ä#ö => #f•(#b •[:f :b :z])•#x•#y•|:a•#å#ä#ö', async () => {
-        doc.selections = [new ModelEditSelection(26, 26)];
+        doc.selections = [new model.ModelEditSelection(26, 26)];
         await paredit.dragSexprForward(doc);
-        expect(doc.model.getText(0, Infinity)).toBe('#f\n(#b \n[:f :b :z])\n#x\n#y\n1\n#å#ä#ö');
-        expect(doc.selections).toEqual([new ModelEditSelection(26)]);
+        expectLib
+          .expect(doc.model.getText(0, Infinity))
+          .toBe('#f\n(#b \n[:f :b :z])\n#x\n#y\n1\n#å#ä#ö');
+        expectLib.expect(doc.selections).toEqual([new model.ModelEditSelection(26)]);
       });
     });
   });
@@ -1229,69 +1500,75 @@ describe('paredit', () => {
     describe('selectRangeBackward', () => {
       // TODO: Fix #498
       it('Extends backward selections backwards', () => {
-        const a = docFromTextNotation('(def foo [:foo :bar <0:baz<0])');
-        const selDoc = docFromTextNotation('(def foo [:foo |:bar| :baz])');
-        const b = docFromTextNotation('(def foo [:foo <0:bar :baz<0])');
+        const a = textNotation.docFromTextNotation('(def foo [:foo :bar <0:baz<0])');
+        const selDoc = textNotation.docFromTextNotation('(def foo [:foo |:bar| :baz])');
+        const b = textNotation.docFromTextNotation('(def foo [:foo <0:bar :baz<0])');
         paredit.selectRangeBackward(a, [selDoc.selections[0].asDirectedRange]);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Contracts forward selection and extends backwards', () => {
-        const a = docFromTextNotation('(def foo [:foo :bar >0:baz>0])');
-        const selDoc = docFromTextNotation('(def foo [:foo |:bar| :baz])');
-        const b = docFromTextNotation('(def foo [:foo <0:bar <0:baz])');
+        const a = textNotation.docFromTextNotation('(def foo [:foo :bar >0:baz>0])');
+        const selDoc = textNotation.docFromTextNotation('(def foo [:foo |:bar| :baz])');
+        const b = textNotation.docFromTextNotation('(def foo [:foo <0:bar <0:baz])');
         paredit.selectRangeBackward(a, [selDoc.selections[0].asDirectedRange]);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
     describe('selectRangeForward', () => {
       it('(def foo [:foo >:bar> >|:baz>|]) => (def foo [:foo >:bar :baz>])', () => {
-        const barSelection = new ModelEditSelection(15, 19),
+        const barSelection = new model.ModelEditSelection(15, 19),
           bazRange = [20, 24] as [number, number],
-          barBazSelection = new ModelEditSelection(15, 24);
+          barBazSelection = new model.ModelEditSelection(15, 24);
         doc.selections = [barSelection];
         paredit.selectRangeForward(doc, [bazRange]);
-        expect(doc.selections).toEqual([barBazSelection]);
+        expectLib.expect(doc.selections).toEqual([barBazSelection]);
       });
       it('(def foo [<:foo :bar< >|:baz>|]) => (def foo [>:foo :bar :baz>])', () => {
         const [fooLeft, barRight] = [10, 19],
-          barFooSelection = new ModelEditSelection(barRight, fooLeft),
+          barFooSelection = new model.ModelEditSelection(barRight, fooLeft),
           bazRange = [20, 24] as [number, number],
-          fooBazSelection = new ModelEditSelection(19, 24);
+          fooBazSelection = new model.ModelEditSelection(19, 24);
         doc.selections = [barFooSelection];
         paredit.selectRangeForward(doc, [bazRange]);
-        expect(doc.selections).toEqual([fooBazSelection]);
+        expectLib.expect(doc.selections).toEqual([fooBazSelection]);
       });
       it('(def foo [<:foo :bar< <|:baz<|]) => (def foo [>:foo :bar :baz>])', () => {
         const [fooLeft, barRight] = [10, 19],
-          barFooSelection = new ModelEditSelection(barRight, fooLeft),
+          barFooSelection = new model.ModelEditSelection(barRight, fooLeft),
           bazRange = [24, 20] as [number, number],
-          fooBazSelection = new ModelEditSelection(19, 24);
+          fooBazSelection = new model.ModelEditSelection(19, 24);
         doc.selections = [barFooSelection];
         paredit.selectRangeForward(doc, [bazRange]);
-        expect(doc.selections).toEqual([fooBazSelection]);
+        expectLib.expect(doc.selections).toEqual([fooBazSelection]);
       });
     });
   });
 
   describe('selection stack', () => {
-    const range: ModelEditRange = [15, 20];
+    const range: model.ModelEditRange = [15, 20];
     it('should make grow selection the topmost element on the stack', () => {
       paredit.growSelectionStack(doc, [range]);
-      expect(last(doc.selectionsStack)).toEqual([new ModelEditSelection(range[0], range[1])]);
+      expectLib
+        .expect(_.last(doc.selectionsStack))
+        .toEqual([new model.ModelEditSelection(range[0], range[1])]);
     });
     it('get us back to where we started if we just grow, then shrink', () => {
       const selectionBefore = startSelection.clone();
       paredit.growSelectionStack(doc, [range]);
       paredit.shrinkSelection(doc, [doc.selections[0]]);
-      expect(last(doc.selectionsStack)).toEqual([selectionBefore]);
+      expectLib.expect(_.last(doc.selectionsStack)).toEqual([selectionBefore]);
     });
     it('should not add selections identical to the topmost', () => {
       const selectionBefore = doc.selections[0].clone();
       paredit.growSelectionStack(doc, [range]);
       paredit.growSelectionStack(doc, [range]);
       paredit.shrinkSelection(doc, [doc.selections[0]]);
-      expect(last(doc.selectionsStack)).toEqual([selectionBefore]);
+      expectLib.expect(_.last(doc.selectionsStack)).toEqual([selectionBefore]);
     });
     it('should have A topmost after adding A, then B, then shrinking', () => {
       const a = range,
@@ -1299,348 +1576,398 @@ describe('paredit', () => {
       paredit.growSelectionStack(doc, [a]);
       paredit.growSelectionStack(doc, [b]);
       paredit.shrinkSelection(doc, [doc.selections[0]]);
-      expect(last(doc.selectionsStack)).toEqual([new ModelEditSelection(a[0], a[1])]);
+      expectLib
+        .expect(_.last(doc.selectionsStack))
+        .toEqual([new model.ModelEditSelection(a[0], a[1])]);
     });
     it('grows selection to binding pairs', () => {
-      const a = docFromTextNotation('(a (let [b c |e| f]))');
+      const a = textNotation.docFromTextNotation('(a (let [b c |e| f]))');
       // const aSelection = new ModelEditSelection(a.selections[0].anchor, a.selections[0].active);
       const aSelection = a.selections[0];
-      const b = docFromTextNotation('(a (let [b c |e f|]))');
+      const b = textNotation.docFromTextNotation('(a (let [b c |e f|]))');
       // const bSelection = new ModelEditSelection(b.selections[0].anchor, b.selections[0].active);
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('grows selection to all of binding box when binding pairs are selected', () => {
-      const a = docFromTextNotation('(a (let [b c |e f|]))');
-      const aSelection = new ModelEditSelection(a.selections[0].anchor, a.selections[0].active);
-      const b = docFromTextNotation('(a (let [|b c e f|]))');
-      const bSelection = new ModelEditSelection(b.selections[0].anchor, b.selections[0].active);
+      const a = textNotation.docFromTextNotation('(a (let [b c |e f|]))');
+      const aSelection = new model.ModelEditSelection(
+        a.selections[0].anchor,
+        a.selections[0].active
+      );
+      const b = textNotation.docFromTextNotation('(a (let [|b c e f|]))');
+      const bSelection = new model.ModelEditSelection(
+        b.selections[0].anchor,
+        b.selections[0].active
+      );
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('grows selection to the binding box when all binding pairs are selected', () => {
-      const a = docFromTextNotation('(a (let [|b c e f|]))');
-      const aSelection = new ModelEditSelection(a.selections[0].anchor, a.selections[0].active);
-      const b = docFromTextNotation('(a (let |[b c e f]|))');
-      const bSelection = new ModelEditSelection(b.selections[0].anchor, b.selections[0].active);
+      const a = textNotation.docFromTextNotation('(a (let [|b c e f|]))');
+      const aSelection = new model.ModelEditSelection(
+        a.selections[0].anchor,
+        a.selections[0].active
+      );
+      const b = textNotation.docFromTextNotation('(a (let |[b c e f]|))');
+      const bSelection = new model.ModelEditSelection(
+        b.selections[0].anchor,
+        b.selections[0].active
+      );
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('grows selection to binding pairs in :let within for (value selected first)', () => {
-      const a = docFromTextNotation('(for [x [1 2] :let [a |b| c d]] [a c])');
+      const a = textNotation.docFromTextNotation('(for [x [1 2] :let [a |b| c d]] [a c])');
       const aSelection = a.selections[0];
-      const b = docFromTextNotation('(for [x [1 2] :let [|a b| c d]] [a c])');
+      const b = textNotation.docFromTextNotation('(for [x [1 2] :let [|a b| c d]] [a c])');
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('grows selection from cursor to form to pair in :let within for', () => {
-      const a = docFromTextNotation('(for [x [1 2] :let [a |b c d]] [a c])');
+      const a = textNotation.docFromTextNotation('(for [x [1 2] :let [a |b c d]] [a c])');
       const aSelection = a.selections[0];
-      const b = docFromTextNotation('(for [x [1 2] :let [a |b| c d]] [a c])');
+      const b = textNotation.docFromTextNotation('(for [x [1 2] :let [a |b| c d]] [a c])');
       const bSelection = b.selections[0];
-      const c = docFromTextNotation('(for [x [1 2] :let [|a b| c d]] [a c])');
+      const c = textNotation.docFromTextNotation('(for [x [1 2] :let [|a b| c d]] [a c])');
       const cSelection = c.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection], [cSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection], [cSelection]]);
     });
     it('grows selection to all of binding box in :let within for', () => {
-      const a = docFromTextNotation('(for [x [1 2] :let [a |b c| d]] [a c])');
-      const aSelection = new ModelEditSelection(a.selections[0].anchor, a.selections[0].active);
-      const b = docFromTextNotation('(for [x [1 2] :let [|a b c d|]] [a c])');
-      const bSelection = new ModelEditSelection(b.selections[0].anchor, b.selections[0].active);
+      const a = textNotation.docFromTextNotation('(for [x [1 2] :let [a |b c| d]] [a c])');
+      const aSelection = new model.ModelEditSelection(
+        a.selections[0].anchor,
+        a.selections[0].active
+      );
+      const b = textNotation.docFromTextNotation('(for [x [1 2] :let [|a b c d|]] [a c])');
+      const bSelection = new model.ModelEditSelection(
+        b.selections[0].anchor,
+        b.selections[0].active
+      );
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('grows selection to binding pairs in :let within doseq', () => {
-      const a = docFromTextNotation('(doseq [x xs] :let [a |b| c d] (println a))');
+      const a = textNotation.docFromTextNotation('(doseq [x xs] :let [a |b| c d] (println a))');
       const aSelection = a.selections[0];
-      const b = docFromTextNotation('(doseq [x xs] :let [|a b| c d] (println a))');
+      const b = textNotation.docFromTextNotation('(doseq [x xs] :let [|a b| c d] (println a))');
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('grows selection to all of binding box in :let within doseq', () => {
-      const a = docFromTextNotation('(doseq [x xs] :let [a |b c| d] (println a))');
-      const aSelection = new ModelEditSelection(a.selections[0].anchor, a.selections[0].active);
-      const b = docFromTextNotation('(doseq [x xs] :let [|a b c d|] (println a))');
-      const bSelection = new ModelEditSelection(b.selections[0].anchor, b.selections[0].active);
+      const a = textNotation.docFromTextNotation('(doseq [x xs] :let [a |b c| d] (println a))');
+      const aSelection = new model.ModelEditSelection(
+        a.selections[0].anchor,
+        a.selections[0].active
+      );
+      const b = textNotation.docFromTextNotation('(doseq [x xs] :let [|a b c d|] (println a))');
+      const bSelection = new model.ModelEditSelection(
+        b.selections[0].anchor,
+        b.selections[0].active
+      );
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
 
     it('grows selection to binding pairs in :let with diverse interspersed comments', () => {
       // Comment inside the vector between pairs
-      const e = docFromTextNotation('(for [x xs :let [a b ; comment\n c |d|]])');
+      const e = textNotation.docFromTextNotation('(for [x xs :let [a b ; comment\n c |d|]])');
       const eSelection = e.selections[0];
-      const f = docFromTextNotation('(for [x xs :let [a b ; comment\n |c d|]])');
+      const f = textNotation.docFromTextNotation('(for [x xs :let [a b ; comment\n |c d|]])');
       const fSelection = f.selections[0];
       paredit.growSelection(e);
-      expect(e.selectionsStack).toEqual([[eSelection], [fSelection]]);
+      expectLib.expect(e.selectionsStack).toEqual([[eSelection], [fSelection]]);
 
       // Comment inside a pair
-      const g = docFromTextNotation('(for [x xs :let [a ; comment\n |b| c d]])');
+      const g = textNotation.docFromTextNotation('(for [x xs :let [a ; comment\n |b| c d]])');
       const gSelection = g.selections[0];
-      const h = docFromTextNotation('(for [x xs :let [|a ; comment\n b| c d]])');
+      const h = textNotation.docFromTextNotation('(for [x xs :let [|a ; comment\n b| c d]])');
       const hSelection = h.selections[0];
       paredit.growSelection(g);
-      expect(g.selectionsStack).toEqual([[gSelection], [hSelection]]);
+      expectLib.expect(g.selectionsStack).toEqual([[gSelection], [hSelection]]);
     });
 
     it('does not treat regular vectors in let body as pair forms', () => {
-      const a = docFromTextNotation(
+      const a = textNotation.docFromTextNotation(
         '(let [[root left right] tree] [root |(mirror-tree left)| (mirror-tree right)])'
       );
       const aSelection = a.selections[0];
-      const b = docFromTextNotation(
+      const b = textNotation.docFromTextNotation(
         '(let [[root left right] tree] [|root (mirror-tree left) (mirror-tree right)|])'
       );
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
 
     it('does not treat regular vectors in doseq :let body as pair forms', () => {
-      const a = docFromTextNotation(
+      const a = textNotation.docFromTextNotation(
         '(doseq [a (range 10) :let [aminus (dec a)]] [aminus |a| (inc a)])'
       );
       const aSelection = a.selections[0];
-      const b = docFromTextNotation(
+      const b = textNotation.docFromTextNotation(
         '(doseq [a (range 10) :let [aminus (dec a)]] [|aminus a (inc a)|])'
       );
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
 
     describe('cond pairs', () => {
       it('grows selection to test/expr pairs in cond (expr selected first)', () => {
-        const a = docFromTextNotation('(cond true |:yes| false :no)');
+        const a = textNotation.docFromTextNotation('(cond true |:yes| false :no)');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(cond |true :yes| false :no)');
+        const b = textNotation.docFromTextNotation('(cond |true :yes| false :no)');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
       it('grows selection to test/expr pairs in cond (test selected first)', () => {
-        const a = docFromTextNotation('(cond |true| :yes false :no)');
+        const a = textNotation.docFromTextNotation('(cond |true| :yes false :no)');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(cond |true :yes| false :no)');
+        const b = textNotation.docFromTextNotation('(cond |true :yes| false :no)');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
       it('grows selection to test/expr pairs in cond (second pair)', () => {
-        const a = docFromTextNotation('(cond (pos? x) :positive |(neg? x)| :negative :else :zero)');
+        const a = textNotation.docFromTextNotation(
+          '(cond (pos? x) :positive |(neg? x)| :negative :else :zero)'
+        );
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(cond (pos? x) :positive |(neg? x) :negative| :else :zero)');
+        const b = textNotation.docFromTextNotation(
+          '(cond (pos? x) :positive |(neg? x) :negative| :else :zero)'
+        );
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
       it('grows selection to test/expr pairs in cond with comment between', () => {
-        const a = docFromTextNotation('(cond true ;; comment\n |:yes| false :no)');
+        const a = textNotation.docFromTextNotation('(cond true ;; comment\n |:yes| false :no)');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(cond |true ;; comment\n :yes| false :no)');
+        const b = textNotation.docFromTextNotation('(cond |true ;; comment\n :yes| false :no)');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
     });
 
     describe('cond-> and cond->> pairs', () => {
       it('grows selection to test/expr pairs in cond-> (expr selected first)', () => {
-        const a = docFromTextNotation('(cond-> x (> 0 x) |inc| (even? x) (* 2 x))');
+        const a = textNotation.docFromTextNotation('(cond-> x (> 0 x) |inc| (even? x) (* 2 x))');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
+        const b = textNotation.docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
       it('grows selection to test/expr pairs in cond-> (test selected first)', () => {
-        const a = docFromTextNotation('(cond-> x |(> 0 x)| inc (even? x) (* 2 x))');
+        const a = textNotation.docFromTextNotation('(cond-> x |(> 0 x)| inc (even? x) (* 2 x))');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
+        const b = textNotation.docFromTextNotation('(cond-> x |(> 0 x) inc| (even? x) (* 2 x))');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
       it('grows selection to test/expr pairs in cond->> (expr selected first)', () => {
-        const a = docFromTextNotation('(cond->> x (> 0 x) |inc| (even? x) (* 2 x))');
+        const a = textNotation.docFromTextNotation('(cond->> x (> 0 x) |inc| (even? x) (* 2 x))');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
+        const b = textNotation.docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
       it('grows selection to test/expr pairs in cond->> (test selected first)', () => {
-        const a = docFromTextNotation('(cond->> x |(> 0 x)| inc (even? x) (* 2 x))');
+        const a = textNotation.docFromTextNotation('(cond->> x |(> 0 x)| inc (even? x) (* 2 x))');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
+        const b = textNotation.docFromTextNotation('(cond->> x |(> 0 x) inc| (even? x) (* 2 x))');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
     });
 
     describe('pair selection with case', () => {
       it('grows selection to value/result pairs in case (result selected first)', () => {
-        const a = docFromTextNotation('(case x "x" |"one"| "y" "two" "default")');
+        const a = textNotation.docFromTextNotation('(case x "x" |"one"| "y" "two" "default")');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(case x |"x" "one"| "y" "two" "default")');
+        const b = textNotation.docFromTextNotation('(case x |"x" "one"| "y" "two" "default")');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
       it('grows selection to value/result pairs in case (value selected first)', () => {
-        const a = docFromTextNotation('(case x |"x"| "one" "y" "two" "default")');
+        const a = textNotation.docFromTextNotation('(case x |"x"| "one" "y" "two" "default")');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(case x |"x" "one"| "y" "two" "default")');
+        const b = textNotation.docFromTextNotation('(case x |"x" "one"| "y" "two" "default")');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
       it('grows selection to value/result pairs in case with list value', () => {
-        const a = docFromTextNotation('(case x (2 3) |"two or three"| 4 "four" "default")');
+        const a = textNotation.docFromTextNotation(
+          '(case x (2 3) |"two or three"| 4 "four" "default")'
+        );
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(case x |(2 3) "two or three"| 4 "four" "default")');
+        const b = textNotation.docFromTextNotation(
+          '(case x |(2 3) "two or three"| 4 "four" "default")'
+        );
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
       it('does not treat default as pair when growing selection in case', () => {
-        const a = docFromTextNotation('(case x 1 "one" 2 "two" |"default"|)');
+        const a = textNotation.docFromTextNotation('(case x 1 "one" 2 "two" |"default"|)');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(|case x 1 "one" 2 "two" "default"|)');
+        const b = textNotation.docFromTextNotation('(|case x 1 "one" 2 "two" "default"|)');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
       it('grows selection from case keyword to list contents', () => {
-        const a = docFromTextNotation('(|case| x 1 "one" 2 "two" "default")');
+        const a = textNotation.docFromTextNotation('(|case| x 1 "one" 2 "two" "default")');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(|case x 1 "one" 2 "two" "default"|)');
+        const b = textNotation.docFromTextNotation('(|case x 1 "one" 2 "two" "default"|)');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
     });
 
     describe('assoc pairs', () => {
       it('grows selection to key/value pairs in assoc (value selected first)', () => {
-        const a = docFromTextNotation('(assoc m :a |"one"| :b "two")');
+        const a = textNotation.docFromTextNotation('(assoc m :a |"one"| :b "two")');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(assoc m |:a "one"| :b "two")');
+        const b = textNotation.docFromTextNotation('(assoc m |:a "one"| :b "two")');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
       it('grows selection to key/value pairs in assoc (key selected first)', () => {
-        const a = docFromTextNotation('(assoc m |:a| "one" :b "two")');
+        const a = textNotation.docFromTextNotation('(assoc m |:a| "one" :b "two")');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(assoc m |:a "one"| :b "two")');
+        const b = textNotation.docFromTextNotation('(assoc m |:a "one"| :b "two")');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
       it('grows selection to key/value pairs in assoc (second pair)', () => {
-        const a = docFromTextNotation('(assoc m :a "one" |:b| "two")');
+        const a = textNotation.docFromTextNotation('(assoc m :a "one" |:b| "two")');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(assoc m :a "one" |:b "two"|)');
+        const b = textNotation.docFromTextNotation('(assoc m :a "one" |:b "two"|)');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
       it('does not treat map argument as part of pair', () => {
-        const a = docFromTextNotation('(assoc |m| :a "one" :b "two")');
+        const a = textNotation.docFromTextNotation('(assoc |m| :a "one" :b "two")');
         const aSelection = a.selections[0];
-        const b = docFromTextNotation('(|assoc m :a "one" :b "two"|)');
+        const b = textNotation.docFromTextNotation('(|assoc m :a "one" :b "two"|)');
         const bSelection = b.selections[0];
         paredit.growSelection(a);
-        expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+        expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
       });
     });
   });
 
   describe('condp pair/triple selection tests', () => {
     it('grows selection to test/result pairs in condp (result selected first)', () => {
-      const a = docFromTextNotation('(condp = x 1 |"one"| 2 "two" "default")');
+      const a = textNotation.docFromTextNotation('(condp = x 1 |"one"| 2 "two" "default")');
       const aSelection = a.selections[0];
-      const b = docFromTextNotation('(condp = x |01 "one"|0 2 "two" "default")');
+      const b = textNotation.docFromTextNotation('(condp = x |01 "one"|0 2 "two" "default")');
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('grows selection to test/result pairs in condp (test selected first)', () => {
-      const a = docFromTextNotation('(condp = x |"x"| "one" "y" "two" "default")');
+      const a = textNotation.docFromTextNotation('(condp = x |"x"| "one" "y" "two" "default")');
       const aSelection = a.selections[0];
-      const b = docFromTextNotation('(condp = x |"x" "one"| "y" "two" "default")');
+      const b = textNotation.docFromTextNotation('(condp = x |"x" "one"| "y" "two" "default")');
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('grows selection to test/result pairs in condp with set test', () => {
-      const a = docFromTextNotation('(condp = x #{1 2} |"one or two"| 3 "three" "default")');
+      const a = textNotation.docFromTextNotation(
+        '(condp = x #{1 2} |"one or two"| 3 "three" "default")'
+      );
       const aSelection = a.selections[0];
-      const b = docFromTextNotation('(condp = x |0#{1 2} "one or two"|0 3 "three" "default")');
+      const b = textNotation.docFromTextNotation(
+        '(condp = x |0#{1 2} "one or two"|0 3 "three" "default")'
+      );
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('grows selection to triple in condp with :>> (test selected)', () => {
-      const a = docFromTextNotation('(condp some [1 2 3 4] |#{0 6 7}| :>> inc #{5 9} :>> dec)');
+      const a = textNotation.docFromTextNotation(
+        '(condp some [1 2 3 4] |#{0 6 7}| :>> inc #{5 9} :>> dec)'
+      );
       const aSelection = a.selections[0];
-      const b = docFromTextNotation('(condp some [1 2 3 4] |0#{0 6 7} :>> inc|0 #{5 9} :>> dec)');
+      const b = textNotation.docFromTextNotation(
+        '(condp some [1 2 3 4] |0#{0 6 7} :>> inc|0 #{5 9} :>> dec)'
+      );
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('grows selection to triple in condp with :>> (:>> selected)', () => {
-      const a = docFromTextNotation('(condp some [1 2 3 4] #{0 6 7} |:>>| inc #{5 9} :>> dec)');
+      const a = textNotation.docFromTextNotation(
+        '(condp some [1 2 3 4] #{0 6 7} |:>>| inc #{5 9} :>> dec)'
+      );
       const aSelection = a.selections[0];
-      const b = docFromTextNotation('(condp some [1 2 3 4] |0#{0 6 7} :>> inc|0 #{5 9} :>> dec)');
+      const b = textNotation.docFromTextNotation(
+        '(condp some [1 2 3 4] |0#{0 6 7} :>> inc|0 #{5 9} :>> dec)'
+      );
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('grows selection to triple in condp with :>> (function selected)', () => {
-      const a = docFromTextNotation('(condp some [1 2 3 4] #{0 6 7} :>> |inc| #{5 9} :>> dec)');
+      const a = textNotation.docFromTextNotation(
+        '(condp some [1 2 3 4] #{0 6 7} :>> |inc| #{5 9} :>> dec)'
+      );
       const aSelection = a.selections[0];
-      const b = docFromTextNotation('(condp some [1 2 3 4] |0#{0 6 7} :>> inc|0 #{5 9} :>> dec)');
+      const b = textNotation.docFromTextNotation(
+        '(condp some [1 2 3 4] |0#{0 6 7} :>> inc|0 #{5 9} :>> dec)'
+      );
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('grows selection to triple in condp with :>> and fn form', () => {
-      const a = docFromTextNotation(
+      const a = textNotation.docFromTextNotation(
         '(condp some [1 2 3 4] #{1 2 3} :>> |#(+ % 3)| #{5 9} :>> dec)'
       );
       const aSelection = a.selections[0];
-      const b = docFromTextNotation(
+      const b = textNotation.docFromTextNotation(
         '(condp some [1 2 3 4] |0#{1 2 3} :>> #(+ % 3)|0 #{5 9} :>> dec)'
       );
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('does not treat default as pair when growing selection in condp', () => {
-      const a = docFromTextNotation('(condp = x 1 "one" 2 "two" |"default"|)');
+      const a = textNotation.docFromTextNotation('(condp = x 1 "one" 2 "two" |"default"|)');
       const aSelection = a.selections[0];
-      const b = docFromTextNotation('(|condp = x 1 "one" 2 "two" "default"|)');
+      const b = textNotation.docFromTextNotation('(|condp = x 1 "one" 2 "two" "default"|)');
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
     it('grows selection from condp keyword to list contents', () => {
-      const a = docFromTextNotation('(|condp| = x 1 "one" 2 "two" "default")');
+      const a = textNotation.docFromTextNotation('(|condp| = x 1 "one" 2 "two" "default")');
       const aSelection = a.selections[0];
-      const b = docFromTextNotation('(|condp = x 1 "one" 2 "two" "default"|)');
+      const b = textNotation.docFromTextNotation('(|condp = x 1 "one" 2 "two" "default"|)');
       const bSelection = b.selections[0];
       paredit.growSelection(a);
-      expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+      expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
     });
   });
 
@@ -1654,381 +1981,485 @@ describe('paredit', () => {
       });
 
       it('drags forward in regular lists', async () => {
-        const a = docFromTextNotation(`(c• [:|f '(0 "t")•   "b" :s]•)`);
-        const b = docFromTextNotation(`(c• ['(0 "t") :|f•   "b" :s]•)`);
+        const a = textNotation.docFromTextNotation(`(c• [:|f '(0 "t")•   "b" :s]•)`);
+        const b = textNotation.docFromTextNotation(`(c• ['(0 "t") :|f•   "b" :s]•)`);
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags backward in regular lists', async () => {
-        const a = docFromTextNotation(`(c• [:f '(0 "t")•   "b"| :s]•)`);
-        const b = docFromTextNotation(`(c• [:f "b"|•   '(0 "t") :s]•)`);
+        const a = textNotation.docFromTextNotation(`(c• [:f '(0 "t")•   "b"| :s]•)`);
+        const b = textNotation.docFromTextNotation(`(c• [:f "b"|•   '(0 "t") :s]•)`);
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('does not drag forward when sexpr is last in regular lists', async () => {
         const dotText = `(c• [:f '(0 "t")•   "b" |:s ]•)`;
-        const a = docFromTextNotation(dotText);
-        const b = docFromTextNotation(dotText);
+        const a = textNotation.docFromTextNotation(dotText);
+        const b = textNotation.docFromTextNotation(dotText);
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('does not drag backward when sexpr is last in regular lists', async () => {
         const dotText = `(c• [ :|f '(0 "t")•   "b" :s ]•)`;
-        const a = docFromTextNotation(dotText);
-        const b = docFromTextNotation(dotText);
+        const a = textNotation.docFromTextNotation(dotText);
+        const b = textNotation.docFromTextNotation(dotText);
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags pair forward in maps', async () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           `(c• {:|e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`
         );
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           `(c• {3 {:w? 'w}•   :|e '(e o ea)•   :t '(t i o im)•   :b 'b}•)`
         );
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags pair backwards in maps', async () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           `(c• {:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)|•   :b 'b}•)`
         );
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           `(c• {:e '(e o ea)•   :t '(t i o im)|•   3 {:w? 'w}•   :b 'b}•)`
         );
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags pair backwards in meta-data maps', async () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           `(c• ^{:e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)|•   :b 'b}•)`
         );
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           `(c• ^{:e '(e o ea)•   :t '(t i o im)|•   3 {:w? 'w}•   :b 'b}•)`
         );
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags single sexpr forward in sets', async () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           `(c• #{:|e '(e o ea)•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`
         );
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           `(c• #{'(e o ea) :|e•   3 {:w? 'w}•   :t '(t i o im)•   :b 'b}•)`
         );
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags pair in binding box', async () => {
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           `(let• [:e '(e o ea)•   3 {:w? 'w}•   :t |'(t i o im)•   :b 'b]•)`
         );
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           `(let• [:e '(e o ea)•   3 {:w? 'w}•   :b 'b•   :t |'(t i o im)]•)`
         );
         await paredit.dragSexprForward(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
 
       it('drags single sexpr forward in destructing lists', async () => {
-        const a = docFromTextNotation(`(let [{:keys [a |b c d]} some-map])`);
-        const b = docFromTextNotation(`(let [{:keys [a c |b d]} some-map])`);
+        const a = textNotation.docFromTextNotation(`(let [{:keys [a |b c d]} some-map])`);
+        const b = textNotation.docFromTextNotation(`(let [{:keys [a c |b d]} some-map])`);
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags single sexpr backward in destructing lists', async () => {
-        const a = docFromTextNotation(`(let [{:keys [a b c |d]} some-map])`);
-        const b = docFromTextNotation(`(let [{:keys [a b |d c]} some-map])`);
+        const a = textNotation.docFromTextNotation(`(let [{:keys [a b c |d]} some-map])`);
+        const b = textNotation.docFromTextNotation(`(let [{:keys [a b |d c]} some-map])`);
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags single sexpr forward in bound vectors', async () => {
-        const a = docFromTextNotation(`(let [x [1| 2 3]])`);
-        const b = docFromTextNotation(`(let [x [2 1| 3]])`);
+        const a = textNotation.docFromTextNotation(`(let [x [1| 2 3]])`);
+        const b = textNotation.docFromTextNotation(`(let [x [2 1| 3]])`);
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags single sexpr backward in bound vectors', async () => {
-        const a = docFromTextNotation(`(let [x [1 2 |:a]])`);
-        const b = docFromTextNotation(`(let [x [1 |:a 2]])`);
+        const a = textNotation.docFromTextNotation(`(let [x [1 2 |:a]])`);
+        const b = textNotation.docFromTextNotation(`(let [x [1 |:a 2]])`);
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags single sexpr forward in bound lists', async () => {
-        const a = docFromTextNotation(`(let [x (1 2| 3)])`);
-        const b = docFromTextNotation(`(let [x (1 3 2|)])`);
+        const a = textNotation.docFromTextNotation(`(let [x (1 2| 3)])`);
+        const b = textNotation.docFromTextNotation(`(let [x (1 3 2|)])`);
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags single sexpr backward in bound lists', async () => {
-        const a = docFromTextNotation(`(let [x (1 2 |:a)])`);
-        const b = docFromTextNotation(`(let [x (1 |:a 2)])`);
+        const a = textNotation.docFromTextNotation(`(let [x (1 2 |:a)])`);
+        const b = textNotation.docFromTextNotation(`(let [x (1 |:a 2)])`);
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
     describe('backwardUp - one line', () => {
       it('Drags up from start of vector', async () => {
-        const b = docFromTextNotation(`(def foo [:|foo :bar :baz])`);
-        const a = docFromTextNotation(`(def foo :|foo [:bar :baz])`);
+        const b = textNotation.docFromTextNotation(`(def foo [:|foo :bar :baz])`);
+        const a = textNotation.docFromTextNotation(`(def foo :|foo [:bar :baz])`);
         await paredit.dragSexprBackwardUp(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
       it('Drags up from middle of vector', async () => {
-        const b = docFromTextNotation(`(def foo [:foo |:bar :baz])`);
-        const a = docFromTextNotation(`(def foo |:bar [:foo :baz])`);
+        const b = textNotation.docFromTextNotation(`(def foo [:foo |:bar :baz])`);
+        const a = textNotation.docFromTextNotation(`(def foo |:bar [:foo :baz])`);
         await paredit.dragSexprBackwardUp(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
       it('Drags up from end of vector', async () => {
-        const b = docFromTextNotation(`(def foo [:foo :bar :baz|])`);
-        const a = docFromTextNotation(`(def foo :baz| [:foo :bar])`);
+        const b = textNotation.docFromTextNotation(`(def foo [:foo :bar :baz|])`);
+        const a = textNotation.docFromTextNotation(`(def foo :baz| [:foo :bar])`);
         await paredit.dragSexprBackwardUp(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
       it('Drags up from start of list', async () => {
-        const b = docFromTextNotation(`(d|e|f foo [:foo :bar :baz])`);
-        const a = docFromTextNotation(`de|f (foo [:foo :bar :baz])`);
+        const b = textNotation.docFromTextNotation(`(d|e|f foo [:foo :bar :baz])`);
+        const a = textNotation.docFromTextNotation(`de|f (foo [:foo :bar :baz])`);
         await paredit.dragSexprBackwardUp(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
       it('Drags up without killing preceding line comments', async () => {
-        const b = docFromTextNotation(`(;;foo•de|f foo [:foo :bar :baz])`);
-        const a = docFromTextNotation(`de|f•(;;foo• foo [:foo :bar :baz])`);
+        const b = textNotation.docFromTextNotation(`(;;foo•de|f foo [:foo :bar :baz])`);
+        const a = textNotation.docFromTextNotation(`de|f•(;;foo• foo [:foo :bar :baz])`);
         await paredit.dragSexprBackwardUp(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
       it('Drags up without killing preceding line comments or trailing parens', async () => {
-        const b = docFromTextNotation(`(def ;; foo•  |:foo)`);
-        const a = docFromTextNotation(`|:foo•(def ;; foo•)`);
+        const b = textNotation.docFromTextNotation(`(def ;; foo•  |:foo)`);
+        const a = textNotation.docFromTextNotation(`|:foo•(def ;; foo•)`);
         await paredit.dragSexprBackwardUp(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
     });
     describe('backwardUp - multi-line', () => {
       it('Drags up from indented vector', async () => {
-        const b = docFromTextNotation(`((fn foo•  [x]•  [|:foo•   :bar•   :baz])• 1)`);
-        const a = docFromTextNotation(`((fn foo•  [x]•  |:foo•  [:bar•   :baz])• 1)`);
+        const b = textNotation.docFromTextNotation(`((fn foo•  [x]•  [|:foo•   :bar•   :baz])• 1)`);
+        const a = textNotation.docFromTextNotation(`((fn foo•  [x]•  |:foo•  [:bar•   :baz])• 1)`);
         await paredit.dragSexprBackwardUp(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
       it('Drags up from indented list', async () => {
-        const b = docFromTextNotation(`(|(fn foo•  [x]•  [:foo•   :bar•   :baz])• 1)`);
-        const a = docFromTextNotation(`|(fn foo•  [x]•  [:foo•   :bar•   :baz])•(1)`);
+        const b = textNotation.docFromTextNotation(`(|(fn foo•  [x]•  [:foo•   :bar•   :baz])• 1)`);
+        const a = textNotation.docFromTextNotation(`|(fn foo•  [x]•  [:foo•   :bar•   :baz])•(1)`);
         await paredit.dragSexprBackwardUp(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
       it('Drags up from end of indented list', async () => {
-        const b = docFromTextNotation(`((fn foo•  [x]•  [:foo•   :bar•   :baz])• |:a)`);
-        const a = docFromTextNotation(`|:a•((fn foo•  [x]•  [:foo•   :bar•   :baz]))`);
+        const b = textNotation.docFromTextNotation(
+          `((fn foo•  [x]•  [:foo•   :bar•   :baz])• |:a)`
+        );
+        const a = textNotation.docFromTextNotation(`|:a•((fn foo•  [x]•  [:foo•   :bar•   :baz]))`);
         await paredit.dragSexprBackwardUp(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
       it('Drags up from indented vector w/o killing preceding comment', async () => {
-        const b = docFromTextNotation(`((fn foo•  [x]•  [:foo•   ;; foo•   :b|ar•   :baz])• 1)`);
-        const a = docFromTextNotation(`((fn foo•  [x]•  :b|ar•  [:foo•   ;; foo••   :baz])• 1)`);
+        const b = textNotation.docFromTextNotation(
+          `((fn foo•  [x]•  [:foo•   ;; foo•   :b|ar•   :baz])• 1)`
+        );
+        const a = textNotation.docFromTextNotation(
+          `((fn foo•  [x]•  :b|ar•  [:foo•   ;; foo••   :baz])• 1)`
+        );
         await paredit.dragSexprBackwardUp(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
     });
     describe('forwardDown - one line', () => {
       it('Drags down into vector', async () => {
-        const b = docFromTextNotation(`(def f|oo [:foo :bar :baz])`);
-        const a = docFromTextNotation(`(def [f|oo :foo :bar :baz])`);
+        const b = textNotation.docFromTextNotation(`(def f|oo [:foo :bar :baz])`);
+        const a = textNotation.docFromTextNotation(`(def [f|oo :foo :bar :baz])`);
         await paredit.dragSexprForwardDown(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
       it('Drags down into vector past sexpression on the same level', async () => {
-        const b = docFromTextNotation(`(d|ef| foo [:foo :bar :baz])`);
-        const a = docFromTextNotation(`(foo [def| :foo :bar :baz])`);
+        const b = textNotation.docFromTextNotation(`(d|ef| foo [:foo :bar :baz])`);
+        const a = textNotation.docFromTextNotation(`(foo [def| :foo :bar :baz])`);
         await paredit.dragSexprForwardDown(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
       it('Drags down into vector w/o killing line comments on the way', async () => {
-        const b = docFromTextNotation(`(d|ef ;; foo• [:foo :bar :baz])`);
-        const a = docFromTextNotation(`(;; foo• [d|ef :foo :bar :baz])`);
+        const b = textNotation.docFromTextNotation(`(d|ef ;; foo• [:foo :bar :baz])`);
+        const a = textNotation.docFromTextNotation(`(;; foo• [d|ef :foo :bar :baz])`);
         await paredit.dragSexprForwardDown(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
     });
     describe('forwardUp', () => {
       it('Drags forward out of vector', async () => {
-        const b = docFromTextNotation(`((fn foo [x] [:foo :b|ar])) :baz`);
-        const a = docFromTextNotation(`((fn foo [x] [:foo] :b|ar)) :baz`);
+        const b = textNotation.docFromTextNotation(`((fn foo [x] [:foo :b|ar])) :baz`);
+        const a = textNotation.docFromTextNotation(`((fn foo [x] [:foo] :b|ar)) :baz`);
         await paredit.dragSexprForwardUp(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
       it('Drags forward out of vector w/o killing line comments on the way', async () => {
-        const b = docFromTextNotation(`((fn foo [x] [:foo :b|ar ;; bar•])) :baz`);
-        const a = docFromTextNotation(`((fn foo [x] [:foo ;; bar•] :b|ar)) :baz`);
+        const b = textNotation.docFromTextNotation(`((fn foo [x] [:foo :b|ar ;; bar•])) :baz`);
+        const a = textNotation.docFromTextNotation(`((fn foo [x] [:foo ;; bar•] :b|ar)) :baz`);
         await paredit.dragSexprForwardUp(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
     });
     describe('backwardDown', () => {
       it('Drags backward down into list', async () => {
-        const b = docFromTextNotation(`((fn foo [x] [:foo :bar])) :b|az`);
-        const a = docFromTextNotation(`((fn foo [x] [:foo :bar]) :b|az)`);
+        const b = textNotation.docFromTextNotation(`((fn foo [x] [:foo :bar])) :b|az`);
+        const a = textNotation.docFromTextNotation(`((fn foo [x] [:foo :bar]) :b|az)`);
         await paredit.dragSexprBackwardDown(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
       it('Drags backward down into list w/o killing line comments on the way', async () => {
-        const b = docFromTextNotation(`((fn foo [x] [:foo :bar])) ;; baz•:b|az`);
-        const a = docFromTextNotation(`((fn foo [x] [:foo :bar]) :b|az) ;; baz`);
+        const b = textNotation.docFromTextNotation(`((fn foo [x] [:foo :bar])) ;; baz•:b|az`);
+        const a = textNotation.docFromTextNotation(`((fn foo [x] [:foo :bar]) :b|az) ;; baz`);
         await paredit.dragSexprBackwardDown(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
       it("Does not drag when can't drag down", async () => {
-        const b = docFromTextNotation(`((fn foo [x] [:foo :b|ar])) :baz`);
-        const a = docFromTextNotation(`((fn foo [x] [:foo :b|ar])) :baz`);
+        const b = textNotation.docFromTextNotation(`((fn foo [x] [:foo :b|ar])) :baz`);
+        const a = textNotation.docFromTextNotation(`((fn foo [x] [:foo :b|ar])) :baz`);
         await paredit.dragSexprBackwardDown(b);
-        expect(textAndSelection(b)).toStrictEqual(textAndSelection(a));
+        expectLib
+          .expect(textNotation.textAndSelection(b))
+          .toStrictEqual(textNotation.textAndSelection(a));
       });
     });
   });
   describe('Drag Sexp with pairs/triples', () => {
     describe('cond forms', () => {
       it('drags test/expr pair forward in cond', async () => {
-        const a = docFromTextNotation('(cond |:a 1 :b 2)');
-        const b = docFromTextNotation('(cond :b 2 |:a 1)');
+        const a = textNotation.docFromTextNotation('(cond |:a 1 :b 2)');
+        const b = textNotation.docFromTextNotation('(cond :b 2 |:a 1)');
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags test/expr pair backward in cond', async () => {
-        const a = docFromTextNotation('(cond :a 1 |:b 2)');
-        const b = docFromTextNotation('(cond |:b 2 :a 1)');
+        const a = textNotation.docFromTextNotation('(cond :a 1 |:b 2)');
+        const b = textNotation.docFromTextNotation('(cond |:b 2 :a 1)');
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags test/expr pair forward in cond when cursor on expr', async () => {
-        const a = docFromTextNotation('(cond :a |01 :b 2)');
-        const b = docFromTextNotation('(cond :b 2 :a |01)');
+        const a = textNotation.docFromTextNotation('(cond :a |01 :b 2)');
+        const b = textNotation.docFromTextNotation('(cond :b 2 :a |01)');
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
     describe('cond-> and cond->> forms', () => {
       it('drags test/expr pair forward in cond->', async () => {
-        const a = docFromTextNotation('(cond-> x |:a (inc) :b (dec))');
-        const b = docFromTextNotation('(cond-> x :b (dec) |:a (inc))');
+        const a = textNotation.docFromTextNotation('(cond-> x |:a (inc) :b (dec))');
+        const b = textNotation.docFromTextNotation('(cond-> x :b (dec) |:a (inc))');
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags test/expr pair backward in cond->>', async () => {
-        const a = docFromTextNotation('(cond->> x :a (inc) |:b (dec))');
-        const b = docFromTextNotation('(cond->> x |:b (dec) :a (inc))');
+        const a = textNotation.docFromTextNotation('(cond->> x :a (inc) |:b (dec))');
+        const b = textNotation.docFromTextNotation('(cond->> x |:b (dec) :a (inc))');
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
     describe('case forms', () => {
       it('drags value/result pair forward in case', async () => {
-        const a = docFromTextNotation('(case x |01 "one" 2 "two" "default")');
-        const b = docFromTextNotation('(case x 2 "two" |01 "one" "default")');
+        const a = textNotation.docFromTextNotation('(case x |01 "one" 2 "two" "default")');
+        const b = textNotation.docFromTextNotation('(case x 2 "two" |01 "one" "default")');
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags value/result pair backward in case', async () => {
-        const a = docFromTextNotation('(case x 1 "one" |02 "two" "default")');
-        const b = docFromTextNotation('(case x |02 "two" 1 "one" "default")');
+        const a = textNotation.docFromTextNotation('(case x 1 "one" |02 "two" "default")');
+        const b = textNotation.docFromTextNotation('(case x |02 "two" 1 "one" "default")');
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('does not drag default value as pair in case', async () => {
-        const a = docFromTextNotation('(case x 1 "one" |"default")');
+        const a = textNotation.docFromTextNotation('(case x 1 "one" |"default")');
         // Default is a single form, not a pair, so it should drag alone
-        const b = docFromTextNotation('(case x |"default" 1 "one")');
+        const b = textNotation.docFromTextNotation('(case x |"default" 1 "one")');
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
     describe('condp forms', () => {
       it('drags test/result pair forward in condp', async () => {
-        const a = docFromTextNotation('(condp = x |01 "one" 2 "two" "default")');
-        const b = docFromTextNotation('(condp = x 2 "two" |01 "one" "default")');
+        const a = textNotation.docFromTextNotation('(condp = x |01 "one" 2 "two" "default")');
+        const b = textNotation.docFromTextNotation('(condp = x 2 "two" |01 "one" "default")');
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags test/result pair backward in condp', async () => {
-        const a = docFromTextNotation('(condp = x 1 "one" |02 "two" "default")');
-        const b = docFromTextNotation('(condp = x |02 "two" 1 "one" "default")');
+        const a = textNotation.docFromTextNotation('(condp = x 1 "one" |02 "two" "default")');
+        const b = textNotation.docFromTextNotation('(condp = x |02 "two" 1 "one" "default")');
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags triple (:>> form) forward in condp', async () => {
-        const a = docFromTextNotation('(condp some [1 2] |#{1} :>> inc #{2} :>> dec)');
-        const b = docFromTextNotation('(condp some [1 2] #{2} :>> dec |#{1} :>> inc)');
+        const a = textNotation.docFromTextNotation('(condp some [1 2] |#{1} :>> inc #{2} :>> dec)');
+        const b = textNotation.docFromTextNotation('(condp some [1 2] #{2} :>> dec |#{1} :>> inc)');
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags triple (:>> form) backward in condp', async () => {
-        const a = docFromTextNotation('(condp some [1 2] #{1} :>> inc |#{2} :>> dec)');
-        const b = docFromTextNotation('(condp some [1 2] |#{2} :>> dec #{1} :>> inc)');
+        const a = textNotation.docFromTextNotation('(condp some [1 2] #{1} :>> inc |#{2} :>> dec)');
+        const b = textNotation.docFromTextNotation('(condp some [1 2] |#{2} :>> dec #{1} :>> inc)');
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
     describe(':let bindings in for/doseq', () => {
       it('drags binding pair forward in :let within for', async () => {
-        const a = docFromTextNotation('(for [x xs :let [|a 1 b 2]] [a b])');
-        const b = docFromTextNotation('(for [x xs :let [b 2 |a 1]] [a b])');
+        const a = textNotation.docFromTextNotation('(for [x xs :let [|a 1 b 2]] [a b])');
+        const b = textNotation.docFromTextNotation('(for [x xs :let [b 2 |a 1]] [a b])');
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags binding pair backward in :let within doseq', async () => {
-        const a = docFromTextNotation('(doseq [x xs :let [a 1 |b 2]] (println a b))');
-        const b = docFromTextNotation('(doseq [x xs :let [|b 2 a 1]] (println a b))');
+        const a = textNotation.docFromTextNotation('(doseq [x xs :let [a 1 |b 2]] (println a b))');
+        const b = textNotation.docFromTextNotation('(doseq [x xs :let [|b 2 a 1]] (println a b))');
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('does not treat regular vectors in doseq :let body as pairs when dragging forward', async () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(doseq [a (range 10) :let [aminus (dec a)]] [|a aminus (inc a)])'
         );
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(doseq [a (range 10) :let [aminus (dec a)]] [aminus |a (inc a)])'
         );
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('does not treat regular vectors in doseq :let body as pairs when dragging backward', async () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(doseq [a (range 10) :let [aminus (dec a)]] [aminus |a (inc a)])'
         );
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(doseq [a (range 10) :let [aminus (dec a)]] [|a aminus (inc a)])'
         );
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
@@ -2036,185 +2467,219 @@ describe('paredit', () => {
       it('does not treat regular vector in let body as pairs when dragging backward', async () => {
         // https://github.com/BetterThanTomorrow/calva/issues/2735
         // Regular vectors in let body should not have pair semantics
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(let [[root left right] tree] [root (mirror-tree left) |(mirror-tree right)])'
         );
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(let [[root left right] tree] [root |(mirror-tree right) (mirror-tree left)])'
         );
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('does NOT treat regular vector in let body as pairs when dragging forward', async () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(let [[root left right] tree] [root |(mirror-tree left) (mirror-tree right)])'
         );
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(let [[root left right] tree] [root (mirror-tree right) |(mirror-tree left)])'
         );
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
     describe('assoc forms', () => {
       it('drags key/value pair forward in assoc', async () => {
-        const a = docFromTextNotation('(assoc m |:a "one" :b "two")');
-        const b = docFromTextNotation('(assoc m :b "two" |:a "one")');
+        const a = textNotation.docFromTextNotation('(assoc m |:a "one" :b "two")');
+        const b = textNotation.docFromTextNotation('(assoc m :b "two" |:a "one")');
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags key/value pair backward in assoc', async () => {
-        const a = docFromTextNotation('(assoc m :a "one" |:b "two")');
-        const b = docFromTextNotation('(assoc m |:b "two" :a "one")');
+        const a = textNotation.docFromTextNotation('(assoc m :a "one" |:b "two")');
+        const b = textNotation.docFromTextNotation('(assoc m |:b "two" :a "one")');
         await paredit.dragSexprBackward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags key/value pair forward in assoc when cursor on value', async () => {
-        const a = docFromTextNotation('(assoc m :a |"one" :b "two")');
-        const b = docFromTextNotation('(assoc m :b "two" :a |"one")');
+        const a = textNotation.docFromTextNotation('(assoc m :a |"one" :b "two")');
+        const b = textNotation.docFromTextNotation('(assoc m :b "two" :a |"one")');
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('drags map argument past pair when dragging forward in assoc', async () => {
-        const a = docFromTextNotation('(assoc |m :a "one" :b "two")');
+        const a = textNotation.docFromTextNotation('(assoc |m :a "one" :b "two")');
         // Map drags past the first key-value pair to maintain pair structure
-        const b = docFromTextNotation('(assoc :a "one" |m :b "two")');
+        const b = textNotation.docFromTextNotation('(assoc :a "one" |m :b "two")');
         await paredit.dragSexprForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
     describe('threading macros with pairs', () => {
       describe('assoc in -> macro', () => {
         it('grows selection to key/value pairs in assoc inside ->', () => {
-          const a = docFromTextNotation('(-> m (assoc |:a| "one" :b "two"))');
+          const a = textNotation.docFromTextNotation('(-> m (assoc |:a| "one" :b "two"))');
           const aSelection = a.selections[0];
-          const b = docFromTextNotation('(-> m (assoc |:a "one"| :b "two"))');
+          const b = textNotation.docFromTextNotation('(-> m (assoc |:a "one"| :b "two"))');
           const bSelection = b.selections[0];
           paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+          expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
         });
 
         it('drags key/value pair forward in assoc inside ->', async () => {
-          const a = docFromTextNotation('(-> m (assoc |:a "one" :b "two"))');
-          const b = docFromTextNotation('(-> m (assoc :b "two" |:a "one"))');
+          const a = textNotation.docFromTextNotation('(-> m (assoc |:a "one" :b "two"))');
+          const b = textNotation.docFromTextNotation('(-> m (assoc :b "two" |:a "one"))');
           await paredit.dragSexprForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
 
       describe('cond-> inside -> macro (nested threading)', () => {
         it('grows selection to pair inside cond-> which is itself inside ->', () => {
-          const a = docFromTextNotation('(-> {} (cond-> |true| (assoc :a "one")))');
+          const a = textNotation.docFromTextNotation('(-> {} (cond-> |true| (assoc :a "one")))');
           const aSelection = a.selections[0];
-          const b = docFromTextNotation('(-> {} (cond-> |true (assoc :a "one")|))');
+          const b = textNotation.docFromTextNotation('(-> {} (cond-> |true (assoc :a "one")|))');
           const bSelection = b.selections[0];
           paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+          expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
         });
 
         it('drags pair forward in cond-> which is inside ->', async () => {
-          const a = docFromTextNotation(
+          const a = textNotation.docFromTextNotation(
             '(-> {} (cond-> |true (assoc :a "one") false (assoc :b "two")))'
           );
-          const b = docFromTextNotation(
+          const b = textNotation.docFromTextNotation(
             '(-> {} (cond-> false (assoc :b "two") |true (assoc :a "one")))'
           );
           await paredit.dragSexprForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
 
       describe('case inside -> macro', () => {
         it('grows selection to value/result pair inside case>', () => {
-          const a = docFromTextNotation('(-> x (case |"x"| "one" 2 "two" "default"))');
+          const a = textNotation.docFromTextNotation('(-> x (case |"x"| "one" 2 "two" "default"))');
           const aSelection = a.selections[0];
-          const b = docFromTextNotation('(-> x (case |"x" "one"| 2 "two" "default"))');
+          const b = textNotation.docFromTextNotation('(-> x (case |"x" "one"| 2 "two" "default"))');
           const bSelection = b.selections[0];
           paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+          expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
         });
         it('drags value/result pair backward in case inside ->', async () => {
-          const a = docFromTextNotation('(-> x (case |"x" "one" 2 "two" "default"))');
-          const b = docFromTextNotation('(-> x (case 2 "two" |"x" "one" "default"))');
+          const a = textNotation.docFromTextNotation('(-> x (case |"x" "one" 2 "two" "default"))');
+          const b = textNotation.docFromTextNotation('(-> x (case 2 "two" |"x" "one" "default"))');
           await paredit.dragSexprForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
 
       describe('assoc in ->> macro', () => {
         it('grows selection to key/value pairs with trailing unpaired key in assoc inside ->>', () => {
-          const a = docFromTextNotation('(->> "two" (assoc {} |:one| "one" :two))');
+          const a = textNotation.docFromTextNotation('(->> "two" (assoc {} |:one| "one" :two))');
           const aSelection = a.selections[0];
-          const b = docFromTextNotation('(->> "two" (assoc {} |:one "one"| :two))');
+          const b = textNotation.docFromTextNotation('(->> "two" (assoc {} |:one "one"| :two))');
           const bSelection = b.selections[0];
           paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+          expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
         });
         it('grows selection to entire form because :two is trailing unpaired key', () => {
-          const a = docFromTextNotation('(->> "two" (assoc {} :one "one" |:two|))');
+          const a = textNotation.docFromTextNotation('(->> "two" (assoc {} :one "one" |:two|))');
           const aSelection = a.selections[0];
-          const b = docFromTextNotation('(->> "two" (|assoc {} :one "one" :two|))');
+          const b = textNotation.docFromTextNotation('(->> "two" (|assoc {} :one "one" :two|))');
           const bSelection = b.selections[0];
           paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+          expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
         });
         it('drags key/value pair forward with trailing unpaired key in assoc inside ->>', async () => {
-          const a = docFromTextNotation('(->> "three" (assoc {} |:one "one" :two "two" :three))');
-          const b = docFromTextNotation('(->> "three" (assoc {} :two "two" |:one "one" :three))');
+          const a = textNotation.docFromTextNotation(
+            '(->> "three" (assoc {} |:one "one" :two "two" :three))'
+          );
+          const b = textNotation.docFromTextNotation(
+            '(->> "three" (assoc {} :two "two" |:one "one" :three))'
+          );
           await paredit.dragSexprForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
       describe('case inside ->> macro', () => {
         it('grows selection to value/result pair inside case inside ->>', () => {
-          const a = docFromTextNotation('(->> "default" (case "x" :four "four" :five |"five"|))');
+          const a = textNotation.docFromTextNotation(
+            '(->> "default" (case "x" :four "four" :five |"five"|))'
+          );
           const aSelection = a.selections[0];
-          const b = docFromTextNotation('(->> "default" (case "x" :four "four" |:five "five"|))');
+          const b = textNotation.docFromTextNotation(
+            '(->> "default" (case "x" :four "four" |:five "five"|))'
+          );
           const bSelection = b.selections[0];
           paredit.growSelection(a);
-          expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
+          expectLib.expect(a.selectionsStack).toEqual([[aSelection], [bSelection]]);
         });
         it('drags value/result pair backward in case inside ->>', async () => {
-          const a = docFromTextNotation('(->> "default" (case "x" |:four "four" :five "five"))');
-          const b = docFromTextNotation('(->> "default" (case "x" :five "five" |:four "four"))');
+          const a = textNotation.docFromTextNotation(
+            '(->> "default" (case "x" |:four "four" :five "five"))'
+          );
+          const b = textNotation.docFromTextNotation(
+            '(->> "default" (case "x" :five "five" |:four "four"))'
+          );
           await paredit.dragSexprForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
 
       describe('Nested threading)', () => {
         it('handles cond-> inside -> with assoc pairs (first expansion)', () => {
-          const a = docFromTextNotation('(-> {} (cond-> true (assoc |:a "one")))');
-          const b = docFromTextNotation('(-> {} (cond-> true (assoc |:a "one"|)))');
+          const a = textNotation.docFromTextNotation('(-> {} (cond-> true (assoc |:a "one")))');
+          const b = textNotation.docFromTextNotation('(-> {} (cond-> true (assoc |:a "one"|)))');
           paredit.growSelection(a, a.selections);
-          expect(getText(a)).toBe(getText(b));
+          expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
         });
 
         it('handles cond-> inside -> with assoc form (second expansion)', () => {
-          const a = docFromTextNotation('(-> {} (cond-> true |(assoc :a "one")))');
-          const b = docFromTextNotation('(-> {} (cond-> |true (assoc :a "one")|))');
+          const a = textNotation.docFromTextNotation('(-> {} (cond-> true |(assoc :a "one")))');
+          const b = textNotation.docFromTextNotation('(-> {} (cond-> |true (assoc :a "one")|))');
           paredit.growSelection(a, a.selections);
-          expect(getText(a)).toBe(getText(b));
+          expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
         });
 
         it('handles cond->> inside ->> with assoc pairs', () => {
-          const a = docFromTextNotation('(->> {} (cond->> true (assoc |:a "one")))');
-          const b = docFromTextNotation('(->> {} (cond->> true (assoc |:a "one"|)))');
+          const a = textNotation.docFromTextNotation('(->> {} (cond->> true (assoc |:a "one")))');
+          const b = textNotation.docFromTextNotation('(->> {} (cond->> true (assoc |:a "one"|)))');
           paredit.growSelection(a, a.selections);
-          expect(getText(a)).toBe(getText(b));
+          expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
         });
 
         it('handles cond->> inside ->> with condition pairs', () => {
-          const a = docFromTextNotation('(->> {} (cond->> |true (assoc :a "one")))');
-          const b = docFromTextNotation('(->> {} (cond->> |true (assoc :a "one")|))');
+          const a = textNotation.docFromTextNotation('(->> {} (cond->> |true (assoc :a "one")))');
+          const b = textNotation.docFromTextNotation('(->> {} (cond->> |true (assoc :a "one")|))');
           paredit.growSelection(a, a.selections);
-          expect(getText(a)).toBe(getText(b));
+          expectLib.expect(textNotation.getText(a)).toBe(textNotation.getText(b));
         });
       });
     });
@@ -2223,303 +2688,397 @@ describe('paredit', () => {
   describe('edits', () => {
     describe('Close lists', () => {
       it('Advances cursor if at end of list of the same type', async () => {
-        const a = docFromTextNotation('(str "foo"|)');
-        const b = docFromTextNotation('(str "foo")|');
+        const a = textNotation.docFromTextNotation('(str "foo"|)');
+        const b = textNotation.docFromTextNotation('(str "foo")|');
         await paredit.close(a, ')');
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Does not enter new closing parens in balanced doc', async () => {
-        const a = docFromTextNotation('(str |"foo")');
-        const b = docFromTextNotation('(str |"foo")');
+        const a = textNotation.docFromTextNotation('(str |"foo")');
+        const b = textNotation.docFromTextNotation('(str |"foo")');
         await paredit.close(a, ')');
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       xit('Enter new closing parens in unbalanced doc', async () => {
         // TODO: Reinstall this test once the corresponding cursor test works
         //       (The extension actually behaves correctly.)
-        const a = docFromTextNotation('(str |"foo"');
-        const b = docFromTextNotation('(str )|"foo"');
+        const a = textNotation.docFromTextNotation('(str |"foo"');
+        const b = textNotation.docFromTextNotation('(str )|"foo"');
         await paredit.close(a, ')');
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Enter new closing parens in string', async () => {
-        const a = docFromTextNotation('(str "|foo"');
-        const b = docFromTextNotation('(str ")|foo"');
+        const a = textNotation.docFromTextNotation('(str "|foo"');
+        const b = textNotation.docFromTextNotation('(str ")|foo"');
         await paredit.close(a, ')');
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
     describe('String quoting', () => {
       it('Closes quote at end of string', async () => {
-        const a = docFromTextNotation('(str "foo|")');
-        const b = docFromTextNotation('(str "foo"|)');
+        const a = textNotation.docFromTextNotation('(str "foo|")');
+        const b = textNotation.docFromTextNotation('(str "foo"|)');
         await paredit.stringQuote(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
     describe('Rewrap', () => {
       it('Rewraps () -> []', async () => {
-        const a = docFromTextNotation('a (b c|) d');
-        const b = docFromTextNotation('a [b c|] d');
+        const a = textNotation.docFromTextNotation('a (b c|) d');
+        const b = textNotation.docFromTextNotation('a [b c|] d');
         await paredit.rewrapSexpr(a, '[', ']');
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Rewraps [] -> ()', async () => {
-        const a = docFromTextNotation('a [b c|] d');
-        const b = docFromTextNotation('a (b c|) d');
+        const a = textNotation.docFromTextNotation('a [b c|] d');
+        const b = textNotation.docFromTextNotation('a (b c|) d');
         await paredit.rewrapSexpr(a, '(', ')');
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Rewraps [] -> {}', async () => {
-        const a = docFromTextNotation('a [b c|] d');
-        const b = docFromTextNotation('a {b c|} d');
+        const a = textNotation.docFromTextNotation('a [b c|] d');
+        const b = textNotation.docFromTextNotation('a {b c|} d');
         await paredit.rewrapSexpr(a, '{', '}');
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Rewraps #{} -> {}', async () => {
-        const a = docFromTextNotation('a #{b c|} d');
-        const b = docFromTextNotation('a {b c|} d');
+        const a = textNotation.docFromTextNotation('a #{b c|} d');
+        const b = textNotation.docFromTextNotation('a {b c|} d');
         await paredit.rewrapSexpr(a, '{', '}');
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Rewraps #{} -> ""', async () => {
-        const a = docFromTextNotation('a #{b c|} d');
-        const b = docFromTextNotation('a "b c|" d');
+        const a = textNotation.docFromTextNotation('a #{b c|} d');
+        const b = textNotation.docFromTextNotation('a "b c|" d');
         await paredit.rewrapSexpr(a, '"', '"');
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Rewraps [] -> #{}', async () => {
-        const a = docFromTextNotation('[b c|] d');
-        const b = docFromTextNotation('#{b c|} d');
+        const a = textNotation.docFromTextNotation('[b c|] d');
+        const b = textNotation.docFromTextNotation('#{b c|} d');
         await paredit.rewrapSexpr(a, '#{', '}');
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       // TODO: This tests current behavior. What should happen?
       it('Rewraps ^{} -> #{}', async () => {
-        const a = docFromTextNotation('^{b c|} d');
-        const b = docFromTextNotation('#{b c|} d');
+        const a = textNotation.docFromTextNotation('^{b c|} d');
+        const b = textNotation.docFromTextNotation('#{b c|} d');
         await paredit.rewrapSexpr(a, '#{', '}');
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       // TODO: This tests current behavior. What should happen?
       it('Rewraps ~{} -> #{}', async () => {
-        const a = docFromTextNotation('~{b c|} d');
-        const b = docFromTextNotation('#{b c|} d');
+        const a = textNotation.docFromTextNotation('~{b c|} d');
+        const b = textNotation.docFromTextNotation('#{b c|} d');
         await paredit.rewrapSexpr(a, '#{', '}');
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
     describe('Slurping', () => {
       describe('Slurping forwards', () => {
         it('slurps form after list', async () => {
-          const a = docFromTextNotation('(str|) "foo"');
-          const b = docFromTextNotation('(str| "foo")');
+          const a = textNotation.docFromTextNotation('(str|) "foo"');
+          const b = textNotation.docFromTextNotation('(str| "foo")');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps, in multiline document', async () => {
-          const a = docFromTextNotation('(foo• (str| ) "foo")');
-          const b = docFromTextNotation('(foo• (str| "foo"))');
+          const a = textNotation.docFromTextNotation('(foo• (str| ) "foo")');
+          const b = textNotation.docFromTextNotation('(foo• (str| "foo"))');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps and adds leading space', async () => {
-          const a = docFromTextNotation('(s|tr)#(foo)');
-          const b = docFromTextNotation('(s|tr #(foo))');
+          const a = textNotation.docFromTextNotation('(s|tr)#(foo)');
+          const b = textNotation.docFromTextNotation('(s|tr #(foo))');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps without adding a space', async () => {
-          const a = docFromTextNotation('(s|tr )#(foo)');
-          const b = docFromTextNotation('(s|tr #(foo))');
+          const a = textNotation.docFromTextNotation('(s|tr )#(foo)');
+          const b = textNotation.docFromTextNotation('(s|tr #(foo))');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps, trimming inside whitespace', async () => {
-          const a = docFromTextNotation('(str|   )"foo"');
-          const b = docFromTextNotation('(str| "foo")');
+          const a = textNotation.docFromTextNotation('(str|   )"foo"');
+          const b = textNotation.docFromTextNotation('(str| "foo")');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps, trimming outside whitespace', async () => {
-          const a = docFromTextNotation('(str|)   "foo"');
-          const b = docFromTextNotation('(str| "foo")');
+          const a = textNotation.docFromTextNotation('(str|)   "foo"');
+          const b = textNotation.docFromTextNotation('(str| "foo")');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps, trimming inside and outside whitespace', async () => {
-          const a = docFromTextNotation('(str|   )   "foo"');
-          const b = docFromTextNotation('(str| "foo")');
+          const a = textNotation.docFromTextNotation('(str|   )   "foo"');
+          const b = textNotation.docFromTextNotation('(str| "foo")');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form after empty list without adding leading space', async () => {
-          const a = docFromTextNotation('(|) "foo"');
-          const b = docFromTextNotation('(|"foo")');
+          const a = textNotation.docFromTextNotation('(|) "foo"');
+          const b = textNotation.docFromTextNotation('(|"foo")');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form after whitespace-only list without adding leading space', async () => {
-          const a = docFromTextNotation('(|   ) "foo"');
-          const b = docFromTextNotation('(|"foo")');
+          const a = textNotation.docFromTextNotation('(|   ) "foo"');
+          const b = textNotation.docFromTextNotation('(|"foo")');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('leaves newlines when slurp', async () => {
-          const a = docFromTextNotation('(fo|o•)  bar');
-          const b = docFromTextNotation('(fo|o•  bar)');
+          const a = textNotation.docFromTextNotation('(fo|o•)  bar');
+          const b = textNotation.docFromTextNotation('(fo|o•  bar)');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps properly when closing paren is on new line', async () => {
           // https://github.com/BetterThanTomorrow/calva/issues/1171
-          const a = docFromTextNotation('(def foo•  (str|•   )•  42)');
-          const b = docFromTextNotation('(def foo•  (str|•   •  42))');
+          const a = textNotation.docFromTextNotation('(def foo•  (str|•   )•  42)');
+          const b = textNotation.docFromTextNotation('(def foo•  (str|•   •  42))');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form including meta and readers into empty list', async () => {
-          const a = docFromTextNotation('(|) ^{:a b} #c ^d "foo"');
-          const b = docFromTextNotation('(|^{:a b} #c ^d "foo")');
+          const a = textNotation.docFromTextNotation('(|) ^{:a b} #c ^d "foo"');
+          const b = textNotation.docFromTextNotation('(|^{:a b} #c ^d "foo")');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps in the nearest enclosing list that has a next member (1)', async () => {
-          const a = docFromTextNotation('#{([a|]) b}');
-          const b = docFromTextNotation('#{([a|] b)}');
+          const a = textNotation.docFromTextNotation('#{([a|]) b}');
+          const b = textNotation.docFromTextNotation('#{([a|] b)}');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps in the nearest enclosing list that has a next member (2)', async () => {
-          const a = docFromTextNotation('#{[([a|])] b}');
-          const b = docFromTextNotation('#{[([a|]) b]}');
+          const a = textNotation.docFromTextNotation('#{[([a|])] b}');
+          const b = textNotation.docFromTextNotation('#{[([a|]) b]}');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps forward at multiple cursors', async () => {
-          const a = docFromTextNotation('(str|) "foo"•(str|1) "foo"');
-          const b = docFromTextNotation('(str| "foo")•(str|1 "foo")');
+          const a = textNotation.docFromTextNotation('(str|) "foo"•(str|1) "foo"');
+          const b = textNotation.docFromTextNotation('(str| "foo")•(str|1 "foo")');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form after empty string without adding leading space', async () => {
-          const a = docFromTextNotation('"|"somestuff');
-          const b = docFromTextNotation('"|somestuff"');
+          const a = textNotation.docFromTextNotation('"|"somestuff');
+          const b = textNotation.docFromTextNotation('"|somestuff"');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form after non-empty list with leading space', async () => {
-          const a = docFromTextNotation('(bar|) foo');
-          const b = docFromTextNotation('(bar| foo)');
+          const a = textNotation.docFromTextNotation('(bar|) foo');
+          const b = textNotation.docFromTextNotation('(bar| foo)');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form after non-empty string with leading space', async () => {
-          const a = docFromTextNotation('"a|" b');
-          const b = docFromTextNotation('"a| b"');
+          const a = textNotation.docFromTextNotation('"a|" b');
+          const b = textNotation.docFromTextNotation('"a| b"');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps into nested empty list - first slurp', async () => {
-          const a = docFromTextNotation('([|]) "nested"');
-          const b = docFromTextNotation('([|] "nested")');
+          const a = textNotation.docFromTextNotation('([|]) "nested"');
+          const b = textNotation.docFromTextNotation('([|] "nested")');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps into nested empty list - second slurp', async () => {
-          const a = docFromTextNotation('([|] "nested")');
-          const b = docFromTextNotation('([|"nested"])');
+          const a = textNotation.docFromTextNotation('([|] "nested")');
+          const b = textNotation.docFromTextNotation('([|"nested"])');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form after empty list with ignore marker following', async () => {
-          const a = docFromTextNotation('(|) #_(dosomething)');
-          const b = docFromTextNotation('(|#_(dosomething))');
+          const a = textNotation.docFromTextNotation('(|) #_(dosomething)');
+          const b = textNotation.docFromTextNotation('(|#_(dosomething))');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form after empty list with ignore marker following but does not slurp next sexp', async () => {
-          const a = docFromTextNotation('(|) #_(dosomething) something');
-          const b = docFromTextNotation('(|#_(dosomething)) something');
+          const a = textNotation.docFromTextNotation('(|) #_(dosomething) something');
+          const b = textNotation.docFromTextNotation('(|#_(dosomething)) something');
           await paredit.forwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
 
       describe('Slurping backwards', () => {
         it('slurps form before non-empty string', async () => {
-          const a = docFromTextNotation('(str) "fo|o"');
-          const b = docFromTextNotation('"(str) fo|o"');
+          const a = textNotation.docFromTextNotation('(str) "fo|o"');
+          const b = textNotation.docFromTextNotation('"(str) fo|o"');
           await paredit.backwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form before empty string without adding trailing space', async () => {
-          const a = docFromTextNotation('foo "|"');
-          const b = docFromTextNotation('"foo|"');
+          const a = textNotation.docFromTextNotation('foo "|"');
+          const b = textNotation.docFromTextNotation('"foo|"');
           await paredit.backwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form before empty list without adding trailing space', async () => {
-          const a = docFromTextNotation('foo (|)');
-          const b = docFromTextNotation('(foo|)');
+          const a = textNotation.docFromTextNotation('foo (|)');
+          const b = textNotation.docFromTextNotation('(foo|)');
           await paredit.backwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form before whitespace-only list without adding trailing space', async () => {
-          const a = docFromTextNotation('foo (|   )');
-          const b = docFromTextNotation('(foo|)');
+          const a = textNotation.docFromTextNotation('foo (|   )');
+          const b = textNotation.docFromTextNotation('(foo|)');
           await paredit.backwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form before empty vector without adding trailing space', async () => {
-          const a = docFromTextNotation('foo [|]');
-          const b = docFromTextNotation('[foo|]');
+          const a = textNotation.docFromTextNotation('foo [|]');
+          const b = textNotation.docFromTextNotation('[foo|]');
           await paredit.backwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form before list', async () => {
-          const a = docFromTextNotation('(str) (fo|o)');
-          const b = docFromTextNotation('((str) fo|o)');
+          const a = textNotation.docFromTextNotation('(str) (fo|o)');
+          const b = textNotation.docFromTextNotation('((str) fo|o)');
           await paredit.backwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form before list including meta and readers', async () => {
-          const a = docFromTextNotation('^{:a b} #c ^d "foo" (|)');
-          const b = docFromTextNotation('(^{:a b} #c ^d "foo"|)');
+          const a = textNotation.docFromTextNotation('^{:a b} #c ^d "foo" (|)');
+          const b = textNotation.docFromTextNotation('(^{:a b} #c ^d "foo"|)');
           await paredit.backwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps in the nearest enclosing list that has a previous member (1)', async () => {
-          const a = docFromTextNotation('#{a ([b|])}');
-          const b = docFromTextNotation('#{(a [b|])}');
+          const a = textNotation.docFromTextNotation('#{a ([b|])}');
+          const b = textNotation.docFromTextNotation('#{(a [b|])}');
           await paredit.backwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps in the nearest enclosing list that has a previous member (2)', async () => {
-          const a = docFromTextNotation('#{a [([b|])]}');
-          const b = docFromTextNotation('#{[a ([b|])]}');
+          const a = textNotation.docFromTextNotation('#{a [([b|])]}');
+          const b = textNotation.docFromTextNotation('#{[a ([b|])]}');
           await paredit.backwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps backward at multiple cursors', async () => {
-          const a = docFromTextNotation('(str) (fo|o)•(str) (fo|1o)');
-          const b = docFromTextNotation('((str) fo|o)•((str) fo|1o)');
+          const a = textNotation.docFromTextNotation('(str) (fo|o)•(str) (fo|1o)');
+          const b = textNotation.docFromTextNotation('((str) fo|o)•((str) fo|1o)');
           await paredit.backwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form before empty list with ignore marker preceding', async () => {
-          const a = docFromTextNotation('#_(dosomething) (|)');
-          const b = docFromTextNotation('(#_(dosomething)|)');
+          const a = textNotation.docFromTextNotation('#_(dosomething) (|)');
+          const b = textNotation.docFromTextNotation('(#_(dosomething)|)');
           await paredit.backwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('slurps form before empty list with ignore marker preceding but does not slurp previous sexp', async () => {
-          const a = docFromTextNotation('something #_(dosomething) (|)');
-          const b = docFromTextNotation('something (#_(dosomething)|)');
+          const a = textNotation.docFromTextNotation('something #_(dosomething) (|)');
+          const b = textNotation.docFromTextNotation('something (#_(dosomething)|)');
           await paredit.backwardSlurpSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
     });
@@ -2527,786 +3086,1022 @@ describe('paredit', () => {
     describe('Barfing', () => {
       describe('Barfing forwards', () => {
         it('barfs last form in list', async () => {
-          const a = docFromTextNotation('(str| "foo")');
-          const b = docFromTextNotation('(str|) "foo"');
+          const a = textNotation.docFromTextNotation('(str| "foo")');
+          const b = textNotation.docFromTextNotation('(str|) "foo"');
           await paredit.forwardBarfSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('leaves newlines when slurp', async () => {
-          const a = docFromTextNotation('(fo|o•  bar)');
-          const b = docFromTextNotation('(fo|o)•  bar');
+          const a = textNotation.docFromTextNotation('(fo|o•  bar)');
+          const b = textNotation.docFromTextNotation('(fo|o)•  bar');
           await paredit.forwardBarfSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('barfs form including meta and readers', async () => {
-          const a = docFromTextNotation('(| ^{:a b} #c ^d "foo")');
-          const b = docFromTextNotation('(|) ^{:a b} #c ^d "foo"');
+          const a = textNotation.docFromTextNotation('(| ^{:a b} #c ^d "foo")');
+          const b = textNotation.docFromTextNotation('(|) ^{:a b} #c ^d "foo"');
           await paredit.forwardBarfSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('barfs form from balanced list, when inside unclosed list', async () => {
           // Trying to expose:
           // https://github.com/BetterThanTomorrow/calva/issues/1585
-          const a = docFromTextNotation('(let [a| a)');
-          const b = docFromTextNotation('(let [a|) a');
+          const a = textNotation.docFromTextNotation('(let [a| a)');
+          const b = textNotation.docFromTextNotation('(let [a|) a');
           await paredit.forwardBarfSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('keeps cursor within the list that lost a member (1)', async () => {
-          const a = docFromTextNotation('(str |"foo")');
-          const b = docFromTextNotation('(str|) "foo"');
+          const a = textNotation.docFromTextNotation('(str |"foo")');
+          const b = textNotation.docFromTextNotation('(str|) "foo"');
           await paredit.forwardBarfSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('keeps cursor within the list that lost a member (2)', async () => {
-          const a = docFromTextNotation('(str "foo"|)');
-          const b = docFromTextNotation('(str|) "foo"');
+          const a = textNotation.docFromTextNotation('(str "foo"|)');
+          const b = textNotation.docFromTextNotation('(str|) "foo"');
           await paredit.forwardBarfSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('barfs forward at multiple cursors', async () => {
-          const a = docFromTextNotation('(str| "foo")•(str|1 "foo")');
-          const b = docFromTextNotation('(str|) "foo"•(str|1) "foo"');
+          const a = textNotation.docFromTextNotation('(str| "foo")•(str|1 "foo")');
+          const b = textNotation.docFromTextNotation('(str|) "foo"•(str|1) "foo"');
           await paredit.forwardBarfSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
 
       describe('Barfing backwards', () => {
         it('barfs first form in list', async () => {
-          const a = docFromTextNotation('((str) fo|o)');
-          const b = docFromTextNotation('(str) (fo|o)');
+          const a = textNotation.docFromTextNotation('((str) fo|o)');
+          const b = textNotation.docFromTextNotation('(str) (fo|o)');
           await paredit.backwardBarfSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('barfs first form in list including meta and readers', async () => {
-          const a = docFromTextNotation('(^{:a b} #c ^d "foo"|)');
-          const b = docFromTextNotation('^{:a b} #c ^d "foo"(|)');
+          const a = textNotation.docFromTextNotation('(^{:a b} #c ^d "foo"|)');
+          const b = textNotation.docFromTextNotation('^{:a b} #c ^d "foo"(|)');
           await paredit.backwardBarfSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('barfs backward at multiple cursors', async () => {
-          const a = docFromTextNotation('((str) fo|o)•((str) fo|1o)');
-          const b = docFromTextNotation('(str) (fo|o)•(str) (fo|1o)');
+          const a = textNotation.docFromTextNotation('((str) fo|o)•((str) fo|1o)');
+          const b = textNotation.docFromTextNotation('(str) (fo|o)•(str) (fo|1o)');
           await paredit.backwardBarfSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('keeps cursor within the list that lost its first member', async () => {
-          const a = docFromTextNotation('(|(str) foo)');
-          const b = docFromTextNotation('(str) (|foo)');
+          const a = textNotation.docFromTextNotation('(|(str) foo)');
+          const b = textNotation.docFromTextNotation('(str) (|foo)');
           await paredit.backwardBarfSexp(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
     });
 
     describe('Raise', () => {
       it('raises the current form when cursor is preceding', async () => {
-        const a = docFromTextNotation('(comment•  (str |#(foo)))');
-        const b = docFromTextNotation('(comment•  |#(foo))');
+        const a = textNotation.docFromTextNotation('(comment•  (str |#(foo)))');
+        const b = textNotation.docFromTextNotation('(comment•  |#(foo))');
         await paredit.raiseSexp(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('raises the current form when cursor is trailing', async () => {
-        const a = docFromTextNotation('(comment•  (str #(foo)|))');
-        const b = docFromTextNotation('(comment•  #(foo)|)');
+        const a = textNotation.docFromTextNotation('(comment•  (str #(foo)|))');
+        const b = textNotation.docFromTextNotation('(comment•  #(foo)|)');
         await paredit.raiseSexp(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
     describe('Kill character backwards (backspace)', () => {
       it('Deletes a selected range', () => {
-        const a = docFromTextNotation('{::foo ()• :|:bar |:foo}');
-        const b = docFromTextNotation('{::foo ()• :|:foo}');
+        const a = textNotation.docFromTextNotation('{::foo ()• :|:bar |:foo}');
+        const b = textNotation.docFromTextNotation('{::foo ()• :|:foo}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Leaves closing paren of empty list alone', () => {
-        const a = docFromTextNotation('{::foo ()|• ::bar :foo}');
-        const b = docFromTextNotation('{::foo (|)• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo ()|• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo (|)• ::bar :foo}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes closing paren if unbalance', () => {
-        const a = docFromTextNotation('{::foo )|• ::bar :foo}');
-        const b = docFromTextNotation('{::foo |• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo )|• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo |• ::bar :foo}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Leaves opening paren of non-empty list alone', () => {
-        const a = docFromTextNotation('{::foo (|a)• ::bar :foo}');
-        const b = docFromTextNotation('{::foo |(a)• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo (|a)• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo |(a)• ::bar :foo}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Leaves opening quote of non-empty string alone', () => {
-        const a = docFromTextNotation('{::foo "|a"• ::bar :foo}');
-        const b = docFromTextNotation('{::foo |"a"• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo "|a"• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo |"a"• ::bar :foo}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Leaves closing quote of non-empty string alone', () => {
-        const a = docFromTextNotation('{::foo "a"|• ::bar :foo}');
-        const b = docFromTextNotation('{::foo "a|"• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo "a"|• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo "a|"• ::bar :foo}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes contents in strings', () => {
-        const a = docFromTextNotation('{::foo "a|"• ::bar :foo}');
-        const b = docFromTextNotation('{::foo "|"• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo "a|"• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo "|"• ::bar :foo}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes contents in strings 2', () => {
-        const a = docFromTextNotation('{::foo "a|a"• ::bar :foo}');
-        const b = docFromTextNotation('{::foo "|a"• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo "a|a"• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo "|a"• ::bar :foo}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes contents in strings 3', () => {
-        const a = docFromTextNotation('{::foo "aa|"• ::bar :foo}');
-        const b = docFromTextNotation('{::foo "a|"• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo "aa|"• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo "a|"• ::bar :foo}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes quoted quote', () => {
-        const a = docFromTextNotation('{::foo \\"|• ::bar :foo}');
-        const b = docFromTextNotation('{::foo |• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo \\"|• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo |• ::bar :foo}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes quoted quote in string', () => {
-        const a = docFromTextNotation('{::foo "\\"|"• ::bar :foo}');
-        const b = docFromTextNotation('{::foo "|"• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo "\\"|"• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo "|"• ::bar :foo}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes contents in list', () => {
-        const a = docFromTextNotation('{::foo (a|)• ::bar :foo}');
-        const b = docFromTextNotation('{::foo (|)• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo (a|)• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo (|)• ::bar :foo}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes empty list function', () => {
-        const a = docFromTextNotation('{::foo (|)• ::bar :foo}');
-        const b = docFromTextNotation('{::foo |• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo (|)• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo |• ::bar :foo}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes empty set', () => {
-        const a = docFromTextNotation('#{|}');
-        const b = docFromTextNotation('|');
+        const a = textNotation.docFromTextNotation('#{|}');
+        const b = textNotation.docFromTextNotation('|');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes empty literal function with trailing newline', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1079
-        const a = docFromTextNotation('{::foo #(|)• ::bar :foo}');
-        const b = docFromTextNotation('{::foo |• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo #(|)• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo |• ::bar :foo}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes open paren prefix characters', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1122
-        const a = docFromTextNotation('#|(foo)');
-        const b = docFromTextNotation('|(foo)');
+        const a = textNotation.docFromTextNotation('#|(foo)');
+        const b = textNotation.docFromTextNotation('|(foo)');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes open map curly prefix/ns characters', () => {
-        const a = docFromTextNotation('#:same|{:thing :here}');
-        const b = docFromTextNotation('#:sam|{:thing :here}');
+        const a = textNotation.docFromTextNotation('#:same|{:thing :here}');
+        const b = textNotation.docFromTextNotation('#:sam|{:thing :here}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes open set hash characters', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1122
-        const a = docFromTextNotation('#|{:thing :here}');
-        const b = docFromTextNotation('|{:thing :here}');
+        const a = textNotation.docFromTextNotation('#|{:thing :here}');
+        const b = textNotation.docFromTextNotation('|{:thing :here}');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes quote prefix from quoted list with content', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/3020
-        const a = docFromTextNotation("'('|(1 2 3) '(4 5 6) '(7 8 9))");
-        const b = docFromTextNotation("'(|(1 2 3) '(4 5 6) '(7 8 9))");
+        const a = textNotation.docFromTextNotation("'('|(1 2 3) '(4 5 6) '(7 8 9))");
+        const b = textNotation.docFromTextNotation("'(|(1 2 3) '(4 5 6) '(7 8 9))");
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes quote prefix from nested quoted list', () => {
-        const a = docFromTextNotation("(foo '|(bar baz))");
-        const b = docFromTextNotation('(foo |(bar baz))');
+        const a = textNotation.docFromTextNotation("(foo '|(bar baz))");
+        const b = textNotation.docFromTextNotation('(foo |(bar baz))');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes quote prefix from quoted vector', () => {
-        const a = docFromTextNotation("'|[1 2 3]");
-        const b = docFromTextNotation('|[1 2 3]');
+        const a = textNotation.docFromTextNotation("'|[1 2 3]");
+        const b = textNotation.docFromTextNotation('|[1 2 3]');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Moves cursor past entire open paren, including prefix characters', () => {
-        const a = docFromTextNotation('#(|foo)');
-        const b = docFromTextNotation('|#(foo)');
+        const a = textNotation.docFromTextNotation('#(|foo)');
+        const b = textNotation.docFromTextNotation('|#(foo)');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes unbalanced bracket', () => {
         // This hangs the structural editing in the real editor
         // https://github.com/BetterThanTomorrow/calva/issues/1573
-        const a = docFromTextNotation('([{|)');
-        const b = docFromTextNotation('([|');
+        const a = textNotation.docFromTextNotation('([{|)');
+        const b = textNotation.docFromTextNotation('([|');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes whitespace to the left of the cursor', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           `
 (if false nil
   |true)
         `.trim()
         );
-        const b = docFromTextNotation(`(if false nil |true)`.trim());
+        const b = textNotation.docFromTextNotation(`(if false nil |true)`.trim());
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('Deletes whitespace to the left of the cursor without crossing multiple lines', () => {
-        const a = docFromTextNotation('[•• |::foo]');
-        const b = docFromTextNotation('[• |::foo]');
+        const a = textNotation.docFromTextNotation('[•• |::foo]');
+        const b = textNotation.docFromTextNotation('[• |::foo]');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('Deletes whitespace to the left and right of the cursor when inside whitespace', () => {
-        const a = docFromTextNotation('[• | ::foo]');
-        const b = docFromTextNotation('[|::foo]');
+        const a = textNotation.docFromTextNotation('[• | ::foo]');
+        const b = textNotation.docFromTextNotation('[|::foo]');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('Deletes whitespace to the left and inserts a space when arriving at the end of a line', () => {
-        const a = docFromTextNotation('(if :foo•  |:bar   :baz)');
-        const b = docFromTextNotation('(if :foo |:bar   :baz)');
+        const a = textNotation.docFromTextNotation('(if :foo•  |:bar   :baz)');
+        const b = textNotation.docFromTextNotation('(if :foo |:bar   :baz)');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('Deletes whitespace to the left and inserts a single space when ending up on a line with trailing whitespace', () => {
-        const a = docFromTextNotation('(if :foo    •  |:bar   :baz)');
-        const b = docFromTextNotation('(if :foo |:bar   :baz)');
+        const a = textNotation.docFromTextNotation('(if :foo    •  |:bar   :baz)');
+        const b = textNotation.docFromTextNotation('(if :foo |:bar   :baz)');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('Deletes whitespace to the left and avoids inserting a space if on a close token', () => {
-        const a = docFromTextNotation('(if :foo•    |)');
-        const b = docFromTextNotation('(if :foo|)');
+        const a = textNotation.docFromTextNotation('(if :foo•    |)');
+        const b = textNotation.docFromTextNotation('(if :foo|)');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       // https://github.com/BetterThanTomorrow/calva/issues/2108
       it('Deletes whitespace to the left and avoids inserting indent if at top level', () => {
-        const a = docFromTextNotation('a\n\n    |b');
-        const b = docFromTextNotation('a\n\n   |b');
+        const a = textNotation.docFromTextNotation('a\n\n    |b');
+        const b = textNotation.docFromTextNotation('a\n\n   |b');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('Deletes whitespace to the left, inserting indents if at top level inside RFC', () => {
-        const a = docFromTextNotation('(comment\n  a\n\n    |b)');
-        const b = docFromTextNotation('(comment\n  a\n  |b)');
+        const a = textNotation.docFromTextNotation('(comment\n  a\n\n    |b)');
+        const b = textNotation.docFromTextNotation('(comment\n  a\n  |b)');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('Deletes a character when inside a token on a blank line', () => {
-        const a = docFromTextNotation('(if• :|foo)');
-        const b = docFromTextNotation('(if• |foo)');
+        const a = textNotation.docFromTextNotation('(if• :|foo)');
+        const b = textNotation.docFromTextNotation('(if• |foo)');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       // https://github.com/BetterThanTomorrow/calva/issues/2327
       it('Deletes hash character to the left of a list, inside a list', () => {
-        const a = docFromTextNotation('(#|())');
-        const b = docFromTextNotation('(|())');
+        const a = textNotation.docFromTextNotation('(#|())');
+        const b = textNotation.docFromTextNotation('(|())');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes hash character to the left of a vector, inside a list', () => {
-        const a = docFromTextNotation('(#|[])');
-        const b = docFromTextNotation('(|[])');
+        const a = textNotation.docFromTextNotation('(#|[])');
+        const b = textNotation.docFromTextNotation('(|[])');
         paredit.backspace(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       describe('Hash character deletion with non-empty reader macros', () => {
         it('Deletes # inside non-empty anonymous function', () => {
-          const a = docFromTextNotation('[#|(prn "hello")]');
-          const b = docFromTextNotation('[|(prn "hello")]');
+          const a = textNotation.docFromTextNotation('[#|(prn "hello")]');
+          const b = textNotation.docFromTextNotation('[|(prn "hello")]');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes # and space together after invalid # with space', () => {
-          const a = docFromTextNotation('[# |(prn "hello")]');
-          const b = docFromTextNotation('[|(prn "hello")]');
+          const a = textNotation.docFromTextNotation('[# |(prn "hello")]');
+          const b = textNotation.docFromTextNotation('[|(prn "hello")]');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes # inside non-empty set', () => {
-          const a = docFromTextNotation('[#|{:foo :bar}]');
-          const b = docFromTextNotation('[|{:foo :bar}]');
+          const a = textNotation.docFromTextNotation('[#|{:foo :bar}]');
+          const b = textNotation.docFromTextNotation('[|{:foo :bar}]');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes # inside empty anonymous function', () => {
-          const a = docFromTextNotation('(#|())');
-          const b = docFromTextNotation('(|())');
+          const a = textNotation.docFromTextNotation('(#|())');
+          const b = textNotation.docFromTextNotation('(|())');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes # inside empty set', () => {
-          const a = docFromTextNotation('(#|{})');
-          const b = docFromTextNotation('(|{})');
+          const a = textNotation.docFromTextNotation('(#|{})');
+          const b = textNotation.docFromTextNotation('(|{})');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Jumps over # when cursor is after opening paren', () => {
-          const a = docFromTextNotation('#(|foo)');
-          const b = docFromTextNotation('|#(foo)');
+          const a = textNotation.docFromTextNotation('#(|foo)');
+          const b = textNotation.docFromTextNotation('|#(foo)');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Jumps over # when cursor is after opening brace', () => {
-          const a = docFromTextNotation('#{|:foo}');
-          const b = docFromTextNotation('|#{:foo}');
+          const a = textNotation.docFromTextNotation('#{|:foo}');
+          const b = textNotation.docFromTextNotation('|#{:foo}');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
       describe('Quote prefix deletion with empty forms', () => {
         it("Deletes ' before empty list", () => {
-          const a = docFromTextNotation("'|()");
-          const b = docFromTextNotation('|()');
+          const a = textNotation.docFromTextNotation("'|()");
+          const b = textNotation.docFromTextNotation('|()');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it("Deletes ' before empty vector", () => {
-          const a = docFromTextNotation("'|[]");
-          const b = docFromTextNotation('|[]');
+          const a = textNotation.docFromTextNotation("'|[]");
+          const b = textNotation.docFromTextNotation('|[]');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it("Deletes ' before empty map", () => {
-          const a = docFromTextNotation("'|{}");
-          const b = docFromTextNotation('|{}');
+          const a = textNotation.docFromTextNotation("'|{}");
+          const b = textNotation.docFromTextNotation('|{}');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it("Deletes ' before non-empty list", () => {
-          const a = docFromTextNotation("'|(foo)");
-          const b = docFromTextNotation('|(foo)');
+          const a = textNotation.docFromTextNotation("'|(foo)");
+          const b = textNotation.docFromTextNotation('|(foo)');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
       describe('Discard comment (#_) deletion', () => {
         it('Deletes #_ when cursor is right after it', () => {
-          const a = docFromTextNotation('#_|foo');
-          const b = docFromTextNotation('|foo');
+          const a = textNotation.docFromTextNotation('#_|foo');
+          const b = textNotation.docFromTextNotation('|foo');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes #_ when cursor is between #_ and a vector', () => {
-          const a = docFromTextNotation('#_|[a b]');
-          const b = docFromTextNotation('|[a b]');
+          const a = textNotation.docFromTextNotation('#_|[a b]');
+          const b = textNotation.docFromTextNotation('|[a b]');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes #_ when cursor is between #_ and a map', () => {
-          const a = docFromTextNotation('#_|{:a 1}');
-          const b = docFromTextNotation('|{:a 1}');
+          const a = textNotation.docFromTextNotation('#_|{:a 1}');
+          const b = textNotation.docFromTextNotation('|{:a 1}');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes #_ when cursor is between #_ and a paren list', () => {
-          const a = docFromTextNotation('#_|(foo bar)');
-          const b = docFromTextNotation('|(foo bar)');
+          const a = textNotation.docFromTextNotation('#_|(foo bar)');
+          const b = textNotation.docFromTextNotation('|(foo bar)');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes #_ inside another form', () => {
-          const a = docFromTextNotation('(a #_|b c)');
-          const b = docFromTextNotation('(a |b c)');
+          const a = textNotation.docFromTextNotation('(a #_|b c)');
+          const b = textNotation.docFromTextNotation('(a |b c)');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes #_ before a nested list inside a form', () => {
-          const a = docFromTextNotation('(a #_|[1 2] c)');
-          const b = docFromTextNotation('(a |[1 2] c)');
+          const a = textNotation.docFromTextNotation('(a #_|[1 2] c)');
+          const b = textNotation.docFromTextNotation('(a |[1 2] c)');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes standalone #_ with nothing after it', () => {
-          const a = docFromTextNotation('#_|');
-          const b = docFromTextNotation('|');
+          const a = textNotation.docFromTextNotation('#_|');
+          const b = textNotation.docFromTextNotation('|');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes standalone #_ with nothing after it inside a form', () => {
-          const a = docFromTextNotation('(a #_|)');
-          const b = docFromTextNotation('(a |)');
+          const a = textNotation.docFromTextNotation('(a #_|)');
+          const b = textNotation.docFromTextNotation('(a |)');
           paredit.backspace(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
     });
 
     describe('Kill character forwards (delete)', () => {
       it('Leaves closing paren of empty list alone', () => {
-        const a = docFromTextNotation('{::foo |()• ::bar :foo}');
-        const b = docFromTextNotation('{::foo (|)• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo |()• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo (|)• ::bar :foo}');
         paredit.deleteForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes closing paren if unbalance', () => {
-        const a = docFromTextNotation('{::foo |)• ::bar :foo}');
-        const b = docFromTextNotation('{::foo |• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo |)• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo |• ::bar :foo}');
         paredit.deleteForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Leaves opening paren of non-empty list alone', () => {
-        const a = docFromTextNotation('{::foo |(a)• ::bar :foo}');
-        const b = docFromTextNotation('{::foo (|a)• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo |(a)• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo (|a)• ::bar :foo}');
         paredit.deleteForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Leaves opening quote of non-empty string alone', () => {
-        const a = docFromTextNotation('{::foo |"a"• ::bar :foo}');
-        const b = docFromTextNotation('{::foo "|a"• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo |"a"• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo "|a"• ::bar :foo}');
         paredit.deleteForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Leaves closing quote of non-empty string alone', () => {
-        const a = docFromTextNotation('{::foo "a|"• ::bar :foo}');
-        const b = docFromTextNotation('{::foo "a"|• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo "a|"• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo "a"|• ::bar :foo}');
         paredit.deleteForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes contents in strings', () => {
-        const a = docFromTextNotation('{::foo "|a"• ::bar :foo}');
-        const b = docFromTextNotation('{::foo "|"• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo "|a"• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo "|"• ::bar :foo}');
         paredit.deleteForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes contents in strings 2', () => {
-        const a = docFromTextNotation('{::foo "|aa"• ::bar :foo}');
-        const b = docFromTextNotation('{::foo "|a"• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo "|aa"• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo "|a"• ::bar :foo}');
         paredit.deleteForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes quoted quote', () => {
-        const a = docFromTextNotation('{::foo |\\"• ::bar :foo}');
-        const b = docFromTextNotation('{::foo |• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo |\\"• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo |• ::bar :foo}');
         paredit.deleteForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes quoted quote in string', () => {
-        const a = docFromTextNotation('{::foo "|\\""• ::bar :foo}');
-        const b = docFromTextNotation('{::foo "|"• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo "|\\""• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo "|"• ::bar :foo}');
         paredit.deleteForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes contents in list', () => {
-        const a = docFromTextNotation('{::foo (|a)• ::bar :foo}');
-        const b = docFromTextNotation('{::foo (|)• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo (|a)• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo (|)• ::bar :foo}');
         paredit.deleteForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes empty list function', () => {
-        const a = docFromTextNotation('{::foo (|)• ::bar :foo}');
-        const b = docFromTextNotation('{::foo |• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo (|)• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo |• ::bar :foo}');
         paredit.deleteForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes empty set', () => {
-        const a = docFromTextNotation('#{|}');
-        const b = docFromTextNotation('|');
+        const a = textNotation.docFromTextNotation('#{|}');
+        const b = textNotation.docFromTextNotation('|');
         paredit.deleteForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes empty literal function with trailing newline', () => {
         // https://github.com/BetterThanTomorrow/calva/issues/1079
-        const a = docFromTextNotation('{::foo #(|)• ::bar :foo}');
-        const b = docFromTextNotation('{::foo |• ::bar :foo}');
+        const a = textNotation.docFromTextNotation('{::foo #(|)• ::bar :foo}');
+        const b = textNotation.docFromTextNotation('{::foo |• ::bar :foo}');
         paredit.deleteForward(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       // https://github.com/BetterThanTomorrow/calva/issues/3020
       describe('Quote prefix deletion', () => {
         it('Deletes quote prefix from quoted list with content', () => {
-          const a = docFromTextNotation("'(|'(1 2 3) '(4 5 6) '(7 8 9))");
-          const b = docFromTextNotation("'(|(1 2 3) '(4 5 6) '(7 8 9))");
+          const a = textNotation.docFromTextNotation("'(|'(1 2 3) '(4 5 6) '(7 8 9))");
+          const b = textNotation.docFromTextNotation("'(|(1 2 3) '(4 5 6) '(7 8 9))");
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes quote prefix from nested quoted list', () => {
-          const a = docFromTextNotation("(foo |'(bar baz))");
-          const b = docFromTextNotation('(foo |(bar baz))');
+          const a = textNotation.docFromTextNotation("(foo |'(bar baz))");
+          const b = textNotation.docFromTextNotation('(foo |(bar baz))');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes quote prefix from quoted vector', () => {
-          const a = docFromTextNotation("|'[1 2 3]");
-          const b = docFromTextNotation('|[1 2 3]');
+          const a = textNotation.docFromTextNotation("|'[1 2 3]");
+          const b = textNotation.docFromTextNotation('|[1 2 3]');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
 
       // https://github.com/BetterThanTomorrow/calva/issues/2766
       describe('Hash character deletion with reader macros', () => {
         it('Deletes # before non-empty anonymous function', () => {
-          const a = docFromTextNotation('[|#(prn "hello")]');
-          const b = docFromTextNotation('[|(prn "hello")]');
+          const a = textNotation.docFromTextNotation('[|#(prn "hello")]');
+          const b = textNotation.docFromTextNotation('[|(prn "hello")]');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes # before non-empty set', () => {
-          const a = docFromTextNotation('[|#{:foo :bar}]');
-          const b = docFromTextNotation('[|{:foo :bar}]');
+          const a = textNotation.docFromTextNotation('[|#{:foo :bar}]');
+          const b = textNotation.docFromTextNotation('[|{:foo :bar}]');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes # with invalid syntax before vector', () => {
-          const a = docFromTextNotation('[|#[:foo]]');
-          const b = docFromTextNotation('[|[:foo]]');
+          const a = textNotation.docFromTextNotation('[|#[:foo]]');
+          const b = textNotation.docFromTextNotation('[|[:foo]]');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes # before empty anonymous function', () => {
-          const a = docFromTextNotation('[|#()]');
-          const b = docFromTextNotation('[|()]');
+          const a = textNotation.docFromTextNotation('[|#()]');
+          const b = textNotation.docFromTextNotation('[|()]');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes # before empty set', () => {
-          const a = docFromTextNotation('[|#{}]');
-          const b = docFromTextNotation('[|{}]');
+          const a = textNotation.docFromTextNotation('[|#{}]');
+          const b = textNotation.docFromTextNotation('[|{}]');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
       describe('Quote prefix deletion with empty forms', () => {
         it("Deletes ' before empty list", () => {
-          const a = docFromTextNotation("|'()");
-          const b = docFromTextNotation('|()');
+          const a = textNotation.docFromTextNotation("|'()");
+          const b = textNotation.docFromTextNotation('|()');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it("Deletes ' before empty vector", () => {
-          const a = docFromTextNotation("|'[]");
-          const b = docFromTextNotation('|[]');
+          const a = textNotation.docFromTextNotation("|'[]");
+          const b = textNotation.docFromTextNotation('|[]');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it("Deletes ' before empty map", () => {
-          const a = docFromTextNotation("|'{}");
-          const b = docFromTextNotation('|{}');
+          const a = textNotation.docFromTextNotation("|'{}");
+          const b = textNotation.docFromTextNotation('|{}');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it("Deletes ' before non-empty list", () => {
-          const a = docFromTextNotation("|'(foo)");
-          const b = docFromTextNotation('|(foo)');
+          const a = textNotation.docFromTextNotation("|'(foo)");
+          const b = textNotation.docFromTextNotation('|(foo)');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
       describe('Discard comment (#_) deletion', () => {
         it('Deletes #_ when cursor is right before it', () => {
-          const a = docFromTextNotation('|#_foo');
-          const b = docFromTextNotation('|foo');
+          const a = textNotation.docFromTextNotation('|#_foo');
+          const b = textNotation.docFromTextNotation('|foo');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes #_ when cursor is before #_ and a list', () => {
-          const a = docFromTextNotation('|#_[a b]');
-          const b = docFromTextNotation('|[a b]');
+          const a = textNotation.docFromTextNotation('|#_[a b]');
+          const b = textNotation.docFromTextNotation('|[a b]');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes #_ when cursor is before #_ and a map', () => {
-          const a = docFromTextNotation('|#_{:a 1}');
-          const b = docFromTextNotation('|{:a 1}');
+          const a = textNotation.docFromTextNotation('|#_{:a 1}');
+          const b = textNotation.docFromTextNotation('|{:a 1}');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes #_ when cursor is before #_ and a paren list', () => {
-          const a = docFromTextNotation('|#_(foo bar)');
-          const b = docFromTextNotation('|(foo bar)');
+          const a = textNotation.docFromTextNotation('|#_(foo bar)');
+          const b = textNotation.docFromTextNotation('|(foo bar)');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes #_ inside another form', () => {
-          const a = docFromTextNotation('(a |#_b c)');
-          const b = docFromTextNotation('(a |b c)');
+          const a = textNotation.docFromTextNotation('(a |#_b c)');
+          const b = textNotation.docFromTextNotation('(a |b c)');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes #_ before a nested list inside a form', () => {
-          const a = docFromTextNotation('(a |#_[1 2] c)');
-          const b = docFromTextNotation('(a |[1 2] c)');
+          const a = textNotation.docFromTextNotation('(a |#_[1 2] c)');
+          const b = textNotation.docFromTextNotation('(a |[1 2] c)');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes standalone #_ with nothing after it', () => {
-          const a = docFromTextNotation('|#_');
-          const b = docFromTextNotation('|');
+          const a = textNotation.docFromTextNotation('|#_');
+          const b = textNotation.docFromTextNotation('|');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
         it('Deletes standalone #_ with nothing after it inside a form', () => {
-          const a = docFromTextNotation('(a |#_)');
-          const b = docFromTextNotation('(a |)');
+          const a = textNotation.docFromTextNotation('(a |#_)');
+          const b = textNotation.docFromTextNotation('(a |)');
           paredit.deleteForward(a);
-          expect(textAndSelection(a)).toEqual(textAndSelection(b));
+          expectLib
+            .expect(textNotation.textAndSelection(a))
+            .toEqual(textNotation.textAndSelection(b));
         });
       });
     });
 
     describe('killRange', () => {
       it('Deletes top-level range with backward direction', async () => {
-        const a = docFromTextNotation('a <0b<0 c');
-        const b = docFromTextNotation('a | c');
-        await paredit.killRange(a, textAndSelection(a)[1]);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        const a = textNotation.docFromTextNotation('a <0b<0 c');
+        const b = textNotation.docFromTextNotation('a | c');
+        await paredit.killRange(a, textNotation.textAndSelection(a)[1]);
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes top-level range with backward direction, including space', async () => {
-        const a = docFromTextNotation('a <0b <0c');
-        const b = docFromTextNotation('a |c');
-        await paredit.killRange(a, textAndSelection(a)[1]);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        const a = textNotation.docFromTextNotation('a <0b <0c');
+        const b = textNotation.docFromTextNotation('a |c');
+        await paredit.killRange(a, textNotation.textAndSelection(a)[1]);
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes top-level range with forward direction', async () => {
-        const a = docFromTextNotation('a >0b >0c');
-        const b = docFromTextNotation('a |c');
-        await paredit.killRange(a, textAndSelection(a)[1]);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        const a = textNotation.docFromTextNotation('a >0b >0c');
+        const b = textNotation.docFromTextNotation('a |c');
+        await paredit.killRange(a, textNotation.textAndSelection(a)[1]);
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes nested range with backward direction', async () => {
-        const a = docFromTextNotation('{a <0b <0c}');
-        const b = docFromTextNotation('{a |c}');
-        await paredit.killRange(a, textAndSelection(a)[1]);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        const a = textNotation.docFromTextNotation('{a <0b <0c}');
+        const b = textNotation.docFromTextNotation('{a |c}');
+        await paredit.killRange(a, textNotation.textAndSelection(a)[1]);
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Deletes nested range with forward direction', async () => {
-        const a = docFromTextNotation('{a >0b >0c}');
-        const b = docFromTextNotation('{a |c}');
-        await paredit.killRange(a, textAndSelection(a)[1]);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        const a = textNotation.docFromTextNotation('{a >0b >0c}');
+        const b = textNotation.docFromTextNotation('{a |c}');
+        await paredit.killRange(a, textNotation.textAndSelection(a)[1]);
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
     describe('addRichComment', () => {
       it('Adds Rich Comment after Top Level form', async () => {
-        const a = docFromTextNotation('(fo|o)••(bar)');
-        const b = docFromTextNotation('(foo)••(comment•  |•  :rcf)••(bar)');
+        const a = textNotation.docFromTextNotation('(fo|o)••(bar)');
+        const b = textNotation.docFromTextNotation('(foo)••(comment•  |•  :rcf)••(bar)');
         await paredit.addRichComment(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Inserts Rich Comment between Top Levels', async () => {
-        const a = docFromTextNotation('(foo)•|•(bar)');
-        const b = docFromTextNotation('(foo)••(comment•  |•  :rcf)••(bar)');
+        const a = textNotation.docFromTextNotation('(foo)•|•(bar)');
+        const b = textNotation.docFromTextNotation('(foo)••(comment•  |•  :rcf)••(bar)');
         await paredit.addRichComment(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Inserts Rich Comment between Top Levels, before Top Level form', async () => {
-        const a = docFromTextNotation('(foo)••|(bar)');
-        const b = docFromTextNotation('(foo)••(comment•  |•  :rcf)••(bar)');
+        const a = textNotation.docFromTextNotation('(foo)••|(bar)');
+        const b = textNotation.docFromTextNotation('(foo)••(comment•  |•  :rcf)••(bar)');
         await paredit.addRichComment(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Inserts Rich Comment between Top Levels, after Top Level form', async () => {
-        const a = docFromTextNotation('(foo)|••(bar)');
-        const b = docFromTextNotation('(foo)••(comment•  |•  :rcf)••(bar)');
+        const a = textNotation.docFromTextNotation('(foo)|••(bar)');
+        const b = textNotation.docFromTextNotation('(foo)••(comment•  |•  :rcf)••(bar)');
         await paredit.addRichComment(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Inserts Rich Comment between Top Levels, in comment', async () => {
-        const a = docFromTextNotation('(foo)•;foo| bar•(bar)');
-        const b = docFromTextNotation('(foo)•;foo bar••(comment•  |•  :rcf)••(bar)');
+        const a = textNotation.docFromTextNotation('(foo)•;foo| bar•(bar)');
+        const b = textNotation.docFromTextNotation('(foo)•;foo bar••(comment•  |•  :rcf)••(bar)');
         await paredit.addRichComment(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Moves to Rich Comment below, if any', async () => {
-        const a = docFromTextNotation('(foo|)••(comment••bar••baz)');
-        const b = docFromTextNotation('(foo)••(comment••|bar••baz)');
+        const a = textNotation.docFromTextNotation('(foo|)••(comment••bar••baz)');
+        const b = textNotation.docFromTextNotation('(foo)••(comment••|bar••baz)');
         await paredit.addRichComment(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('Moves to Rich Comment below, if any, looking behind line comments', async () => {
-        const a = docFromTextNotation('(foo|)••;;line comment••(comment••bar••baz)');
-        const b = docFromTextNotation('(foo)••;;line comment••(comment••|bar••baz)');
+        const a = textNotation.docFromTextNotation('(foo|)••;;line comment••(comment••bar••baz)');
+        const b = textNotation.docFromTextNotation('(foo)••;;line comment••(comment••|bar••baz)');
         await paredit.addRichComment(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
     describe('splice sexp', () => {
       it('splice empty', async () => {
-        const a = docFromTextNotation('|');
-        const b = docFromTextNotation('|');
+        const a = textNotation.docFromTextNotation('|');
+        const b = textNotation.docFromTextNotation('|');
         await paredit.spliceSexp(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('splice list', async () => {
-        const a = docFromTextNotation('(a|a b c)');
-        const b = docFromTextNotation('a|a b c');
+        const a = textNotation.docFromTextNotation('(a|a b c)');
+        const b = textNotation.docFromTextNotation('a|a b c');
         await paredit.spliceSexp(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('splice list also when forms have meta and readers', async () => {
-        const a = docFromTextNotation('(^{:d e} #a|a b c)');
-        const b = docFromTextNotation('^{:d e} #a|a b c');
+        const a = textNotation.docFromTextNotation('(^{:d e} #a|a b c)');
+        const b = textNotation.docFromTextNotation('^{:d e} #a|a b c');
         await paredit.spliceSexp(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('splice vector', async () => {
-        const a = docFromTextNotation('[a| b c]');
-        const b = docFromTextNotation('a| b c');
+        const a = textNotation.docFromTextNotation('[a| b c]');
+        const b = textNotation.docFromTextNotation('a| b c');
         await paredit.spliceSexp(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('splice map', async () => {
-        const a = docFromTextNotation('{a| b}');
-        const b = docFromTextNotation('a| b');
+        const a = textNotation.docFromTextNotation('{a| b}');
+        const b = textNotation.docFromTextNotation('a| b');
         await paredit.spliceSexp(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('splice nested', async () => {
-        const a = docFromTextNotation('[1 {ab| cd} 2]');
-        const b = docFromTextNotation('[1 ab| cd 2]');
+        const a = textNotation.docFromTextNotation('[1 {ab| cd} 2]');
+        const b = textNotation.docFromTextNotation('[1 ab| cd 2]');
         await paredit.spliceSexp(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('splice set', async () => {
         // TODO: Figure out why the cursor gets misplaced
-        const a = docFromTextNotation('#{a| b}');
-        const b = docFromTextNotation('a |b');
+        const a = textNotation.docFromTextNotation('#{a| b}');
+        const b = textNotation.docFromTextNotation('a |b');
         await paredit.spliceSexp(a);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
 
       it('splice string', async () => {
-        const a = docFromTextNotation('"h|ello"');
+        const a = textNotation.docFromTextNotation('"h|ello"');
         await paredit.spliceSexp(a);
-        expect(getText(a)).toEqual('hello');
+        expectLib.expect(textNotation.getText(a)).toEqual('hello');
       });
     });
   });
@@ -3315,179 +4110,275 @@ describe('paredit', () => {
 describe('paredit util', () => {
   describe('insertSemiColon', () => {
     it('inserts a semicolon at cursor when structure would not break', async () => {
-      const a = docFromTextNotation('abc|');
-      const b = docFromTextNotation('abc;|');
+      const a = textNotation.docFromTextNotation('abc|');
+      const b = textNotation.docFromTextNotation('abc;|');
       await paredit.insertSemiColon(a);
-      expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      expectLib.expect(textNotation.textAndSelection(a)).toEqual(textNotation.textAndSelection(b));
     });
     it('inserts a newline to preserve structure when needed', async () => {
-      const a = docFromTextNotation('(defn foo []•  |(println "test"))');
-      const b = docFromTextNotation('(defn foo []•  ;|(println "test")•  )');
+      const a = textNotation.docFromTextNotation('(defn foo []•  |(println "test"))');
+      const b = textNotation.docFromTextNotation('(defn foo []•  ;|(println "test")•  )');
       await paredit.insertSemiColon(a);
-      expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      expectLib.expect(textNotation.textAndSelection(a)).toEqual(textNotation.textAndSelection(b));
     });
     it('inserts a newline to preserve structure at offset 0', async () => {
-      const a = docFromTextNotation('|(defn hi []•  (prn "hi"))');
-      const b = docFromTextNotation(';|•(defn hi []•  (prn "hi"))');
+      const a = textNotation.docFromTextNotation('|(defn hi []•  (prn "hi"))');
+      const b = textNotation.docFromTextNotation(';|•(defn hi []•  (prn "hi"))');
       await paredit.insertSemiColon(a);
-      expect(textAndSelection(a)).toEqual(textAndSelection(b));
+      expectLib.expect(textNotation.textAndSelection(a)).toEqual(textNotation.textAndSelection(b));
     });
   });
 
   describe('_semiColonWouldBreakStructureWhere', () => {
     it('returns false at the end of the document', () => {
-      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" (d)|'))).toBe(
-        false
-      );
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a "b c" (d)|')
+          )
+        )
+        .toBe(false);
     });
     it('returns false at the end of the line', () => {
-      expect(
-        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" (d)|• •   •'))
-      ).toBe(false);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a "b c" (d)|• •   •')
+          )
+        )
+        .toBe(false);
     });
     it('returns false at in the whitespace at the end of the line', () => {
-      expect(
-        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" (d)  | • •   •'))
-      ).toBe(false);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a "b c" (d)  | • •   •')
+          )
+        )
+        .toBe(false);
     });
     it('returns false withing a string', () => {
-      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b| c" d'))).toBe(
-        false
-      );
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(textNotation.docFromTextNotation('a "b| c" d'))
+        )
+        .toBe(false);
     });
     it('returns false a semicolon would be (illegally) escaped withing a string', () => {
-      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b\\| c" d'))).toBe(
-        false
-      );
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a "b\\| c" d')
+          )
+        )
+        .toBe(false);
     });
     it('returns false withing a comment', () => {
-      expect(
-        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" d ; e| f'))
-      ).toBe(false);
-      expect(
-        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" d ; e f|•'))
-      ).toBe(false);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a "b c" d ; e| f')
+          )
+        )
+        .toBe(false);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a "b c" d ; e f|•')
+          )
+        )
+        .toBe(false);
     });
     it('returns false in whitespace before a comment', () => {
-      expect(
-        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" d |; e f'))
-      ).toBe(false);
-      expect(
-        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" d | ; e f•'))
-      ).toBe(false);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a "b c" d |; e f')
+          )
+        )
+        .toBe(false);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a "b c" d | ; e f•')
+          )
+        )
+        .toBe(false);
     });
     it('returns true inside a list ending on the same line', () => {
-      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a (b |c)• d '))).toBe(
-        6
-      );
-      expect(
-        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a (b {|} c•) d '))
-      ).toBe(6);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a (b |c)• d ')
+          )
+        )
+        .toBe(6);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a (b {|} c•) d ')
+          )
+        )
+        .toBe(6);
     });
     it('returns false inside a list ending on some other line', () => {
-      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a (b |•c)• d '))).toBe(
-        false
-      );
-      expect(
-        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a (b {|•} c•) d '))
-      ).toBe(false);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a (b |•c)• d ')
+          )
+        )
+        .toBe(false);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a (b {|•} c•) d ')
+          )
+        )
+        .toBe(false);
     });
     it('returns false before a list ending on the same line', () => {
-      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" | (d)'))).toBe(
-        false
-      );
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a "b c" | (d)')
+          )
+        )
+        .toBe(false);
     });
     it('returns split position when cursor is immediately before list close', () => {
-      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('(bar 24 |)'))).toBe(8);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(textNotation.docFromTextNotation('(bar 24 |)'))
+        )
+        .toBe(8);
     });
     it('returns false if can move by sexp to the end of the line', () => {
-      expect(
-        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a "b c" | (d) • e'))
-      ).toBe(false);
-      expect(
-        paredit._semiColonWouldBreakStructureWhere(
-          docFromTextNotation('a [b c• |(d) {[e]}•f g] • ')
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a "b c" | (d) • e')
+          )
         )
-      ).toBe(false);
+        .toBe(false);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a [b c• |(d) {[e]}•f g] • ')
+          )
+        )
+        .toBe(false);
     });
     it('returns true before a list ending on some other line', () => {
-      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('a |(b •c)• d '))).toBe(
-        2
-      );
-      expect(
-        paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('|a (b {•} c•) d '))
-      ).toBe(2);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('a |(b •c)• d ')
+          )
+        )
+        .toBe(2);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('|a (b {•} c•) d ')
+          )
+        )
+        .toBe(2);
     });
     it('returns 0 when a multi-line form starts at offset 0', () => {
-      expect(
-        paredit._semiColonWouldBreakStructureWhere(
-          docFromTextNotation('|(defn hi []•  (prn "hi"))')
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(
+            textNotation.docFromTextNotation('|(defn hi []•  (prn "hi"))')
+          )
         )
-      ).toBe(0);
+        .toBe(0);
     });
     it('Multiline inside a list where close is at the end of current line (#3096)', () => {
-      expect(paredit._semiColonWouldBreakStructureWhere(docFromTextNotation('(a •|b)'))).toBe(5);
+      expectLib
+        .expect(
+          paredit._semiColonWouldBreakStructureWhere(textNotation.docFromTextNotation('(a •|b)'))
+        )
+        .toBe(5);
     });
   });
 
   describe('toggle ignore form', () => {
     describe('in parent form', () => {
       it('toggles ignore form on a list', async () => {
-        const a = docFromTextNotation('(foo| bar)');
-        const b = docFromTextNotation('#_(foo| bar)');
+        const a = textNotation.docFromTextNotation('(foo| bar)');
+        const b = textNotation.docFromTextNotation('#_(foo| bar)');
         await paredit.toggleIgnoreForm(a, true);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('should add #_ to parent form when cursor is in literal', async () => {
-        const a = docFromTextNotation('(defn foo []•  (when true•    (+ |-5 2)))');
-        const b = docFromTextNotation('(defn foo []•  (when true•    #_(+ |-5 2)))');
+        const a = textNotation.docFromTextNotation('(defn foo []•  (when true•    (+ |-5 2)))');
+        const b = textNotation.docFromTextNotation('(defn foo []•  (when true•    #_(+ |-5 2)))');
         await paredit.toggleIgnoreForm(a, true);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('should remove #_ from current literal', async () => {
-        const a = docFromTextNotation('(defn foo []•  (when true•    (+ #_|-5 2)))');
-        const b = docFromTextNotation('(defn foo []•  (when true•    (+ |-5 2)))');
+        const a = textNotation.docFromTextNotation('(defn foo []•  (when true•    (+ #_|-5 2)))');
+        const b = textNotation.docFromTextNotation('(defn foo []•  (when true•    (+ |-5 2)))');
         await paredit.toggleIgnoreForm(a, true);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
 
     describe('in current form', () => {
       it('should add #_ to current form when cursor is on a symbol', async () => {
-        const a = docFromTextNotation('(defn foo []•  |(println "test"))');
-        const b = docFromTextNotation('(defn foo []•  #_|(println "test"))');
+        const a = textNotation.docFromTextNotation('(defn foo []•  |(println "test"))');
+        const b = textNotation.docFromTextNotation('(defn foo []•  #_|(println "test"))');
         await paredit.toggleIgnoreForm(a, false);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('should remove #_ from current form when cursor is inside ignored form (ignoreCurrentForm)', async () => {
-        const a = docFromTextNotation('(defn foo []•  #_|(println "test"))');
-        const b = docFromTextNotation('(defn foo []•  |(println "test"))');
+        const a = textNotation.docFromTextNotation('(defn foo []•  #_|(println "test"))');
+        const b = textNotation.docFromTextNotation('(defn foo []•  |(println "test"))');
         await paredit.toggleIgnoreForm(a, false);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('should add #_ to current literal when cursor is on it', async () => {
-        const a = docFromTextNotation('(defn foo []•  (when true•    (+ |-5 2)))');
-        const b = docFromTextNotation('(defn foo []•  (when true•    (+ #_|-5 2)))');
+        const a = textNotation.docFromTextNotation('(defn foo []•  (when true•    (+ |-5 2)))');
+        const b = textNotation.docFromTextNotation('(defn foo []•  (when true•    (+ #_|-5 2)))');
         await paredit.toggleIgnoreForm(a, false);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('should remove #_ from current literal', async () => {
-        const a = docFromTextNotation('(defn foo []•  (when true•    (+ #_|-5 2)))');
-        const b = docFromTextNotation('(defn foo []•  (when true•    (+ |-5 2)))');
+        const a = textNotation.docFromTextNotation('(defn foo []•  (when true•    (+ #_|-5 2)))');
+        const b = textNotation.docFromTextNotation('(defn foo []•  (when true•    (+ |-5 2)))');
         await paredit.toggleIgnoreForm(a, false);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('should remove #_ when cursor is directly before the marker (decision 3)', async () => {
-        const a = docFromTextNotation(':bar |#_"foo"');
-        const b = docFromTextNotation(':bar |"foo"');
+        const a = textNotation.docFromTextNotation(':bar |#_"foo"');
+        const b = textNotation.docFromTextNotation(':bar |"foo"');
         await paredit.toggleIgnoreForm(a, false);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
       it('should remove #_ when cursor is at start of file before the marker', async () => {
-        const a = docFromTextNotation('|#_(foo bar)');
-        const b = docFromTextNotation('|(foo bar)');
+        const a = textNotation.docFromTextNotation('|#_(foo bar)');
+        const b = textNotation.docFromTextNotation('|(foo bar)');
         await paredit.toggleIgnoreForm(a, false);
-        expect(textAndSelection(a)).toEqual(textAndSelection(b));
+        expectLib
+          .expect(textNotation.textAndSelection(a))
+          .toEqual(textNotation.textAndSelection(b));
       });
     });
   });

--- a/src/extension-test/unit/cursor-doc/token-cursor-test.ts
+++ b/src/extension-test/unit/cursor-doc/token-cursor-test.ts
@@ -1,1020 +1,1150 @@
-import { expect } from 'expect';
-import { createStringCursor, LispTokenCursor } from '../../../cursor-doc/token-cursor';
-import { docFromTextNotation, textAndSelection } from '../common/text-notation';
+import * as expectLib from 'expect';
+import * as tokenCursor from '../../../cursor-doc/token-cursor';
+import * as textNotation from '../common/text-notation';
 
 describe('Token Cursor', () => {
   describe('backwardWhitespace', () => {
     it('it moves past whitespace', () => {
-      const a = docFromTextNotation('a •|c');
-      const b = docFromTextNotation('a| •c');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('a •|c');
+      const b = textNotation.docFromTextNotation('a| •c');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardWhitespace();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('it moves past whitespace from inside symbol', () => {
-      const a = docFromTextNotation('a •c|c');
-      const b = docFromTextNotation('a| •cc');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('a •c|c');
+      const b = textNotation.docFromTextNotation('a| •cc');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardWhitespace();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
   });
 
   describe('forwardSexp', () => {
     it('moves from beginning to end of symbol', () => {
-      const a = docFromTextNotation('(|c•#f)');
-      const b = docFromTextNotation('(c|•#f)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(|c•#f)');
+      const b = textNotation.docFromTextNotation('(c|•#f)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('forwardSexp with newline', () => {
-      const a = docFromTextNotation('|(a\n(b))');
-      const b = docFromTextNotation('(a\n(b))|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('|(a\n(b))');
+      const b = textNotation.docFromTextNotation('(a\n(b))|');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('forwardSexp with newline (MS-Windows)', () => {
-      const a = docFromTextNotation('|(a\r\n(b))');
-      const b = docFromTextNotation('(a\r\n(b))|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('|(a\r\n(b))');
+      const b = textNotation.docFromTextNotation('(a\r\n(b))|');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('moves from beginning to end of nested list ', () => {
-      const a = docFromTextNotation('|(a(b(c•#f•(#b •[:f])•#z•1)))');
-      const b = docFromTextNotation('(a(b(c•#f•(#b •[:f])•#z•1)))|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('|(a(b(c•#f•(#b •[:f])•#z•1)))');
+      const b = textNotation.docFromTextNotation('(a(b(c•#f•(#b •[:f])•#z•1)))|');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Includes reader tag as part of a list form', () => {
-      const a = docFromTextNotation('(c|•#f•(#b •[:f :b :z])•#z•1)');
-      const b = docFromTextNotation('(c•#f•(#b •[:f :b :z])|•#z•1)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(c|•#f•(#b •[:f :b :z])•#z•1)');
+      const b = textNotation.docFromTextNotation('(c•#f•(#b •[:f :b :z])|•#z•1)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Includes reader tag as part of a symbol', () => {
-      const a = docFromTextNotation('(c•#f•(#b •[:f :b :z])|•#z•1)');
-      const b = docFromTextNotation('(c•#f•(#b •[:f :b :z])•#z•1|)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(c•#f•(#b •[:f :b :z])|•#z•1)');
+      const b = textNotation.docFromTextNotation('(c•#f•(#b •[:f :b :z])•#z•1|)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Does not move out of a list', () => {
-      const a = docFromTextNotation('(c•#f•(#b •[:f :b :z])•#z•1|)');
-      const b = docFromTextNotation('(c•#f•(#b •[:f :b :z])•#z•1|)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(c•#f•(#b •[:f :b :z])•#z•1|)');
+      const b = textNotation.docFromTextNotation('(c•#f•(#b •[:f :b :z])•#z•1|)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Skip metadata if skipMetadata is true', () => {
-      const a = docFromTextNotation('(a |^{:a 1} (= 1 1))');
-      const b = docFromTextNotation('(a ^{:a 1} (= 1 1)|)');
+      const a = textNotation.docFromTextNotation('(a |^{:a 1} (= 1 1))');
+      const b = textNotation.docFromTextNotation('(a ^{:a 1} (= 1 1)|)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Skip metadata and reader if skipMetadata is true', () => {
-      const a = docFromTextNotation('(a |^{:a 1} #a (= 1 1))');
-      const b = docFromTextNotation('(a ^{:a 1} #a (= 1 1)|)');
+      const a = textNotation.docFromTextNotation('(a |^{:a 1} #a (= 1 1))');
+      const b = textNotation.docFromTextNotation('(a ^{:a 1} #a (= 1 1)|)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Skip reader and metadata if skipMetadata is true', () => {
-      const a = docFromTextNotation('(a |#a ^{:a 1} (= 1 1))');
-      const b = docFromTextNotation('(a #a ^{:a 1} (= 1 1)|)');
+      const a = textNotation.docFromTextNotation('(a |#a ^{:a 1} (= 1 1))');
+      const b = textNotation.docFromTextNotation('(a #a ^{:a 1} (= 1 1)|)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Skips multiple metadata maps if skipMetadata is true', () => {
-      const a = docFromTextNotation('(a |^{:a 1} ^{:b 2} (= 1 1))');
-      const b = docFromTextNotation('(a ^{:a 1} ^{:b 2} (= 1 1)|)');
+      const a = textNotation.docFromTextNotation('(a |^{:a 1} ^{:b 2} (= 1 1))');
+      const b = textNotation.docFromTextNotation('(a ^{:a 1} ^{:b 2} (= 1 1)|)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Skips symbol shorthand for metadata if skipMetadata is true', () => {
-      const a = docFromTextNotation('(a| ^String (= 1 1))');
-      const b = docFromTextNotation('(a ^String (= 1 1)|)');
+      const a = textNotation.docFromTextNotation('(a| ^String (= 1 1))');
+      const b = textNotation.docFromTextNotation('(a ^String (= 1 1)|)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Skips keyword shorthand for metadata if skipMetadata is true', () => {
-      const a = docFromTextNotation('(a| ^:hello (= 1 1))');
-      const b = docFromTextNotation('(a ^:hello (= 1 1)|)');
+      const a = textNotation.docFromTextNotation('(a| ^:hello (= 1 1))');
+      const b = textNotation.docFromTextNotation('(a ^:hello (= 1 1)|)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Skips multiple keyword shorthands for metadata if skipMetadata is true', () => {
-      const a = docFromTextNotation('(a| ^:hello ^:world (= 1 1))');
-      const b = docFromTextNotation('(a ^:hello ^:world (= 1 1)|)');
+      const a = textNotation.docFromTextNotation('(a| ^:hello ^:world (= 1 1))');
+      const b = textNotation.docFromTextNotation('(a ^:hello ^:world (= 1 1)|)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Does not skip ignored forms if skipIgnoredForms is false', () => {
-      const a = docFromTextNotation('(a| #_1 #_2 3)');
-      const b = docFromTextNotation('(a #_1| #_2 3)');
+      const a = textNotation.docFromTextNotation('(a| #_1 #_2 3)');
+      const b = textNotation.docFromTextNotation('(a #_1| #_2 3)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Skip ignored forms if skipIgnoredForms is true', () => {
-      const a = docFromTextNotation('(a| #_1 #_2 3)');
-      const b = docFromTextNotation('(a #_1 #_2 3|)');
+      const a = textNotation.docFromTextNotation('(a| #_1 #_2 3)');
+      const b = textNotation.docFromTextNotation('(a #_1 #_2 3|)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp(true, true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('should skip stacked ignored forms if skipIgnoredForms is true', () => {
-      const a = docFromTextNotation('(a| #_ #_ 1 2 3)');
-      const b = docFromTextNotation('(a #_ #_ 1 2 3|)');
+      const a = textNotation.docFromTextNotation('(a| #_ #_ 1 2 3)');
+      const b = textNotation.docFromTextNotation('(a #_ #_ 1 2 3|)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardSexp(true, true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     xit('Does not move past unbalanced top level form', () => {
       //TODO: Figure out why this doesn't work
-      const d = docFromTextNotation('|(foo "bar"');
-      const cursor: LispTokenCursor = d.getTokenCursor(d.selections[0].anchor);
+      const d = textNotation.docFromTextNotation('|(foo "bar"');
+      const cursor: tokenCursor.LispTokenCursor = d.getTokenCursor(d.selections[0].anchor);
       const offsetStart = cursor.offsetStart;
       cursor.forwardSexp();
-      expect(cursor.offsetStart).toBe(offsetStart);
+      expectLib.expect(cursor.offsetStart).toBe(offsetStart);
     });
   });
 
   describe('backwardSexp', () => {
     it('moves from end to beginning of symbol', () => {
-      const a = docFromTextNotation('(a(b(c|•#f•(#b •[:f :b :z])•#z•1)))');
-      const b = docFromTextNotation('(a(b(|c•#f•(#b •[:f :b :z])•#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(a(b(c|•#f•(#b •[:f :b :z])•#z•1)))');
+      const b = textNotation.docFromTextNotation('(a(b(|c•#f•(#b •[:f :b :z])•#z•1)))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('moves from end to beginning of nested list ', () => {
-      const a = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1)))|');
-      const b = docFromTextNotation('|(a(b(c•#f•(#b •[:f :b :z])•#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1)))|');
+      const b = textNotation.docFromTextNotation('|(a(b(c•#f•(#b •[:f :b :z])•#z•1)))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Includes reader tag as part of a list form', () => {
-      const a = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])|•#z•1)))');
-      const b = docFromTextNotation('(a(b(c•|#f•(#b •[:f :b :z])•#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])|•#z•1)))');
+      const b = textNotation.docFromTextNotation('(a(b(c•|#f•(#b •[:f :b :z])•#z•1)))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Includes reader tag as part of a symbol', () => {
-      const a = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1|)))');
-      const b = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•|#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1|)))');
+      const b = textNotation.docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•|#z•1)))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Does not move out of a list', () => {
-      const a = docFromTextNotation('(a(|b(c•#f•(#b •[:f :b :z])•#z•1)))');
-      const b = docFromTextNotation('(a(|b(c•#f•(#b •[:f :b :z])•#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(a(|b(c•#f•(#b •[:f :b :z])•#z•1)))');
+      const b = textNotation.docFromTextNotation('(a(|b(c•#f•(#b •[:f :b :z])•#z•1)))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Skip metadata if skipMetadata is true', () => {
-      const a = docFromTextNotation('(a ^{:a 1} (= 1 1)|)');
-      const b = docFromTextNotation('(a |^{:a 1} (= 1 1))');
+      const a = textNotation.docFromTextNotation('(a ^{:a 1} (= 1 1)|)');
+      const b = textNotation.docFromTextNotation('(a |^{:a 1} (= 1 1))');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Treats metadata as part of the sexp if skipMetadata is true', () => {
-      const a = docFromTextNotation('(a ^{:a 1}| (= 1 1))');
-      const b = docFromTextNotation('(a |^{:a 1} (= 1 1))');
+      const a = textNotation.docFromTextNotation('(a ^{:a 1}| (= 1 1))');
+      const b = textNotation.docFromTextNotation('(a |^{:a 1} (= 1 1))');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Skips multiple metadata maps if skipMetadata is true', () => {
-      const a = docFromTextNotation('(a ^{:a 1} ^{:b 2} (= 1 1)|)');
-      const b = docFromTextNotation('(a |^{:a 1} ^{:b 2} (= 1 1))');
+      const a = textNotation.docFromTextNotation('(a ^{:a 1} ^{:b 2} (= 1 1)|)');
+      const b = textNotation.docFromTextNotation('(a |^{:a 1} ^{:b 2} (= 1 1))');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Treats metadata and readers as part of the sexp if skipMetadata is true', () => {
-      const a = docFromTextNotation('#bar •^baz•|[:a :b :c]•x');
-      const b = docFromTextNotation('|#bar •^baz•[:a :b :c]•x');
+      const a = textNotation.docFromTextNotation('#bar •^baz•|[:a :b :c]•x');
+      const b = textNotation.docFromTextNotation('|#bar •^baz•[:a :b :c]•x');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Treats reader and metadata as part of the sexp if skipMetadata is true', () => {
-      const a = docFromTextNotation('^bar •#baz•|[:a :b :c]•x');
-      const b = docFromTextNotation('|^bar •#baz•[:a :b :c]•x');
+      const a = textNotation.docFromTextNotation('^bar •#baz•|[:a :b :c]•x');
+      const b = textNotation.docFromTextNotation('|^bar •#baz•[:a :b :c]•x');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Treats readers and metadata:s mixed as part of the sexp from behind the sexp if skipMetadata is true', () => {
-      const a = docFromTextNotation('^d #c ^b •#a•[:a :b :c]|•x');
-      const b = docFromTextNotation('|^d #c ^b •#a•[:a :b :c]•x');
+      const a = textNotation.docFromTextNotation('^d #c ^b •#a•[:a :b :c]|•x');
+      const b = textNotation.docFromTextNotation('|^d #c ^b •#a•[:a :b :c]•x');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Does not skip ignored forms if skipIgnoredForms', () => {
-      const a = docFromTextNotation('(a #_1 #_2 |3)');
-      const b = docFromTextNotation('(a #_a #_|2 3)');
+      const a = textNotation.docFromTextNotation('(a #_1 #_2 |3)');
+      const b = textNotation.docFromTextNotation('(a #_a #_|2 3)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Does not skip stacked ignored forms', () => {
-      const a = docFromTextNotation('(a #_ #_ 1 2 |3)');
-      const b = docFromTextNotation('(a #_ #_ 1 |2 3)');
+      const a = textNotation.docFromTextNotation('(a #_ #_ 1 2 |3)');
+      const b = textNotation.docFromTextNotation('(a #_ #_ 1 |2 3)');
       const cursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp(true, true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
   });
 
   describe('downList', () => {
     it('Puts cursor to the right of the following open paren', () => {
-      const a = docFromTextNotation('(a |(b 1))');
-      const b = docFromTextNotation('(a (|b 1))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(a |(b 1))');
+      const b = textNotation.docFromTextNotation('(a (|b 1))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.downList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Puts cursor to the right of the following open curly brace:', () => {
-      const a = docFromTextNotation('(a |{:b 1}))');
-      const b = docFromTextNotation('(a {|:b 1}))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(a |{:b 1}))');
+      const b = textNotation.docFromTextNotation('(a {|:b 1}))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.downList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Puts cursor to the right of the following open bracket', () => {
-      const a = docFromTextNotation('(a| [1 2]))');
-      const b = docFromTextNotation('(a [|a 2]))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(a| [1 2]))');
+      const b = textNotation.docFromTextNotation('(a [|a 2]))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.downList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it(`Puts cursor to the right of the following opening quoted list`, () => {
-      const a = docFromTextNotation(`(a| '(b 1))`);
-      const b = docFromTextNotation(`(a '(|b 1))`);
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation(`(a| '(b 1))`);
+      const b = textNotation.docFromTextNotation(`(a '(|b 1))`);
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.downList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Skips whitespace', () => {
-      const a = docFromTextNotation('(a|•  (b 1))');
-      const b = docFromTextNotation('(a•  (|b 1))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(a|•  (b 1))');
+      const b = textNotation.docFromTextNotation('(a•  (|b 1))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.downList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Does not skip metadata', () => {
-      const a = docFromTextNotation('(a| ^{:x 1} (b 1))');
-      const b = docFromTextNotation('(a ^{|:x 1} (b 1))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(a| ^{:x 1} (b 1))');
+      const b = textNotation.docFromTextNotation('(a ^{|:x 1} (b 1))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.downList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
   });
 
   describe('downListSkippingMeta', () => {
     it('Moves down, skipping metadata', () => {
-      const a = docFromTextNotation('(|a #b ^{:x 1} (c 1))');
-      const b = docFromTextNotation('(a #b ^{:x 1} (|c 1))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(|a #b ^{:x 1} (c 1))');
+      const b = textNotation.docFromTextNotation('(a #b ^{:x 1} (|c 1))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.downListSkippingMeta();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Moves down when there is no metadata', () => {
-      const a = docFromTextNotation('(|a #b (c 1))');
-      const b = docFromTextNotation('(a #b (|c 1))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(|a #b (c 1))');
+      const b = textNotation.docFromTextNotation('(a #b (|c 1))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.downListSkippingMeta();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
   });
 
   it('upList', () => {
-    const a = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1|)))');
-    const b = docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1)|))');
-    const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+    const a = textNotation.docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1|)))');
+    const b = textNotation.docFromTextNotation('(a(b(c•#f•(#b •[:f :b :z])•#z•1)|))');
+    const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
     cursor.upList();
-    expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+    expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
   });
 
   describe('forwardList', () => {
     it('Finds end of list', () => {
-      const a = docFromTextNotation('(|foo (bar baz) [])');
-      const b = docFromTextNotation('(foo (bar baz) []|)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(|foo (bar baz) [])');
+      const b = textNotation.docFromTextNotation('(foo (bar baz) []|)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Finds end of list through readers and meta', () => {
-      const a = docFromTextNotation('(|#a ^{:b c} #d (bar baz) [])');
-      const b = docFromTextNotation('(#a ^{:b c} #d (bar baz) []|)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(|#a ^{:b c} #d (bar baz) [])');
+      const b = textNotation.docFromTextNotation('(#a ^{:b c} #d (bar baz) []|)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Does not move at top level', () => {
-      const a = docFromTextNotation('|foo (bar baz)');
-      const b = docFromTextNotation('|foo (bar baz)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('|foo (bar baz)');
+      const b = textNotation.docFromTextNotation('|foo (bar baz)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Does not move at top level when unbalanced document from extra closings', () => {
-      const a = docFromTextNotation('|foo (bar baz))');
-      const b = docFromTextNotation('|foo (bar baz))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('|foo (bar baz))');
+      const b = textNotation.docFromTextNotation('|foo (bar baz))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Does not move at top level when unbalanced document from extra opens', () => {
-      const a = docFromTextNotation('|foo ((bar baz)');
-      const b = docFromTextNotation('|foo ((bar baz)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('|foo ((bar baz)');
+      const b = textNotation.docFromTextNotation('|foo ((bar baz)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Does not move when unbalanced from extra opens', () => {
-      const a = docFromTextNotation('(|[');
-      const b = docFromTextNotation('(|[');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(|[');
+      const b = textNotation.docFromTextNotation('(|[');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Does not move when at end of list, returns true', () => {
-      const a = docFromTextNotation('(|)');
-      const b = docFromTextNotation('(|)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(|)');
+      const b = textNotation.docFromTextNotation('(|)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.forwardList();
-      expect(result).toBe(true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(true);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Finds the list end when unbalanced from extra closes outside the current list', () => {
-      const a = docFromTextNotation('(|a #b []))');
-      const b = docFromTextNotation('(a #b []|))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(|a #b []))');
+      const b = textNotation.docFromTextNotation('(a #b []|))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
   });
 
   describe('backwardList', () => {
     it('Finds start of list', () => {
-      const a = docFromTextNotation('(((c•(#b •[:f])•#z•|a)))');
-      const b = docFromTextNotation('(((|c•(#b •[:f])•#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(((c•(#b •[:f])•#z•|a)))');
+      const b = textNotation.docFromTextNotation('(((|c•(#b •[:f])•#z•1)))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Finds start of list through readers', () => {
-      const a = docFromTextNotation('(((c•#a• #f•(#b •[:f])•#z•|a)))');
-      const b = docFromTextNotation('(((|c•#a• #f•(#b •[:f])•#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(((c•#a• #f•(#b •[:f])•#z•|a)))');
+      const b = textNotation.docFromTextNotation('(((|c•#a• #f•(#b •[:f])•#z•1)))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Finds start of list through metadata', () => {
-      const a = docFromTextNotation('(((c•^{:a c} (#b •[:f])•#z•|a)))');
-      const b = docFromTextNotation('(((|c•^{:a c} (#b •[:f])•#z•1)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(((c•^{:a c} (#b •[:f])•#z•|a)))');
+      const b = textNotation.docFromTextNotation('(((|c•^{:a c} (#b •[:f])•#z•1)))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Does not move at top level', () => {
-      const a = docFromTextNotation('foo |(bar baz)');
-      const b = docFromTextNotation('foo |(bar baz)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('foo |(bar baz)');
+      const b = textNotation.docFromTextNotation('foo |(bar baz)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Does not move when at start of unbalanced list', () => {
       // https://github.com/BetterThanTomorrow/calva/issues/1573
       // https://github.com/BetterThanTomorrow/calva/commit/d77359fcea16bc052ab829853d5711434330a375
-      const a = docFromTextNotation('([|');
-      const b = docFromTextNotation('([|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('([|');
+      const b = textNotation.docFromTextNotation('([|');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.backwardList();
-      expect(result).toBe(false);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(false);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Does not move to start of an unbalanced list when outer list is also unbalanced', () => {
       // NB: This is a bit arbitrary, this test documents the current behaviour
-      const a = docFromTextNotation('(let [a| a');
-      const b = docFromTextNotation('(let [a| a');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(let [a| a');
+      const b = textNotation.docFromTextNotation('(let [a| a');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.backwardList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
-      expect(result).toBe(false);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(false);
     });
     it('Moves to start of an unbalanced list when outer list is balanced', () => {
       // NB: This is a bit arbitrary, this test documents the current behaviour
-      const a = docFromTextNotation('(let [a| a)');
-      const b = docFromTextNotation('(let [|a a)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(let [a| a)');
+      const b = textNotation.docFromTextNotation('(let [|a a)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.backwardList();
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
-      expect(result).toBe(true);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(true);
     });
     it('Finds the list start when unbalanced from extra closes outside the current list', () => {
-      const a = docFromTextNotation('([]|))');
-      const b = docFromTextNotation('(|[]))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('([]|))');
+      const b = textNotation.docFromTextNotation('(|[]))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.backwardList();
-      expect(result).toBe(true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(true);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
   });
 
   describe('forwardListOfType', () => {
     it('Finds end of list', () => {
-      const a = docFromTextNotation('([#{|c•(#b •[:f])•#z•1}])');
-      const b = docFromTextNotation('([#{c•(#b •[:f])•#z•1}]|)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('([#{|c•(#b •[:f])•#z•1}])');
+      const b = textNotation.docFromTextNotation('([#{c•(#b •[:f])•#z•1}]|)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.forwardListOfType(')');
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
-      expect(result).toBe(true);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(true);
     });
     it('Finds end of vector', () => {
-      const a = docFromTextNotation('([(c•(#b| •[:f])•#z•1)])');
-      const b = docFromTextNotation('([(c•(#b •[:f])•#z•1)|])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('([(c•(#b| •[:f])•#z•1)])');
+      const b = textNotation.docFromTextNotation('([(c•(#b •[:f])•#z•1)|])');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.forwardListOfType(']');
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
-      expect(result).toBe(true);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(true);
     });
     it('Finds end of map', () => {
-      const a = docFromTextNotation('({:a [(c•(#|b •[:f])•#z•|a)]})');
-      const b = docFromTextNotation('({:a [(c•(#b •[:f])•#z•1)]|})');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('({:a [(c•(#|b •[:f])•#z•|a)]})');
+      const b = textNotation.docFromTextNotation('({:a [(c•(#b •[:f])•#z•1)]|})');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.forwardListOfType('}');
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
-      expect(result).toBe(true);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(true);
     });
     it('Does not move when list is unbalanced from missing open', () => {
-      const a = docFromTextNotation('|])');
-      const b = docFromTextNotation('|])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('|])');
+      const b = textNotation.docFromTextNotation('|])');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.forwardListOfType(')');
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
-      expect(result).toBe(false);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(false);
     });
     it('Does not move when list type is not found', () => {
-      const a = docFromTextNotation('([|])');
-      const b = docFromTextNotation('([|])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('([|])');
+      const b = textNotation.docFromTextNotation('([|])');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.forwardListOfType('}');
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
-      expect(result).toBe(false);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(false);
     });
   });
 
   describe('backwardListOfType', () => {
     it('Finds start of list', () => {
-      const a = docFromTextNotation('([#{c•(#b •[:f])•#z•|a}])');
-      const b = docFromTextNotation('(|[#{c•(#b •[:f])•#z•1}])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('([#{c•(#b •[:f])•#z•|a}])');
+      const b = textNotation.docFromTextNotation('(|[#{c•(#b •[:f])•#z•1}])');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.backwardListOfType('(');
-      expect(result).toBe(true);
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(true);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
     });
     it('Finds start of vector', () => {
-      const a = docFromTextNotation('([(c•(#b •[:f])•#z•|a)])');
-      const b = docFromTextNotation('([|(c•(#b •[:f])•#z•1)])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('([(c•(#b •[:f])•#z•|a)])');
+      const b = textNotation.docFromTextNotation('([|(c•(#b •[:f])•#z•1)])');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.backwardListOfType('[');
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
-      expect(result).toBe(true);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(true);
     });
     it('Finds start of map', () => {
-      const a = docFromTextNotation('({:a [(c•(#b •[:f])•#z•|a)]})');
-      const b = docFromTextNotation('({|:a [(c•(#b •[:f])•#z•1)]})');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('({:a [(c•(#b •[:f])•#z•|a)]})');
+      const b = textNotation.docFromTextNotation('({|:a [(c•(#b •[:f])•#z•1)]})');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.backwardListOfType('{');
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
-      expect(result).toBe(true);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(true);
     });
     it('Does not move when list type is unbalanced from missing close', () => {
       // This hung the structural editing in the real editor
       // https://github.com/BetterThanTomorrow/calva/issues/1573
-      const a = docFromTextNotation('([|');
-      const b = docFromTextNotation('([|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('([|');
+      const b = textNotation.docFromTextNotation('([|');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.backwardListOfType('(');
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
-      expect(result).toBe(false);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(false);
     });
     it('Moves backward in unbalanced list when outer list is balanced', () => {
       // https://github.com/BetterThanTomorrow/calva/issues/1585
-      const a = docFromTextNotation('(let [a|)');
-      const b = docFromTextNotation('(let [|a)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(let [a|)');
+      const b = textNotation.docFromTextNotation('(let [|a)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.backwardListOfType('[');
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
-      expect(result).toBe(true);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(true);
     });
     it('Moves backward in balanced list when inner list is unbalanced', () => {
       // This never completes in Calva v2.0.252
       // https://github.com/BetterThanTomorrow/calva/issues/1585
-      const a = docFromTextNotation('(let [a|)');
-      const b = docFromTextNotation('(|let [a)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(let [a|)');
+      const b = textNotation.docFromTextNotation('(|let [a)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.backwardListOfType('(');
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
-      expect(result).toBe(true);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(true);
     });
     it('Does not move when list type is not found', () => {
-      const a = docFromTextNotation('([|])');
-      const b = docFromTextNotation('([|])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('([|])');
+      const b = textNotation.docFromTextNotation('([|])');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       const result = cursor.backwardListOfType('{');
-      expect(cursor.offsetStart).toBe(b.selections[0].anchor);
-      expect(result).toBe(false);
+      expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+      expectLib.expect(result).toBe(false);
     });
   });
 
   it('backwardUpList', () => {
-    const a = docFromTextNotation('(a(b(c•#f•(#b •|[:f :b :z])•#z•1)))');
-    const b = docFromTextNotation('(a(b(c•#f•|(#b •[:f :b :z])•#z•1)))');
-    const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+    const a = textNotation.docFromTextNotation('(a(b(c•#f•(#b •|[:f :b :z])•#z•1)))');
+    const b = textNotation.docFromTextNotation('(a(b(c•#f•|(#b •[:f :b :z])•#z•1)))');
+    const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
     cursor.backwardUpList();
-    expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+    expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
   });
 
   describe('Navigation in and around strings', () => {
     it('backwardList moves to start of string', () => {
-      const a = docFromTextNotation('(str [] "", "foo" "f |  b  b"   "   f b b   " "\\"" \\")');
-      const b = docFromTextNotation('(str [] "", "foo" "|f   b  b"   "   f b b   " "\\"" \\")');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation(
+        '(str [] "", "foo" "f |  b  b"   "   f b b   " "\\"" \\")'
+      );
+      const b = textNotation.docFromTextNotation(
+        '(str [] "", "foo" "|f   b  b"   "   f b b   " "\\"" \\")'
+      );
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardList();
-      expect(cursor.offsetStart).toEqual(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toEqual(b.selections[0].anchor);
     });
     it('forwardList moves to end of string', () => {
-      const a = docFromTextNotation('(str [] "", "foo" "f |  b  b"   "   f b b   " "\\"" \\")');
-      const b = docFromTextNotation('(str [] "", "foo" "f   b  b|"   "   f b b   " "\\"" \\")');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation(
+        '(str [] "", "foo" "f |  b  b"   "   f b b   " "\\"" \\")'
+      );
+      const b = textNotation.docFromTextNotation(
+        '(str [] "", "foo" "f   b  b|"   "   f b b   " "\\"" \\")'
+      );
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.forwardList();
-      expect(cursor.offsetStart).toEqual(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toEqual(b.selections[0].anchor);
     });
     it('backwardSexpr inside string moves past quoted characters', () => {
-      const a = docFromTextNotation('(str [] "foo \\"| bar")');
-      const b = docFromTextNotation('(str [] "foo |\\" bar")');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('(str [] "foo \\"| bar")');
+      const b = textNotation.docFromTextNotation('(str [] "foo |\\" bar")');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp();
-      expect(cursor.offsetStart).toEqual(b.selections[0].anchor);
+      expectLib.expect(cursor.offsetStart).toEqual(b.selections[0].anchor);
     });
   });
 
   describe('The REPL prompt', () => {
     it('Backward sexp bypasses prompt', () => {
-      const a = docFromTextNotation('foo•clj꞉foo꞉> |');
-      const b = docFromTextNotation('|foo•clj꞉foo꞉> ');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('foo•clj꞉foo꞉> |');
+      const b = textNotation.docFromTextNotation('|foo•clj꞉foo꞉> ');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp();
-      expect(cursor.offsetStart).toEqual(b.selections[0].active);
+      expectLib.expect(cursor.offsetStart).toEqual(b.selections[0].active);
     });
     it('Backward sexp not skipping comments bypasses prompt finding its start', () => {
-      const a = docFromTextNotation('foo•clj꞉foo꞉> |');
-      const b = docFromTextNotation('foo•|clj꞉foo꞉> ');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      const a = textNotation.docFromTextNotation('foo•clj꞉foo꞉> |');
+      const b = textNotation.docFromTextNotation('foo•|clj꞉foo꞉> ');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
       cursor.backwardSexp(false);
-      expect(cursor.offsetStart).toEqual(b.selections[0].active);
+      expectLib.expect(cursor.offsetStart).toEqual(b.selections[0].active);
     });
   });
 
   describe('Current Form', () => {
     it('0: selects from within non-list form', () => {
-      const a = docFromTextNotation('(a|aa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x');
-      const b = docFromTextNotation('(|aaa| (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('(a|aa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x');
+      const b = textNotation.docFromTextNotation('(|aaa| (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('0: selects from within non-list form including reader tag', () => {
-      const a = docFromTextNotation('(#a a|aa (foo bar)))');
-      const b = docFromTextNotation('(|#a aaa| (foo bar)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('(#a a|aa (foo bar)))');
+      const b = textNotation.docFromTextNotation('(|#a aaa| (foo bar)))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('0: selects from within non-list form including multiple reader tags', () => {
-      const a = docFromTextNotation('(#aa #a #b a|aa (foo bar)))');
-      const b = docFromTextNotation('(|#aa #a #b aaa| (foo bar)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('(#aa #a #b a|aa (foo bar)))');
+      const b = textNotation.docFromTextNotation('(|#aa #a #b aaa| (foo bar)))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('0: selects from within non-list form including metadata', () => {
-      const a = docFromTextNotation('(^aa #a a|aa (foo bar)))');
-      const b = docFromTextNotation('(|^aa #a aaa| (foo bar)))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('(^aa #a a|aa (foo bar)))');
+      const b = textNotation.docFromTextNotation('(|^aa #a aaa| (foo bar)))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('0: selects from within non-list form including readers and metadata', () => {
-      const a = docFromTextNotation('(^aa #a a|aa (foo bar))');
-      const b = docFromTextNotation('(|^aa #a aaa| (foo bar))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('(^aa #a a|aa (foo bar))');
+      const b = textNotation.docFromTextNotation('(|^aa #a aaa| (foo bar))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('0: selects from within non-list form including metadata and readers', () => {
-      const a = docFromTextNotation('(#a ^aa a|aa (foo bar))');
-      const b = docFromTextNotation('(|#a ^aa aaa| (foo bar))');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('(#a ^aa a|aa (foo bar))');
+      const b = textNotation.docFromTextNotation('(|#a ^aa aaa| (foo bar))');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('1: selects from adjacent when after form', () => {
-      const a = docFromTextNotation('(aaa •x•#(a b c)|)•#baz•yyy•)');
-      const b = docFromTextNotation('(aaa •x•|#(a b c)|)•#baz•yyy•)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('(aaa •x•#(a b c)|)•#baz•yyy•)');
+      const b = textNotation.docFromTextNotation('(aaa •x•|#(a b c)|)•#baz•yyy•)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('1: selects from adjacent when after form, including reader tags', () => {
-      const a = docFromTextNotation('(x• #a #b •#(a b c)|)•#baz•yyy•)');
-      const b = docFromTextNotation('(x• |#a #b •#(a b c)|)•#baz•yyy•)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('(x• #a #b •#(a b c)|)•#baz•yyy•)');
+      const b = textNotation.docFromTextNotation('(x• |#a #b •#(a b c)|)•#baz•yyy•)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('1: selects from adjacent when after form, including readers and meta data', () => {
-      const a = docFromTextNotation('(x• ^a #b •#(a b c)|)•#baz•yyy•)');
-      const b = docFromTextNotation('(x• |^a #b •#(a b c)|)•#baz•yyy•)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('(x• ^a #b •#(a b c)|)•#baz•yyy•)');
+      const b = textNotation.docFromTextNotation('(x• |^a #b •#(a b c)|)•#baz•yyy•)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('1: selects from adjacent when after form, including meta data and readers', () => {
-      const a = docFromTextNotation('(x• #a ^b •#(a b c)|)•#baz•yyy•)');
-      const b = docFromTextNotation('(x• |#a ^b •#(a b c)|)•#baz•yyy•)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('(x• #a ^b •#(a b c)|)•#baz•yyy•)');
+      const b = textNotation.docFromTextNotation('(x• |#a ^b •#(a b c)|)•#baz•yyy•)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before form', () => {
-      const a = docFromTextNotation('#bar •#baz•[:a :b :c]•x•|#(a b c)');
-      const b = docFromTextNotation('#bar •#baz•[:a :b :c]•x•|#(a b c)|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('#bar •#baz•[:a :b :c]•x•|#(a b c)');
+      const b = textNotation.docFromTextNotation('#bar •#baz•[:a :b :c]•x•|#(a b c)|');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before form, including reader tags', () => {
-      const a = docFromTextNotation('|#bar •#baz•[:a :b :c]•x');
-      const b = docFromTextNotation('|#bar •#baz•[:a :b :c]|•x');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('|#bar •#baz•[:a :b :c]•x');
+      const b = textNotation.docFromTextNotation('|#bar •#baz•[:a :b :c]|•x');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before form, including meta data', () => {
-      const a = docFromTextNotation('|^bar •[:a :b :c]•x');
-      const b = docFromTextNotation('|^bar •[:a :b :c]|•x');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('|^bar •[:a :b :c]•x');
+      const b = textNotation.docFromTextNotation('|^bar •[:a :b :c]|•x');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before form, including meta data and reader', () => {
-      const a = docFromTextNotation('|^bar •#baz•[:a :b :c]•x');
-      const b = docFromTextNotation('|^bar •#baz•[:a :b :c]|•x');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('|^bar •#baz•[:a :b :c]•x');
+      const b = textNotation.docFromTextNotation('|^bar •#baz•[:a :b :c]|•x');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before form, including preceding reader and meta data', () => {
-      const a = docFromTextNotation('^bar •#baz•|[:a :b :c]•x');
-      const b = docFromTextNotation('|^bar •#baz•[:a :b :c]|•x');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('^bar •#baz•|[:a :b :c]•x');
+      const b = textNotation.docFromTextNotation('|^bar •#baz•[:a :b :c]|•x');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before form, including preceding meta data and reader', () => {
-      const a = docFromTextNotation('#bar •^baz•|[:a :b :c]•x');
-      const b = docFromTextNotation('|#bar •^baz•[:a :b :c]|•x');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('#bar •^baz•|[:a :b :c]•x');
+      const b = textNotation.docFromTextNotation('|#bar •^baz•[:a :b :c]|•x');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before form, or in readers', () => {
-      const a = docFromTextNotation('ccc •#foo•|•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy');
-      const b = docFromTextNotation('ccc •|#foo••(#bar •#baz•[:a :b :c]•x•#(a b c))|•#baz•yyy');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation(
+        'ccc •#foo•|•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy'
+      );
+      const b = textNotation.docFromTextNotation(
+        'ccc •|#foo••(#bar •#baz•[:a :b :c]•x•#(a b c))|•#baz•yyy'
+      );
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('2: selects from adjacent before a form with reader tags', () => {
-      const a = docFromTextNotation('#bar |•#baz•[:a :b :c]•x');
-      const b = docFromTextNotation('|#bar •#baz•[:a :b :c]|•x');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('#bar |•#baz•[:a :b :c]•x');
+      const b = textNotation.docFromTextNotation('|#bar •#baz•[:a :b :c]|•x');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('3: selects previous form, if on the same line', () => {
-      const a = docFromTextNotation('z z  | •foo•   •   bar');
-      const b = docFromTextNotation('z |z|   •foo•   •   bar');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('z z  | •foo•   •   bar');
+      const b = textNotation.docFromTextNotation('z |z|   •foo•   •   bar');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('4: selects next form, if on the same line', () => {
-      const a = docFromTextNotation('yyy•|   z z z   •foo•   •   bar');
-      const b = docFromTextNotation('yyy•   |z| z z   •foo•   •   bar');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('yyy•|   z z z   •foo•   •   bar');
+      const b = textNotation.docFromTextNotation('yyy•   |z| z z   •foo•   •   bar');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('5: selects previous form, if any', () => {
-      const a = docFromTextNotation('yyy•   z z z   •foo•   |•   bar');
-      const b = docFromTextNotation('yyy•   z z z   •|foo|•   •   bar');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('yyy•   z z z   •foo•   |•   bar');
+      const b = textNotation.docFromTextNotation('yyy•   z z z   •|foo|•   •   bar');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('5: selects previous form, if any, when next form has metadata', () => {
-      const a = docFromTextNotation('z•foo•|•^{:a b}•bar');
-      const b = docFromTextNotation('z•|foo|••^{:a b}•bar');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('z•foo•|•^{:a b}•bar');
+      const b = textNotation.docFromTextNotation('z•|foo|••^{:a b}•bar');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('6: selects next form, if any', () => {
-      const a = docFromTextNotation(' | •  (foo {:a b})•(c)');
-      const b = docFromTextNotation('  •  |(foo {:a b})|•(c)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation(' | •  (foo {:a b})•(c)');
+      const b = textNotation.docFromTextNotation('  •  |(foo {:a b})|•(c)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('7: selects enclosing form, if any', () => {
-      const a = docFromTextNotation('(|)  •  (foo {:a b})•(c)');
-      const b = docFromTextNotation('|()|  •  (foo {:a b})•(c)');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('(|)  •  (foo {:a b})•(c)');
+      const b = textNotation.docFromTextNotation('|()|  •  (foo {:a b})•(c)');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('2: selects anonymous function when cursor is before #', () => {
-      const a = docFromTextNotation('(map |#(println %) [1 2])');
-      const b = docFromTextNotation('(map |#(println %)| [1 2])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('(map |#(println %) [1 2])');
+      const b = textNotation.docFromTextNotation('(map |#(println %)| [1 2])');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('2: selects anonymous function when cursor is after # and before (', () => {
-      const a = docFromTextNotation('(map #|(println %) [1 2])');
-      const b = docFromTextNotation('(map |#(println %)| [1 2])');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('(map #|(println %) [1 2])');
+      const b = textNotation.docFromTextNotation('(map |#(println %)| [1 2])');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('8: does not croak on unbalance', () => {
       // This hangs the structural editing in the real editor
       // https://github.com/BetterThanTomorrow/calva/issues/1573
-      const a = docFromTextNotation('([|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toBeUndefined();
+      const a = textNotation.docFromTextNotation('([|');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib.expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toBeUndefined();
     });
     it('2: selects ignore form including #_ when cursor is before the marker', () => {
-      const a = docFromTextNotation(':bar |#_"foo"');
-      const b = docFromTextNotation(':bar |#_"foo"|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation(':bar |#_"foo"');
+      const b = textNotation.docFromTextNotation(':bar |#_"foo"|');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('2: selects ignore form including #_ when cursor is before marker at start of file', () => {
-      const a = docFromTextNotation('|#_(foo bar)');
-      const b = docFromTextNotation('|#_(foo bar)|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('|#_(foo bar)');
+      const b = textNotation.docFromTextNotation('|#_(foo bar)|');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('selects ignore form including #_ for all cursor positions within #_:a', () => {
-      const b = docFromTextNotation('|#_:a|');
-      const expected = textAndSelection(b)[1];
+      const b = textNotation.docFromTextNotation('|#_:a|');
+      const expected = textNotation.textAndSelection(b)[1];
       for (const notation of ['|#_:a', '#|_:a', '#_|:a', '#_:|a', '#_:a|']) {
-        const a = docFromTextNotation(notation);
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-        expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(expected);
+        const a = textNotation.docFromTextNotation(notation);
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+        expectLib.expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(expected);
       }
     });
     it('selects ignore form including #_ for cursor before, within, and adjacent to #_(foo bar)', () => {
-      const b = docFromTextNotation('|#_(foo bar)|');
-      const expected = textAndSelection(b)[1];
+      const b = textNotation.docFromTextNotation('|#_(foo bar)|');
+      const expected = textNotation.textAndSelection(b)[1];
       for (const notation of ['|#_(foo bar)', '#|_(foo bar)', '#_|(foo bar)']) {
-        const a = docFromTextNotation(notation);
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-        expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(expected);
+        const a = textNotation.docFromTextNotation(notation);
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+        expectLib.expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(expected);
       }
     });
     it('selects ignore form including #_ when cursor after #_:a in #_:a :b', () => {
-      const a = docFromTextNotation('#_:a| :b');
-      const b = docFromTextNotation('|#_:a| :b');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('#_:a| :b');
+      const b = textNotation.docFromTextNotation('|#_:a| :b');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('selects ignore form including #_ when cursor is at end of #_     :a (spaces between)', () => {
-      const a = docFromTextNotation('#_     :a|');
-      const b = docFromTextNotation('|#_     :a|');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-      expect(cursor.rangeForCurrentForm(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('#_     :a|');
+      const b = textNotation.docFromTextNotation('|#_     :a|');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+      expectLib
+        .expect(cursor.rangeForCurrentForm(a.selections[0].anchor))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
   });
 
   describe('Top Level Form', () => {
     it('Finds range when nested down some forms', () => {
-      const a = docFromTextNotation(
+      const a = textNotation.docFromTextNotation(
         'aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b| :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) (ddd eee)'
       );
-      const b = docFromTextNotation(
+      const b = textNotation.docFromTextNotation(
         'aaa |(bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar))| (ddd eee)'
       );
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-      expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+      expectLib
+        .expect(cursor.rangeForDefun(a.selections[0].active))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('Finds range when in current form is top level', () => {
-      const a = docFromTextNotation(
+      const a = textNotation.docFromTextNotation(
         'aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) |(ddd eee)'
       );
-      const b = docFromTextNotation(
+      const b = textNotation.docFromTextNotation(
         'aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) |(ddd eee)|'
       );
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-      expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+      expectLib
+        .expect(cursor.rangeForDefun(a.selections[0].active))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('Finds range when in ”solid” top level form', () => {
-      const a = docFromTextNotation(
+      const a = textNotation.docFromTextNotation(
         'a|aa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) (ddd eee)'
       );
-      const b = docFromTextNotation(
+      const b = textNotation.docFromTextNotation(
         '|aaa| (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) (ddd eee)'
       );
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-      expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+      expectLib
+        .expect(cursor.rangeForDefun(a.selections[0].active))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     it('Finds something when there is unbalance', () => {
-      const a = docFromTextNotation(
+      const a = textNotation.docFromTextNotation(
         '(ns xxx)•(def xxx|•{()"#"\\$" #"(?!\\w)"))))))))))))))))))))))))))))))))))))))))'
       );
-      const b = docFromTextNotation(
+      const b = textNotation.docFromTextNotation(
         '(ns xxx)•(def xxx•|{()"#"\\$" #"(?!\\w)"))))))))))))))))))))))))))))))))))))))))|'
       );
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-      expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+      expectLib
+        .expect(cursor.rangeForDefun(a.selections[0].active))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     // https://github.com/BetterThanTomorrow/calva/issues/2655
     it('Does not include ignore marker', () => {
-      const a = docFromTextNotation('a #_ [b (c|)] [d]');
-      const b = docFromTextNotation('a #_ |[b (c)]| [d]');
-      const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-      expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+      const a = textNotation.docFromTextNotation('a #_ [b (c|)] [d]');
+      const b = textNotation.docFromTextNotation('a #_ |[b (c)]| [d]');
+      const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+      expectLib
+        .expect(cursor.rangeForDefun(a.selections[0].active))
+        .toEqual(textNotation.textAndSelection(b)[1]);
     });
     describe('Rich Comment Form top level context', () => {
       it('Finds range for a top level form inside a comment', () => {
-        const a = docFromTextNotation('aaa (comment [bbb cc|c]  ddd)');
-        const b = docFromTextNotation('aaa (comment |[bbb ccc]|  ddd)');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('aaa (comment [bbb cc|c]  ddd)');
+        const b = textNotation.docFromTextNotation('aaa (comment |[bbb ccc]|  ddd)');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].active))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds range for a top level map inside a comment', () => {
-        const a = docFromTextNotation('aaa (comment {bbb cc|c}  ddd)');
-        const b = docFromTextNotation('aaa (comment |{bbb ccc}|  ddd)');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('aaa (comment {bbb cc|c}  ddd)');
+        const b = textNotation.docFromTextNotation('aaa (comment |{bbb ccc}|  ddd)');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].active))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       // https://github.com/BetterThanTomorrow/calva/issues/2290
       describe('Rich Comment Form top level context from inside form', () => {
         it('Finds range for a top level function call inside a comment from inside a string', () => {
-          const a = docFromTextNotation('aaa (comment (bbb "cc|c")  ddd)');
-          const b = docFromTextNotation('aaa (comment |(bbb "ccc")|  ddd)');
-          const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-          expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+          const a = textNotation.docFromTextNotation('aaa (comment (bbb "cc|c")  ddd)');
+          const b = textNotation.docFromTextNotation('aaa (comment |(bbb "ccc")|  ddd)');
+          const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+          expectLib
+            .expect(cursor.rangeForDefun(a.selections[0].active))
+            .toEqual(textNotation.textAndSelection(b)[1]);
         });
         it('Finds range for a top level shortcut lambda function inside a comment from inside a string', () => {
-          const a = docFromTextNotation('aaa (comment #(bbb "cc|c")  ddd)');
-          const b = docFromTextNotation('aaa (comment |#(bbb "ccc")|  ddd)');
-          const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-          expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+          const a = textNotation.docFromTextNotation('aaa (comment #(bbb "cc|c")  ddd)');
+          const b = textNotation.docFromTextNotation('aaa (comment |#(bbb "ccc")|  ddd)');
+          const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+          expectLib
+            .expect(cursor.rangeForDefun(a.selections[0].active))
+            .toEqual(textNotation.textAndSelection(b)[1]);
         });
         it('Finds range for a top level quoted list inside a comment from inside a string', () => {
-          const a = docFromTextNotation(`aaa (comment '(bbb "cc|c")  ddd)`);
-          const b = docFromTextNotation(`aaa (comment |'(bbb "ccc")|  ddd)`);
-          const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-          expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+          const a = textNotation.docFromTextNotation(`aaa (comment '(bbb "cc|c")  ddd)`);
+          const b = textNotation.docFromTextNotation(`aaa (comment |'(bbb "ccc")|  ddd)`);
+          const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+          expectLib
+            .expect(cursor.rangeForDefun(a.selections[0].active))
+            .toEqual(textNotation.textAndSelection(b)[1]);
         });
         it('Finds range for a top level map inside a comment from inside a string', () => {
-          const a = docFromTextNotation('aaa (comment {bbb "cc|c"}  ddd)');
-          const b = docFromTextNotation('aaa (comment |{bbb "ccc"}|  ddd)');
-          const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-          expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+          const a = textNotation.docFromTextNotation('aaa (comment {bbb "cc|c"}  ddd)');
+          const b = textNotation.docFromTextNotation('aaa (comment |{bbb "ccc"}|  ddd)');
+          const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+          expectLib
+            .expect(cursor.rangeForDefun(a.selections[0].active))
+            .toEqual(textNotation.textAndSelection(b)[1]);
         });
         it('Finds range for a top level map inside a comment from inside a form', () => {
-          const a = docFromTextNotation('aaa (comment {bbb [cc|c]}  ddd)');
-          const b = docFromTextNotation('aaa (comment |{bbb [ccc]}|  ddd)');
-          const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-          expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+          const a = textNotation.docFromTextNotation('aaa (comment {bbb [cc|c]}  ddd)');
+          const b = textNotation.docFromTextNotation('aaa (comment |{bbb [ccc]}|  ddd)');
+          const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+          expectLib
+            .expect(cursor.rangeForDefun(a.selections[0].active))
+            .toEqual(textNotation.textAndSelection(b)[1]);
         });
         it('Finds range for a top level set inside a comment from inside a string', () => {
-          const a = docFromTextNotation('aaa (comment #{bbb "cc|c"}  ddd)');
-          const b = docFromTextNotation('aaa (comment |#{bbb "ccc"}|  ddd)');
-          const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-          expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+          const a = textNotation.docFromTextNotation('aaa (comment #{bbb "cc|c"}  ddd)');
+          const b = textNotation.docFromTextNotation('aaa (comment |#{bbb "ccc"}|  ddd)');
+          const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+          expectLib
+            .expect(cursor.rangeForDefun(a.selections[0].active))
+            .toEqual(textNotation.textAndSelection(b)[1]);
         });
         it('Finds range for a top level vector inside a comment from inside a string', () => {
-          const a = docFromTextNotation('aaa (comment [bbb "cc|c"]  ddd)');
-          const b = docFromTextNotation('aaa (comment |[bbb "ccc"]|  ddd)');
-          const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-          expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+          const a = textNotation.docFromTextNotation('aaa (comment [bbb "cc|c"]  ddd)');
+          const b = textNotation.docFromTextNotation('aaa (comment |[bbb "ccc"]|  ddd)');
+          const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+          expectLib
+            .expect(cursor.rangeForDefun(a.selections[0].active))
+            .toEqual(textNotation.textAndSelection(b)[1]);
         });
       });
       it('Finds range for a top level form inside a comment inside a form', () => {
-        const a = docFromTextNotation('a (b (comment [c |d] e))');
-        const b = docFromTextNotation('a (b (comment |[c d]| e))');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('a (b (comment [c |d] e))');
+        const b = textNotation.docFromTextNotation('a (b (comment |[c d]| e))');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].active))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds top level comment range if comment special treatment is disabled', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           'aaa (comment (ccc •#foo•(#bar •#baz•[:a :b| :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) (ddd eee)'
         );
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           'aaa |(comment (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar))| (ddd eee)'
         );
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.rangeForDefun(a.selections[0].active, false)).toEqual(textAndSelection(b)[1]);
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].active, false))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds comment range for empty comment form', () => {
         // Unimportant use case, just documenting how it behaves
-        const a = docFromTextNotation('aaa (comment |  ) bbb');
-        const b = docFromTextNotation('aaa (|comment|   ) bbb');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('aaa (comment |  ) bbb');
+        const b = textNotation.docFromTextNotation('aaa (|comment|   ) bbb');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].active))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Does not find comment range when comments are nested', () => {
-        const a = docFromTextNotation('aaa (comment (comment [bbb ccc] | ddd))');
-        const b = docFromTextNotation('aaa (comment (comment |[bbb ccc]|  ddd))');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('aaa (comment (comment [bbb ccc] | ddd))');
+        const b = textNotation.docFromTextNotation('aaa (comment (comment |[bbb ccc]|  ddd))');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].active))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds comment range when current form is top level comment form', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           'aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) |(comment eee)'
         );
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           'aaa (bbb (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) |(comment eee)|'
         );
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].active))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Includes reader tag', () => {
-        const a = docFromTextNotation('aaa (comment #r [bbb ccc|]  ddd)');
-        const b = docFromTextNotation('aaa (comment |#r [bbb ccc]|  ddd)');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('aaa (comment #r [bbb ccc|]  ddd)');
+        const b = textNotation.docFromTextNotation('aaa (comment |#r [bbb ccc]|  ddd)');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].active))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the preceding range when cursor is between to forms on the same line', () => {
-        const a = docFromTextNotation('aaa (comment [bbb ccc] | ddd)');
-        const b = docFromTextNotation('aaa (comment |[bbb ccc]|  ddd)');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('aaa (comment [bbb ccc] | ddd)');
+        const b = textNotation.docFromTextNotation('aaa (comment |[bbb ccc]|  ddd)');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].active))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the succeeding range when cursor is at the start of the line', () => {
-        const a = docFromTextNotation('aaa (comment [bbb ccc]• | ddd)');
-        const b = docFromTextNotation('aaa (comment [bbb ccc]•  |ddd|)');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('aaa (comment [bbb ccc]• | ddd)');
+        const b = textNotation.docFromTextNotation('aaa (comment [bbb ccc]•  |ddd|)');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].active))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the preceding comment symbol range when cursor is between that and something else on the same line', () => {
         // This is a bit funny, but is not an important use case
-        const a = docFromTextNotation('aaa (comment  | [bbb ccc]  ddd)');
-        const b = docFromTextNotation('aaa (|comment|   [bbb ccc]  ddd)');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('aaa (comment  | [bbb ccc]  ddd)');
+        const b = textNotation.docFromTextNotation('aaa (|comment|   [bbb ccc]  ddd)');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].active))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Can find the comment range for a top level form inside a comment', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           'aaa (comment (ccc •#foo•(#bar •#baz•[:a :b| :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar)) (ddd eee)'
         );
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           'aaa |(comment (ccc •#foo•(#bar •#baz•[:a :b :c]•x•#(a b c))•#baz•yyy•   z z z   •foo•   •   bar))| (ddd eee)'
         );
-        const cursor: LispTokenCursor = a.getTokenCursor(0);
-        expect(cursor.rangeForDefun(a.selections[0].anchor, false)).toEqual(textAndSelection(b)[1]);
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(0);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].anchor, false))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds closest form inside multiple nested comments', () => {
-        const a = docFromTextNotation('aaa (comment (comment [bbb ccc] | ddd))');
-        const b = docFromTextNotation('aaa (comment (comment |[bbb ccc]|  ddd))');
-        const cursor: LispTokenCursor = a.getTokenCursor(0);
-        expect(cursor.rangeForDefun(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('aaa (comment (comment [bbb ccc] | ddd))');
+        const b = textNotation.docFromTextNotation('aaa (comment (comment |[bbb ccc]|  ddd))');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(0);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].anchor))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds the preceding range when cursor is between two forms on the same line', () => {
-        const a = docFromTextNotation('aaa (comment [bbb ccc] | ddd)');
-        const b = docFromTextNotation('aaa (comment |[bbb ccc]|  ddd)');
-        const cursor: LispTokenCursor = a.getTokenCursor(0);
-        expect(cursor.rangeForDefun(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('aaa (comment [bbb ccc] | ddd)');
+        const b = textNotation.docFromTextNotation('aaa (comment |[bbb ccc]|  ddd)');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(0);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].anchor))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Finds top level form when deref in comment', () => {
-        const a = docFromTextNotation('(comment @(foo [bar|]))');
-        const b = docFromTextNotation('(comment |@(foo [bar])|)');
-        const cursor: LispTokenCursor = a.getTokenCursor(0);
-        expect(cursor.rangeForDefun(a.selections[0].anchor)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('(comment @(foo [bar|]))');
+        const b = textNotation.docFromTextNotation('(comment |@(foo [bar])|)');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(0);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].anchor))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       // https://github.com/BetterThanTomorrow/calva/issues/2655
       it('Does not include ignore marker', () => {
-        const a = docFromTextNotation('aaa (comment #_ [bbb ccc|]  ddd)');
-        const b = docFromTextNotation('aaa (comment #_ |[bbb ccc]|  ddd)');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('aaa (comment #_ [bbb ccc|]  ddd)');
+        const b = textNotation.docFromTextNotation('aaa (comment #_ |[bbb ccc]|  ddd)');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].active))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
       it('Does not include ignore marker with no whitespaces', () => {
-        const a = docFromTextNotation('aaa (comment #_[bbb ccc|]  ddd)');
-        const b = docFromTextNotation('aaa (comment #_|[bbb ccc]|  ddd)');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.rangeForDefun(a.selections[0].active)).toEqual(textAndSelection(b)[1]);
+        const a = textNotation.docFromTextNotation('aaa (comment #_[bbb ccc|]  ddd)');
+        const b = textNotation.docFromTextNotation('aaa (comment #_|[bbb ccc]|  ddd)');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib
+          .expect(cursor.rangeForDefun(a.selections[0].active))
+          .toEqual(textNotation.textAndSelection(b)[1]);
       });
     });
   });
@@ -1022,169 +1152,171 @@ describe('Token Cursor', () => {
   describe('Utilities', () => {
     describe('getFunctionName', () => {
       it('Finds function name in the current list', () => {
-        const a = docFromTextNotation('(foo [|])');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-        expect(cursor.getFunctionName()).toEqual('foo');
+        const a = textNotation.docFromTextNotation('(foo [|])');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+        expectLib.expect(cursor.getFunctionName()).toEqual('foo');
       });
       it('Does not croak finding function name in unbalance', () => {
         // This hung the structural editing in the real editor
         // https://github.com/BetterThanTomorrow/calva/issues/1573
-        const a = docFromTextNotation('([|');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-        expect(cursor.getFunctionName()).toBeUndefined();
+        const a = textNotation.docFromTextNotation('([|');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+        expectLib.expect(cursor.getFunctionName()).toBeUndefined();
       });
     });
     describe('createStringCursor', () => {
       it('Ranges account for newline', () => {
-        const cursor = createStringCursor('(a\n(b))');
+        const cursor = tokenCursor.createStringCursor('(a\n(b))');
         const topLevelRanges = cursor.rangesForTopLevelForms().flat();
-        expect(topLevelRanges).toEqual([0, 7]);
+        expectLib.expect(topLevelRanges).toEqual([0, 7]);
       });
       it('Ranges account for newline (MS-Windows)', () => {
-        const cursor = createStringCursor('(a\r\n(b))');
+        const cursor = tokenCursor.createStringCursor('(a\r\n(b))');
         const topLevelRanges = cursor.rangesForTopLevelForms().flat();
-        expect(topLevelRanges).toEqual([0, 8]);
+        expectLib.expect(topLevelRanges).toEqual([0, 8]);
       });
     });
     describe('atTopLevel', () => {
       it('Returns true when at top level', () => {
-        const a = docFromTextNotation('(foo []) |(bar :baz)');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.atTopLevel()).toEqual(true);
+        const a = textNotation.docFromTextNotation('(foo []) |(bar :baz)');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib.expect(cursor.atTopLevel()).toEqual(true);
       });
       it('Returns true when at top level in rich comment if instructed so', () => {
-        const a = docFromTextNotation('( comment (foo []) |(bar :baz))');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.atTopLevel(true)).toEqual(true);
+        const a = textNotation.docFromTextNotation('( comment (foo []) |(bar :baz))');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib.expect(cursor.atTopLevel(true)).toEqual(true);
       });
       it('Returns true when at a top level map in rich comment if instructed so', () => {
-        const a = docFromTextNotation('( comment (foo []) |{bar :baz})');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.atTopLevel(true)).toEqual(true);
+        const a = textNotation.docFromTextNotation('( comment (foo []) |{bar :baz})');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib.expect(cursor.atTopLevel(true)).toEqual(true);
       });
       // TODO: Figure out if this should be how it works
       // Related to: https://github.com/BetterThanTomorrow/calva/issues/2109
       it('Returns true when at top level in rich comment if instructed so, even if comment is not at top level', () => {
-        const a = docFromTextNotation('(a ( comment (foo []) |(bar :baz)))');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.atTopLevel(true)).toEqual(true);
+        const a = textNotation.docFromTextNotation('(a ( comment (foo []) |(bar :baz)))');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib.expect(cursor.atTopLevel(true)).toEqual(true);
       });
       it('Returns true when at a top level map in rich comment if instructed so, even if comment is not at top level', () => {
-        const a = docFromTextNotation('(a ( comment (foo []) |{bar :baz}))');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.atTopLevel(true)).toEqual(true);
+        const a = textNotation.docFromTextNotation('(a ( comment (foo []) |{bar :baz}))');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib.expect(cursor.atTopLevel(true)).toEqual(true);
       });
       it('Returns false when at top level in rich comment if not instructed to treat it so', () => {
-        const a = docFromTextNotation('( comment (foo []) |(bar :baz))');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.atTopLevel()).toEqual(false);
+        const a = textNotation.docFromTextNotation('( comment (foo []) |(bar :baz))');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib.expect(cursor.atTopLevel()).toEqual(false);
       });
       it('Returns false when not at top level', () => {
-        const a = docFromTextNotation('(foo |[])');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].active);
-        expect(cursor.atTopLevel()).toEqual(false);
+        const a = textNotation.docFromTextNotation('(foo |[])');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].active);
+        expectLib.expect(cursor.atTopLevel()).toEqual(false);
       });
     });
 
     describe('docIsBalanced', () => {
       it('Reports balance for balanced structure', () => {
-        const doc = docFromTextNotation('(a)•|(b)');
-        const cursor: LispTokenCursor = doc.getTokenCursor(doc.selections[0].active);
-        expect(cursor.docIsBalanced()).toBe(true);
+        const doc = textNotation.docFromTextNotation('(a)•|(b)');
+        const cursor: tokenCursor.LispTokenCursor = doc.getTokenCursor(doc.selections[0].active);
+        expectLib.expect(cursor.docIsBalanced()).toBe(true);
       });
       it('Detects unbalance when lacking opening brackets', () => {
-        const doc = docFromTextNotation('(a)•|(b))');
-        const cursor: LispTokenCursor = doc.getTokenCursor(doc.selections[0].active);
-        expect(cursor.docIsBalanced()).toBe(false);
+        const doc = textNotation.docFromTextNotation('(a)•|(b))');
+        const cursor: tokenCursor.LispTokenCursor = doc.getTokenCursor(doc.selections[0].active);
+        expectLib.expect(cursor.docIsBalanced()).toBe(false);
       });
       // TODO: Fix this
       xit('Detects unbalance when lacking closing brackets', () => {
-        const doc = docFromTextNotation('(a)•|(b');
-        const cursor: LispTokenCursor = doc.getTokenCursor(doc.selections[0].active);
-        expect(cursor.docIsBalanced()).toBe(false);
+        const doc = textNotation.docFromTextNotation('(a)•|(b');
+        const cursor: tokenCursor.LispTokenCursor = doc.getTokenCursor(doc.selections[0].active);
+        expectLib.expect(cursor.docIsBalanced()).toBe(false);
       });
       // TODO: Fix this too
       xit('Detects unbalance when lacking man closing brackets', () => {
-        const doc = docFromTextNotation('(a)•|([{((((b)');
-        const cursor: LispTokenCursor = doc.getTokenCursor(doc.selections[0].active);
-        expect(cursor.docIsBalanced()).toBe(false);
+        const doc = textNotation.docFromTextNotation('(a)•|([{((((b)');
+        const cursor: tokenCursor.LispTokenCursor = doc.getTokenCursor(doc.selections[0].active);
+        expectLib.expect(cursor.docIsBalanced()).toBe(false);
       });
     });
 
     describe('backwardFunction', () => {
       it('Finds current function start', () => {
-        const a = docFromTextNotation('(a b |c)');
-        const b = docFromTextNotation('(|a b c)');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-        expect(cursor.backwardFunction()).toBe(true);
-        expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+        const a = textNotation.docFromTextNotation('(a b |c)');
+        const b = textNotation.docFromTextNotation('(|a b c)');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+        expectLib.expect(cursor.backwardFunction()).toBe(true);
+        expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
       });
       it('Finds current function start when nested', () => {
-        const a = docFromTextNotation('(a b (c d|))');
-        const b = docFromTextNotation('(a b (|c d))');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-        expect(cursor.backwardFunction()).toBe(true);
-        expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+        const a = textNotation.docFromTextNotation('(a b (c d|))');
+        const b = textNotation.docFromTextNotation('(a b (|c d))');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+        expectLib.expect(cursor.backwardFunction()).toBe(true);
+        expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
       });
       it('Finds current function start when nested and inside non-function', () => {
-        const a = docFromTextNotation('(a b (c d [e f|]))');
-        const b = docFromTextNotation('(a b (|c d [e f]))');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-        expect(cursor.backwardFunction()).toBe(true);
-        expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+        const a = textNotation.docFromTextNotation('(a b (c d [e f|]))');
+        const b = textNotation.docFromTextNotation('(a b (|c d [e f]))');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+        expectLib.expect(cursor.backwardFunction()).toBe(true);
+        expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
       });
       it('Finds current function start when nested in rich comment', () => {
-        const a = docFromTextNotation('(comment a b (c d|))');
-        const b = docFromTextNotation('(comment a b (|c d))');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-        expect(cursor.backwardFunction()).toBe(true);
-        expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+        const a = textNotation.docFromTextNotation('(comment a b (c d|))');
+        const b = textNotation.docFromTextNotation('(comment a b (|c d))');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+        expectLib.expect(cursor.backwardFunction()).toBe(true);
+        expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
       });
       it('Finds parent function start', () => {
-        const a = docFromTextNotation('(a b (c d|))');
-        const b = docFromTextNotation('(|a b (c d))');
-        const cursor: LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
-        expect(cursor.backwardFunction(1)).toBe(true);
-        expect(cursor.offsetStart).toBe(b.selections[0].anchor);
+        const a = textNotation.docFromTextNotation('(a b (c d|))');
+        const b = textNotation.docFromTextNotation('(|a b (c d))');
+        const cursor: tokenCursor.LispTokenCursor = a.getTokenCursor(a.selections[0].anchor);
+        expectLib.expect(cursor.backwardFunction(1)).toBe(true);
+        expectLib.expect(cursor.offsetStart).toBe(b.selections[0].anchor);
       });
     });
   });
 
   describe('Location State', () => {
     it('Knows when inside string', () => {
-      const doc = docFromTextNotation('(str [] "", "foo" "f   b  b"   "   f b b   " "\\"" \\")');
+      const doc = textNotation.docFromTextNotation(
+        '(str [] "", "foo" "f   b  b"   "   f b b   " "\\"" \\")'
+      );
       const withinEmpty = doc.getTokenCursor(9);
-      expect(withinEmpty.withinString()).toBe(true);
+      expectLib.expect(withinEmpty.withinString()).toBe(true);
       const adjacentOutsideLeft = doc.getTokenCursor(8);
-      expect(adjacentOutsideLeft.withinString()).toBe(false);
+      expectLib.expect(adjacentOutsideLeft.withinString()).toBe(false);
       const adjacentOutsideRight = doc.getTokenCursor(10);
-      expect(adjacentOutsideRight.withinString()).toBe(false);
+      expectLib.expect(adjacentOutsideRight.withinString()).toBe(false);
       const noStringWS = doc.getTokenCursor(11);
-      expect(noStringWS.withinString()).toBe(false);
+      expectLib.expect(noStringWS.withinString()).toBe(false);
       const leftOfFirstWord = doc.getTokenCursor(13);
-      expect(leftOfFirstWord.withinString()).toBe(true);
+      expectLib.expect(leftOfFirstWord.withinString()).toBe(true);
       const rightOfLastWord = doc.getTokenCursor(16);
-      expect(rightOfLastWord.withinString()).toBe(true);
+      expectLib.expect(rightOfLastWord.withinString()).toBe(true);
       const inWord = doc.getTokenCursor(14);
-      expect(inWord.withinString()).toBe(true);
+      expectLib.expect(inWord.withinString()).toBe(true);
       const spaceBetweenWords = doc.getTokenCursor(21);
-      expect(spaceBetweenWords.withinString()).toBe(true);
+      expectLib.expect(spaceBetweenWords.withinString()).toBe(true);
       const spaceBeforeFirstWord = doc.getTokenCursor(33);
-      expect(spaceBeforeFirstWord.withinString()).toBe(true);
+      expectLib.expect(spaceBeforeFirstWord.withinString()).toBe(true);
       const spaceAfterLastWord = doc.getTokenCursor(41);
-      expect(spaceAfterLastWord.withinString()).toBe(true);
+      expectLib.expect(spaceAfterLastWord.withinString()).toBe(true);
       const beforeQuotedStringQuote = doc.getTokenCursor(46);
-      expect(beforeQuotedStringQuote.withinString()).toBe(true);
+      expectLib.expect(beforeQuotedStringQuote.withinString()).toBe(true);
       const inQuotedStringQuote = doc.getTokenCursor(47);
-      expect(inQuotedStringQuote.withinString()).toBe(true);
+      expectLib.expect(inQuotedStringQuote.withinString()).toBe(true);
       const afterQuotedStringQuote = doc.getTokenCursor(48);
-      expect(afterQuotedStringQuote.withinString()).toBe(true);
+      expectLib.expect(afterQuotedStringQuote.withinString()).toBe(true);
       const beforeLiteralQuote = doc.getTokenCursor(50);
-      expect(beforeLiteralQuote.withinString()).toBe(false);
+      expectLib.expect(beforeLiteralQuote.withinString()).toBe(false);
       const inLiteralQuote = doc.getTokenCursor(51);
-      expect(inLiteralQuote.withinString()).toBe(false);
+      expectLib.expect(inLiteralQuote.withinString()).toBe(false);
       const afterLiteralQuote = doc.getTokenCursor(52);
-      expect(afterLiteralQuote.withinString()).toBe(false);
+      expectLib.expect(afterLiteralQuote.withinString()).toBe(false);
     });
   });
 });

--- a/src/extension-test/unit/cursor-doc/utilities-test.ts
+++ b/src/extension-test/unit/cursor-doc/utilities-test.ts
@@ -1,6 +1,6 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as utilities from '../../../cursor-doc/utilities';
-import { docFromTextNotation } from '../common/text-notation';
+import * as textNotation from '../common/text-notation';
 //import { docFromTextNotation, textAndSelection } from '../common/text-notation';
 
 describe('Utilities that need cursor doc things', () => {
@@ -8,47 +8,49 @@ describe('Utilities that need cursor doc things', () => {
     it('Adds missing brackets', () => {
       const text = '(a b) (c {:d [1 2 3 "four"';
       const append = ']})';
-      expect(utilities.getMissingBrackets(text)).toEqual({ append: append, prepend: '' });
+      expectLib.expect(utilities.getMissingBrackets(text)).toEqual({ append: append, prepend: '' });
     });
     it('Closes strings', () => {
       const text = '(a b) (c {:d [1 2 3 "four';
       const append = '"]})';
-      expect(utilities.getMissingBrackets(text)).toEqual({ append: append, prepend: '' });
+      expectLib.expect(utilities.getMissingBrackets(text)).toEqual({ append: append, prepend: '' });
     });
     it('Leaves non-broken structure alone', () => {
       const text = '(a b) (c {:d [1 2 3 "four"] :e :f} g) h';
-      expect(utilities.getMissingBrackets(text)).toEqual({ append: '', prepend: '' });
+      expectLib.expect(utilities.getMissingBrackets(text)).toEqual({ append: '', prepend: '' });
     });
     it('Adds missing opening brackets', () => {
       const text = '(a b) (c {:d [1 2 3 "four"]}) extra ] closing } brackets)';
       const prepend = '({[';
-      expect(utilities.getMissingBrackets(text)).toEqual({ append: '', prepend: prepend });
+      expectLib
+        .expect(utilities.getMissingBrackets(text))
+        .toEqual({ append: '', prepend: prepend });
     });
     it('Ignores brackets in strings', () => {
       const text = '(a b) "{{" (c {:d [1 2 3 "four([{" [';
       const append = ']]})';
-      expect(utilities.getMissingBrackets(text)).toEqual({ append: append, prepend: '' });
+      expectLib.expect(utilities.getMissingBrackets(text)).toEqual({ append: append, prepend: '' });
     });
     it('Ignores brackets in line comments', () => {
       const text = '(a b) (c {:d \n; ( [ ( {\n[1 2 3 "four"';
       const append = ']})';
-      expect(utilities.getMissingBrackets(text)).toEqual({ append: append, prepend: '' });
+      expectLib.expect(utilities.getMissingBrackets(text)).toEqual({ append: append, prepend: '' });
     });
   });
   describe('isRightSexpStructural', () => {
     it('map', () => {
-      const cursor = docFromTextNotation('|{:a 1}').getTokenCursor(0);
-      expect(utilities.isRightSexpStructural(cursor)).toBe(true);
+      const cursor = textNotation.docFromTextNotation('|{:a 1}').getTokenCursor(0);
+      expectLib.expect(utilities.isRightSexpStructural(cursor)).toBe(true);
     });
     it('Tagged map', () => {
-      const cursor = docFromTextNotation('|#foo {:a 1}').getTokenCursor(0);
-      expect(utilities.isRightSexpStructural(cursor)).toBe(true);
+      const cursor = textNotation.docFromTextNotation('|#foo {:a 1}').getTokenCursor(0);
+      expectLib.expect(utilities.isRightSexpStructural(cursor)).toBe(true);
     });
   });
   describe('structureForRightSexp', () => {
     it('[map]', () => {
-      const cursor = docFromTextNotation('|[{:a 1}]').getTokenCursor(0);
-      expect(utilities.structureForRightSexp(cursor)).toEqual([
+      const cursor = textNotation.docFromTextNotation('|[{:a 1}]').getTokenCursor(0);
+      expectLib.expect(utilities.structureForRightSexp(cursor)).toEqual([
         {
           originalString: '{:a 1}',
           value: new Map<any, any>([
@@ -61,8 +63,8 @@ describe('Utilities that need cursor doc things', () => {
       ]);
     });
     it('[tagged map]', () => {
-      const cursor = docFromTextNotation('|[#t {:a 1}]').getTokenCursor(0);
-      expect(utilities.structureForRightSexp(cursor)).toEqual([
+      const cursor = textNotation.docFromTextNotation('|[#t {:a 1}]').getTokenCursor(0);
+      expectLib.expect(utilities.structureForRightSexp(cursor)).toEqual([
         {
           originalString: '#t {:a 1}',
           value: new Map<any, any>([

--- a/src/extension-test/unit/debugger/util-test.ts
+++ b/src/extension-test/unit/debugger/util-test.ts
@@ -1,5 +1,5 @@
-import { expect } from 'expect';
-import { moveTokenCursorToBreakpoint } from '../../../debugger/util';
+import * as expectLib from 'expect';
+import * as util from '../../../debugger/util';
 import * as model from '../../../cursor-doc/model';
 
 function getCoordinates(text: string): (string | number)[] {
@@ -32,8 +32,8 @@ describe('Debugger Util', () => {
       const doc = new model.StringDocument();
       doc.insertString(coorsAndBody);
       const tokenCursor = doc.getTokenCursor(0);
-      moveTokenCursorToBreakpoint(tokenCursor, debugResponse);
-      expect(tokenCursor.getPrevToken().raw.endsWith('|')).toBe(true);
+      util.moveTokenCursorToBreakpoint(tokenCursor, debugResponse);
+      expectLib.expect(tokenCursor.getPrevToken().raw.endsWith('|')).toBe(true);
     }
 
     it('simple example', () => {

--- a/src/extension-test/unit/edit/comment-prefix-test.ts
+++ b/src/extension-test/unit/edit/comment-prefix-test.ts
@@ -1,9 +1,9 @@
-import { expect } from 'expect';
-import { calculateCommentPrefixRemovalEnd } from '../../../comment-prefix';
+import * as expectLib from 'expect';
+import * as commentPrefix from '../../../comment-prefix';
 
 function stripLeadingCommentPrefix(lineText: string): string {
   const firstNonWhitespace = lineText.search(/\S|$/);
-  const removalEnd = calculateCommentPrefixRemovalEnd(lineText, firstNonWhitespace);
+  const removalEnd = commentPrefix.calculateCommentPrefixRemovalEnd(lineText, firstNonWhitespace);
   if (removalEnd === undefined) {
     return lineText;
   }
@@ -12,30 +12,30 @@ function stripLeadingCommentPrefix(lineText: string): string {
 
 describe('prefix removal', () => {
   it('strips single semicolon prefix and following space', () => {
-    expect(stripLeadingCommentPrefix('  ; code')).toBe('  code');
+    expectLib.expect(stripLeadingCommentPrefix('  ; code')).toBe('  code');
   });
 
   it('strips double semicolon prefix and following space', () => {
-    expect(stripLeadingCommentPrefix('  ;; code')).toBe('  code');
+    expectLib.expect(stripLeadingCommentPrefix('  ;; code')).toBe('  code');
   });
 
   it('strips triple semicolon prefix and following space', () => {
-    expect(stripLeadingCommentPrefix('  ;;; header')).toBe('  header');
+    expectLib.expect(stripLeadingCommentPrefix('  ;;; header')).toBe('  header');
   });
 
   it('strips semicolon prefix and one separating space before content', () => {
-    expect(stripLeadingCommentPrefix(';;;   header')).toBe('  header');
+    expectLib.expect(stripLeadingCommentPrefix(';;;   header')).toBe('  header');
   });
 
   it('preserves indentation spaces after comment prefix', () => {
-    expect(stripLeadingCommentPrefix(';;       h)')).toBe('      h)');
+    expectLib.expect(stripLeadingCommentPrefix(';;       h)')).toBe('      h)');
   });
 
   it('strips fully blank commented line to empty', () => {
-    expect(stripLeadingCommentPrefix(';;      ')).toBe('');
+    expectLib.expect(stripLeadingCommentPrefix(';;      ')).toBe('');
   });
 
   it('keeps non-comment lines unchanged', () => {
-    expect(stripLeadingCommentPrefix('  code')).toBe('  code');
+    expectLib.expect(stripLeadingCommentPrefix('  code')).toBe('  code');
   });
 });

--- a/src/extension-test/unit/file-output-test.ts
+++ b/src/extension-test/unit/file-output-test.ts
@@ -1,106 +1,99 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import {
-  isFilePathDestination,
-  expandTilde,
-  resolveOutputFilePath,
-  appendToOutputFile,
-  reportFileOutputError,
-  resetFileOutputErrors,
-} from '../../results-output/file-output';
+import * as fileOutput from '../../results-output/file-output';
 
 describe('file-output', () => {
   describe('isFilePathDestination', () => {
     it('matches relative paths starting with ./', () => {
-      expect(isFilePathDestination('./foo')).toBe(true);
-      expect(isFilePathDestination('./logs/output.txt')).toBe(true);
+      expectLib.expect(fileOutput.isFilePathDestination('./foo')).toBe(true);
+      expectLib.expect(fileOutput.isFilePathDestination('./logs/output.txt')).toBe(true);
     });
 
     it('matches relative paths starting with ../', () => {
-      expect(isFilePathDestination('../foo')).toBe(true);
+      expectLib.expect(fileOutput.isFilePathDestination('../foo')).toBe(true);
     });
 
     it('matches absolute Unix paths', () => {
-      expect(isFilePathDestination('/abs/path')).toBe(true);
-      expect(isFilePathDestination('/tmp/output.txt')).toBe(true);
+      expectLib.expect(fileOutput.isFilePathDestination('/abs/path')).toBe(true);
+      expectLib.expect(fileOutput.isFilePathDestination('/tmp/output.txt')).toBe(true);
     });
 
     it('matches tilde paths', () => {
-      expect(isFilePathDestination('~/foo')).toBe(true);
-      expect(isFilePathDestination('~/logs/output.txt')).toBe(true);
+      expectLib.expect(fileOutput.isFilePathDestination('~/foo')).toBe(true);
+      expectLib.expect(fileOutput.isFilePathDestination('~/logs/output.txt')).toBe(true);
     });
 
     it('matches Windows drive letter paths', () => {
-      expect(isFilePathDestination('C:\\foo')).toBe(true);
-      expect(isFilePathDestination('D:/foo')).toBe(true);
+      expectLib.expect(fileOutput.isFilePathDestination('C:\\foo')).toBe(true);
+      expectLib.expect(fileOutput.isFilePathDestination('D:/foo')).toBe(true);
     });
 
     it('does not match builtin destination names', () => {
-      expect(isFilePathDestination('terminal')).toBe(false);
-      expect(isFilePathDestination('repl-window')).toBe(false);
-      expect(isFilePathDestination('output-channel')).toBe(false);
-      expect(isFilePathDestination('output-view')).toBe(false);
+      expectLib.expect(fileOutput.isFilePathDestination('terminal')).toBe(false);
+      expectLib.expect(fileOutput.isFilePathDestination('repl-window')).toBe(false);
+      expectLib.expect(fileOutput.isFilePathDestination('output-channel')).toBe(false);
+      expectLib.expect(fileOutput.isFilePathDestination('output-view')).toBe(false);
     });
 
     it('does not match bare strings (future enum values)', () => {
-      expect(isFilePathDestination('some-future-name')).toBe(false);
+      expectLib.expect(fileOutput.isFilePathDestination('some-future-name')).toBe(false);
     });
 
     it('does not match empty string', () => {
-      expect(isFilePathDestination('')).toBe(false);
+      expectLib.expect(fileOutput.isFilePathDestination('')).toBe(false);
     });
   });
 
   describe('expandTilde', () => {
     it('expands ~/path to homedir', () => {
-      const result = expandTilde('~/logs');
-      expect(result).toBe(path.join(os.homedir(), 'logs'));
+      const result = fileOutput.expandTilde('~/logs');
+      expectLib.expect(result).toBe(path.join(os.homedir(), 'logs'));
     });
 
     it('expands ~\\path to homedir (Windows separator)', () => {
-      const result = expandTilde('~\\logs');
-      expect(result).toBe(path.join(os.homedir(), 'logs'));
+      const result = fileOutput.expandTilde('~\\logs');
+      expectLib.expect(result).toBe(path.join(os.homedir(), 'logs'));
     });
 
     it('leaves relative paths unchanged', () => {
-      expect(expandTilde('./rel')).toBe('./rel');
+      expectLib.expect(fileOutput.expandTilde('./rel')).toBe('./rel');
     });
 
     it('leaves ~user/foo unchanged (not supported)', () => {
-      expect(expandTilde('~user/foo')).toBe('~user/foo');
+      expectLib.expect(fileOutput.expandTilde('~user/foo')).toBe('~user/foo');
     });
 
     it('leaves absolute paths unchanged', () => {
-      expect(expandTilde('/abs/path')).toBe('/abs/path');
+      expectLib.expect(fileOutput.expandTilde('/abs/path')).toBe('/abs/path');
     });
   });
 
   describe('resolveOutputFilePath', () => {
     it('resolves relative path against workspace root', () => {
-      const result = resolveOutputFilePath('./logs/out.txt', '/workspace');
-      expect(result).toBe(path.join('/workspace', 'logs', 'out.txt'));
+      const result = fileOutput.resolveOutputFilePath('./logs/out.txt', '/workspace');
+      expectLib.expect(result).toBe(path.join('/workspace', 'logs', 'out.txt'));
     });
 
     it('returns absolute path as-is', () => {
-      const result = resolveOutputFilePath('/tmp/output.txt', '/workspace');
-      expect(result).toBe('/tmp/output.txt');
+      const result = fileOutput.resolveOutputFilePath('/tmp/output.txt', '/workspace');
+      expectLib.expect(result).toBe('/tmp/output.txt');
     });
 
     it('expands tilde before resolving', () => {
-      const result = resolveOutputFilePath('~/logs/out.txt', '/workspace');
-      expect(result).toBe(path.join(os.homedir(), 'logs', 'out.txt'));
+      const result = fileOutput.resolveOutputFilePath('~/logs/out.txt', '/workspace');
+      expectLib.expect(result).toBe(path.join(os.homedir(), 'logs', 'out.txt'));
     });
 
     it('joins array segments then resolves', () => {
-      const result = resolveOutputFilePath(['.', 'logs', 'out.txt'], '/workspace');
-      expect(result).toBe(path.join('/workspace', 'logs', 'out.txt'));
+      const result = fileOutput.resolveOutputFilePath(['.', 'logs', 'out.txt'], '/workspace');
+      expectLib.expect(result).toBe(path.join('/workspace', 'logs', 'out.txt'));
     });
 
     it('returns undefined when relative path and no workspace root', () => {
-      const result = resolveOutputFilePath('./logs/out.txt', undefined);
-      expect(result).toBeUndefined();
+      const result = fileOutput.resolveOutputFilePath('./logs/out.txt', undefined);
+      expectLib.expect(result).toBeUndefined();
     });
   });
 
@@ -117,65 +110,65 @@ describe('file-output', () => {
 
     it('creates directory and file', async () => {
       const filePath = path.join(tmpDir, 'sub', 'dir', 'output.txt');
-      await appendToOutputFile(filePath, 'hello');
+      await fileOutput.appendToOutputFile(filePath, 'hello');
       const content = fs.readFileSync(filePath, 'utf-8');
-      expect(content).toBe('hello');
+      expectLib.expect(content).toBe('hello');
     });
 
     it('appends to existing file', async () => {
       const filePath = path.join(tmpDir, 'output.txt');
-      await appendToOutputFile(filePath, 'first');
-      await appendToOutputFile(filePath, 'second');
+      await fileOutput.appendToOutputFile(filePath, 'first');
+      await fileOutput.appendToOutputFile(filePath, 'second');
       const content = fs.readFileSync(filePath, 'utf-8');
-      expect(content).toBe('firstsecond');
+      expectLib.expect(content).toBe('firstsecond');
     });
 
     it('multiple appends accumulate', async () => {
       const filePath = path.join(tmpDir, 'output.txt');
-      await appendToOutputFile(filePath, 'a\n');
-      await appendToOutputFile(filePath, 'b\n');
-      await appendToOutputFile(filePath, 'c\n');
+      await fileOutput.appendToOutputFile(filePath, 'a\n');
+      await fileOutput.appendToOutputFile(filePath, 'b\n');
+      await fileOutput.appendToOutputFile(filePath, 'c\n');
       const content = fs.readFileSync(filePath, 'utf-8');
-      expect(content).toBe('a\nb\nc\n');
+      expectLib.expect(content).toBe('a\nb\nc\n');
     });
   });
 
   describe('reportFileOutputError / resetFileOutputErrors', () => {
     beforeEach(() => {
-      resetFileOutputErrors();
+      fileOutput.resetFileOutputErrors();
     });
 
     it('calls showError on first occurrence', () => {
       const calls: string[] = [];
       const showError = (msg: string) => calls.push(msg);
-      reportFileOutputError('./log.txt', new Error('EACCES'), showError);
-      expect(calls).toHaveLength(1);
-      expect(calls[0]).toContain('./log.txt');
+      fileOutput.reportFileOutputError('./log.txt', new Error('EACCES'), showError);
+      expectLib.expect(calls).toHaveLength(1);
+      expectLib.expect(calls[0]).toContain('./log.txt');
     });
 
     it('does not call showError on second occurrence for same destination', () => {
       const calls: string[] = [];
       const showError = (msg: string) => calls.push(msg);
-      reportFileOutputError('./log.txt', new Error('EACCES'), showError);
-      reportFileOutputError('./log.txt', new Error('EACCES'), showError);
-      expect(calls).toHaveLength(1);
+      fileOutput.reportFileOutputError('./log.txt', new Error('EACCES'), showError);
+      fileOutput.reportFileOutputError('./log.txt', new Error('EACCES'), showError);
+      expectLib.expect(calls).toHaveLength(1);
     });
 
     it('calls showError for different destinations independently', () => {
       const calls: string[] = [];
       const showError = (msg: string) => calls.push(msg);
-      reportFileOutputError('./log1.txt', new Error('EACCES'), showError);
-      reportFileOutputError('./log2.txt', new Error('EACCES'), showError);
-      expect(calls).toHaveLength(2);
+      fileOutput.reportFileOutputError('./log1.txt', new Error('EACCES'), showError);
+      fileOutput.reportFileOutputError('./log2.txt', new Error('EACCES'), showError);
+      expectLib.expect(calls).toHaveLength(2);
     });
 
     it('calls showError again after reset', () => {
       const calls: string[] = [];
       const showError = (msg: string) => calls.push(msg);
-      reportFileOutputError('./log.txt', new Error('EACCES'), showError);
-      resetFileOutputErrors();
-      reportFileOutputError('./log.txt', new Error('EACCES'), showError);
-      expect(calls).toHaveLength(2);
+      fileOutput.reportFileOutputError('./log.txt', new Error('EACCES'), showError);
+      fileOutput.resetFileOutputErrors();
+      fileOutput.reportFileOutputError('./log.txt', new Error('EACCES'), showError);
+      expectLib.expect(calls).toHaveLength(2);
     });
 
     it('always logs to console.error', () => {
@@ -185,9 +178,9 @@ describe('file-output', () => {
       try {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         const showError = () => {};
-        reportFileOutputError('./log.txt', new Error('fail'), showError);
-        reportFileOutputError('./log.txt', new Error('fail'), showError);
-        expect(consoleCalls).toHaveLength(2);
+        fileOutput.reportFileOutputError('./log.txt', new Error('fail'), showError);
+        fileOutput.reportFileOutputError('./log.txt', new Error('fail'), showError);
+        expectLib.expect(consoleCalls).toHaveLength(2);
       } finally {
         console.error = origConsoleError;
       }

--- a/src/extension-test/unit/file-switcher/util-test.ts
+++ b/src/extension-test/unit/file-switcher/util-test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as util from '../../../file-switcher/util';
 import * as path from 'path';
 
@@ -25,7 +25,7 @@ describe('getNewSourcePath', () => {
       'test',
       'check'
     );
-    expect(util.getNewSourcePath(filePath)).toBe(expected);
+    expectLib.expect(util.getNewSourcePath(filePath)).toBe(expected);
   });
   it('should get new source path for maven style test folder', () => {
     const filePath = path.join(
@@ -49,22 +49,22 @@ describe('getNewSourcePath', () => {
       'test',
       'check'
     );
-    expect(util.getNewSourcePath(filePath)).toBe(expected);
+    expectLib.expect(util.getNewSourcePath(filePath)).toBe(expected);
   });
   it('should get new source path for leiningen style src folder', () => {
     const filePath = path.join('~', 'leiningen', 'src', 'leiningen', 'change.clj');
     const expected = path.join('~', 'leiningen', 'test', 'leiningen');
-    expect(util.getNewSourcePath(filePath)).toBe(expected);
+    expectLib.expect(util.getNewSourcePath(filePath)).toBe(expected);
   });
   it('should get new source path for leiningen style test folder', () => {
     const filePath = path.join('~', 'leiningen', 'test', 'leiningen', 'change_test.clj');
     const expected = path.join('~', 'leiningen', 'src', 'leiningen');
-    expect(util.getNewSourcePath(filePath)).toBe(expected);
+    expectLib.expect(util.getNewSourcePath(filePath)).toBe(expected);
   });
   it('should handle the case where source path has "src" or "test" keyword in it', () => {
     const filePath = path.join('~', 'tests', 'project-name', 'src', 'change.clj');
     const expected = path.join('~', 'tests', 'project-name', 'test');
-    expect(util.getNewSourcePath(filePath)).toBe(expected);
+    expectLib.expect(util.getNewSourcePath(filePath)).toBe(expected);
   });
 });
 
@@ -73,31 +73,31 @@ describe('getNewFileName', () => {
     const fileName = 'main';
     const extension = '.clj';
     const expected = 'main_test.clj';
-    expect(util.getNewFilename(fileName, extension)).toBe(expected);
+    expectLib.expect(util.getNewFilename(fileName, extension)).toBe(expected);
   });
   it('should get new file name for test file', () => {
     const fileName = 'utils_test';
     const extension = '.cljs';
     const expected = 'utils.cljs';
-    expect(util.getNewFilename(fileName, extension)).toBe(expected);
+    expectLib.expect(util.getNewFilename(fileName, extension)).toBe(expected);
   });
   it('should handle the case where src file name has multiple dots', () => {
     const fileName = 'one.two.three';
     const extension = '.clj';
     const expected = 'one.two.three_test.clj';
-    expect(util.getNewFilename(fileName, extension)).toBe(expected);
+    expectLib.expect(util.getNewFilename(fileName, extension)).toBe(expected);
   });
   it('should handle the case where test file name has multiple dots', () => {
     const fileName = 'one.two.three_test';
     const extension = '.clj';
     const expected = 'one.two.three.clj';
-    expect(util.getNewFilename(fileName, extension)).toBe(expected);
+    expectLib.expect(util.getNewFilename(fileName, extension)).toBe(expected);
   });
   it('should handle the case where test file starts with "_test"', () => {
     const fileName = 'test_abc';
     const extension = '.cljs';
     const expected = 'abc.cljs';
-    expect(util.getNewFilename(fileName, extension)).toBe(expected);
+    expectLib.expect(util.getNewFilename(fileName, extension)).toBe(expected);
   });
 });
 
@@ -106,16 +106,16 @@ describe('isFileValid', () => {
     const fileName = 'change.clj';
     const pathAfterRoot = path.join('src', 'leiningen');
     const { success } = util.isFileValid(fileName, pathAfterRoot);
-    expect(success).toBeTruthy();
+    expectLib.expect(success).toBeTruthy();
   });
   it('should return false if the file path is invalid', () => {
     const fileName = 'main.cljc';
     const pathAfterRoot = path.join('');
     let { success } = util.isFileValid(fileName, pathAfterRoot);
-    expect(success).toBeFalsy();
+    expectLib.expect(success).toBeFalsy();
     const anotherFileName = 'foo';
     const anotherPathAfterRoot = path.join('leiningen');
     success = util.isFileValid(anotherFileName, anotherPathAfterRoot).success;
-    expect(success).toBeFalsy();
+    expectLib.expect(success).toBeFalsy();
   });
 });

--- a/src/extension-test/unit/formatting-test.ts
+++ b/src/extension-test/unit/formatting-test.ts
@@ -1,8 +1,8 @@
-import { expect } from 'expect';
-import { formatIndexes } from '../../calva-fmt/src/format-index';
-import { backspaceOnWhitespace } from '../../cursor-doc/backspace-on-whitespace';
+import * as expectLib from 'expect';
+import * as formatIndex from '../../calva-fmt/src/format-index';
+import * as backspaceOnWhitespaceLib from '../../cursor-doc/backspace-on-whitespace';
 import * as indent from '../../cursor-doc/indent';
-import { docFromTextNotation, textAndSelection } from './common/text-notation';
+import * as textNotation from './common/text-notation';
 
 describe('formatter, indenter and paredit comparison', () => {
   const configs = [
@@ -29,8 +29,8 @@ describe('formatter, indenter and paredit comparison', () => {
         const formatterIndent = getFormatterIndent('(and x\n|y)', config);
         const indenterIndent = getIndenterIndent('(and x\n|y)', config);
         const pareditIndent = getPareditIndent('(and x\n\n  |y)', config);
-        expect(formatterIndent).toEqual(indenterIndent);
-        expect(formatterIndent).toEqual(pareditIndent);
+        expectLib.expect(formatterIndent).toEqual(indenterIndent);
+        expectLib.expect(formatterIndent).toEqual(pareditIndent);
       });
     });
   });
@@ -41,8 +41,8 @@ describe('formatter, indenter and paredit comparison', () => {
         const formatterIndent = getFormatterIndent('(:kw x\n|y)', config);
         const indenterIndent = getIndenterIndent('(:kw x\n|y)', config);
         const pareditIndent = getPareditIndent('(:kw x\n\n  |y)', config);
-        expect(formatterIndent).toEqual(indenterIndent);
-        expect(formatterIndent).toEqual(pareditIndent);
+        expectLib.expect(formatterIndent).toEqual(indenterIndent);
+        expectLib.expect(formatterIndent).toEqual(pareditIndent);
       });
     });
   });
@@ -59,7 +59,7 @@ describe('formatter trimming', () => {
         },
       })
     );
-    expect(formattedText).toEqual(' (and x\n   y) ');
+    expectLib.expect(formattedText).toEqual(' (and x\n   y) ');
   });
   it('formatter trims trailing space when config enables that', () => {
     const formattedText = getFormattedText(
@@ -71,23 +71,30 @@ describe('formatter trimming', () => {
         },
       })
     );
-    expect(formattedText).toEqual(' (and x\n   y)');
+    expectLib.expect(formattedText).toEqual(' (and x\n   y)');
   });
 });
 
 function getIndenterIndent(form: string, config: ReturnType<typeof mkConfig>) {
-  const doc = docFromTextNotation(form);
-  const p = textAndSelection(doc)[1][0];
+  const doc = textNotation.docFromTextNotation(form);
+  const p = textNotation.textAndSelection(doc)[1][0];
   return indent.getIndent(doc.model, p, config);
 }
 
 function getFormattedText(notation: string, config: ReturnType<typeof mkConfig>) {
-  const doc = docFromTextNotation(notation);
-  const form = textAndSelection(doc)[0];
-  const p = textAndSelection(doc)[1][0];
+  const doc = textNotation.docFromTextNotation(notation);
+  const form = textNotation.textAndSelection(doc)[0];
+  const p = textNotation.textAndSelection(doc)[1][0];
   const docText = doc.model.getText(0, 999, false);
 
-  const formatterResult = formatIndexes(form, [0, notation.length], [p], '\n', false, config);
+  const formatterResult = formatIndex.formatIndexes(
+    form,
+    [0, notation.length],
+    [p],
+    '\n',
+    false,
+    config
+  );
   return (
     docText.substring(0, formatterResult.range[0]) +
     formatterResult['range-text'] +
@@ -104,8 +111,8 @@ function getFormatterIndent(notation: string, config: ReturnType<typeof mkConfig
   // (2) Count spaces to its left.
 
   // Non-space chars before p:
-  const doc = docFromTextNotation(notation);
-  const p = textAndSelection(doc)[1][0];
+  const doc = textNotation.docFromTextNotation(notation);
+  const p = textNotation.textAndSelection(doc)[1][0];
   const docTextBeforeP = doc.model.getText(0, p, false);
   const rxSpace = new RegExp(/[\s,]/, 'g');
   const nSolidsBeforeP = docTextBeforeP.replace(rxSpace, '').length;
@@ -123,9 +130,9 @@ function getFormatterIndent(notation: string, config: ReturnType<typeof mkConfig
 }
 
 function getPareditIndent(notation: string, config: ReturnType<typeof mkConfig>) {
-  const doc = docFromTextNotation(notation);
-  const p = textAndSelection(doc)[1][0];
-  return backspaceOnWhitespace(doc, doc.getTokenCursor(p), config).indent;
+  const doc = textNotation.docFromTextNotation(notation);
+  const p = textNotation.textAndSelection(doc)[1][0];
+  return backspaceOnWhitespaceLib.backspaceOnWhitespace(doc, doc.getTokenCursor(p), config).indent;
 }
 
 function mkConfig(options: { indents?: indent.IndentRules } & Record<string, any>) {

--- a/src/extension-test/unit/lsp/downloader-test.ts
+++ b/src/extension-test/unit/lsp/downloader-test.ts
@@ -1,8 +1,8 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import { downloadWithBackupRecovery } from '../../../lsp/client/downloader-utils';
+import * as downloaderUtils from '../../../lsp/client/downloader-utils';
 
 describe('downloader', () => {
   let tmpDir: string;
@@ -20,33 +20,33 @@ describe('downloader', () => {
   });
 
   it('replaces binary with new version on successful download', async () => {
-    const result = await downloadWithBackupRecovery(binaryPath, () => {
+    const result = await downloaderUtils.downloadWithBackupRecovery(binaryPath, () => {
       fs.writeFileSync(binaryPath, 'new-version');
       return Promise.resolve();
     });
 
-    expect(result.restored).toBe(false);
-    expect(fs.readFileSync(binaryPath, 'utf8')).toBe('new-version');
+    expectLib.expect(result.restored).toBe(false);
+    expectLib.expect(fs.readFileSync(binaryPath, 'utf8')).toBe('new-version');
     const backupPath = path.join(tmpDir, 'backup', 'clojure-lsp');
-    expect(fs.existsSync(backupPath)).toBe(false);
+    expectLib.expect(fs.existsSync(backupPath)).toBe(false);
   });
 
   it('restores binary to original path after failed download so offline startup works', async () => {
-    await downloadWithBackupRecovery(binaryPath, () => {
+    await downloaderUtils.downloadWithBackupRecovery(binaryPath, () => {
       return Promise.reject(new Error('network unavailable'));
     });
 
-    expect(fs.existsSync(binaryPath)).toBe(true);
-    expect(fs.readFileSync(binaryPath, 'utf8')).toBe(binaryContent);
+    expectLib.expect(fs.existsSync(binaryPath)).toBe(true);
+    expectLib.expect(fs.readFileSync(binaryPath, 'utf8')).toBe(binaryContent);
   });
 
   it('restores original binary even when download corrupts the file before failing', async () => {
-    await downloadWithBackupRecovery(binaryPath, () => {
+    await downloaderUtils.downloadWithBackupRecovery(binaryPath, () => {
       fs.writeFileSync(binaryPath, 'corrupted-partial-download');
       return Promise.reject(new Error('connection reset'));
     });
 
-    expect(fs.existsSync(binaryPath)).toBe(true);
-    expect(fs.readFileSync(binaryPath, 'utf8')).toBe(binaryContent);
+    expectLib.expect(fs.existsSync(binaryPath)).toBe(true);
+    expectLib.expect(fs.readFileSync(binaryPath, 'utf8')).toBe(binaryContent);
   });
 });

--- a/src/extension-test/unit/lsp/semantic-token-filter-test.ts
+++ b/src/extension-test/unit/lsp/semantic-token-filter-test.ts
@@ -1,27 +1,29 @@
-import { expect } from 'expect';
-import { filterCommentTokens } from '../../../lsp/client/semantic-token-filter';
+import * as expectLib from 'expect';
+import * as semanticTokenFilter from '../../../lsp/client/semantic-token-filter';
 
 describe('Semantic token filtering', () => {
   it('Handles empty token array', () => {
-    expect(filterCommentTokens(new Uint32Array([]), 10)).toEqual([]);
+    expectLib.expect(semanticTokenFilter.filterCommentTokens(new Uint32Array([]), 10)).toEqual([]);
   });
 
   it('Empties token array with only comments', () => {
     // Document:
     //   #[
     //   ]
-    expect(
-      filterCommentTokens(
-        new Uint32Array([
-          0,
-          0,
-          5,
-          10,
-          0, // the two-line comment, line 0, col 0, len 5, type comment
-        ]),
-        10
+    expectLib
+      .expect(
+        semanticTokenFilter.filterCommentTokens(
+          new Uint32Array([
+            0,
+            0,
+            5,
+            10,
+            0, // the two-line comment, line 0, col 0, len 5, type comment
+          ]),
+          10
+        )
       )
-    ).toEqual([]);
+      .toEqual([]);
   });
 
   it('Leaves a token array with no comments alone', () => {
@@ -46,7 +48,9 @@ describe('Semantic token filtering', () => {
       2,
       0, // [x], line +2, col 3, len 1, type function
     ];
-    expect(filterCommentTokens(new Uint32Array(tokens), 10)).toEqual(tokens);
+    expectLib
+      .expect(semanticTokenFilter.filterCommentTokens(new Uint32Array(tokens), 10))
+      .toEqual(tokens);
   });
 
   it('Removes comment token between two non-comments', () => {
@@ -55,39 +59,41 @@ describe('Semantic token filtering', () => {
     //   #_
     //   f
     //   (defn)
-    expect(
-      filterCommentTokens(
-        new Uint32Array([
-          0,
-          4,
-          15,
-          0,
-          0, // [clojure-lsp.foo] line 0, col 4, len 15, type namespace
-          1,
-          0,
-          4,
-          10,
-          0, // [#_ f] line +1, col 0, len 4, type comment
-          2,
-          1,
-          4,
-          3,
-          0, // [defn] line +2, col 1, len 4, type macro
-        ]),
-        10
+    expectLib
+      .expect(
+        semanticTokenFilter.filterCommentTokens(
+          new Uint32Array([
+            0,
+            4,
+            15,
+            0,
+            0, // [clojure-lsp.foo] line 0, col 4, len 15, type namespace
+            1,
+            0,
+            4,
+            10,
+            0, // [#_ f] line +1, col 0, len 4, type comment
+            2,
+            1,
+            4,
+            3,
+            0, // [defn] line +2, col 1, len 4, type macro
+          ]),
+          10
+        )
       )
-    ).toEqual([
-      0,
-      4,
-      15,
-      0,
-      0, // [ns] preserved position
-      3,
-      1,
-      4,
-      3,
-      0, // [defn] line +3 (accumulated), col 1
-    ]);
+      .toEqual([
+        0,
+        4,
+        15,
+        0,
+        0, // [ns] preserved position
+        3,
+        1,
+        4,
+        3,
+        0, // [defn] line +3 (accumulated), col 1
+      ]);
   });
 
   it('maintains token positioning with multiple comments', () => {
@@ -97,44 +103,46 @@ describe('Semantic token filtering', () => {
     //   ; comment
     //   #_ form2
     //   (defn)
-    expect(
-      filterCommentTokens(
-        new Uint32Array([
-          0,
-          0,
-          7,
-          0,
-          0, // [ns] line 0, col 0, len 7, type namespace
-          1,
-          0,
-          7,
-          10,
-          0, // [#_ form1] line +1, col 0, type comment
-          1,
-          0,
-          7,
-          10,
-          0, // [#_ form2] line +1, col 0, type comment
-          2,
-          0,
-          5,
-          3,
-          0, // [defn] line +1, col 0, type macro
-        ]),
-        10
+    expectLib
+      .expect(
+        semanticTokenFilter.filterCommentTokens(
+          new Uint32Array([
+            0,
+            0,
+            7,
+            0,
+            0, // [ns] line 0, col 0, len 7, type namespace
+            1,
+            0,
+            7,
+            10,
+            0, // [#_ form1] line +1, col 0, type comment
+            1,
+            0,
+            7,
+            10,
+            0, // [#_ form2] line +1, col 0, type comment
+            2,
+            0,
+            5,
+            3,
+            0, // [defn] line +1, col 0, type macro
+          ]),
+          10
+        )
       )
-    ).toEqual([
-      0,
-      0,
-      7,
-      0,
-      0, // [ns] preserved position
-      4,
-      0,
-      5,
-      3,
-      0, // [defn] line +4 (accumulated), col 0
-    ]);
+      .toEqual([
+        0,
+        0,
+        7,
+        0,
+        0, // [ns] preserved position
+        4,
+        0,
+        5,
+        3,
+        0, // [defn] line +4 (accumulated), col 0
+      ]);
   });
 
   it('handles complex nested reader conditionals and consecutive comments', () => {
@@ -168,229 +176,231 @@ describe('Semantic token filtering', () => {
     //
     //   (defn bar [foo]
     //     (println foo))
-    expect(
-      filterCommentTokens(
-        new Uint32Array([
-          0,
-          4,
-          15,
-          0,
-          0, // [ns] line 0, col 4, len 15, type namespace
-          1,
-          4,
-          7,
-          4,
-          0, // [require] line +1, col 4, len 7, type keyword
-          1,
-          27,
-          2,
-          4,
-          0, // [b] line +1, col 27, len 2, type keyword
-          1,
-          0,
-          4,
-          10,
-          0, // [#_ f] line +1, col 0, len 4, type comment
-          2,
-          0,
-          30,
-          10,
-          0, // [#_(defn...)] line +2, col 0, len 30, type comment
-          2,
-          0,
-          6,
-          10,
-          0, // [#_[] line +2, col 0, len 6, type comment
-          4,
-          1,
-          3,
-          3,
-          0, // [def] line +4, col 1, len 3, type macro
-          0,
-          4,
-          1,
-          2,
-          1, // [f] line +0, col 4, len 1, type function
-          3,
-          2,
-          3,
-          0,
-          0, // [fn] line +3, col 2, len 3, type function
-          0,
-          4,
-          1,
-          2,
-          1, // [a] line +0, col 4, len 1, type function
-          3,
-          2,
-          3,
-          0,
-          0, // [b] line +3, col 2, len 3, type function
-          2,
-          0,
-          26,
-          10,
-          0, // [#_ #_ [...]] line +2, col 0, len 26, type comment
-          7,
-          2,
-          1,
-          4,
-          0, // [q] line +7, col 2, len 1, type keyword
-          0,
-          4,
-          4,
-          10,
-          0, // [#_:b] line +0, col 4, len 4, type comment
-          0,
-          5,
-          53,
-          10,
-          0, // [#_[2...5]] line +0, col 5, len 53, type comment
-          3,
-          17,
-          8,
-          10,
-          0, // [#_#_:c 3] line +3, col 17, len 8, type comment
-          0,
-          10,
-          1,
-          4,
-          0, // [:d] line +0, col 10, len 1, type keyword
-          5,
-          1,
-          4,
-          0,
-          0, // [:e] line +5, col 1, len 4, type keyword
-          5,
-          1,
-          4,
-          0,
-          0, // [:f] line +5, col 1, len 4, type keyword
-          5,
-          1,
-          4,
-          0,
-          0, // [:g] line +5, col 1, len 4, type keyword
-          2,
-          1,
-          4,
-          3,
-          0, // [defn] line +2, col 1, len 4, type macro
-          0,
-          5,
-          3,
-          2,
-          1, // [bar] line +0, col 5, len 3, type function
-          5,
-          3,
-          6,
-          0,
-          1, // [foo] line +5, col 3, len 6, type variable
-          3,
-          7,
-          2,
-          0,
-          0, // [println] line +3, col 7, len 2, type function
-          0,
-          8,
-          3,
-          6,
-          0, // [foo] line +0, col 8, len 3, type variable
-        ]),
-        10
+    expectLib
+      .expect(
+        semanticTokenFilter.filterCommentTokens(
+          new Uint32Array([
+            0,
+            4,
+            15,
+            0,
+            0, // [ns] line 0, col 4, len 15, type namespace
+            1,
+            4,
+            7,
+            4,
+            0, // [require] line +1, col 4, len 7, type keyword
+            1,
+            27,
+            2,
+            4,
+            0, // [b] line +1, col 27, len 2, type keyword
+            1,
+            0,
+            4,
+            10,
+            0, // [#_ f] line +1, col 0, len 4, type comment
+            2,
+            0,
+            30,
+            10,
+            0, // [#_(defn...)] line +2, col 0, len 30, type comment
+            2,
+            0,
+            6,
+            10,
+            0, // [#_[] line +2, col 0, len 6, type comment
+            4,
+            1,
+            3,
+            3,
+            0, // [def] line +4, col 1, len 3, type macro
+            0,
+            4,
+            1,
+            2,
+            1, // [f] line +0, col 4, len 1, type function
+            3,
+            2,
+            3,
+            0,
+            0, // [fn] line +3, col 2, len 3, type function
+            0,
+            4,
+            1,
+            2,
+            1, // [a] line +0, col 4, len 1, type function
+            3,
+            2,
+            3,
+            0,
+            0, // [b] line +3, col 2, len 3, type function
+            2,
+            0,
+            26,
+            10,
+            0, // [#_ #_ [...]] line +2, col 0, len 26, type comment
+            7,
+            2,
+            1,
+            4,
+            0, // [q] line +7, col 2, len 1, type keyword
+            0,
+            4,
+            4,
+            10,
+            0, // [#_:b] line +0, col 4, len 4, type comment
+            0,
+            5,
+            53,
+            10,
+            0, // [#_[2...5]] line +0, col 5, len 53, type comment
+            3,
+            17,
+            8,
+            10,
+            0, // [#_#_:c 3] line +3, col 17, len 8, type comment
+            0,
+            10,
+            1,
+            4,
+            0, // [:d] line +0, col 10, len 1, type keyword
+            5,
+            1,
+            4,
+            0,
+            0, // [:e] line +5, col 1, len 4, type keyword
+            5,
+            1,
+            4,
+            0,
+            0, // [:f] line +5, col 1, len 4, type keyword
+            5,
+            1,
+            4,
+            0,
+            0, // [:g] line +5, col 1, len 4, type keyword
+            2,
+            1,
+            4,
+            3,
+            0, // [defn] line +2, col 1, len 4, type macro
+            0,
+            5,
+            3,
+            2,
+            1, // [bar] line +0, col 5, len 3, type function
+            5,
+            3,
+            6,
+            0,
+            1, // [foo] line +5, col 3, len 6, type variable
+            3,
+            7,
+            2,
+            0,
+            0, // [println] line +3, col 7, len 2, type function
+            0,
+            8,
+            3,
+            6,
+            0, // [foo] line +0, col 8, len 3, type variable
+          ]),
+          10
+        )
       )
-    ).toEqual([
-      0,
-      4,
-      15,
-      0,
-      0, // [ns] preserved
-      1,
-      4,
-      7,
-      4,
-      0, // [require] preserved
-      1,
-      27,
-      2,
-      4,
-      0, // [b] preserved
-      9,
-      1,
-      3,
-      3,
-      0, // [def] accumulated delta (1+2+2+4)
-      0,
-      4,
-      1,
-      2,
-      1, // [f] preserved relative
-      3,
-      2,
-      3,
-      0,
-      0, // [fn] preserved relative
-      0,
-      4,
-      1,
-      2,
-      1, // [a] preserved relative
-      3,
-      2,
-      3,
-      0,
-      0, // [b] preserved relative
-      9,
-      2,
-      1,
-      4,
-      0, // [q] accumulated delta from removed comment block
-      3,
-      10,
-      1,
-      4,
-      0, // [:d] delta from q (not accumulated from removed comments)
-      5,
-      1,
-      4,
-      0,
-      0, // [:e] preserved relative
-      5,
-      1,
-      4,
-      0,
-      0, // [:f] preserved relative
-      5,
-      1,
-      4,
-      0,
-      0, // [:g] preserved relative
-      2,
-      1,
-      4,
-      3,
-      0, // [defn] preserved relative
-      0,
-      5,
-      3,
-      2,
-      1, // [bar] preserved relative
-      5,
-      3,
-      6,
-      0,
-      1, // [foo] preserved relative
-      3,
-      7,
-      2,
-      0,
-      0, // [println] preserved relative
-      0,
-      8,
-      3,
-      6,
-      0, // [foo] preserved relative
-    ]);
+      .toEqual([
+        0,
+        4,
+        15,
+        0,
+        0, // [ns] preserved
+        1,
+        4,
+        7,
+        4,
+        0, // [require] preserved
+        1,
+        27,
+        2,
+        4,
+        0, // [b] preserved
+        9,
+        1,
+        3,
+        3,
+        0, // [def] accumulated delta (1+2+2+4)
+        0,
+        4,
+        1,
+        2,
+        1, // [f] preserved relative
+        3,
+        2,
+        3,
+        0,
+        0, // [fn] preserved relative
+        0,
+        4,
+        1,
+        2,
+        1, // [a] preserved relative
+        3,
+        2,
+        3,
+        0,
+        0, // [b] preserved relative
+        9,
+        2,
+        1,
+        4,
+        0, // [q] accumulated delta from removed comment block
+        3,
+        10,
+        1,
+        4,
+        0, // [:d] delta from q (not accumulated from removed comments)
+        5,
+        1,
+        4,
+        0,
+        0, // [:e] preserved relative
+        5,
+        1,
+        4,
+        0,
+        0, // [:f] preserved relative
+        5,
+        1,
+        4,
+        0,
+        0, // [:g] preserved relative
+        2,
+        1,
+        4,
+        3,
+        0, // [defn] preserved relative
+        0,
+        5,
+        3,
+        2,
+        1, // [bar] preserved relative
+        5,
+        3,
+        6,
+        0,
+        1, // [foo] preserved relative
+        3,
+        7,
+        2,
+        0,
+        0, // [println] preserved relative
+        0,
+        8,
+        3,
+        6,
+        0, // [foo] preserved relative
+      ]);
   });
   it('handles comment as first token with delta accumulation', () => {
     // Two tokens: first is a comment (type 10), second is not (type 0)
@@ -414,6 +424,8 @@ describe('Semantic token filtering', () => {
       0, // tokenType
       0, // modifiers
     ];
-    expect(filterCommentTokens(new Uint32Array(input), 10)).toEqual(expected);
+    expectLib
+      .expect(semanticTokenFilter.filterCommentTokens(new Uint32Array(input), 10))
+      .toEqual(expected);
   });
 });

--- a/src/extension-test/unit/name-suffix-test.ts
+++ b/src/extension-test/unit/name-suffix-test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as nameSuffix from '../../nrepl/session-name-suffix';
 
 describe('name-suffix', () => {
@@ -10,41 +10,41 @@ describe('name-suffix', () => {
     it('returns an available suffix', () => {
       const suffix = nameSuffix.acquireNextAvailableSuffix();
 
-      expect(suffix).toBeDefined();
-      expect(typeof suffix).toBe('string');
+      expectLib.expect(suffix).toBeDefined();
+      expectLib.expect(typeof suffix).toBe('string');
     });
 
     it('returns different suffixes on subsequent calls', () => {
       const suffix1 = nameSuffix.acquireNextAvailableSuffix();
       const suffix2 = nameSuffix.acquireNextAvailableSuffix();
 
-      expect(suffix1).not.toBe(suffix2);
+      expectLib.expect(suffix1).not.toBe(suffix2);
     });
 
     it('marks acquired suffix as used', () => {
       const suffix = nameSuffix.acquireNextAvailableSuffix();
 
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
-      expect(nameSuffix.getAvailableSuffixes()).not.toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getAvailableSuffixes()).not.toContain(suffix);
     });
   });
 
   describe('releaseSuffix', () => {
     it('makes a suffix available again', () => {
       const suffix = nameSuffix.acquireNextAvailableSuffix();
-      expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain(suffix);
 
       nameSuffix.releaseSuffix(suffix);
 
-      expect(nameSuffix.getUsedSuffixes()).not.toContain(suffix);
-      expect(nameSuffix.getAvailableSuffixes()).toContain(suffix);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).not.toContain(suffix);
+      expectLib.expect(nameSuffix.getAvailableSuffixes()).toContain(suffix);
     });
 
     it('is idempotent for unused suffixes', () => {
       nameSuffix.releaseSuffix('apple');
       nameSuffix.releaseSuffix('apple');
 
-      expect(nameSuffix.getUsedSuffixes()).not.toContain('apple');
+      expectLib.expect(nameSuffix.getUsedSuffixes()).not.toContain('apple');
     });
   });
 
@@ -52,16 +52,16 @@ describe('name-suffix', () => {
     it('reserves a specific suffix, marking it as used', () => {
       const result = nameSuffix.reserveSuffix('apple');
 
-      expect(result).toBe(true);
-      expect(nameSuffix.getUsedSuffixes()).toContain('apple');
-      expect(nameSuffix.getAvailableSuffixes()).not.toContain('apple');
+      expectLib.expect(result).toBe(true);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain('apple');
+      expectLib.expect(nameSuffix.getAvailableSuffixes()).not.toContain('apple');
     });
 
     it('returns false if the suffix is already in use', () => {
       nameSuffix.reserveSuffix('apple');
       const result = nameSuffix.reserveSuffix('apple');
 
-      expect(result).toBe(false);
+      expectLib.expect(result).toBe(false);
     });
 
     it('prevents acquireSuffix from returning the reserved suffix', () => {
@@ -76,7 +76,7 @@ describe('name-suffix', () => {
         }
       }
 
-      expect(acquired).not.toContain('apple');
+      expectLib.expect(acquired).not.toContain('apple');
     });
 
     it('allows re-reserving a suffix after it has been released', () => {
@@ -84,14 +84,14 @@ describe('name-suffix', () => {
       nameSuffix.releaseSuffix('apple');
       const result = nameSuffix.reserveSuffix('apple');
 
-      expect(result).toBe(true);
-      expect(nameSuffix.getUsedSuffixes()).toContain('apple');
+      expectLib.expect(result).toBe(true);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toContain('apple');
     });
   });
 
   describe('isPoolExhausted', () => {
     it('returns false when suffixes are available', () => {
-      expect(nameSuffix.isPoolExhausted()).toBe(false);
+      expectLib.expect(nameSuffix.isPoolExhausted()).toBe(false);
     });
 
     it('returns true when all suffixes are used', () => {
@@ -100,7 +100,7 @@ describe('name-suffix', () => {
         nameSuffix.acquireNextAvailableSuffix();
       }
 
-      expect(nameSuffix.isPoolExhausted()).toBe(true);
+      expectLib.expect(nameSuffix.isPoolExhausted()).toBe(true);
     });
 
     it('returns false after releasing a suffix from exhausted pool', () => {
@@ -111,61 +111,61 @@ describe('name-suffix', () => {
           suffixes.push(suffix);
         }
       }
-      expect(nameSuffix.isPoolExhausted()).toBe(true);
+      expectLib.expect(nameSuffix.isPoolExhausted()).toBe(true);
 
       nameSuffix.releaseSuffix(suffixes[0]);
 
-      expect(nameSuffix.isPoolExhausted()).toBe(false);
+      expectLib.expect(nameSuffix.isPoolExhausted()).toBe(false);
     });
   });
 
   describe('extractSuffix', () => {
     it('extracts suffix from suffixed name', () => {
-      expect(nameSuffix.extractSuffix('clj:2')).toBe('2');
-      expect(nameSuffix.extractSuffix('cljs:3')).toBe('3');
-      expect(nameSuffix.extractSuffix('my-session:4')).toBe('4');
+      expectLib.expect(nameSuffix.extractSuffix('clj:2')).toBe('2');
+      expectLib.expect(nameSuffix.extractSuffix('cljs:3')).toBe('3');
+      expectLib.expect(nameSuffix.extractSuffix('my-session:4')).toBe('4');
     });
 
     it('returns undefined for names without suffix', () => {
-      expect(nameSuffix.extractSuffix('clj')).toBeUndefined();
-      expect(nameSuffix.extractSuffix('cljs')).toBeUndefined();
-      expect(nameSuffix.extractSuffix('my-session')).toBeUndefined();
+      expectLib.expect(nameSuffix.extractSuffix('clj')).toBeUndefined();
+      expectLib.expect(nameSuffix.extractSuffix('cljs')).toBeUndefined();
+      expectLib.expect(nameSuffix.extractSuffix('my-session')).toBeUndefined();
     });
 
     it('returns undefined for names with non-pool suffix', () => {
-      expect(nameSuffix.extractSuffix('clj:a')).toBeUndefined();
-      expect(nameSuffix.extractSuffix('clj:b')).toBeUndefined();
+      expectLib.expect(nameSuffix.extractSuffix('clj:a')).toBeUndefined();
+      expectLib.expect(nameSuffix.extractSuffix('clj:b')).toBeUndefined();
     });
 
     it('only matches suffix, not prefix or middle', () => {
-      expect(nameSuffix.extractSuffix('2:clj')).toBeUndefined();
-      expect(nameSuffix.extractSuffix('2')).toBeUndefined();
+      expectLib.expect(nameSuffix.extractSuffix('2:clj')).toBeUndefined();
+      expectLib.expect(nameSuffix.extractSuffix('2')).toBeUndefined();
     });
   });
 
   describe('applySuffix', () => {
     it('applies suffix to base name', () => {
-      expect(nameSuffix.applySuffix('clj', '2')).toBe('clj:2');
-      expect(nameSuffix.applySuffix('cljs', '3')).toBe('cljs:3');
-      expect(nameSuffix.applySuffix('my-session', '4')).toBe('my-session:4');
+      expectLib.expect(nameSuffix.applySuffix('clj', '2')).toBe('clj:2');
+      expectLib.expect(nameSuffix.applySuffix('cljs', '3')).toBe('cljs:3');
+      expectLib.expect(nameSuffix.applySuffix('my-session', '4')).toBe('my-session:4');
     });
   });
 
   describe('stripSuffix', () => {
     it('strips suffix from suffixed name', () => {
-      expect(nameSuffix.stripSuffix('clj:2')).toBe('clj');
-      expect(nameSuffix.stripSuffix('cljs:3')).toBe('cljs');
-      expect(nameSuffix.stripSuffix('my-session:4')).toBe('my-session');
+      expectLib.expect(nameSuffix.stripSuffix('clj:2')).toBe('clj');
+      expectLib.expect(nameSuffix.stripSuffix('cljs:3')).toBe('cljs');
+      expectLib.expect(nameSuffix.stripSuffix('my-session:4')).toBe('my-session');
     });
 
     it('returns name unchanged when no suffix', () => {
-      expect(nameSuffix.stripSuffix('clj')).toBe('clj');
-      expect(nameSuffix.stripSuffix('cljs')).toBe('cljs');
-      expect(nameSuffix.stripSuffix('my-session')).toBe('my-session');
+      expectLib.expect(nameSuffix.stripSuffix('clj')).toBe('clj');
+      expectLib.expect(nameSuffix.stripSuffix('cljs')).toBe('cljs');
+      expectLib.expect(nameSuffix.stripSuffix('my-session')).toBe('my-session');
     });
 
     it('returns name unchanged for non-pool suffixes', () => {
-      expect(nameSuffix.stripSuffix('clj:tiger')).toBe('clj:tiger');
+      expectLib.expect(nameSuffix.stripSuffix('clj:tiger')).toBe('clj:tiger');
     });
   });
 
@@ -174,11 +174,11 @@ describe('name-suffix', () => {
       nameSuffix.acquireNextAvailableSuffix();
       nameSuffix.acquireNextAvailableSuffix();
       nameSuffix.acquireNextAvailableSuffix();
-      expect(nameSuffix.getUsedSuffixes().length).toBe(3);
+      expectLib.expect(nameSuffix.getUsedSuffixes().length).toBe(3);
 
       nameSuffix.resetPool();
 
-      expect(nameSuffix.getUsedSuffixes()).toEqual([]);
+      expectLib.expect(nameSuffix.getUsedSuffixes()).toEqual([]);
     });
   });
 
@@ -186,16 +186,16 @@ describe('name-suffix', () => {
     it('returns all suffixes when none are used', () => {
       const available = nameSuffix.getAvailableSuffixes();
 
-      expect(available.length).toBeGreaterThan(0);
-      expect(available).toContain('2');
-      expect(available).toContain('3');
+      expectLib.expect(available.length).toBeGreaterThan(0);
+      expectLib.expect(available).toContain('2');
+      expectLib.expect(available).toContain('3');
     });
 
     it('excludes used suffixes', () => {
       const suffix = nameSuffix.acquireNextAvailableSuffix();
       const available = nameSuffix.getAvailableSuffixes();
 
-      expect(available).not.toContain(suffix);
+      expectLib.expect(available).not.toContain(suffix);
     });
   });
 
@@ -205,7 +205,7 @@ describe('name-suffix', () => {
       nameSuffix.releaseSuffix(suffix1);
       const suffix2 = nameSuffix.acquireNextAvailableSuffix();
 
-      expect(suffix2).toBe(suffix1);
+      expectLib.expect(suffix2).toBe(suffix1);
     });
 
     it('can exhaust and replenish the pool', () => {
@@ -217,15 +217,15 @@ describe('name-suffix', () => {
         }
       }
 
-      expect(nameSuffix.acquireNextAvailableSuffix()).toBeUndefined();
+      expectLib.expect(nameSuffix.acquireNextAvailableSuffix()).toBeUndefined();
 
       // Release all suffixes
       for (const suffix of acquired) {
         nameSuffix.releaseSuffix(suffix);
       }
 
-      expect(nameSuffix.isPoolExhausted()).toBe(false);
-      expect(nameSuffix.acquireNextAvailableSuffix()).toBeDefined();
+      expectLib.expect(nameSuffix.isPoolExhausted()).toBe(false);
+      expectLib.expect(nameSuffix.acquireNextAvailableSuffix()).toBeDefined();
     });
   });
 });

--- a/src/extension-test/unit/normalize-evaluate-comment-args-test.ts
+++ b/src/extension-test/unit/normalize-evaluate-comment-args-test.ts
@@ -1,33 +1,33 @@
-import { expect } from 'expect';
-import { normalizeEvaluateAsCommentArgs } from '../../evaluate-utils';
+import * as expectLib from 'expect';
+import * as evaluateUtils from '../../evaluate-utils';
 
 describe('normalizeEvaluateAsCommentArgs', () => {
   it('normalizes command invocation (options first)', () => {
     const documentArg = { some: 'document-context' };
-    const normalized = normalizeEvaluateAsCommentArgs(
+    const normalized = evaluateUtils.normalizeEvaluateAsCommentArgs(
       { commentStyle: 'ignore' },
       documentArg as any
     );
 
-    expect(normalized.options.commentStyle).toBe('ignore');
-    expect(normalized.document).toBe(documentArg);
+    expectLib.expect(normalized.options.commentStyle).toBe('ignore');
+    expectLib.expect(normalized.document).toBe(documentArg);
   });
 
   it('normalizes context menu invocation (document first)', () => {
     const documentArg = { some: 'document-context' };
-    const normalized = normalizeEvaluateAsCommentArgs(documentArg, {
+    const normalized = evaluateUtils.normalizeEvaluateAsCommentArgs(documentArg, {
       commentStyle: 'rcf',
     });
 
-    expect(normalized.document).toBe(documentArg);
-    expect(normalized.options.commentStyle).toBe('rcf');
+    expectLib.expect(normalized.document).toBe(documentArg);
+    expectLib.expect(normalized.options.commentStyle).toBe('rcf');
   });
 
   it('defaults comment style to line when context menu invocation omits options', () => {
     const documentArg = { some: 'document-context' };
-    const normalized = normalizeEvaluateAsCommentArgs(documentArg);
+    const normalized = evaluateUtils.normalizeEvaluateAsCommentArgs(documentArg);
 
-    expect(normalized.document).toBe(documentArg);
-    expect(normalized.options.commentStyle).toBe('line');
+    expectLib.expect(normalized.document).toBe(documentArg);
+    expectLib.expect(normalized.options.commentStyle).toBe('line');
   });
 });

--- a/src/extension-test/unit/nrepl/client-registry-test.ts
+++ b/src/extension-test/unit/nrepl/client-registry-test.ts
@@ -1,11 +1,11 @@
-import { expect } from 'expect';
-import type { NReplClient } from '../../../../src/nrepl';
+import * as expectLib from 'expect';
+import type * as nrepl from '../../../../src/nrepl';
 import * as clientRegistry from '../../../../src/nrepl/client-registry';
 
-const createClient = (key: string): NReplClient =>
+const createClient = (key: string): nrepl.NReplClient =>
   ({
     clientKey: key,
-  } as unknown as NReplClient);
+  } as unknown as nrepl.NReplClient);
 
 describe('client registry', () => {
   afterEach(() => {
@@ -20,7 +20,7 @@ describe('client registry', () => {
     clientRegistry.registerClient(beta, { connectSequenceName: 'Beta' });
 
     const clients = clientRegistry.listClients();
-    expect(clients.map((c) => c.key)).toEqual(['alpha-client', 'beta-client']);
+    expectLib.expect(clients.map((c) => c.key)).toEqual(['alpha-client', 'beta-client']);
   });
 
   it('unregisters clients correctly', () => {
@@ -31,7 +31,7 @@ describe('client registry', () => {
 
     clientRegistry.unregisterClient('beta-client');
     const clients = clientRegistry.listClients();
-    expect(clients.map((c) => c.key)).toEqual(['alpha-client']);
+    expectLib.expect(clients.map((c) => c.key)).toEqual(['alpha-client']);
   });
 });
 
@@ -44,11 +44,11 @@ describe('cljc target for connection', () => {
     const client = createClient('test-client');
     clientRegistry.registerClient(client, { connectSequenceName: 'Test' });
 
-    expect(clientRegistry.getCljcTargetForConnection('test-client')).toBe('primary');
+    expectLib.expect(clientRegistry.getCljcTargetForConnection('test-client')).toBe('primary');
   });
 
   it('returns primary for non-existent client', () => {
-    expect(clientRegistry.getCljcTargetForConnection('non-existent')).toBe('primary');
+    expectLib.expect(clientRegistry.getCljcTargetForConnection('non-existent')).toBe('primary');
   });
 
   it('sets and gets cljc target', () => {
@@ -56,10 +56,10 @@ describe('cljc target for connection', () => {
     clientRegistry.registerClient(client, { connectSequenceName: 'Test' });
 
     clientRegistry.setCljcTargetForConnection('test-client', 'secondary');
-    expect(clientRegistry.getCljcTargetForConnection('test-client')).toBe('secondary');
+    expectLib.expect(clientRegistry.getCljcTargetForConnection('test-client')).toBe('secondary');
 
     clientRegistry.setCljcTargetForConnection('test-client', 'primary');
-    expect(clientRegistry.getCljcTargetForConnection('test-client')).toBe('primary');
+    expectLib.expect(clientRegistry.getCljcTargetForConnection('test-client')).toBe('primary');
   });
 
   it('preserves cljc target when updating other connection state', () => {
@@ -69,7 +69,7 @@ describe('cljc target for connection', () => {
     clientRegistry.setCljcTargetForConnection('test-client', 'secondary');
     clientRegistry.setConnectionState('test-client', { cljsBuild: ':app' });
 
-    expect(clientRegistry.getCljcTargetForConnection('test-client')).toBe('secondary');
+    expectLib.expect(clientRegistry.getCljcTargetForConnection('test-client')).toBe('secondary');
   });
 
   it('can set cljc target via connection state', () => {
@@ -79,6 +79,6 @@ describe('cljc target for connection', () => {
       connectionState: { cljcTarget: 'secondary' },
     });
 
-    expect(clientRegistry.getCljcTargetForConnection('test-client')).toBe('secondary');
+    expectLib.expect(clientRegistry.getCljcTargetForConnection('test-client')).toBe('secondary');
   });
 });

--- a/src/extension-test/unit/nrepl/connect-sequence-inheritance-test.ts
+++ b/src/extension-test/unit/nrepl/connect-sequence-inheritance-test.ts
@@ -1,30 +1,34 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as connectSequenceInheritance from '../../../../src/nrepl/connect-sequence-inheritance';
 
 describe('connect-sequence-inheritance', () => {
   describe('effectiveNReplPortFileSegments', () => {
     it('prefers the explicit connect sequence port file', () => {
-      expect(
-        connectSequenceInheritance.effectiveNReplPortFileSegments(
-          { nReplPortFile: ['custom', '.nrepl-port'] },
-          { defaultNReplPortFile: ['default', '.nrepl-port'] }
+      expectLib
+        .expect(
+          connectSequenceInheritance.effectiveNReplPortFileSegments(
+            { nReplPortFile: ['custom', '.nrepl-port'] },
+            { defaultNReplPortFile: ['default', '.nrepl-port'] }
+          )
         )
-      ).toStrictEqual(['custom', '.nrepl-port']);
+        .toStrictEqual(['custom', '.nrepl-port']);
     });
 
     it('inherits the project type default port file when sequence does not override it', () => {
-      expect(
-        connectSequenceInheritance.effectiveNReplPortFileSegments(
-          {},
-          { defaultNReplPortFile: ['default', '.nrepl-port'] }
+      expectLib
+        .expect(
+          connectSequenceInheritance.effectiveNReplPortFileSegments(
+            {},
+            { defaultNReplPortFile: ['default', '.nrepl-port'] }
+          )
         )
-      ).toStrictEqual(['default', '.nrepl-port']);
+        .toStrictEqual(['default', '.nrepl-port']);
     });
 
     it('returns undefined when neither sequence nor project type provides a port file', () => {
-      expect(
-        connectSequenceInheritance.effectiveNReplPortFileSegments({}, undefined)
-      ).toBeUndefined();
+      expectLib
+        .expect(connectSequenceInheritance.effectiveNReplPortFileSegments({}, undefined))
+        .toBeUndefined();
     });
 
     it('returns a copy of the port file segments', () => {
@@ -36,51 +40,59 @@ describe('connect-sequence-inheritance', () => {
       );
       resolvedPortFile.push('mutated');
 
-      expect(projectTypeDefaults.defaultNReplPortFile).toStrictEqual(['default', '.nrepl-port']);
+      expectLib
+        .expect(projectTypeDefaults.defaultNReplPortFile)
+        .toStrictEqual(['default', '.nrepl-port']);
     });
   });
 
   describe('effectiveFallbackPort', () => {
     it('prefers the explicit connect sequence fallback port', () => {
-      expect(
-        connectSequenceInheritance.effectiveFallbackPort(
-          { fallbackPort: 4444 },
-          { defaultFallbackPort: 3339 }
+      expectLib
+        .expect(
+          connectSequenceInheritance.effectiveFallbackPort(
+            { fallbackPort: 4444 },
+            { defaultFallbackPort: 3339 }
+          )
         )
-      ).toBe(4444);
+        .toBe(4444);
     });
 
     it('inherits the project type fallback port when sequence does not override it', () => {
-      expect(
-        connectSequenceInheritance.effectiveFallbackPort({}, { defaultFallbackPort: 3339 })
-      ).toBe(3339);
+      expectLib
+        .expect(connectSequenceInheritance.effectiveFallbackPort({}, { defaultFallbackPort: 3339 }))
+        .toBe(3339);
     });
 
     it('returns undefined when neither sequence nor project type provides a fallback port', () => {
-      expect(connectSequenceInheritance.effectiveFallbackPort({}, undefined)).toBeUndefined();
+      expectLib
+        .expect(connectSequenceInheritance.effectiveFallbackPort({}, undefined))
+        .toBeUndefined();
     });
 
     it('does not treat zero as undefined', () => {
-      expect(connectSequenceInheritance.effectiveFallbackPort({ fallbackPort: 0 }, undefined)).toBe(
-        0
-      );
+      expectLib
+        .expect(connectSequenceInheritance.effectiveFallbackPort({ fallbackPort: 0 }, undefined))
+        .toBe(0);
     });
   });
 
   describe('effectiveSelectedPortBehaviour', () => {
     it('prefers the explicit connect sequence selected port behaviour', () => {
-      expect(
-        connectSequenceInheritance.effectiveSelectedPortBehaviour(
-          { selectedPortBehaviour: 'prompt' },
-          'connect'
+      expectLib
+        .expect(
+          connectSequenceInheritance.effectiveSelectedPortBehaviour(
+            { selectedPortBehaviour: 'prompt' },
+            'connect'
+          )
         )
-      ).toBe('prompt');
+        .toBe('prompt');
     });
 
     it('inherits the default selected port behaviour when sequence does not override it', () => {
-      expect(connectSequenceInheritance.effectiveSelectedPortBehaviour({}, 'connect')).toBe(
-        'connect'
-      );
+      expectLib
+        .expect(connectSequenceInheritance.effectiveSelectedPortBehaviour({}, 'connect'))
+        .toBe('connect');
     });
   });
 });

--- a/src/extension-test/unit/nrepl/dram-manifest-test.ts
+++ b/src/extension-test/unit/nrepl/dram-manifest-test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as cljsLib from '../../../../out/cljs-lib/cljs-lib';
 import * as dramManifest from '../../../../src/nrepl/dram-manifest';
 
@@ -50,57 +50,58 @@ describe('dram manifest legacy helpers', () => {
   it('preserves staging order for the current mini starter manifest', () => {
     const config = parseManifest(miniDramEdn);
 
-    expect(dramManifest.getLegacyDramFilePaths(config.files)).toEqual([
-      'src/mini/playground.clj',
-      'deps.edn',
-      '.gitignore',
-      '.vscode/settings.json',
-    ]);
+    expectLib
+      .expect(dramManifest.getLegacyDramFilePaths(config.files))
+      .toEqual(['src/mini/playground.clj', 'deps.edn', '.gitignore', '.vscode/settings.json']);
   });
 
   it('derives the current open list in file order for the getting started starter', () => {
     const config = parseManifest(gettingStartedDramEdn);
 
-    expect(dramManifest.getLegacyOpenDramFiles(config.files).map((file) => file.path)).toEqual([
-      'src/get_started/hello_repl.clj',
-      'src/get_started/welcome_to_clojure.clj',
-      'src/get_started/hello_paredit.clj',
-    ]);
+    expectLib
+      .expect(dramManifest.getLegacyOpenDramFiles(config.files).map((file) => file.path))
+      .toEqual([
+        'src/get_started/hello_repl.clj',
+        'src/get_started/welcome_to_clojure.clj',
+        'src/get_started/hello_paredit.clj',
+      ]);
   });
 
   it('pins the current implicit primary target assumption for surfaced legacy starters', () => {
     const surfacedConfigs = [parseManifest(miniDramEdn), parseManifest(gettingStartedDramEdn)];
 
-    expect(
-      surfacedConfigs.every(
-        (config) => dramManifest.normalizeLegacyDramFiles(config.files)[0]?.['open?']
+    expectLib
+      .expect(
+        surfacedConfigs.every(
+          (config) => dramManifest.normalizeLegacyDramFiles(config.files)[0]?.['open?']
+        )
       )
-    ).toBe(true);
+      .toBe(true);
   });
 
   it('resolves legacy-only manifests to the current legacy open list', () => {
     const config = parseManifest(gettingStartedDramEdn);
 
-    expect(dramManifest.resolveDramOpenPaths(config)).toEqual([
-      'src/get_started/hello_repl.clj',
-      'src/get_started/welcome_to_clojure.clj',
-      'src/get_started/hello_paredit.clj',
-    ]);
+    expectLib
+      .expect(dramManifest.resolveDramOpenPaths(config))
+      .toEqual([
+        'src/get_started/hello_repl.clj',
+        'src/get_started/welcome_to_clojure.clj',
+        'src/get_started/hello_paredit.clj',
+      ]);
   });
 
   it('supports top-level open without relying on file-level open markers', () => {
     const config = parseManifest(topLevelOpenOnlyDramEdn);
 
-    expect(dramManifest.resolveDramOpenPaths(config)).toEqual(['deps.edn', '.gitignore']);
+    expectLib.expect(dramManifest.resolveDramOpenPaths(config)).toEqual(['deps.edn', '.gitignore']);
   });
 
   it('deduplicates mixed legacy and top-level open paths by the last requested position', () => {
     const config = parseManifest(mixedOpenDramEdn);
 
-    expect(dramManifest.resolveDramOpenPaths(config)).toEqual([
-      'src/example/c.clj',
-      'src/example/b.clj',
-      'src/example/a.clj',
-    ]);
+    expectLib
+      .expect(dramManifest.resolveDramOpenPaths(config))
+      .toEqual(['src/example/c.clj', 'src/example/b.clj', 'src/example/a.clj']);
   });
 });

--- a/src/extension-test/unit/nrepl/dram-staging-test.ts
+++ b/src/extension-test/unit/nrepl/dram-staging-test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -37,31 +37,35 @@ describe('dram staging', () => {
 
     await dramStaging.stageGithubArchive(zipPath, destinationPath);
 
-    expect(fs.existsSync(path.join(destinationPath, 'src/try_clojure/core.clj'))).toBe(true);
-    expect(fs.existsSync(path.join(destinationPath, 'calva-README.md'))).toBe(true);
-    expect(fs.existsSync(path.join(destinationPath, 'try-clojure-main'))).toBe(false);
+    expectLib
+      .expect(fs.existsSync(path.join(destinationPath, 'src/try_clojure/core.clj')))
+      .toBe(true);
+    expectLib.expect(fs.existsSync(path.join(destinationPath, 'calva-README.md'))).toBe(true);
+    expectLib.expect(fs.existsSync(path.join(destinationPath, 'try-clojure-main'))).toBe(false);
   });
 
   it('normalizes safe archive paths and rejects traversal paths', () => {
-    expect(
-      dramStaging.buildGithubArchiveStagingPlan([
-        'try-clojure-main/src/../README.md',
-        'try-clojure-main/src/try_clojure/core.clj',
-      ])
-    ).toEqual([
-      {
-        archivePath: 'try-clojure-main/src/../README.md',
-        relativePath: 'README.md',
-      },
-      {
-        archivePath: 'try-clojure-main/src/try_clojure/core.clj',
-        relativePath: 'src/try_clojure/core.clj',
-      },
-    ]);
+    expectLib
+      .expect(
+        dramStaging.buildGithubArchiveStagingPlan([
+          'try-clojure-main/src/../README.md',
+          'try-clojure-main/src/try_clojure/core.clj',
+        ])
+      )
+      .toEqual([
+        {
+          archivePath: 'try-clojure-main/src/../README.md',
+          relativePath: 'README.md',
+        },
+        {
+          archivePath: 'try-clojure-main/src/try_clojure/core.clj',
+          relativePath: 'src/try_clojure/core.clj',
+        },
+      ]);
 
-    expect(() =>
-      dramStaging.buildGithubArchiveStagingPlan(['try-clojure-main/../../evil.txt'])
-    ).toThrow('Unsafe archive entry path: try-clojure-main/../../evil.txt');
+    expectLib
+      .expect(() => dramStaging.buildGithubArchiveStagingPlan(['try-clojure-main/../../evil.txt']))
+      .toThrow('Unsafe archive entry path: try-clojure-main/../../evil.txt');
   });
 
   it('lets later overlay files replace extracted archive files in the staging area', async () => {
@@ -78,8 +82,8 @@ describe('dram staging', () => {
     await dramStaging.stageGithubArchive(zipPath, destinationPath);
     await dramStaging.stageOverlayFile(overlaySourcePath, destinationPath, 'calva-README.md');
 
-    expect(fs.readFileSync(path.join(destinationPath, 'calva-README.md'), 'utf8')).toBe(
-      '# Overlay README'
-    );
+    expectLib
+      .expect(fs.readFileSync(path.join(destinationPath, 'calva-README.md'), 'utf8'))
+      .toBe('# Overlay README');
   });
 });

--- a/src/extension-test/unit/nrepl/glob-routing-test.ts
+++ b/src/extension-test/unit/nrepl/glob-routing-test.ts
@@ -1,8 +1,8 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as minimatchLib from 'minimatch';
 import * as sessionRegistry from '../../../../src/nrepl/session-registry';
 import * as globs from '../../../../src/nrepl/globs';
-import type { NReplSession } from '../../../../src/nrepl';
+import type * as nrepl from '../../../../src/nrepl';
 
 /**
  * Pure glob matching logic extracted for testing.
@@ -53,8 +53,8 @@ function findSessionKeyByGlob(
 }
 
 describe('glob-based session routing', () => {
-  const createSession = (clientKey: string): NReplSession =>
-    ({ client: { clientKey } } as unknown as NReplSession);
+  const createSession = (clientKey: string): nrepl.NReplSession =>
+    ({ client: { clientKey } } as unknown as nrepl.NReplSession);
 
   afterEach(() => {
     sessionRegistry._testUtility_registeredSessions.clear();
@@ -80,8 +80,8 @@ describe('glob-based session routing', () => {
         },
       ];
 
-      expect(findSessionKeyByGlob('src/app/core.clj', sessions)).toBe('clj');
-      expect(findSessionKeyByGlob('test/app_test.clj', sessions)).toBe('clj');
+      expectLib.expect(findSessionKeyByGlob('src/app/core.clj', sessions)).toBe('clj');
+      expectLib.expect(findSessionKeyByGlob('test/app_test.clj', sessions)).toBe('clj');
     });
 
     it('routes .cljs files to secondary session', () => {
@@ -102,7 +102,7 @@ describe('glob-based session routing', () => {
         },
       ];
 
-      expect(findSessionKeyByGlob('src/app/ui.cljs', sessions)).toBe('cljs');
+      expectLib.expect(findSessionKeyByGlob('src/app/ui.cljs', sessions)).toBe('cljs');
     });
 
     it('prefers always-claim over is-fallback-for', () => {
@@ -123,8 +123,8 @@ describe('glob-based session routing', () => {
         },
       ];
 
-      expect(findSessionKeyByGlob('src/special/core.clj', sessions)).toBe('special');
-      expect(findSessionKeyByGlob('src/other/core.clj', sessions)).toBe('clj');
+      expectLib.expect(findSessionKeyByGlob('src/special/core.clj', sessions)).toBe('special');
+      expectLib.expect(findSessionKeyByGlob('src/other/core.clj', sessions)).toBe('clj');
     });
   });
 
@@ -169,10 +169,14 @@ describe('glob-based session routing', () => {
       // Combined sessions as would appear in registry
       const allSessions = [...sessionsA, ...sessionsB];
 
-      expect(findSessionKeyByGlob('app/src/core.clj', allSessions)).toBe('app-clj');
-      expect(findSessionKeyByGlob('app/src/ui.cljs', allSessions)).toBe('app-cljs');
-      expect(findSessionKeyByGlob('admin/src/dashboard.clj', allSessions)).toBe('admin-clj');
-      expect(findSessionKeyByGlob('admin/src/views.cljs', allSessions)).toBe('admin-cljs');
+      expectLib.expect(findSessionKeyByGlob('app/src/core.clj', allSessions)).toBe('app-clj');
+      expectLib.expect(findSessionKeyByGlob('app/src/ui.cljs', allSessions)).toBe('app-cljs');
+      expectLib
+        .expect(findSessionKeyByGlob('admin/src/dashboard.clj', allSessions))
+        .toBe('admin-clj');
+      expectLib
+        .expect(findSessionKeyByGlob('admin/src/views.cljs', allSessions))
+        .toBe('admin-cljs');
     });
 
     it('uses specificity to resolve overlapping globs from different connections', () => {
@@ -194,8 +198,10 @@ describe('glob-based session routing', () => {
       ];
 
       // More specific pattern wins
-      expect(findSessionKeyByGlob('src/app/special/handler.clj', sessions)).toBe('specific-clj');
-      expect(findSessionKeyByGlob('src/other/handler.clj', sessions)).toBe('generic-clj');
+      expectLib
+        .expect(findSessionKeyByGlob('src/app/special/handler.clj', sessions))
+        .toBe('specific-clj');
+      expectLib.expect(findSessionKeyByGlob('src/other/handler.clj', sessions)).toBe('generic-clj');
     });
 
     it('respects tier priority across connections', () => {
@@ -217,9 +223,9 @@ describe('glob-based session routing', () => {
       ];
 
       // always-claim beats is-fallback-for even if less specific
-      expect(findSessionKeyByGlob('src/core.clj', sessions)).toBe('claim-clj');
+      expectLib.expect(findSessionKeyByGlob('src/core.clj', sessions)).toBe('claim-clj');
       // Fallback handles non-matching paths
-      expect(findSessionKeyByGlob('test/core.clj', sessions)).toBe('fallback-clj');
+      expectLib.expect(findSessionKeyByGlob('test/core.clj', sessions)).toBe('fallback-clj');
     });
 
     it('uses registration order as tiebreaker for equal scores', () => {
@@ -241,7 +247,7 @@ describe('glob-based session routing', () => {
       ];
 
       // First registered wins on tie
-      expect(findSessionKeyByGlob('src/core.clj', sessions)).toBe('first-clj');
+      expectLib.expect(findSessionKeyByGlob('src/core.clj', sessions)).toBe('first-clj');
     });
 
     it('returns undefined when no globs match', () => {
@@ -255,7 +261,7 @@ describe('glob-based session routing', () => {
         },
       ];
 
-      expect(findSessionKeyByGlob('lib/core.cljs', sessions)).toBeUndefined();
+      expectLib.expect(findSessionKeyByGlob('lib/core.cljs', sessions)).toBeUndefined();
     });
 
     it('handles empty glob specs gracefully', () => {
@@ -270,7 +276,7 @@ describe('glob-based session routing', () => {
         },
       ];
 
-      expect(findSessionKeyByGlob('src/core.clj', sessions)).toBe('has-globs');
+      expectLib.expect(findSessionKeyByGlob('src/core.clj', sessions)).toBe('has-globs');
     });
   });
 
@@ -287,8 +293,8 @@ describe('glob-based session routing', () => {
       });
 
       const metadata = sessionRegistry.getSessionMetadata('clj');
-      expect(metadata?.globs).toEqual(['**/*.clj']);
-      expect(metadata?.globSpecs).toEqual(globSpecs);
+      expectLib.expect(metadata?.globs).toEqual(['**/*.clj']);
+      expectLib.expect(metadata?.globSpecs).toEqual(globSpecs);
     });
 
     it('listSessions returns glob metadata for routing decisions', () => {
@@ -307,8 +313,8 @@ describe('glob-based session routing', () => {
       const sessions = sessionRegistry.listSessions();
       const sessionData = sessions.map((s) => ({ key: s.key, globSpecs: s.globSpecs }));
 
-      expect(findSessionKeyByGlob('src/core.clj', sessionData)).toBe('clj');
-      expect(findSessionKeyByGlob('src/ui.cljs', sessionData)).toBe('cljs');
+      expectLib.expect(findSessionKeyByGlob('src/core.clj', sessionData)).toBe('clj');
+      expectLib.expect(findSessionKeyByGlob('src/ui.cljs', sessionData)).toBe('cljs');
     });
   });
 });

--- a/src/extension-test/unit/nrepl/globs-test.ts
+++ b/src/extension-test/unit/nrepl/globs-test.ts
@@ -1,43 +1,36 @@
-import { expect } from 'expect';
-import {
-  computeGlobScore,
-  toGlobMetadata,
-  constructGlobsFromFilePatterns,
-  createCatchAllGlobSpec,
-  normalizeProjectRoot,
-  type SessionGlobTiers,
-} from '../../../../src/nrepl/globs';
+import * as expectLib from 'expect';
+import * as globs from '../../../../src/nrepl/globs';
 
 describe('glob scoring utilities', () => {
   it('penalizes broader globs compared to specific ones', () => {
-    const specific = computeGlobScore('src/app/components/**/*.clj');
-    const generic = computeGlobScore('**/*.clj');
+    const specific = globs.computeGlobScore('src/app/components/**/*.clj');
+    const generic = globs.computeGlobScore('**/*.clj');
 
-    expect(specific).toBeGreaterThan(generic);
+    expectLib.expect(specific).toBeGreaterThan(generic);
   });
 
   it('produces glob specs with tier and normalized metadata', () => {
-    const tiers: SessionGlobTiers = {
+    const tiers: globs.SessionGlobTiers = {
       'always-claim': ['src/.joyride/**/*.cljs'],
       'is-fallback-for': ['**/*.clj'],
     };
 
-    const metadata = toGlobMetadata(tiers);
-    expect(metadata.globs).toEqual(['src/.joyride/**/*.cljs', '**/*.clj']);
-    expect(metadata.globSpecs).toEqual([
+    const metadata = globs.toGlobMetadata(tiers);
+    expectLib.expect(metadata.globs).toEqual(['src/.joyride/**/*.cljs', '**/*.clj']);
+    expectLib.expect(metadata.globSpecs).toEqual([
       {
         pattern: 'src/.joyride/**/*.cljs',
         normalizedPattern: 'src/.joyride/**/*.cljs',
         displayPattern: 'src/.joyride/**/*.cljs',
         tier: 'always-claim',
-        score: computeGlobScore('src/.joyride/**/*.cljs'),
+        score: globs.computeGlobScore('src/.joyride/**/*.cljs'),
       },
       {
         pattern: '**/*.clj',
         normalizedPattern: '**/*.clj',
         displayPattern: '**/*.clj',
         tier: 'is-fallback-for',
-        score: computeGlobScore('**/*.clj'),
+        score: globs.computeGlobScore('**/*.clj'),
       },
     ]);
   });
@@ -46,130 +39,146 @@ describe('glob scoring utilities', () => {
 describe('file pattern to glob construction', () => {
   describe('normalizeProjectRoot', () => {
     it('normalizes POSIX path without trailing slash', () => {
-      expect(normalizeProjectRoot('/Users/pez/my-project')).toEqual('/Users/pez/my-project');
+      expectLib
+        .expect(globs.normalizeProjectRoot('/Users/pez/my-project'))
+        .toEqual('/Users/pez/my-project');
     });
 
     it('removes trailing slash', () => {
-      expect(normalizeProjectRoot('/Users/pez/my-project/')).toEqual('/Users/pez/my-project');
+      expectLib
+        .expect(globs.normalizeProjectRoot('/Users/pez/my-project/'))
+        .toEqual('/Users/pez/my-project');
     });
 
     it('converts Windows path to POSIX', () => {
-      expect(normalizeProjectRoot('C:\\Users\\pez\\my-project')).toEqual('C:/Users/pez/my-project');
+      expectLib
+        .expect(globs.normalizeProjectRoot('C:\\Users\\pez\\my-project'))
+        .toEqual('C:/Users/pez/my-project');
     });
   });
 
   describe('constructGlobsFromFilePatterns', () => {
     it('constructs full globs from simple file patterns', () => {
-      const specs = constructGlobsFromFilePatterns('/workspace/my-app', ['*.clj'], 'always-claim');
+      const specs = globs.constructGlobsFromFilePatterns(
+        '/workspace/my-app',
+        ['*.clj'],
+        'always-claim'
+      );
 
-      expect(specs).toHaveLength(1);
-      expect(specs[0].pattern).toEqual('/workspace/my-app/**/*.clj');
-      expect(specs[0].displayPattern).toEqual('*.clj');
-      expect(specs[0].tier).toEqual('always-claim');
+      expectLib.expect(specs).toHaveLength(1);
+      expectLib.expect(specs[0].pattern).toEqual('/workspace/my-app/**/*.clj');
+      expectLib.expect(specs[0].displayPattern).toEqual('*.clj');
+      expectLib.expect(specs[0].tier).toEqual('always-claim');
     });
 
     it('handles multiple file patterns', () => {
-      const specs = constructGlobsFromFilePatterns(
+      const specs = globs.constructGlobsFromFilePatterns(
         '/workspace/my-app',
         ['*.clj', '*.edn'],
         'always-claim'
       );
 
-      expect(specs).toHaveLength(2);
-      expect(specs[0].pattern).toEqual('/workspace/my-app/**/*.clj');
-      expect(specs[1].pattern).toEqual('/workspace/my-app/**/*.edn');
+      expectLib.expect(specs).toHaveLength(2);
+      expectLib.expect(specs[0].pattern).toEqual('/workspace/my-app/**/*.clj');
+      expectLib.expect(specs[1].pattern).toEqual('/workspace/my-app/**/*.edn');
     });
 
     it('handles path-based patterns', () => {
-      const specs = constructGlobsFromFilePatterns(
+      const specs = globs.constructGlobsFromFilePatterns(
         '/workspace/my-app',
         ['scripts/*.clj'],
         'always-claim'
       );
 
-      expect(specs[0].pattern).toEqual('/workspace/my-app/**/scripts/*.clj');
+      expectLib.expect(specs[0].pattern).toEqual('/workspace/my-app/**/scripts/*.clj');
     });
 
     it('returns empty array for empty patterns', () => {
-      const specs = constructGlobsFromFilePatterns('/workspace/my-app', [], 'always-claim');
-      expect(specs).toHaveLength(0);
+      const specs = globs.constructGlobsFromFilePatterns('/workspace/my-app', [], 'always-claim');
+      expectLib.expect(specs).toHaveLength(0);
     });
 
     it('returns empty array for empty project root', () => {
-      const specs = constructGlobsFromFilePatterns('', ['*.clj'], 'always-claim');
-      expect(specs).toHaveLength(0);
+      const specs = globs.constructGlobsFromFilePatterns('', ['*.clj'], 'always-claim');
+      expectLib.expect(specs).toHaveLength(0);
     });
 
     it('assigns correct tier to specs', () => {
-      const claimSpecs = constructGlobsFromFilePatterns(
+      const claimSpecs = globs.constructGlobsFromFilePatterns(
         '/workspace/my-app',
         ['*.clj'],
         'always-claim'
       );
-      const fallbackSpecs = constructGlobsFromFilePatterns(
+      const fallbackSpecs = globs.constructGlobsFromFilePatterns(
         '/workspace/my-app',
         ['*.cljs'],
         'is-fallback-for'
       );
 
-      expect(claimSpecs[0].tier).toEqual('always-claim');
-      expect(fallbackSpecs[0].tier).toEqual('is-fallback-for');
+      expectLib.expect(claimSpecs[0].tier).toEqual('always-claim');
+      expectLib.expect(fallbackSpecs[0].tier).toEqual('is-fallback-for');
     });
 
     it('computes correct scores for constructed globs', () => {
-      const specs = constructGlobsFromFilePatterns('/workspace/my-app', ['*.clj'], 'always-claim');
+      const specs = globs.constructGlobsFromFilePatterns(
+        '/workspace/my-app',
+        ['*.clj'],
+        'always-claim'
+      );
 
       // Score should be computed based on the full pattern
-      expect(specs[0].score).toEqual(computeGlobScore('/workspace/my-app/**/*.clj'));
+      expectLib
+        .expect(specs[0].score)
+        .toEqual(globs.computeGlobScore('/workspace/my-app/**/*.clj'));
     });
 
     it('preserves workspace-wide patterns without project root prefixing', () => {
-      const specs = constructGlobsFromFilePatterns(
+      const specs = globs.constructGlobsFromFilePatterns(
         '/workspace/my-app',
         ['**/*.bb', '**/bb.edn'],
         'is-fallback-for'
       );
 
-      expect(specs).toHaveLength(2);
+      expectLib.expect(specs).toHaveLength(2);
       // Patterns starting with **/ should NOT be prefixed with project root
-      expect(specs[0].pattern).toEqual('**/*.bb');
-      expect(specs[1].pattern).toEqual('**/bb.edn');
+      expectLib.expect(specs[0].pattern).toEqual('**/*.bb');
+      expectLib.expect(specs[1].pattern).toEqual('**/bb.edn');
     });
 
     it('mixes project-scoped and workspace-wide patterns correctly', () => {
-      const specs = constructGlobsFromFilePatterns(
+      const specs = globs.constructGlobsFromFilePatterns(
         '/workspace/my-app',
         ['*.clj', '**/*.bb'],
         'always-claim'
       );
 
-      expect(specs).toHaveLength(2);
+      expectLib.expect(specs).toHaveLength(2);
       // Regular pattern gets project root prefix
-      expect(specs[0].pattern).toEqual('/workspace/my-app/**/*.clj');
+      expectLib.expect(specs[0].pattern).toEqual('/workspace/my-app/**/*.clj');
       // Workspace-wide pattern stays as-is
-      expect(specs[1].pattern).toEqual('**/*.bb');
+      expectLib.expect(specs[1].pattern).toEqual('**/*.bb');
     });
   });
 
   describe('createCatchAllGlobSpec', () => {
     it('creates catch-all glob for project root', () => {
-      const spec = createCatchAllGlobSpec('/workspace/my-app');
+      const spec = globs.createCatchAllGlobSpec('/workspace/my-app');
 
-      expect(spec.pattern).toEqual('/workspace/my-app/**/*');
-      expect(spec.displayPattern).toEqual('**/*');
-      expect(spec.tier).toEqual('project-fallback');
+      expectLib.expect(spec.pattern).toEqual('/workspace/my-app/**/*');
+      expectLib.expect(spec.displayPattern).toEqual('**/*');
+      expectLib.expect(spec.tier).toEqual('project-fallback');
     });
 
     it('handles trailing slash in project root', () => {
-      const spec = createCatchAllGlobSpec('/workspace/my-app/');
+      const spec = globs.createCatchAllGlobSpec('/workspace/my-app/');
 
-      expect(spec.pattern).toEqual('/workspace/my-app/**/*');
+      expectLib.expect(spec.pattern).toEqual('/workspace/my-app/**/*');
     });
 
     it('computes correct score for catch-all glob', () => {
-      const spec = createCatchAllGlobSpec('/workspace/my-app');
+      const spec = globs.createCatchAllGlobSpec('/workspace/my-app');
 
-      expect(spec.score).toEqual(computeGlobScore('/workspace/my-app/**/*'));
+      expectLib.expect(spec.score).toEqual(globs.computeGlobScore('/workspace/my-app/**/*'));
     });
   });
 });

--- a/src/extension-test/unit/nrepl/jack-in-port-detection-test.ts
+++ b/src/extension-test/unit/nrepl/jack-in-port-detection-test.ts
@@ -1,28 +1,30 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as jackInPortDetection from '../../../../src/nrepl/jack-in-port-detection';
 
 describe('jack-in port detection', () => {
   describe('parseReplStart', () => {
     it('parses localhost port output', () => {
-      expect(
-        jackInPortDetection.parseReplStart(
-          'nREPL server started on port 61419 on host localhost - nrepl://localhost:61419'
+      expectLib
+        .expect(
+          jackInPortDetection.parseReplStart(
+            'nREPL server started on port 61419 on host localhost - nrepl://localhost:61419'
+          )
         )
-      ).toStrictEqual({
-        host: 'localhost',
-        port: '61419',
-        matchedText: 'nREPL server started on port 61419 on host localhost',
-      });
+        .toStrictEqual({
+          host: 'localhost',
+          port: '61419',
+          matchedText: 'nREPL server started on port 61419 on host localhost',
+        });
     });
 
     it('parses host colon port output', () => {
-      expect(
-        jackInPortDetection.parseReplStart('Started nREPL server at 127.0.0.1:1337')
-      ).toStrictEqual({
-        host: '127.0.0.1',
-        port: '1337',
-        matchedText: 'Started nREPL server at 127.0.0.1:1337',
-      });
+      expectLib
+        .expect(jackInPortDetection.parseReplStart('Started nREPL server at 127.0.0.1:1337'))
+        .toStrictEqual({
+          host: '127.0.0.1',
+          port: '1337',
+          matchedText: 'Started nREPL server at 127.0.0.1:1337',
+        });
     });
   });
 
@@ -33,15 +35,15 @@ describe('jack-in port detection', () => {
         'nREPL server started on port 6141'
       );
 
-      expect(firstChunk.match).toBeUndefined();
-      expect(firstChunk.buffer).toBe('nREPL server started on port 6141');
+      expectLib.expect(firstChunk.match).toBeUndefined();
+      expectLib.expect(firstChunk.buffer).toBe('nREPL server started on port 6141');
 
       const secondChunk = jackInPortDetection.detectBufferedReplStart(
         firstChunk.buffer,
         '9 on host localhost - nrepl://localhost:61419\n'
       );
 
-      expect(secondChunk).toStrictEqual({
+      expectLib.expect(secondChunk).toStrictEqual({
         buffer: '',
         match: {
           host: 'localhost',

--- a/src/extension-test/unit/nrepl/jack-in-version-resolution-test.ts
+++ b/src/extension-test/unit/nrepl/jack-in-version-resolution-test.ts
@@ -1,17 +1,19 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as jackInVersionResolution from '../../../../src/nrepl/jack-in-version-resolution';
 
 describe('jack-in version resolution', () => {
   describe('isPrereleaseVersion', () => {
     it('detects semver prereleases', () => {
-      expect(jackInVersionResolution.isPrereleaseVersion('1.6.0-alpha3')).toBe(true);
-      expect(jackInVersionResolution.isPrereleaseVersion('1.6.0-rc1')).toBe(true);
-      expect(jackInVersionResolution.isPrereleaseVersion('1.5.1')).toBe(false);
+      expectLib.expect(jackInVersionResolution.isPrereleaseVersion('1.6.0-alpha3')).toBe(true);
+      expectLib.expect(jackInVersionResolution.isPrereleaseVersion('1.6.0-rc1')).toBe(true);
+      expectLib.expect(jackInVersionResolution.isPrereleaseVersion('1.5.1')).toBe(false);
     });
 
     it('detects common non-semver prerelease tokens', () => {
-      expect(jackInVersionResolution.isPrereleaseVersion('2025.10.1-SNAPSHOT')).toBe(true);
-      expect(jackInVersionResolution.isPrereleaseVersion('2.0.0-preview')).toBe(true);
+      expectLib
+        .expect(jackInVersionResolution.isPrereleaseVersion('2025.10.1-SNAPSHOT'))
+        .toBe(true);
+      expectLib.expect(jackInVersionResolution.isPrereleaseVersion('2.0.0-preview')).toBe(true);
     });
   });
 
@@ -21,13 +23,13 @@ describe('jack-in version resolution', () => {
 
       const result = jackInVersionResolution.selectLatestStableAndPrerelease(versions);
 
-      expect(result).toStrictEqual({ stable: '1.5.4', prerelease: '1.6.0-beta1' });
+      expectLib.expect(result).toStrictEqual({ stable: '1.5.4', prerelease: '1.6.0-beta1' });
     });
 
     it('returns only stable when no prerelease exists', () => {
       const result = jackInVersionResolution.selectLatestStableAndPrerelease(['1.4.0', '1.3.9']);
 
-      expect(result).toStrictEqual({ stable: '1.4.0', prerelease: undefined });
+      expectLib.expect(result).toStrictEqual({ stable: '1.4.0', prerelease: undefined });
     });
 
     it('returns only prerelease when no stable exists', () => {
@@ -36,7 +38,7 @@ describe('jack-in version resolution', () => {
         '1.6.0-alpha3',
       ]);
 
-      expect(result).toStrictEqual({ stable: undefined, prerelease: '1.6.0-alpha3' });
+      expectLib.expect(result).toStrictEqual({ stable: undefined, prerelease: '1.6.0-alpha3' });
     });
   });
 });

--- a/src/extension-test/unit/nrepl/session-label-test.ts
+++ b/src/extension-test/unit/nrepl/session-label-test.ts
@@ -1,14 +1,9 @@
-import { expect } from 'expect';
-import {
-  determineSessionLabelContext,
-  formatSessionLabel,
-  type SessionLabelContext,
-  type SessionLabelContextOptions,
-} from '../../../nrepl/session-label';
+import * as expectLib from 'expect';
+import * as sessionLabel from '../../../nrepl/session-label';
 
 describe('session-label', () => {
   describe('determineSessionLabelContext', () => {
-    const defaultOptions: SessionLabelContextOptions = {
+    const defaultOptions: sessionLabel.SessionLabelContextOptions = {
       isPinned: false,
       isReplWindow: false,
       isCljcRouting: false,
@@ -17,80 +12,80 @@ describe('session-label', () => {
 
     describe('pinned sessions', () => {
       it('returns none for pinned sessions regardless of other context', () => {
-        const result = determineSessionLabelContext({
+        const result = sessionLabel.determineSessionLabelContext({
           ...defaultOptions,
           isPinned: true,
           isReplWindow: true, // Would normally return 'repl-window'
         });
-        expect(result).toEqual({ type: 'none' });
+        expectLib.expect(result).toEqual({ type: 'none' });
       });
 
       it('returns none for pinned sessions even with cljc routing', () => {
-        const result = determineSessionLabelContext({
+        const result = sessionLabel.determineSessionLabelContext({
           ...defaultOptions,
           isPinned: true,
           isCljcRouting: true,
           fileExtension: 'cljc',
         });
-        expect(result).toEqual({ type: 'none' });
+        expectLib.expect(result).toEqual({ type: 'none' });
       });
     });
 
     describe('REPL window context', () => {
       it('returns repl-window when in REPL window', () => {
-        const result = determineSessionLabelContext({
+        const result = sessionLabel.determineSessionLabelContext({
           ...defaultOptions,
           isReplWindow: true,
         });
-        expect(result).toEqual({ type: 'repl-window' });
+        expectLib.expect(result).toEqual({ type: 'repl-window' });
       });
 
       it('prioritizes repl-window over cljc routing', () => {
-        const result = determineSessionLabelContext({
+        const result = sessionLabel.determineSessionLabelContext({
           ...defaultOptions,
           isReplWindow: true,
           isCljcRouting: true,
           fileExtension: 'cljc',
         });
-        expect(result).toEqual({ type: 'repl-window' });
+        expectLib.expect(result).toEqual({ type: 'repl-window' });
       });
     });
 
     describe('cljc routing context', () => {
       it('returns cljc-routing with file extension when isCljcRouting is true', () => {
-        const result = determineSessionLabelContext({
+        const result = sessionLabel.determineSessionLabelContext({
           ...defaultOptions,
           isCljcRouting: true,
           fileExtension: 'cljc',
         });
-        expect(result).toEqual({ type: 'cljc-routing', fileExtension: 'cljc' });
+        expectLib.expect(result).toEqual({ type: 'cljc-routing', fileExtension: 'cljc' });
       });
 
       it('includes fiddle extension for fiddle files', () => {
-        const result = determineSessionLabelContext({
+        const result = sessionLabel.determineSessionLabelContext({
           ...defaultOptions,
           isCljcRouting: true,
           fileExtension: 'fiddle',
         });
-        expect(result).toEqual({ type: 'cljc-routing', fileExtension: 'fiddle' });
+        expectLib.expect(result).toEqual({ type: 'cljc-routing', fileExtension: 'fiddle' });
       });
 
       it('returns none if cljc routing but no file extension', () => {
-        const result = determineSessionLabelContext({
+        const result = sessionLabel.determineSessionLabelContext({
           ...defaultOptions,
           isCljcRouting: true,
           fileExtension: undefined,
         });
-        expect(result).toEqual({ type: 'none' });
+        expectLib.expect(result).toEqual({ type: 'none' });
       });
     });
 
     describe('no context', () => {
       it('returns none when no special context applies', () => {
-        const result = determineSessionLabelContext({
+        const result = sessionLabel.determineSessionLabelContext({
           ...defaultOptions,
         });
-        expect(result).toEqual({ type: 'none' });
+        expectLib.expect(result).toEqual({ type: 'none' });
       });
     });
   });
@@ -98,46 +93,64 @@ describe('session-label', () => {
   describe('formatSessionLabel', () => {
     describe('repl-window context', () => {
       it('prefixes with repl-w/', () => {
-        expect(formatSessionLabel('cljs', { type: 'repl-window' })).toBe('repl-w/cljs');
+        expectLib
+          .expect(sessionLabel.formatSessionLabel('cljs', { type: 'repl-window' }))
+          .toBe('repl-w/cljs');
       });
 
       it('works with custom session keys', () => {
-        expect(formatSessionLabel('frontend', { type: 'repl-window' })).toBe('repl-w/frontend');
+        expectLib
+          .expect(sessionLabel.formatSessionLabel('frontend', { type: 'repl-window' }))
+          .toBe('repl-w/frontend');
       });
     });
 
     describe('cljc-routing context', () => {
       it('formats as .ext → session for cljc files', () => {
-        expect(formatSessionLabel('clj', { type: 'cljc-routing', fileExtension: 'cljc' })).toBe(
-          '.cljc → clj'
-        );
+        expectLib
+          .expect(
+            sessionLabel.formatSessionLabel('clj', { type: 'cljc-routing', fileExtension: 'cljc' })
+          )
+          .toBe('.cljc → clj');
       });
 
       it('formats as .ext → session for fiddle files', () => {
-        expect(formatSessionLabel('cljs', { type: 'cljc-routing', fileExtension: 'fiddle' })).toBe(
-          '.fiddle → cljs'
-        );
+        expectLib
+          .expect(
+            sessionLabel.formatSessionLabel('cljs', {
+              type: 'cljc-routing',
+              fileExtension: 'fiddle',
+            })
+          )
+          .toBe('.fiddle → cljs');
       });
 
       it('works with custom session keys', () => {
-        expect(
-          formatSessionLabel('frontend', { type: 'cljc-routing', fileExtension: 'cljc' })
-        ).toBe('.cljc → frontend');
+        expectLib
+          .expect(
+            sessionLabel.formatSessionLabel('frontend', {
+              type: 'cljc-routing',
+              fileExtension: 'cljc',
+            })
+          )
+          .toBe('.cljc → frontend');
       });
     });
 
     describe('no context', () => {
       it('returns session key unchanged', () => {
-        expect(formatSessionLabel('clj', { type: 'none' })).toBe('clj');
+        expectLib.expect(sessionLabel.formatSessionLabel('clj', { type: 'none' })).toBe('clj');
       });
 
       it('preserves custom session keys', () => {
-        expect(formatSessionLabel('backend', { type: 'none' })).toBe('backend');
+        expectLib
+          .expect(sessionLabel.formatSessionLabel('backend', { type: 'none' }))
+          .toBe('backend');
       });
     });
 
     describe('various session key formats', () => {
-      const contexts: SessionLabelContext[] = [
+      const contexts: sessionLabel.SessionLabelContext[] = [
         { type: 'repl-window' },
         { type: 'cljc-routing', fileExtension: 'cljc' },
         { type: 'none' },
@@ -146,9 +159,9 @@ describe('session-label', () => {
       it('handles standard session keys', () => {
         for (const key of ['clj', 'cljs', 'cljc']) {
           for (const context of contexts) {
-            const result = formatSessionLabel(key, context);
-            expect(typeof result).toBe('string');
-            expect(result.length).toBeGreaterThan(0);
+            const result = sessionLabel.formatSessionLabel(key, context);
+            expectLib.expect(typeof result).toBe('string');
+            expectLib.expect(result.length).toBeGreaterThan(0);
           }
         }
       });
@@ -156,8 +169,8 @@ describe('session-label', () => {
       it('handles custom session keys with special characters', () => {
         const customKeys = ['frontend-app', 'backend_api', 'my.namespace'];
         for (const key of customKeys) {
-          const result = formatSessionLabel(key, { type: 'none' });
-          expect(result).toBe(key);
+          const result = sessionLabel.formatSessionLabel(key, { type: 'none' });
+          expectLib.expect(result).toBe(key);
         }
       });
     });

--- a/src/extension-test/unit/nrepl/session-registry-test.ts
+++ b/src/extension-test/unit/nrepl/session-registry-test.ts
@@ -1,5 +1,5 @@
-import { expect } from 'expect';
-import type { NReplSession } from '../../../../src/nrepl';
+import * as expectLib from 'expect';
+import type * as nrepl from '../../../../src/nrepl';
 import * as sessionRegistry from '../../../../src/nrepl/session-registry';
 import * as clientRegistry from '../../../../src/nrepl/client-registry';
 
@@ -12,30 +12,30 @@ describe('session registry', () => {
 
   describe('resolveSessionKey', () => {
     it('returns the metadata key when available', () => {
-      const session = { replType: 'clj' } as unknown as NReplSession;
+      const session = { replType: 'clj' } as unknown as nrepl.NReplSession;
       (session as any)._calvaSessionMetadata = { key: 'bb' };
 
-      expect(sessionRegistry.resolveSessionKey(session)).toBe('bb');
+      expectLib.expect(sessionRegistry.resolveSessionKey(session)).toBe('bb');
     });
 
     it('uses the provided fallback when there is no session', () => {
-      expect(sessionRegistry.resolveSessionKey(undefined, 'custom')).toBe('custom');
+      expectLib.expect(sessionRegistry.resolveSessionKey(undefined, 'custom')).toBe('custom');
     });
 
     it('uses the default fallback when session has no metadata', () => {
-      const session = { replType: 'cljs' } as unknown as NReplSession;
+      const session = { replType: 'cljs' } as unknown as nrepl.NReplSession;
 
-      expect(sessionRegistry.resolveSessionKey(session)).toBe('clj');
+      expectLib.expect(sessionRegistry.resolveSessionKey(session)).toBe('clj');
     });
   });
 
   describe('listSessionsByClient', () => {
-    const createSession = (clientKey: string): NReplSession =>
-      ({ client: { clientKey } } as unknown as NReplSession);
+    const createSession = (clientKey: string): nrepl.NReplSession =>
+      ({ client: { clientKey } } as unknown as nrepl.NReplSession);
 
     it('returns empty array for empty clientKey', () => {
       sessionRegistry.registerSession('alpha', createSession('client-a'), {});
-      expect(sessionRegistry.listSessionsByClient('')).toEqual([]);
+      expectLib.expect(sessionRegistry.listSessionsByClient('')).toEqual([]);
     });
 
     it('returns sessions belonging to the specified client', () => {
@@ -45,8 +45,8 @@ describe('session registry', () => {
 
       const sessions = sessionRegistry.listSessionsByClient('client-a');
 
-      expect(sessions).toHaveLength(2);
-      expect(sessions.map((s) => s.key).sort()).toEqual(['alpha', 'beta']);
+      expectLib.expect(sessions).toHaveLength(2);
+      expectLib.expect(sessions.map((s) => s.key).sort()).toEqual(['alpha', 'beta']);
     });
 
     it('returns empty array when no sessions match', () => {
@@ -54,13 +54,13 @@ describe('session registry', () => {
 
       const sessions = sessionRegistry.listSessionsByClient('client-unknown');
 
-      expect(sessions).toEqual([]);
+      expectLib.expect(sessions).toEqual([]);
     });
   });
 
   describe('getConnectionStateForSession', () => {
-    const createSession = (clientKey: string): NReplSession =>
-      ({ client: { clientKey } } as unknown as NReplSession);
+    const createSession = (clientKey: string): nrepl.NReplSession =>
+      ({ client: { clientKey } } as unknown as nrepl.NReplSession);
 
     const createMockClient = (clientKey: string) =>
       ({ clientKey } as unknown as Parameters<typeof clientRegistry.registerClient>[0]);
@@ -76,13 +76,13 @@ describe('session registry', () => {
 
       const state = sessionRegistry.getConnectionStateForSession('alpha');
 
-      expect(state?.cljsBuild).toBe(':app');
-      expect(state?.cljsTypeName).toBe('shadow-cljs');
+      expectLib.expect(state?.cljsBuild).toBe(':app');
+      expectLib.expect(state?.cljsTypeName).toBe('shadow-cljs');
     });
 
     it('returns undefined for unregistered session', () => {
       const state = sessionRegistry.getConnectionStateForSession('unknown');
-      expect(state).toBeUndefined();
+      expectLib.expect(state).toBeUndefined();
     });
 
     it('returns correct state when multiple clients exist', () => {
@@ -95,14 +95,18 @@ describe('session registry', () => {
       sessionRegistry.registerSession('alpha', createSession('client-a'), {});
       sessionRegistry.registerSession('beta', createSession('client-b'), {});
 
-      expect(sessionRegistry.getConnectionStateForSession('alpha')?.cljsBuild).toBe(':app');
-      expect(sessionRegistry.getConnectionStateForSession('beta')?.cljsBuild).toBe(':admin');
+      expectLib
+        .expect(sessionRegistry.getConnectionStateForSession('alpha')?.cljsBuild)
+        .toBe(':app');
+      expectLib
+        .expect(sessionRegistry.getConnectionStateForSession('beta')?.cljsBuild)
+        .toBe(':admin');
     });
   });
 
   describe('findPrimarySessionForConnection', () => {
-    const createSession = (clientKey: string): NReplSession =>
-      ({ client: { clientKey } } as unknown as NReplSession);
+    const createSession = (clientKey: string): nrepl.NReplSession =>
+      ({ client: { clientKey } } as unknown as nrepl.NReplSession);
 
     it('finds primary session for same connection', () => {
       sessionRegistry.registerSession('clj', createSession('client-a'), { isSecondary: false });
@@ -110,17 +114,17 @@ describe('session registry', () => {
 
       const mainSession = sessionRegistry.findPrimarySessionForConnection('cljs');
 
-      expect(mainSession).toBeDefined();
-      expect((mainSession as any)._calvaSessionMetadata?.key).toBe('clj');
+      expectLib.expect(mainSession).toBeDefined();
+      expectLib.expect((mainSession as any)._calvaSessionMetadata?.key).toBe('clj');
     });
 
     it('returns undefined when session has no owner', () => {
-      const session = { replType: 'clj' } as unknown as NReplSession;
+      const session = { replType: 'clj' } as unknown as nrepl.NReplSession;
       (session as any)._calvaSessionMetadata = { key: 'orphan' };
 
       const mainSession = sessionRegistry.findPrimarySessionForConnection('orphan');
 
-      expect(mainSession).toBeUndefined();
+      expectLib.expect(mainSession).toBeUndefined();
     });
 
     it('returns undefined when no main session exists', () => {
@@ -128,7 +132,7 @@ describe('session registry', () => {
 
       const mainSession = sessionRegistry.findPrimarySessionForConnection('cljs');
 
-      expect(mainSession).toBeUndefined();
+      expectLib.expect(mainSession).toBeUndefined();
     });
 
     it('finds main session across multiple connections', () => {
@@ -140,8 +144,8 @@ describe('session registry', () => {
       const mainForA = sessionRegistry.findPrimarySessionForConnection('cljs-a');
       const mainForB = sessionRegistry.findPrimarySessionForConnection('cljs-b');
 
-      expect((mainForA as any)?._calvaSessionMetadata?.key).toBe('clj-a');
-      expect((mainForB as any)?._calvaSessionMetadata?.key).toBe('clj-b');
+      expectLib.expect((mainForA as any)?._calvaSessionMetadata?.key).toBe('clj-a');
+      expectLib.expect((mainForB as any)?._calvaSessionMetadata?.key).toBe('clj-b');
     });
   });
 });

--- a/src/extension-test/unit/nrepl/session-routing-test.ts
+++ b/src/extension-test/unit/nrepl/session-routing-test.ts
@@ -1,13 +1,13 @@
-import { expect } from 'expect';
-import type { NReplSession } from '../../../../src/nrepl';
+import * as expectLib from 'expect';
+import type * as nrepl from '../../../../src/nrepl';
 import * as sessionRouting from '../../../../src/nrepl/session-routing';
 import * as sessionRegistry from '../../../../src/nrepl/session-registry';
 
-const createSession = (replType: string, clientKey?: string): NReplSession =>
+const createSession = (replType: string, clientKey?: string): nrepl.NReplSession =>
   ({
     replType,
     client: clientKey ? { clientKey } : undefined,
-  } as NReplSession);
+  } as nrepl.NReplSession);
 
 describe('session routing preferences', () => {
   beforeEach(() => {
@@ -22,8 +22,8 @@ describe('session routing preferences', () => {
 
     sessionRouting.pinSession('beta');
 
-    expect(sessionRouting.isPinned()).toBe(true);
-    expect(sessionRouting.resolvePinnedSession()).toBe('beta');
+    expectLib.expect(sessionRouting.isPinned()).toBe(true);
+    expectLib.expect(sessionRouting.resolvePinnedSession()).toBe('beta');
   });
 
   it('falls back to auto routing when the pinned session disappears', () => {
@@ -32,8 +32,8 @@ describe('session routing preferences', () => {
 
     sessionRegistry.unregisterSession('alpha');
 
-    expect(sessionRouting.isPinned()).toBe(false);
-    expect(sessionRouting.getRoutingMode()).toBe('auto');
+    expectLib.expect(sessionRouting.isPinned()).toBe(false);
+    expectLib.expect(sessionRouting.getRoutingMode()).toBe('auto');
   });
 });
 
@@ -52,8 +52,8 @@ describe('multi-client session routing', () => {
 
     sessionRouting.pinSession('cljs-b');
 
-    expect(sessionRouting.isPinned()).toBe(true);
-    expect(sessionRouting.resolvePinnedSession()).toBe('cljs-b');
+    expectLib.expect(sessionRouting.isPinned()).toBe(true);
+    expectLib.expect(sessionRouting.resolvePinnedSession()).toBe('cljs-b');
   });
 
   it('pinning overrides regardless of session type', () => {
@@ -63,14 +63,14 @@ describe('multi-client session routing', () => {
     sessionRouting.pinSession('clj-a');
 
     // When pinned, the pinned session is always returned
-    expect(sessionRouting.resolvePinnedSession()).toBe('clj-a');
+    expectLib.expect(sessionRouting.resolvePinnedSession()).toBe('clj-a');
   });
 
   it('resolvePinnedSession returns undefined when not pinned', () => {
     sessionRegistry.registerSession('clj-a', createSession('clj', 'client-a'), {});
     sessionRegistry.registerSession('cljs-b', createSession('cljs', 'client-b'), {});
 
-    expect(sessionRouting.resolvePinnedSession()).toBeUndefined();
+    expectLib.expect(sessionRouting.resolvePinnedSession()).toBeUndefined();
   });
 
   it('clears pin when pinned session is unregistered even with multiple clients', () => {
@@ -80,8 +80,8 @@ describe('multi-client session routing', () => {
     sessionRouting.pinSession('clj-a');
     sessionRegistry.unregisterSession('clj-a');
 
-    expect(sessionRouting.isPinned()).toBe(false);
-    expect(sessionRouting.getRoutingMode()).toBe('auto');
+    expectLib.expect(sessionRouting.isPinned()).toBe(false);
+    expectLib.expect(sessionRouting.getRoutingMode()).toBe('auto');
   });
 
   it('switching pin between sessions from different clients works', () => {
@@ -89,9 +89,9 @@ describe('multi-client session routing', () => {
     sessionRegistry.registerSession('cljs-b', createSession('cljs', 'client-b'), {});
 
     sessionRouting.pinSession('clj-a');
-    expect(sessionRouting.resolvePinnedSession()).toBe('clj-a');
+    expectLib.expect(sessionRouting.resolvePinnedSession()).toBe('clj-a');
 
     sessionRouting.pinSession('cljs-b');
-    expect(sessionRouting.resolvePinnedSession()).toBe('cljs-b');
+    expectLib.expect(sessionRouting.resolvePinnedSession()).toBe('cljs-b');
   });
 });

--- a/src/extension-test/unit/nrepl/session-teardown-test.ts
+++ b/src/extension-test/unit/nrepl/session-teardown-test.ts
@@ -1,13 +1,13 @@
-import { expect } from 'expect';
-import type { NReplSession } from '../../../../src/nrepl';
+import * as expectLib from 'expect';
+import type * as nrepl from '../../../../src/nrepl';
 import * as sessionRegistry from '../../../../src/nrepl/session-registry';
 import * as sessionRouting from '../../../../src/nrepl/session-routing';
 import * as teardown from '../../../../src/nrepl/session-teardown-core';
 
-const createSession = (clientKey: string): NReplSession =>
+const createSession = (clientKey: string): nrepl.NReplSession =>
   ({
     client: { clientKey },
-  } as NReplSession);
+  } as nrepl.NReplSession);
 
 describe('session teardown', () => {
   beforeEach(() => {
@@ -29,9 +29,9 @@ describe('session teardown', () => {
 
     const removed = teardown.teardownSessionsForClient('client');
 
-    expect(removed.sort()).toEqual(['alpha', 'beta']);
+    expectLib.expect(removed.sort()).toEqual(['alpha', 'beta']);
     const remaining = sessionRegistry.listSessions().map((meta) => meta.key);
-    expect(remaining).toEqual(['gamma']);
+    expectLib.expect(remaining).toEqual(['gamma']);
   });
 
   it('clears routing references to removed session keys', () => {
@@ -42,6 +42,6 @@ describe('session teardown', () => {
 
     teardown.teardownSessionKeys(['alpha', 'beta']);
 
-    expect(sessionRouting.getPinnedSessionKey()).toBeUndefined();
+    expectLib.expect(sessionRouting.getPinnedSessionKey()).toBeUndefined();
   });
 });

--- a/src/extension-test/unit/nrepl/util-test.ts
+++ b/src/extension-test/unit/nrepl/util-test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as fc from 'fast-check';
 import * as nreplUtil from '../../../../src/nrepl/util';
 
@@ -27,15 +27,15 @@ const createCustomConfig = (custom: string): nreplUtil.AutoEvaluateCodeConfig =>
 describe('config', () => {
   describe('mergeAutoEvaluateConfigs', () => {
     it('Keeps defaults if no config overrides', () => {
-      expect(
-        nreplUtil.mergeAutoEvaluateConfigs([defaults, defaults, defaults], defaults)
-      ).toStrictEqual(defaults);
+      expectLib
+        .expect(nreplUtil.mergeAutoEvaluateConfigs([defaults, defaults, defaults], defaults))
+        .toStrictEqual(defaults);
     });
 
     it('Keeps defaults if no config overrides, also if a config is undefined', () => {
-      expect(
-        nreplUtil.mergeAutoEvaluateConfigs([defaults, defaults, undefined], defaults)
-      ).toStrictEqual(defaults);
+      expectLib
+        .expect(nreplUtil.mergeAutoEvaluateConfigs([defaults, defaults, undefined], defaults))
+        .toStrictEqual(defaults);
     });
 
     it('Overrides default string with null value', () => {
@@ -47,7 +47,9 @@ describe('config', () => {
         ...defaults,
         onConnect: { clj: null, cljs: null },
       };
-      expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults)).toStrictEqual(expectedResult);
+      expectLib
+        .expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults))
+        .toStrictEqual(expectedResult);
     });
 
     it('Concatenates non-default strings and disregards default strings', () => {
@@ -59,7 +61,9 @@ describe('config', () => {
         ...defaults,
         onConnect: { clj: 'custom1', cljs: 'custom1\ncustom2' },
       };
-      expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults)).toStrictEqual(expectedResult);
+      expectLib
+        .expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults))
+        .toStrictEqual(expectedResult);
     });
 
     it('Concatenates all strings when default value is null', () => {
@@ -71,7 +75,9 @@ describe('config', () => {
         ...defaults,
         onFileLoaded: { clj: 'custom1\ncustom2', cljs: 'custom1\ncustom2' },
       };
-      expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults)).toStrictEqual(expectedResult);
+      expectLib
+        .expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults))
+        .toStrictEqual(expectedResult);
     });
 
     it('Overrides null default value with string value', () => {
@@ -83,7 +89,9 @@ describe('config', () => {
         ...defaults,
         onFileLoaded: { clj: null, cljs: 'custom2' },
       };
-      expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults)).toStrictEqual(expectedResult);
+      expectLib
+        .expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults))
+        .toStrictEqual(expectedResult);
     });
 
     it('Ignores null values when default value is null', () => {
@@ -97,7 +105,9 @@ describe('config', () => {
         onFileLoaded: { clj: null, cljs: null },
       };
 
-      expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults)).toStrictEqual(expectedResult);
+      expectLib
+        .expect(nreplUtil.mergeAutoEvaluateConfigs(configs, defaults))
+        .toStrictEqual(expectedResult);
     });
 
     it('Concatenates all non-default strings, generated', () => {
@@ -121,10 +131,10 @@ describe('config', () => {
             const expectedOnFileLoaded = [custom1, custom2, custom3].join('\n');
             const expectedOnConnectClj = [custom1, custom2, custom3].join('\n');
             const expectedOnConnectCljs = [custom1, custom2, custom3].join('\n');
-            expect(merged.onFileLoaded.clj).toEqual(expectedOnFileLoaded);
-            expect(merged.onFileLoaded.cljs).toEqual(expectedOnFileLoaded);
-            expect(merged.onConnect.clj).toEqual(expectedOnConnectClj);
-            expect(merged.onConnect.cljs).toEqual(expectedOnConnectCljs);
+            expectLib.expect(merged.onFileLoaded.clj).toEqual(expectedOnFileLoaded);
+            expectLib.expect(merged.onFileLoaded.cljs).toEqual(expectedOnFileLoaded);
+            expectLib.expect(merged.onConnect.clj).toEqual(expectedOnConnectClj);
+            expectLib.expect(merged.onConnect.cljs).toEqual(expectedOnConnectCljs);
           }
         )
       );

--- a/src/extension-test/unit/output-destination-test.ts
+++ b/src/extension-test/unit/output-destination-test.ts
@@ -1,69 +1,73 @@
-import { expect } from 'expect';
-import { normalizeDestinations, OutputDestination } from '../../results-output/output-destinations';
+import * as expectLib from 'expect';
+import * as outputDestinations from '../../results-output/output-destinations';
 import * as path from 'path';
 
 describe('output destinations', () => {
   describe('normalizeDestinations', () => {
     it('wraps a single string in an array', () => {
-      expect(normalizeDestinations('terminal')).toStrictEqual(['terminal']);
+      expectLib
+        .expect(outputDestinations.normalizeDestinations('terminal'))
+        .toStrictEqual(['terminal']);
     });
 
     it('wraps each destination type correctly', () => {
-      const destinations: OutputDestination[] = [
+      const destinations: outputDestinations.OutputDestination[] = [
         'repl-window',
         'output-channel',
         'terminal',
         'output-view',
       ];
       for (const dest of destinations) {
-        expect(normalizeDestinations(dest)).toStrictEqual([dest]);
+        expectLib.expect(outputDestinations.normalizeDestinations(dest)).toStrictEqual([dest]);
       }
     });
 
     it('passes through an array unchanged', () => {
-      expect(normalizeDestinations(['terminal', 'repl-window'])).toStrictEqual([
-        'terminal',
-        'repl-window',
-      ]);
+      expectLib
+        .expect(outputDestinations.normalizeDestinations(['terminal', 'repl-window']))
+        .toStrictEqual(['terminal', 'repl-window']);
     });
 
     it('deduplicates an array', () => {
-      expect(normalizeDestinations(['terminal', 'terminal', 'repl-window'])).toStrictEqual([
-        'terminal',
-        'repl-window',
-      ]);
+      expectLib
+        .expect(outputDestinations.normalizeDestinations(['terminal', 'terminal', 'repl-window']))
+        .toStrictEqual(['terminal', 'repl-window']);
     });
 
     it('returns an empty array for an empty array (silent)', () => {
-      expect(normalizeDestinations([])).toStrictEqual([]);
+      expectLib.expect(outputDestinations.normalizeDestinations([])).toStrictEqual([]);
     });
 
     it('wraps a file path string in an array', () => {
-      expect(normalizeDestinations('./log.txt')).toStrictEqual(['./log.txt']);
+      expectLib
+        .expect(outputDestinations.normalizeDestinations('./log.txt'))
+        .toStrictEqual(['./log.txt']);
     });
 
     it('accepts file path strings alongside builtins', () => {
-      expect(normalizeDestinations(['terminal', './log.txt'])).toStrictEqual([
-        'terminal',
-        './log.txt',
-      ]);
+      expectLib
+        .expect(outputDestinations.normalizeDestinations(['terminal', './log.txt']))
+        .toStrictEqual(['terminal', './log.txt']);
     });
 
     it('joins nested array path segments', () => {
-      const result = normalizeDestinations(['terminal', ['.', 'logs', 'out.txt']]);
-      expect(result).toStrictEqual(['terminal', path.join('.', 'logs', 'out.txt')]);
+      const result = outputDestinations.normalizeDestinations([
+        'terminal',
+        ['.', 'logs', 'out.txt'],
+      ]);
+      expectLib.expect(result).toStrictEqual(['terminal', path.join('.', 'logs', 'out.txt')]);
     });
 
     it('treats flat array of strings as separate destinations, not path segments', () => {
-      expect(normalizeDestinations(['.', 'logs', 'out.txt'])).toStrictEqual([
-        '.',
-        'logs',
-        'out.txt',
-      ]);
+      expectLib
+        .expect(outputDestinations.normalizeDestinations(['.', 'logs', 'out.txt']))
+        .toStrictEqual(['.', 'logs', 'out.txt']);
     });
 
     it('deduplicates file path destinations', () => {
-      expect(normalizeDestinations(['./log.txt', './log.txt'])).toStrictEqual(['./log.txt']);
+      expectLib
+        .expect(outputDestinations.normalizeDestinations(['./log.txt', './log.txt']))
+        .toStrictEqual(['./log.txt']);
     });
   });
 });

--- a/src/extension-test/unit/paredit/commands-test.ts
+++ b/src/extension-test/unit/paredit/commands-test.ts
@@ -1,7 +1,7 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as model from '../../../cursor-doc/model';
 import * as handlers from '../../../paredit/commands';
-import { docFromTextNotation, textNotationFromDoc } from '../common/text-notation';
+import * as textNotation from '../common/text-notation';
 import _ = require('lodash');
 
 model.initScanner(20000);
@@ -21,313 +21,313 @@ describe('paredit commands', () => {
   describe('movement', () => {
     describe('forwardSexp', () => {
       it('Single-cursor: find the list in front', () => {
-        const a = docFromTextNotation('|(a b [c])•|1(a b [c])');
-        const b = docFromTextNotation('(a b [c])|•(a b [c])');
+        const a = textNotation.docFromTextNotation('|(a b [c])•|1(a b [c])');
+        const b = textNotation.docFromTextNotation('(a b [c])|•(a b [c])');
         handlers.forwardSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursors: find the list in front', () => {
-        const a = docFromTextNotation('|(a b [c])•|1(a b [c])');
-        const b = docFromTextNotation('(a b [c])|•(a b [c])|1');
+        const a = textNotation.docFromTextNotation('|(a b [c])•|1(a b [c])');
+        const b = textNotation.docFromTextNotation('(a b [c])|•(a b [c])|1');
         handlers.forwardSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Single-cursor: find the list in front through metadata', () => {
-        const a = docFromTextNotation('|^:a (b c [d])•|1^:a (b c [d])');
-        const b = docFromTextNotation('^:a (b c [d])|•^:a (b c [d])');
+        const a = textNotation.docFromTextNotation('|^:a (b c [d])•|1^:a (b c [d])');
+        const b = textNotation.docFromTextNotation('^:a (b c [d])|•^:a (b c [d])');
         handlers.forwardSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursors: find the list in front through metadata', () => {
-        const a = docFromTextNotation('|^:a (b c [d])•|1^:a (b c [d])');
-        const b = docFromTextNotation('^:a (b c [d])|•^:a (b c [d])|1');
+        const a = textNotation.docFromTextNotation('|^:a (b c [d])•|1^:a (b c [d])');
+        const b = textNotation.docFromTextNotation('^:a (b c [d])|•^:a (b c [d])|1');
         handlers.forwardSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Single-cursor: find the list in front through metadata and readers', () => {
-        const a = docFromTextNotation('|^:f #a #b (c d [e])•|1^:f #a #b (c d [e])');
-        const b = docFromTextNotation('^:f #a #b (c d [e])|•^:f #a #b (c d [e])');
+        const a = textNotation.docFromTextNotation('|^:f #a #b (c d [e])•|1^:f #a #b (c d [e])');
+        const b = textNotation.docFromTextNotation('^:f #a #b (c d [e])|•^:f #a #b (c d [e])');
         handlers.forwardSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursors: find the list in front through metadata and readers', () => {
-        const a = docFromTextNotation('|^:f #a #b (c d [e])•|1^:f #a #b (c d [e])');
-        const b = docFromTextNotation('^:f #a #b (c d [e])|•^:f #a #b (c d [e])|1');
+        const a = textNotation.docFromTextNotation('|^:f #a #b (c d [e])•|1^:f #a #b (c d [e])');
+        const b = textNotation.docFromTextNotation('^:f #a #b (c d [e])|•^:f #a #b (c d [e])|1');
         handlers.forwardSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Single-cursor: find the list in front through metadata and readers', () => {
-        const a = docFromTextNotation('|^:f #a #b (c d [e])•|1^:f #a #b (c d [e])');
-        const b = docFromTextNotation('^:f #a #b (c d [e])|•^:f #a #b (c d [e])');
+        const a = textNotation.docFromTextNotation('|^:f #a #b (c d [e])•|1^:f #a #b (c d [e])');
+        const b = textNotation.docFromTextNotation('^:f #a #b (c d [e])|•^:f #a #b (c d [e])');
         handlers.forwardSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursors: find the list in front through metadata and readers', () => {
-        const a = docFromTextNotation('|^:f #a #b (c d [e])•|1^:f #a #b (c d [e])');
-        const b = docFromTextNotation('^:f #a #b (c d [e])|•^:f #a #b (c d [e])|1');
+        const a = textNotation.docFromTextNotation('|^:f #a #b (c d [e])•|1^:f #a #b (c d [e])');
+        const b = textNotation.docFromTextNotation('^:f #a #b (c d [e])|•^:f #a #b (c d [e])|1');
         handlers.forwardSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Single-cursor: do not find anything at end of list', () => {
-        const a = docFromTextNotation('(|)•(|1)');
-        const b = docFromTextNotation('(|)•()');
+        const a = textNotation.docFromTextNotation('(|)•(|1)');
+        const b = textNotation.docFromTextNotation('(|)•()');
         handlers.forwardSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursors: do not find anything at end of list', () => {
-        const a = docFromTextNotation('(|)•(|1)');
-        const b = docFromTextNotation('(|)•(|1)');
+        const a = textNotation.docFromTextNotation('(|)•(|1)');
+        const b = textNotation.docFromTextNotation('(|)•(|1)');
         handlers.forwardSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Single-cursor: Cursor 1 finds fwd sexp, cursor 2 does not, cursor 3 does', () => {
-        const a = docFromTextNotation('(|a)•(|1)•|2(b)');
-        const b = docFromTextNotation('(a|)•()•(b)');
+        const a = textNotation.docFromTextNotation('(|a)•(|1)•|2(b)');
+        const b = textNotation.docFromTextNotation('(a|)•()•(b)');
         handlers.forwardSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursors: Cursor 1 finds fwd sexp, cursor 2 does not, cursor 3 does', () => {
-        const a = docFromTextNotation('(|a)•(|1)•|2(b)');
-        const b = docFromTextNotation('(a|)•(|1)•(b)|2');
+        const a = textNotation.docFromTextNotation('(|a)•(|1)•|2(b)');
+        const b = textNotation.docFromTextNotation('(a|)•(|1)•(b)|2');
         handlers.forwardSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
     });
 
     describe('backwardSexp', () => {
       it('Single-cursor: find the list preceding', () => {
-        const a = docFromTextNotation('(def foo |1[vec])|');
-        const b = docFromTextNotation('|(def foo [vec])');
+        const a = textNotation.docFromTextNotation('(def foo |1[vec])|');
+        const b = textNotation.docFromTextNotation('|(def foo [vec])');
         handlers.backwardSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursor: find the list preceding', () => {
-        const a = docFromTextNotation('(def foo |1[vec])|');
-        const b = docFromTextNotation('|(def |1foo [vec])');
+        const a = textNotation.docFromTextNotation('(def foo |1[vec])|');
+        const b = textNotation.docFromTextNotation('|(def |1foo [vec])');
         handlers.backwardSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: find the list preceding through metadata', () => {
-        const a = docFromTextNotation('^:foo (def |1foo [vec])|');
-        const b = docFromTextNotation('|^:foo (def foo [vec])');
+        const a = textNotation.docFromTextNotation('^:foo (def |1foo [vec])|');
+        const b = textNotation.docFromTextNotation('|^:foo (def foo [vec])');
         handlers.backwardSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursor: find the list preceding through metadata', () => {
-        const a = docFromTextNotation('^:foo (def |1foo [vec])|');
-        const b = docFromTextNotation('|^:foo (|1def foo [vec])');
+        const a = textNotation.docFromTextNotation('^:foo (def |1foo [vec])|');
+        const b = textNotation.docFromTextNotation('|^:foo (|1def foo [vec])');
         handlers.backwardSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: find the list preceding through metadata and readers', () => {
-        const a = docFromTextNotation('^:f #a #b (def |1foo [vec])|');
-        const b = docFromTextNotation('|^:f #a #b (def foo [vec])');
+        const a = textNotation.docFromTextNotation('^:f #a #b (def |1foo [vec])|');
+        const b = textNotation.docFromTextNotation('|^:f #a #b (def foo [vec])');
         handlers.backwardSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursor: find the list preceding through metadata and readers', () => {
-        const a = docFromTextNotation('^:f #a #b (def |1foo [vec])|');
-        const b = docFromTextNotation('|^:f #a #b (|1def foo [vec])');
+        const a = textNotation.docFromTextNotation('^:f #a #b (def |1foo [vec])|');
+        const b = textNotation.docFromTextNotation('|^:f #a #b (|1def foo [vec])');
         handlers.backwardSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: find the list preceding through metadata and readers', () => {
-        const a = docFromTextNotation('#c ^:f #a #b (def |1foo [vec])|');
-        const b = docFromTextNotation('|#c ^:f #a #b (def foo [vec])');
+        const a = textNotation.docFromTextNotation('#c ^:f #a #b (def |1foo [vec])|');
+        const b = textNotation.docFromTextNotation('|#c ^:f #a #b (def foo [vec])');
         handlers.backwardSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursor: find the list preceding through metadata and readers', () => {
-        const a = docFromTextNotation('#c ^:f #a #b (def |1foo [vec])|');
-        const b = docFromTextNotation('|#c ^:f #a #b (|1def foo [vec])');
+        const a = textNotation.docFromTextNotation('#c ^:f #a #b (def |1foo [vec])|');
+        const b = textNotation.docFromTextNotation('|#c ^:f #a #b (|1def foo [vec])');
         handlers.backwardSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: do not find anything at start of list', () => {
-        const a = docFromTextNotation('(|)•(|1)');
-        const b = docFromTextNotation('(|)•()');
+        const a = textNotation.docFromTextNotation('(|)•(|1)');
+        const b = textNotation.docFromTextNotation('(|)•()');
         handlers.backwardSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursor: do not find anything at start of list', () => {
-        const a = docFromTextNotation('(|)•(|1)');
-        const b = docFromTextNotation('(|)•(|1)');
+        const a = textNotation.docFromTextNotation('(|)•(|1)');
+        const b = textNotation.docFromTextNotation('(|)•(|1)');
         handlers.backwardSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds previous form, including space, and reverses direction', () => {
-        const a = docFromTextNotation('(def <foo [vec]<)|1');
-        const b = docFromTextNotation('(|def foo [vec])');
+        const a = textNotation.docFromTextNotation('(def <foo [vec]<)|1');
+        const b = textNotation.docFromTextNotation('(|def foo [vec])');
         handlers.backwardSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursor: Finds previous form, including space, and reverses direction', () => {
-        const a = docFromTextNotation('(def <foo [vec]<)|1');
-        const b = docFromTextNotation('|1(|def foo [vec])');
+        const a = textNotation.docFromTextNotation('(def <foo [vec]<)|1');
+        const b = textNotation.docFromTextNotation('|1(|def foo [vec])');
         handlers.backwardSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Cursor 1 finds bwd sexp, cursor 2 does not, cursor 3 does', () => {
-        const a = docFromTextNotation('(a|)•(|1)•|2(b)');
-        const b = docFromTextNotation('(|a)•()•(b)');
+        const a = textNotation.docFromTextNotation('(a|)•(|1)•|2(b)');
+        const b = textNotation.docFromTextNotation('(|a)•()•(b)');
         handlers.backwardSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursor: Cursor 1 finds bwd sexp, cursor 2 does not, cursor 3 does', () => {
-        const a = docFromTextNotation('(a|)•(|1)•|2(b)');
-        const b = docFromTextNotation('(|a)•|2(|1)•(b)');
+        const a = textNotation.docFromTextNotation('(a|)•(|1)•|2(b)');
+        const b = textNotation.docFromTextNotation('(|a)•|2(|1)•(b)');
         handlers.backwardSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
     });
 
     describe('forwardDownSexp', () => {
       it('Single-cursor: ', () => {
-        const a = docFromTextNotation('(|c•(|1#b •[:f :b :z])•#z•1)');
-        const b = docFromTextNotation('(c•(|#b •[:f :b :z])•#z•1)');
+        const a = textNotation.docFromTextNotation('(|c•(|1#b •[:f :b :z])•#z•1)');
+        const b = textNotation.docFromTextNotation('(c•(|#b •[:f :b :z])•#z•1)');
         handlers.forwardDownSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursor: ', () => {
-        const a = docFromTextNotation('(|c•(|1#b •[:f :b :z])•#z•1)');
-        const b = docFromTextNotation('(c•(|#b •[|1:f :b :z])•#z•1)');
+        const a = textNotation.docFromTextNotation('(|c•(|1#b •[:f :b :z])•#z•1)');
+        const b = textNotation.docFromTextNotation('(c•(|#b •[|1:f :b :z])•#z•1)');
         handlers.forwardDownSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
     });
 
     describe('backwardDownSexp', () => {
       it('Single-cursor: ', () => {
-        const a = docFromTextNotation('(c•(#b •[:f :b :z])|1•#z•1)|');
-        const b = docFromTextNotation('(c•(#b •[:f :b :z])•#z•1|)');
+        const a = textNotation.docFromTextNotation('(c•(#b •[:f :b :z])|1•#z•1)|');
+        const b = textNotation.docFromTextNotation('(c•(#b •[:f :b :z])•#z•1|)');
         handlers.backwardDownSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursor: ', () => {
-        const a = docFromTextNotation('(c•(#b •[:f :b :z])|1•#z•1)|');
-        const b = docFromTextNotation('(c•(#b •[:f :b :z]|1)•#z•1|)');
+        const a = textNotation.docFromTextNotation('(c•(#b •[:f :b :z])|1•#z•1)|');
+        const b = textNotation.docFromTextNotation('(c•(#b •[:f :b :z]|1)•#z•1|)');
         handlers.backwardDownSexp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
     });
 
     describe('forwardUpSexp', () => {
       it('Single-cursor: ', () => {
-        const a = docFromTextNotation('|2(c•(#b •[:f |1:b :z|])•#z•1|3)');
-        const b = docFromTextNotation('(c•(#b •[:f :b :z]|)•#z•1)');
+        const a = textNotation.docFromTextNotation('|2(c•(#b •[:f |1:b :z|])•#z•1|3)');
+        const b = textNotation.docFromTextNotation('(c•(#b •[:f :b :z]|)•#z•1)');
         handlers.forwardUpSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursor: ', () => {
-        const a = docFromTextNotation('|1(c•(#b •[:f |:b :z|])•#z•1|2)');
-        const b = docFromTextNotation('|1(c•(#b •[:f :b :z]|)•#z•1)|2');
+        const a = textNotation.docFromTextNotation('|1(c•(#b •[:f |:b :z|])•#z•1|2)');
+        const b = textNotation.docFromTextNotation('|1(c•(#b •[:f :b :z]|)•#z•1)|2');
         handlers.forwardUpSexp(a, true);
-        expect(a.selections).toEqual(b.selections);
+        expectLib.expect(a.selections).toEqual(b.selections);
       });
     });
 
     describe('backwardUpSexp', () => {
       it('Single-cursor: ', () => {
-        const a = docFromTextNotation('(c•(|#b •[|1:f|2 :b :z])•#z•1)|3');
-        const b = docFromTextNotation('(c•|(#b •[:f :b :z])•#z•1)');
+        const a = textNotation.docFromTextNotation('(c•(|#b •[|1:f|2 :b :z])•#z•1)|3');
+        const b = textNotation.docFromTextNotation('(c•|(#b •[:f :b :z])•#z•1)');
         handlers.backwardUpSexp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursor: ', () => {
-        const a = docFromTextNotation('(c•(|#b •[|1:f|2 :b :z])•#z•1)|3');
-        const b = docFromTextNotation('(c•|(|1#b •[:f :b :z])•#z•1)|2');
+        const a = textNotation.docFromTextNotation('(c•(|#b •[|1:f|2 :b :z])•#z•1)|3');
+        const b = textNotation.docFromTextNotation('(c•|(|1#b •[:f :b :z])•#z•1)|2');
         handlers.backwardUpSexp(a, true);
-        expect(a.selections).toEqual(b.selections);
+        expectLib.expect(a.selections).toEqual(b.selections);
       });
     });
 
     describe('forwardSexpOrUp', () => {
       it('Single-cursor: leave sexp if at the end', () => {
-        const a = docFromTextNotation('(a|)•(b|1)');
-        const b = docFromTextNotation('(a)|•(b)');
+        const a = textNotation.docFromTextNotation('(a|)•(b|1)');
+        const b = textNotation.docFromTextNotation('(a)|•(b)');
         handlers.forwardSexpOrUp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursors: leave sexp if at the end', () => {
-        const a = docFromTextNotation('(a|)•(b|1)');
-        const b = docFromTextNotation('(a)|•(b)|1');
+        const a = textNotation.docFromTextNotation('(a|)•(b|1)');
+        const b = textNotation.docFromTextNotation('(a)|•(b)|1');
         handlers.forwardSexpOrUp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Single-cursor: one goes fwd a sexp, one leaves sexp b/c at the end', () => {
-        const a = docFromTextNotation('(|a)•(b|1)');
-        const b = docFromTextNotation('(a|)•(b)');
+        const a = textNotation.docFromTextNotation('(|a)•(b|1)');
+        const b = textNotation.docFromTextNotation('(a|)•(b)');
         handlers.forwardSexpOrUp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursors: one goes fwd a sexp, one leaves sexp b/c at the end', () => {
-        const a = docFromTextNotation('(|a)•(b|1)');
-        const b = docFromTextNotation('(a|)•(b)|1');
+        const a = textNotation.docFromTextNotation('(|a)•(b|1)');
+        const b = textNotation.docFromTextNotation('(a|)•(b)|1');
         handlers.forwardSexpOrUp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
     });
 
     describe('backwardSexpOrUp', () => {
       it('Single-cursor: go up when at front bounds', () => {
-        const a = docFromTextNotation('(|1a (|b 1))');
-        const b = docFromTextNotation('(a |(b 1))');
+        const a = textNotation.docFromTextNotation('(|1a (|b 1))');
+        const b = textNotation.docFromTextNotation('(a |(b 1))');
         handlers.backwardSexpOrUp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursors: go up when at front bounds', () => {
-        const a = docFromTextNotation('(|1a (|b 1))');
-        const b = docFromTextNotation('|1(a |(b 1))');
+        const a = textNotation.docFromTextNotation('(|1a (|b 1))');
+        const b = textNotation.docFromTextNotation('|1(a |(b 1))');
         handlers.backwardSexpOrUp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Single-cursor: one go up when at front bounds, the other back sexp', () => {
-        const a = docFromTextNotation('(|1a (b c|))');
-        const b = docFromTextNotation('(a (b |c))');
+        const a = textNotation.docFromTextNotation('(|1a (b c|))');
+        const b = textNotation.docFromTextNotation('(a (b |c))');
         handlers.backwardSexpOrUp(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursors: one go up when at front bounds, the other back sexp', () => {
-        const a = docFromTextNotation('(|1a (b c|))');
-        const b = docFromTextNotation('|1(a (b |c))');
+        const a = textNotation.docFromTextNotation('(|1a (b c|))');
+        const b = textNotation.docFromTextNotation('|1(a (b |c))');
         handlers.backwardSexpOrUp(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
     });
 
     describe('closeList', () => {
       it('Single-cursor: ', () => {
-        const a = docFromTextNotation('|(c•(|1#b •[:f :b :z])•#z•1)');
-        const b = docFromTextNotation('|(c•(#b •[:f :b :z])•#z•1)');
+        const a = textNotation.docFromTextNotation('|(c•(|1#b •[:f :b :z])•#z•1)');
+        const b = textNotation.docFromTextNotation('|(c•(#b •[:f :b :z])•#z•1)');
         handlers.closeList(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursor: ', () => {
-        const a = docFromTextNotation('|(c•(|1#b •[:f :b :z])•#z•1)');
-        const b = docFromTextNotation('|(c•(#b •[:f :b :z]|1)•#z•1)');
+        const a = textNotation.docFromTextNotation('|(c•(|1#b •[:f :b :z])•#z•1)');
+        const b = textNotation.docFromTextNotation('|(c•(#b •[:f :b :z]|1)•#z•1)');
         handlers.closeList(a, true);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
     });
 
     describe('openList', () => {
       it('Single-cursor: ', () => {
-        const a = docFromTextNotation('(c•|(|1#b •[:f :b :z])|2•#z•1)');
-        const b = docFromTextNotation('(|c•(#b •[:f :b :z])•#z•1)');
+        const a = textNotation.docFromTextNotation('(c•|(|1#b •[:f :b :z])|2•#z•1)');
+        const b = textNotation.docFromTextNotation('(|c•(#b •[:f :b :z])•#z•1)');
         handlers.openList(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
       it('Multi-cursor: ', () => {
-        const a = docFromTextNotation('(c•|(|1#b •[:f :b :z])|2•#z•1)');
-        const b = docFromTextNotation('(|c•(|1#b •[:f :b :z])•#z•1)');
+        const a = textNotation.docFromTextNotation('(c•|(|1#b •[:f :b :z])|2•#z•1)');
+        const b = textNotation.docFromTextNotation('(|c•(|1#b •[:f :b :z])•#z•1)');
         handlers.openList(a, true);
-        expect(a.selections).toEqual(b.selections);
+        expectLib.expect(a.selections).toEqual(b.selections);
       });
     });
   });
@@ -335,445 +335,461 @@ describe('paredit commands', () => {
   describe('selection', () => {
     describe('selectCurrentForm', () => {
       it('Single-cursor: handles cases like reader tags/metadata + keeps other selections ', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn|1 [a b]•(let [^js a|a #p (+ a)•b b]•{:a aa•:b b}))•(:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [|^js aa| #p (+ a)•b b]•{:a aa•:b b}))•(:a)'
         );
         handlers.selectCurrentForm(a, false);
-        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib
+          .expect(textNotation.textNotationFromDoc(a))
+          .toEqual(textNotation.textNotationFromDoc(b));
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor: handles cases like reader tags/metadata + keeps other selections ', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn|1 |2[a b]•(let [|3^js aa |4#p (+ a)•<5b b<5]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(|1defn|1 |2[a b]|2•(let [|3^js aa|3 |4#p (+ a)|4•<5b b<5]•{:a aa•:b b}))•(|:a|)'
         );
         handlers.selectCurrentForm(a, true);
-        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib
+          .expect(textNotation.textNotationFromDoc(a))
+          .toEqual(textNotation.textNotationFromDoc(b));
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
 
       it('Single-cursor: handles cursor at a distance from form', () => {
-        const a = docFromTextNotation('[|1    a b  |2c    d { e f}|3 g   |]');
+        const a = textNotation.docFromTextNotation('[|1    a b  |2c    d { e f}|3 g   |]');
         const aSelections = a.selections;
-        const b = docFromTextNotation('[    a b  c    d { e f} |g|   ]');
+        const b = textNotation.docFromTextNotation('[    a b  c    d { e f} |g|   ]');
         handlers.selectCurrentForm(a, false);
-        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib
+          .expect(textNotation.textNotationFromDoc(a))
+          .toEqual(textNotation.textNotationFromDoc(b));
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor: handles cursor at a distance from form', () => {
-        const a = docFromTextNotation('[|1    a b  |2c    d { e f}|3 g   |]');
+        const a = textNotation.docFromTextNotation('[|1    a b  |2c    d { e f}|3 g   |]');
         const aSelections = a.selections;
-        const b = docFromTextNotation('[    |1a|1 b  |2c|2    d |3{ e f}|3 |g|   ]');
+        const b = textNotation.docFromTextNotation('[    |1a|1 b  |2c|2    d |3{ e f}|3 |g|   ]');
         handlers.selectCurrentForm(a, true);
-        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib
+          .expect(textNotation.textNotationFromDoc(a))
+          .toEqual(textNotation.textNotationFromDoc(b));
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
 
       it('Single-cursor: collapses overlapping selections', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(de|1fn| [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(|defn| [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:a)'
         );
         handlers.selectCurrentForm(a, false);
-        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib
+          .expect(textNotation.textNotationFromDoc(a))
+          .toEqual(textNotation.textNotationFromDoc(b));
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor: collapses overlapping selections', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(de|5fn|1 |2[a b]•(let [|3^js aa |4#p (+ a)•<5b b<5]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(|1defn|1 |2[a b]|2•(let [|3^js aa|3 |4#p (+ a)|4•<5b b<5]•{:a aa•:b b}))•(|:a|)'
         );
         handlers.selectCurrentForm(a, true);
-        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib
+          .expect(textNotation.textNotationFromDoc(a))
+          .toEqual(textNotation.textNotationFromDoc(b));
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
 
       it('Single-cursor: collapses overlapping selections preferring the larger one', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(de|1fn| [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(|defn| [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:a)'
         );
         handlers.selectCurrentForm(a, false);
-        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib
+          .expect(textNotation.textNotationFromDoc(a))
+          .toEqual(textNotation.textNotationFromDoc(b));
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor: collapses overlapping selections preferring the larger one', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b |b]|1•|3{:a a|2a•:b b}))•(:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let |1[^js aa #p (+ a)•b b]|1•|3{:a aa•:b b}|3))•(:a)'
         );
         handlers.selectCurrentForm(a, true);
-        expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib
+          .expect(textNotation.textNotationFromDoc(a))
+          .toEqual(textNotation.textNotationFromDoc(b));
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
     describe('rangeForDefun', () => {
       it('Single-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•|(:a)|'
         );
         handlers.rangeForDefun(a, false);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '|1(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))|1•|(:a)|'
         );
         handlers.rangeForDefun(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
     describe('sexpRangeExpansion', () => {
       it('Single-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(|:a|)'
         );
         handlers.sexpRangeExpansion(a, false);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(|1defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(|:a|)'
         );
         handlers.sexpRangeExpansion(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
     describe('sexpRangeContraction', () => {
       it('Single-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(|:a|)'
         );
         handlers.sexpRangeExpansion(a, false);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
-        const c = docFromTextNotation(
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        const c = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•|(:a)|'
         );
         handlers.sexpRangeExpansion(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections, c.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections, c.selections]);
         handlers.sexpRangeContraction(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(|1defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(|:a|)'
         );
         handlers.sexpRangeExpansion(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
-        const c = docFromTextNotation(
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        const c = textNotation.docFromTextNotation(
           '(|1defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b})|1)•|(:a)|'
         );
         handlers.sexpRangeExpansion(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections, c.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections, c.selections]);
         handlers.sexpRangeContraction(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
     describe('selectForwardSexp', () => {
       it('Single-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(<1defn<1 [a b]•(let [^js |2aa|2 #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a|)'
         );
         handlers.selectForwardSexp(a, false);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(<1defn<1 [a b]•(let [^js |2aa|2 #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn|1 |1[a b]•(let [^js |2aa #p (+ a)|2•b b]•{:a aa•:b b}))•(:|a|)'
         );
         handlers.selectForwardSexp(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
     describe('selectRight', () => {
       it('Single-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(<1defn<1 [a b]•(let [^js |2aa|2 #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a|)'
         );
         handlers.selectRight(a, false);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(<1defn<1 [a b]•(let [^js |2aa|2 #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn|1 [a b]|1•(let [^js |2aa #p (+ a)|2•b b]•{:a aa•:b b}))•(:|a|)'
         );
         handlers.selectRight(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
     describe('selectBackwardSexp', () => {
       it('Single-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(|1defn|1 [a b]•(let [^js aa #p|2 (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(<:<a)'
         );
         handlers.selectBackwardSexp(a, false);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(|1defn|1 [a b]•(let [^js aa #p|2 (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(|1defn [a b]•(let [<2^js aa #p<2 (+ a)•b b]•{:a aa•:b b}))•(<:<a)'
         );
         handlers.selectBackwardSexp(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
     describe('selectForwardDownSexp', () => {
       it('Single-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(<1defn<1 [a b|2]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•|(:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•|(|:a)'
         );
         handlers.selectForwardDownSexp(a, false);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(<1defn<1 [a b|2]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•|(:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn|1 [|1a b|2]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•|(|:a)'
         );
         handlers.selectForwardDownSexp(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
     describe('selectBackwardDownSexp', () => {
       it('Single-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(<1defn<1 [a b|2]|2•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•|(:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b})<)•<(:a)'
         );
         handlers.selectBackwardDownSexp(a, false);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(<1defn<1 [a b|2]|2•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•|(:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(<1defn<1 [a b|2]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b})<)•<(:a)'
         );
         handlers.selectBackwardDownSexp(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
     describe('selectForwardUpSexp', () => {
       it('Single-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(<1defn<1 [a b|2]|2•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•|(:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•|(:a)'
         );
         handlers.selectForwardUpSexp(a, false);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(<1defn<1 [a b|2]|2•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•|(:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))|1•|(:a)'
         );
         handlers.selectForwardUpSexp(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
     describe('selectForwardSexpOrUp', () => {
       it('Single-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(<1defn<1 [a b|2]|2•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•|(:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•|(:a)|'
         );
         handlers.selectForwardSexpOrUp(a, false);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(<1defn<1 [a b|2]|2•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•|(:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn|1 |1[a b|2]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b})|2)•|(:a)|'
         );
         handlers.selectForwardSexpOrUp(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
     describe('selectBackwardSexpOrUp', () => {
       it('Single-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(<1defn<1 [a b|2]|2•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(|:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•<(<:a)'
         );
         handlers.selectBackwardSexpOrUp(a, false);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(<1defn<1 [a b|2]|2•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(|:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '<1(defn<1 <2[a b<2]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•<(<:a)'
         );
         handlers.selectBackwardSexpOrUp(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
     describe('selectBackwardUpSexp', () => {
       it('Single-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn |1[a b|2]|2•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(|:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•<(<:a)'
         );
         handlers.selectBackwardUpSexp(a, false);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn |1[a b|2]|2•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(|:a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '<1(defn [a b<1]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•<(<:a)'
         );
         handlers.selectBackwardUpSexp(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
     describe('selectCloseList', () => {
       it('Single-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a|)'
         );
         handlers.selectCloseList(a, false);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b})|1)•(:|a|)'
         );
         handlers.selectCloseList(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
     describe('selectOpenList', () => {
       it('Single-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn|1 [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(<:<a)'
         );
         handlers.selectOpenList(a, false);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
       it('Multi-cursor:', () => {
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(:|a)'
         );
         const aSelections = a.selections;
-        const b = docFromTextNotation(
+        const b = textNotation.docFromTextNotation(
           '(defn [a b]•(let [^js aa #p (+ a)•b b]•{:a aa•:b b}))•(<:<a)'
         );
         handlers.selectOpenList(a, true);
-        expect(a.selectionsStack).toEqual([aSelections, b.selections]);
+        expectLib.expect(a.selectionsStack).toEqual([aSelections, b.selections]);
       });
     });
   });
@@ -783,398 +799,408 @@ describe('paredit commands', () => {
       // TODO: Test kill-also-copies?
       // TODO: Test mullticursor
       it('Single-cursor: Finds whole string in list', async () => {
-        const a = docFromTextNotation('("This needs to find the start of the string."|)');
-        const b = docFromTextNotation('(|)');
+        const a = textNotation.docFromTextNotation(
+          '("This needs to find the start of the string."|)'
+        );
+        const b = textNotation.docFromTextNotation('(|)');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds whole string', async () => {
-        const a = docFromTextNotation('"This needs to find the start of the string."|');
-        const b = docFromTextNotation('|');
+        const a = textNotation.docFromTextNotation(
+          '"This needs to find the start of the string."|'
+        );
+        const b = textNotation.docFromTextNotation('|');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, 'model')).toEqual(_.omit(b, 'model'));
+        expectLib.expect(_.omit(a, 'model')).toEqual(_.omit(b, 'model'));
       });
 
       it('Single-cursor: Finds start of string', async () => {
-        const a = docFromTextNotation('"This needs to find the |start of the string."');
-        const b = docFromTextNotation('"|start of the string."');
+        const a = textNotation.docFromTextNotation(
+          '"This needs to find the |start of the string."'
+        );
+        const b = textNotation.docFromTextNotation('"|start of the string."');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds line content start in multi line string', async () => {
-        const a = docFromTextNotation('"This needs to find the start\n of the |string."');
-        const b = docFromTextNotation('"This needs to find the start\n |string."');
+        const a = textNotation.docFromTextNotation(
+          '"This needs to find the start\n of the |string."'
+        );
+        const b = textNotation.docFromTextNotation('"This needs to find the start\n |string."');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds line content start in multi line string (Windows)', async () => {
-        const a = docFromTextNotation('"This needs to find the start\r\n of the |string."');
-        const b = docFromTextNotation('"This needs to find the start\r\n |string."');
+        const a = textNotation.docFromTextNotation(
+          '"This needs to find the start\r\n of the |string."'
+        );
+        const b = textNotation.docFromTextNotation('"This needs to find the start\r\n |string."');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds start of form from inside comment', async () => {
-        const a = docFromTextNotation('(a ;; foo|\n e)');
-        const b = docFromTextNotation('(|\n e)');
+        const a = textNotation.docFromTextNotation('(a ;; foo|\n e)');
+        const b = textNotation.docFromTextNotation('(|\n e)');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds start of form from inside comment (Windows)', async () => {
-        const a = docFromTextNotation('(a ;; foo|\r\n e)');
-        const b = docFromTextNotation('(|\r\n e)');
+        const a = textNotation.docFromTextNotation('(a ;; foo|\r\n e)');
+        const b = textNotation.docFromTextNotation('(|\r\n e)');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Maintains balanced delimiters 1', async () => {
-        const a = docFromTextNotation('(a b (c\n d) e|)');
-        const b = docFromTextNotation('(a b |)');
+        const a = textNotation.docFromTextNotation('(a b (c\n d) e|)');
+        const b = textNotation.docFromTextNotation('(a b |)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Maintains balanced delimiters 1 (Windows)', async () => {
-        const a = docFromTextNotation('(a b (c\r\n d) e|)');
-        const b = docFromTextNotation('(a b |)');
+        const a = textNotation.docFromTextNotation('(a b (c\r\n d) e|)');
+        const b = textNotation.docFromTextNotation('(a b |)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Maintains balanced delimiters 2', async () => {
-        const a = docFromTextNotation('(aa (c (e\nf)) |g)');
-        const b = docFromTextNotation('(aa |g)');
+        const a = textNotation.docFromTextNotation('(aa (c (e\nf)) |g)');
+        const b = textNotation.docFromTextNotation('(aa |g)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Maintains balanced delimiters 2 (Windows)', async () => {
-        const a = docFromTextNotation('(aa (c (e\r\nf)) |g)');
-        const b = docFromTextNotation('(aa |g)');
+        const a = textNotation.docFromTextNotation('(aa (c (e\r\nf)) |g)');
+        const b = textNotation.docFromTextNotation('(aa |g)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Maintains balanced delimiters 3', async () => {
-        const a = docFromTextNotation('(aa (  c (e\nf)) |g)');
-        const b = docFromTextNotation('(aa |g)');
+        const a = textNotation.docFromTextNotation('(aa (  c (e\nf)) |g)');
+        const b = textNotation.docFromTextNotation('(aa |g)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Maintains balanced delimiters 3 (Windows)', async () => {
-        const a = docFromTextNotation('(aa (  c (e\r\nf)) |g)');
-        const b = docFromTextNotation('(aa |g)');
+        const a = textNotation.docFromTextNotation('(aa (  c (e\r\nf)) |g)');
+        const b = textNotation.docFromTextNotation('(aa |g)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Squashes preceding whitespace, stopping at line start', async () => {
-        const a = docFromTextNotation('(a\n |e) g)');
-        const b = docFromTextNotation('(a\n|e) g)');
+        const a = textNotation.docFromTextNotation('(a\n |e) g)');
+        const b = textNotation.docFromTextNotation('(a\n|e) g)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Squashes preceding whitespace, stopping at line start (Windows)', async () => {
-        const a = docFromTextNotation('(a\r\n |e) g)');
-        const b = docFromTextNotation('(a\r\n|e) g)');
+        const a = textNotation.docFromTextNotation('(a\r\n |e) g)');
+        const b = textNotation.docFromTextNotation('(a\r\n|e) g)');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Retreats past line start when invoked at line start', async () => {
-        const a = docFromTextNotation('(a\n| e) g)');
-        const b = docFromTextNotation('(a| e) g)');
+        const a = textNotation.docFromTextNotation('(a\n| e) g)');
+        const b = textNotation.docFromTextNotation('(a| e) g)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Retreats past line start when invoked at line start (Windows)', async () => {
-        const a = docFromTextNotation('(a\r\n| e) g)');
-        const b = docFromTextNotation('(a| e) g)');
+        const a = textNotation.docFromTextNotation('(a\r\n| e) g)');
+        const b = textNotation.docFromTextNotation('(a| e) g)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Retreats past line start when invoked at line start 2', async () => {
-        const a = docFromTextNotation('(:a :b \n|)');
-        const b = docFromTextNotation('(:a :b |)');
+        const a = textNotation.docFromTextNotation('(:a :b \n|)');
+        const b = textNotation.docFromTextNotation('(:a :b |)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       // This one catches the weird `\r\n\|)` case, described inside `backwardHybredSexpRange`'s line comments.
       it('Single-cursor: Retreats past line start when invoked at line start 2 (Windows)', async () => {
-        const a = docFromTextNotation('(:a :b \r\n|)');
-        const b = docFromTextNotation('(:a :b |)');
+        const a = textNotation.docFromTextNotation('(:a :b \r\n|)');
+        const b = textNotation.docFromTextNotation('(:a :b |)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Retreats past line start, squashing whitepace when invoked at line start', async () => {
-        const a = docFromTextNotation('(a  \n| e) g)');
-        const b = docFromTextNotation('(a | e) g)');
+        const a = textNotation.docFromTextNotation('(a  \n| e) g)');
+        const b = textNotation.docFromTextNotation('(a | e) g)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Retreats past line start, squashing whitepace when invoked at line start (Windows)', async () => {
-        const a = docFromTextNotation('(a  \r\n| e) g)');
-        const b = docFromTextNotation('(a | e) g)');
+        const a = textNotation.docFromTextNotation('(a  \r\n| e) g)');
+        const b = textNotation.docFromTextNotation('(a | e) g)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Retreats past line start, squashing only preceding whitepace when invoked at line start', async () => {
-        const a = docFromTextNotation('(a  \n| e) g)');
-        const b = docFromTextNotation('(a | e) g)');
+        const a = textNotation.docFromTextNotation('(a  \n| e) g)');
+        const b = textNotation.docFromTextNotation('(a | e) g)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Retreats past line start, squashing only preceding whitepace when invoked at line start (Windows)', async () => {
-        const a = docFromTextNotation('(a  \r\n| e) g)');
-        const b = docFromTextNotation('(a | e) g)');
+        const a = textNotation.docFromTextNotation('(a  \r\n| e) g)');
+        const b = textNotation.docFromTextNotation('(a | e) g)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       // https://github.com/BetterThanTomorrow/calva/pull/2427#issuecomment-1985910937
       it('Single-cursor: Finds start of line after whitespace', async () => {
-        const a = docFromTextNotation('(a\n |b)');
-        const b = docFromTextNotation('(a\n|b)');
+        const a = textNotation.docFromTextNotation('(a\n |b)');
+        const b = textNotation.docFromTextNotation('(a\n|b)');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds start of line after whitespace (Windows)', async () => {
-        const a = docFromTextNotation('(a\r\n |b)');
-        const b = docFromTextNotation('(a\r\n|b)');
+        const a = textNotation.docFromTextNotation('(a\r\n |b)');
+        const b = textNotation.docFromTextNotation('(a\r\n|b)');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds newline when at line start', async () => {
-        const a = docFromTextNotation('(a\n| b)');
-        const b = docFromTextNotation('(a| b)');
+        const a = textNotation.docFromTextNotation('(a\n| b)');
+        const b = textNotation.docFromTextNotation('(a| b)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Finds newline when at line start (Windows)', async () => {
-        const a = docFromTextNotation('(a\r\n| b)');
-        const b = docFromTextNotation('(a| b)');
+        const a = textNotation.docFromTextNotation('(a\r\n| b)');
+        const b = textNotation.docFromTextNotation('(a| b)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Finds start of vectors', async () => {
-        const a = docFromTextNotation('[a [b c d e| f] g h]');
-        const b = docFromTextNotation('[a [| f] g h]');
+        const a = textNotation.docFromTextNotation('[a [b c d e| f] g h]');
+        const b = textNotation.docFromTextNotation('[a [| f] g h]');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds start of lists', async () => {
-        const a = docFromTextNotation('(foo |bar)\n');
-        const b = docFromTextNotation('(|bar)\n');
+        const a = textNotation.docFromTextNotation('(foo |bar)\n');
+        const b = textNotation.docFromTextNotation('(|bar)\n');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds start of maps', async () => {
-        const a = docFromTextNotation('{:a 1 :b 2| :c 3}');
-        const b = docFromTextNotation('{| :c 3}');
+        const a = textNotation.docFromTextNotation('{:a 1 :b 2| :c 3}');
+        const b = textNotation.docFromTextNotation('{| :c 3}');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds start of line in multiline maps', async () => {
-        const a = docFromTextNotation('{:a 1 \n:b 2| :c 3}');
-        const b = docFromTextNotation('{:a 1 \n| :c 3}');
+        const a = textNotation.docFromTextNotation('{:a 1 \n:b 2| :c 3}');
+        const b = textNotation.docFromTextNotation('{:a 1 \n| :c 3}');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds start of line in multiline maps (Windows)', async () => {
-        const a = docFromTextNotation('{:a 1 \r\n:b 2| :c 3}');
-        const b = docFromTextNotation('{:a 1 \r\n| :c 3}');
+        const a = textNotation.docFromTextNotation('{:a 1 \r\n:b 2| :c 3}');
+        const b = textNotation.docFromTextNotation('{:a 1 \r\n| :c 3}');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds start of expr in multiline maps', async () => {
-        const a = docFromTextNotation('{:a 1 :b 2 (+\n 0\n 2\n) 3| :c 4}');
-        const b = docFromTextNotation('{:a 1 :b 2 | :c 4}');
+        const a = textNotation.docFromTextNotation('{:a 1 :b 2 (+\n 0\n 2\n) 3| :c 4}');
+        const b = textNotation.docFromTextNotation('{:a 1 :b 2 | :c 4}');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Finds start of expr in multiline maps (Windows)', async () => {
-        const a = docFromTextNotation('{:a 1 :b 2 (+\r\n 0\r\n 2\r\n) 3| :c 4}');
-        const b = docFromTextNotation('{:a 1 :b 2 | :c 4}');
+        const a = textNotation.docFromTextNotation('{:a 1 :b 2 (+\r\n 0\r\n 2\r\n) 3| :c 4}');
+        const b = textNotation.docFromTextNotation('{:a 1 :b 2 | :c 4}');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Finds start of immediate list even in bindings if at list close', async () => {
-        const a = docFromTextNotation('(let [a (+ 1 2)\n b (+ 2 3)|] (+ a b))');
-        const b = docFromTextNotation('(let [a (+ 1 2)\n b |] (+ a b))');
+        const a = textNotation.docFromTextNotation('(let [a (+ 1 2)\n b (+ 2 3)|] (+ a b))');
+        const b = textNotation.docFromTextNotation('(let [a (+ 1 2)\n b |] (+ a b))');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds start of line in bindings if not at list close', async () => {
-        const a = docFromTextNotation('(let [{a :a} c\n {b :b} d|] (+ a b))');
-        const b = docFromTextNotation('(let [{a :a} c\n |] (+ a b))');
+        const a = textNotation.docFromTextNotation('(let [{a :a} c\n {b :b} d|] (+ a b))');
+        const b = textNotation.docFromTextNotation('(let [{a :a} c\n |] (+ a b))');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds start of expr in multiline bindings', async () => {
-        const a = docFromTextNotation('(let [{a :a\n b :b} d| c (+ 2 3)] (+ a b))');
-        const b = docFromTextNotation('(let [| c (+ 2 3)] (+ a b))');
+        const a = textNotation.docFromTextNotation('(let [{a :a\n b :b} d| c (+ 2 3)] (+ a b))');
+        const b = textNotation.docFromTextNotation('(let [| c (+ 2 3)] (+ a b))');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Finds start of expr in multiline bindings (Windows)', async () => {
-        const a = docFromTextNotation('(let [{a :a\r\n b :b} d| c (+ 2 3)] (+ a b))');
-        const b = docFromTextNotation('(let [| c (+ 2 3)] (+ a b))');
+        const a = textNotation.docFromTextNotation('(let [{a :a\r\n b :b} d| c (+ 2 3)] (+ a b))');
+        const b = textNotation.docFromTextNotation('(let [| c (+ 2 3)] (+ a b))');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Finds range in line of tokens', async () => {
-        const a = docFromTextNotation('2 \n"hello" :hello/world bye | ');
-        const b = docFromTextNotation('2 \n| ');
+        const a = textNotation.docFromTextNotation('2 \n"hello" :hello/world bye | ');
+        const b = textNotation.docFromTextNotation('2 \n| ');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds range in token with form over multiple lines', async () => {
-        const a = docFromTextNotation('3 [\n 1 \n] a|');
-        const b = docFromTextNotation('3 |');
+        const a = textNotation.docFromTextNotation('3 [\n 1 \n] a|');
+        const b = textNotation.docFromTextNotation('3 |');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Finds range in token with form over multiple lines (Windows)', async () => {
-        const a = docFromTextNotation('3 [\r\n 1 \r\n] a|');
-        const b = docFromTextNotation('3 |');
+        const a = textNotation.docFromTextNotation('3 [\r\n 1 \r\n] a|');
+        const b = textNotation.docFromTextNotation('3 |');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Deals with comments start of line', async () => {
-        const a = docFromTextNotation('\n;;  hi|');
-        const b = docFromTextNotation('\n|');
+        const a = textNotation.docFromTextNotation('\n;;  hi|');
+        const b = textNotation.docFromTextNotation('\n|');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Deals with comments start of line (Windows)', async () => {
-        const a = docFromTextNotation('\r\n;;  hi|');
-        const b = docFromTextNotation('\r\n|');
+        const a = textNotation.docFromTextNotation('\r\n;;  hi|');
+        const b = textNotation.docFromTextNotation('\r\n|');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Deals with comments middle of line', async () => {
-        const a = docFromTextNotation('\n;; |hi');
-        const b = docFromTextNotation('\n|hi');
+        const a = textNotation.docFromTextNotation('\n;; |hi');
+        const b = textNotation.docFromTextNotation('\n|hi');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Deals with comments middle of line (Windows)', async () => {
-        const a = docFromTextNotation('\r\n;; |hi');
-        const b = docFromTextNotation('\r\n|hi');
+        const a = textNotation.docFromTextNotation('\r\n;; |hi');
+        const b = textNotation.docFromTextNotation('\r\n|hi');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Deals with empty lines', async () => {
-        const a = docFromTextNotation('\n|');
-        const b = docFromTextNotation('|');
+        const a = textNotation.docFromTextNotation('\n|');
+        const b = textNotation.docFromTextNotation('|');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Deals with empty lines (Windows)', async () => {
-        const a = docFromTextNotation('\r\n|');
-        const b = docFromTextNotation('|');
+        const a = textNotation.docFromTextNotation('\r\n|');
+        const b = textNotation.docFromTextNotation('|');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Deals with comments with empty line', async () => {
-        const a = docFromTextNotation('\n;; |');
-        const b = docFromTextNotation('\n|');
+        const a = textNotation.docFromTextNotation('\n;; |');
+        const b = textNotation.docFromTextNotation('\n|');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Deals with comments with empty line (Windows)', async () => {
-        const a = docFromTextNotation('\r\n;; |');
-        const b = docFromTextNotation('\r\n|');
+        const a = textNotation.docFromTextNotation('\r\n;; |');
+        const b = textNotation.docFromTextNotation('\r\n|');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Does not retreat when on closing token type ', async () => {
-        const a = docFromTextNotation('\n(|a e)\n');
-        const b = docFromTextNotation('\n(||a e)\n');
+        const a = textNotation.docFromTextNotation('\n(|a e)\n');
+        const b = textNotation.docFromTextNotation('\n(||a e)\n');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
       });
 
       it('Single-cursor: Finds the full form after an ignore marker', async () => {
         // https://github.com/BetterThanTomorrow/calva/pull/1293#issuecomment-927123696
-        const a = docFromTextNotation(
+        const a = textNotation.docFromTextNotation(
           '(comment•  #_[a b (c d•              e•              f) g]|•  :a•)'
         );
-        const b = docFromTextNotation('(comment•  #_|•  :a•)');
+        const b = textNotation.docFromTextNotation('(comment•  #_|•  :a•)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
       });
 
       it('Single-cursor: Takes 3 invocations to kill to first non-whitespace, preceding whitespace and then preceding newline', async () => {
-        const a = docFromTextNotation('(:a :b \n    :c :d|)');
-        const b = docFromTextNotation('(:a :b \n    |)');
+        const a = textNotation.docFromTextNotation('(:a :b \n    :c :d|)');
+        const b = textNotation.docFromTextNotation('(:a :b \n    |)');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
 
-        const c = docFromTextNotation('(:a :b \n|)');
+        const c = textNotation.docFromTextNotation('(:a :b \n|)');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(c);
+        expectLib.expect(a).toEqual(c);
 
-        const d = docFromTextNotation('(:a :b |)');
+        const d = textNotation.docFromTextNotation('(:a :b |)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(d, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(d, defaultDocOmit));
       });
 
       it('Single-cursor: Takes 3 invocations to kill to first non-whitespace, preceding whitespace and then preceding newline (Windows)', async () => {
-        const a = docFromTextNotation('(:a :b \r\n    :c :d|)');
-        const b = docFromTextNotation('(:a :b \r\n    |)');
+        const a = textNotation.docFromTextNotation('(:a :b \r\n    :c :d|)');
+        const b = textNotation.docFromTextNotation('(:a :b \r\n    |)');
         await handlers.killLeft(a, false);
-        expect(a).toEqual(b);
+        expectLib.expect(a).toEqual(b);
 
-        const c = docFromTextNotation('(:a :b \r\n|)');
+        const c = textNotation.docFromTextNotation('(:a :b \r\n|)');
         await handlers.killLeft(a, false);
         // expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(c, defaultDocOmit));
-        expect(a).toEqual(c);
+        expectLib.expect(a).toEqual(c);
         const aText = a.model.getText(0, a.model.maxOffset);
-        expect(aText).toEqual('(:a :b \r\n)');
+        expectLib.expect(aText).toEqual('(:a :b \r\n)');
 
-        const d = docFromTextNotation('(:a :b |)');
+        const d = textNotation.docFromTextNotation('(:a :b |)');
         await handlers.killLeft(a, false);
-        expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(d, defaultDocOmit));
+        expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(d, defaultDocOmit));
       });
     });
   });
@@ -1183,172 +1209,200 @@ describe('paredit commands', () => {
     describe('wrapping', () => {
       describe('rewrap', () => {
         it('Single-cursor: Rewraps () -> []', async () => {
-          const a = docFromTextNotation('a (b c|) d');
-          const b = docFromTextNotation('a [b c|] d');
+          const a = textNotation.docFromTextNotation('a (b c|) d');
+          const b = textNotation.docFromTextNotation('a [b c|] d');
           await handlers.rewrapSquare(a, false);
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Rewraps () -> []', async () => {
-          const a = docFromTextNotation('(a|2 (b c|) |1d)|3');
-          const b = docFromTextNotation('[a|2 [b c|] |1d]|3');
+          const a = textNotation.docFromTextNotation('(a|2 (b c|) |1d)|3');
+          const b = textNotation.docFromTextNotation('[a|2 [b c|] |1d]|3');
           await handlers.rewrapSquare(a, true);
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
 
         it('Single-cursor: Rewraps [] -> ()', async () => {
-          const a = docFromTextNotation('[a [b c|] d]');
-          const b = docFromTextNotation('[a (b c|) d]');
+          const a = textNotation.docFromTextNotation('[a [b c|] d]');
+          const b = textNotation.docFromTextNotation('[a (b c|) d]');
           await handlers.rewrapParens(a, false);
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Rewraps [] -> ()', async () => {
-          const a = docFromTextNotation('[a|2 [b c|] |1d]|3');
-          const b = docFromTextNotation('(a|2 (b c|) |1d)|3');
+          const a = textNotation.docFromTextNotation('[a|2 [b c|] |1d]|3');
+          const b = textNotation.docFromTextNotation('(a|2 (b c|) |1d)|3');
           await handlers.rewrapParens(a, true);
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
 
         it('Single-cursor: Rewraps [] -> {}', async () => {
-          const a = docFromTextNotation('[a [b c|] d]');
-          const b = docFromTextNotation('[a {b c|} d]');
+          const a = textNotation.docFromTextNotation('[a [b c|] d]');
+          const b = textNotation.docFromTextNotation('[a {b c|} d]');
           await handlers.rewrapCurly(a, false);
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Rewraps [] -> {}', async () => {
-          const a = docFromTextNotation('[a|2 [b c|] |1d]|3');
-          const b = docFromTextNotation('{a|2 {b c|} |1d}|3');
+          const a = textNotation.docFromTextNotation('[a|2 [b c|] |1d]|3');
+          const b = textNotation.docFromTextNotation('{a|2 {b c|} |1d}|3');
           await handlers.rewrapCurly(a, true);
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
 
         it('Multi-cursor: Handles rewrapping nested forms [] -> {}', async () => {
-          const a = docFromTextNotation('[:d :e [a|1 [b c|]]]');
-          const b = docFromTextNotation('[:d :e {a|1 {b c|}}]');
+          const a = textNotation.docFromTextNotation('[:d :e [a|1 [b c|]]]');
+          const b = textNotation.docFromTextNotation('[:d :e {a|1 {b c|}}]');
           await handlers.rewrapCurly(a, true);
-          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib
+            .expect(textNotation.textNotationFromDoc(a))
+            .toEqual(textNotation.textNotationFromDoc(b));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Handles rewrapping nested forms [] -> {} 2', async () => {
-          const a = docFromTextNotation('[|1:d :e [a|2 [b c|]]]');
-          const b = docFromTextNotation('{|1:d :e {a|2 {b c|}}}');
+          const a = textNotation.docFromTextNotation('[|1:d :e [a|2 [b c|]]]');
+          const b = textNotation.docFromTextNotation('{|1:d :e {a|2 {b c|}}}');
           await handlers.rewrapCurly(a, true);
-          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib
+            .expect(textNotation.textNotationFromDoc(a))
+            .toEqual(textNotation.textNotationFromDoc(b));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Handles rewrapping nested forms mixed -> {}', async () => {
-          const a = docFromTextNotation('[:d :e (a|1 {b c|})]');
-          const b = docFromTextNotation('[:d :e {a|1 {b c|}}]');
+          const a = textNotation.docFromTextNotation('[:d :e (a|1 {b c|})]');
+          const b = textNotation.docFromTextNotation('[:d :e {a|1 {b c|}}]');
           await handlers.rewrapCurly(a, true);
-          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib
+            .expect(textNotation.textNotationFromDoc(a))
+            .toEqual(textNotation.textNotationFromDoc(b));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Handles rewrapping nested forms mixed -> {} 2', async () => {
-          const a = docFromTextNotation('[|1:d :e (a|2 {b c|})]');
-          const b = docFromTextNotation('{|1:d :e {a|2 {b c|}}}');
+          const a = textNotation.docFromTextNotation('[|1:d :e (a|2 {b c|})]');
+          const b = textNotation.docFromTextNotation('{|1:d :e {a|2 {b c|}}}');
           await handlers.rewrapCurly(a, true);
-          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib
+            .expect(textNotation.textNotationFromDoc(a))
+            .toEqual(textNotation.textNotationFromDoc(b));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
 
         it('Single-cursor: Rewraps #{} -> {}', async () => {
-          const a = docFromTextNotation('#{a #{b c|} d}');
-          const b = docFromTextNotation('#{a {b c|} d}');
+          const a = textNotation.docFromTextNotation('#{a #{b c|} d}');
+          const b = textNotation.docFromTextNotation('#{a {b c|} d}');
           await handlers.rewrapCurly(a, false);
-          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib
+            .expect(textNotation.textNotationFromDoc(a))
+            .toEqual(textNotation.textNotationFromDoc(b));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Rewraps #{} -> {}', async () => {
-          const a = docFromTextNotation('#{a|2 #{b c|} |1d}|3');
-          const b = docFromTextNotation('{a|2 {b c|} |1d}|3');
+          const a = textNotation.docFromTextNotation('#{a|2 #{b c|} |1d}|3');
+          const b = textNotation.docFromTextNotation('{a|2 {b c|} |1d}|3');
           await handlers.rewrapCurly(a, true);
-          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib
+            .expect(textNotation.textNotationFromDoc(a))
+            .toEqual(textNotation.textNotationFromDoc(b));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
 
         it('Single-cursor: Rewraps #{} -> ""', async () => {
-          const a = docFromTextNotation('#{a #{b c|} d}');
-          const b = docFromTextNotation('#{a "b c|" d}');
+          const a = textNotation.docFromTextNotation('#{a #{b c|} d}');
+          const b = textNotation.docFromTextNotation('#{a "b c|" d}');
           await handlers.rewrapQuote(a, false);
-          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib
+            .expect(textNotation.textNotationFromDoc(a))
+            .toEqual(textNotation.textNotationFromDoc(b));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Rewraps #{} -> ""', async () => {
-          const a = docFromTextNotation('#{a|2 #{b c|} |1d}|3');
-          const b = docFromTextNotation('"a|2 "b c|" |1d"|3');
+          const a = textNotation.docFromTextNotation('#{a|2 #{b c|} |1d}|3');
+          const b = textNotation.docFromTextNotation('"a|2 "b c|" |1d"|3');
           await handlers.rewrapQuote(a, true);
-          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib
+            .expect(textNotation.textNotationFromDoc(a))
+            .toEqual(textNotation.textNotationFromDoc(b));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Rewraps #{} -> "" 2', async () => {
-          const a = docFromTextNotation('#{a|2 #{b c|} |1d}|3\n#{a|6 #{b c|4} |5d}|7');
-          const b = docFromTextNotation('"a|2 "b c|" |1d"|3\n"a|6 "b c|4" |5d"|7');
+          const a = textNotation.docFromTextNotation('#{a|2 #{b c|} |1d}|3\n#{a|6 #{b c|4} |5d}|7');
+          const b = textNotation.docFromTextNotation('"a|2 "b c|" |1d"|3\n"a|6 "b c|4" |5d"|7');
           await handlers.rewrapQuote(a, true);
-          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib
+            .expect(textNotation.textNotationFromDoc(a))
+            .toEqual(textNotation.textNotationFromDoc(b));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Rewraps #{} -> [] 3', async () => {
-          const a = docFromTextNotation('#{a|2 #{b c|} |1d\n#{a|6 #{b c|4} |5d}}|3');
-          const b = docFromTextNotation('[a|2 [b c|] |1d\n[a|6 [b c|4] |5d]]|3');
+          const a = textNotation.docFromTextNotation('#{a|2 #{b c|} |1d\n#{a|6 #{b c|4} |5d}}|3');
+          const b = textNotation.docFromTextNotation('[a|2 [b c|] |1d\n[a|6 [b c|4] |5d]]|3');
           await handlers.rewrapSquare(a, true);
-          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib
+            .expect(textNotation.textNotationFromDoc(a))
+            .toEqual(textNotation.textNotationFromDoc(b));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
 
         it('Single-cursor: Rewraps [] -> #{}', async () => {
-          const a = docFromTextNotation('[[b c|] d]');
-          const b = docFromTextNotation('[#{b c|} d]');
+          const a = textNotation.docFromTextNotation('[[b c|] d]');
+          const b = textNotation.docFromTextNotation('[#{b c|} d]');
           await handlers.rewrapSet(a, false);
-          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib
+            .expect(textNotation.textNotationFromDoc(a))
+            .toEqual(textNotation.textNotationFromDoc(b));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Rewraps [] -> #{}', async () => {
-          const a = docFromTextNotation('[[b|2 c|] |1d]|3');
-          const b = docFromTextNotation('#{#{b|2 c|} |1d}|3');
+          const a = textNotation.docFromTextNotation('[[b|2 c|] |1d]|3');
+          const b = textNotation.docFromTextNotation('#{#{b|2 c|} |1d}|3');
           await handlers.rewrapSet(a, true);
-          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib
+            .expect(textNotation.textNotationFromDoc(a))
+            .toEqual(textNotation.textNotationFromDoc(b));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Rewraps [] -> #{} 2', async () => {
-          const a = docFromTextNotation('[[b|2 c|] |1d]|3\n[a|6 [b c|4] |5d]|7');
-          const b = docFromTextNotation('#{#{b|2 c|} |1d}|3\n#{a|6 #{b c|4} |5d}|7');
+          const a = textNotation.docFromTextNotation('[[b|2 c|] |1d]|3\n[a|6 [b c|4] |5d]|7');
+          const b = textNotation.docFromTextNotation('#{#{b|2 c|} |1d}|3\n#{a|6 #{b c|4} |5d}|7');
           await handlers.rewrapSet(a, true);
-          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib
+            .expect(textNotation.textNotationFromDoc(a))
+            .toEqual(textNotation.textNotationFromDoc(b));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Rewraps [] -> #{} 3', async () => {
-          const a = docFromTextNotation('[[b|2 c|] |1d\n[a|6 [b c|4] |5d]]|3');
-          const b = docFromTextNotation('#{#{b|2 c|} |1d\n#{a|6 #{b c|4} |5d}}|3');
+          const a = textNotation.docFromTextNotation('[[b|2 c|] |1d\n[a|6 [b c|4] |5d]]|3');
+          const b = textNotation.docFromTextNotation('#{#{b|2 c|} |1d\n#{a|6 #{b c|4} |5d}}|3');
           await handlers.rewrapSet(a, true);
-          expect(textNotationFromDoc(a)).toEqual(textNotationFromDoc(b));
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib
+            .expect(textNotation.textNotationFromDoc(a))
+            .toEqual(textNotation.textNotationFromDoc(b));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
 
         // TODO: This tests current behavior. What should happen?
         it('Single-cursor: Rewraps ^{} -> #{}', async () => {
-          const a = docFromTextNotation('^{^{b c|} d}');
-          const b = docFromTextNotation('^{#{b c|} d}');
+          const a = textNotation.docFromTextNotation('^{^{b c|} d}');
+          const b = textNotation.docFromTextNotation('^{#{b c|} d}');
           await handlers.rewrapSet(a, false);
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Rewraps ^{} -> #{}', async () => {
-          const a = docFromTextNotation('^{^{b|2 c|} |1d}|3');
-          const b = docFromTextNotation('#{#{b|2 c|} |1d}|3');
+          const a = textNotation.docFromTextNotation('^{^{b|2 c|} |1d}|3');
+          const b = textNotation.docFromTextNotation('#{#{b|2 c|} |1d}|3');
           await handlers.rewrapSet(a, true);
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
 
         // TODO: This tests current behavior. What should happen?
         it('Single-cursor: Rewraps ~{} -> #{}', async () => {
-          const a = docFromTextNotation('~{~{b c|} d}');
-          const b = docFromTextNotation('~{#{b c|} d}');
+          const a = textNotation.docFromTextNotation('~{~{b c|} d}');
+          const b = textNotation.docFromTextNotation('~{#{b c|} d}');
           await handlers.rewrapSet(a, false);
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
         it('Multi-cursor: Rewraps ~{} -> #{}', async () => {
-          const a = docFromTextNotation('~{~{b|2 c|} |1d}|3');
-          const b = docFromTextNotation('#{#{b|2 c|} |1d}|3');
+          const a = textNotation.docFromTextNotation('~{~{b|2 c|} |1d}|3');
+          const b = textNotation.docFromTextNotation('#{#{b|2 c|} |1d}|3');
           await handlers.rewrapSet(a, true);
-          expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
+          expectLib.expect(_.omit(a, defaultDocOmit)).toEqual(_.omit(b, defaultDocOmit));
         });
       });
     });

--- a/src/extension-test/unit/resolve-file-arg-test.ts
+++ b/src/extension-test/unit/resolve-file-arg-test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as path from 'path';
 import * as fileArg from '../../util/resolve-file-arg';
 
@@ -7,85 +7,85 @@ describe('resolveFilePath', () => {
 
   describe('null/undefined/empty arguments', () => {
     it('returns undefined for null', () => {
-      expect(fileArg.resolveFilePath(null, workspaceRoot)).toBeUndefined();
+      expectLib.expect(fileArg.resolveFilePath(null, workspaceRoot)).toBeUndefined();
     });
 
     it('returns undefined for undefined', () => {
-      expect(fileArg.resolveFilePath(undefined, workspaceRoot)).toBeUndefined();
+      expectLib.expect(fileArg.resolveFilePath(undefined, workspaceRoot)).toBeUndefined();
     });
 
     it('returns undefined for empty string', () => {
-      expect(fileArg.resolveFilePath('', workspaceRoot)).toBeUndefined();
+      expectLib.expect(fileArg.resolveFilePath('', workspaceRoot)).toBeUndefined();
     });
 
     it('returns undefined for empty array', () => {
-      expect(fileArg.resolveFilePath([], workspaceRoot)).toBeUndefined();
+      expectLib.expect(fileArg.resolveFilePath([], workspaceRoot)).toBeUndefined();
     });
   });
 
   describe('URI-like objects', () => {
     it('extracts fsPath from a URI-like object with scheme', () => {
       const uri = { scheme: 'file', fsPath: '/some/file.clj' };
-      expect(fileArg.resolveFilePath(uri, workspaceRoot)).toBe('/some/file.clj');
+      expectLib.expect(fileArg.resolveFilePath(uri, workspaceRoot)).toBe('/some/file.clj');
     });
 
     it('returns undefined if URI-like has no fsPath', () => {
       const uri = { scheme: 'file' };
-      expect(fileArg.resolveFilePath(uri, workspaceRoot)).toBeUndefined();
+      expectLib.expect(fileArg.resolveFilePath(uri, workspaceRoot)).toBeUndefined();
     });
   });
 
   describe('string arguments', () => {
     it('returns absolute path as-is', () => {
-      expect(fileArg.resolveFilePath('/absolute/path/foo.clj', workspaceRoot)).toBe(
-        '/absolute/path/foo.clj'
-      );
+      expectLib
+        .expect(fileArg.resolveFilePath('/absolute/path/foo.clj', workspaceRoot))
+        .toBe('/absolute/path/foo.clj');
     });
 
     it('resolves relative path against workspace root', () => {
-      expect(fileArg.resolveFilePath('src/foo.clj', workspaceRoot)).toBe(
-        path.join(workspaceRoot, 'src/foo.clj')
-      );
+      expectLib
+        .expect(fileArg.resolveFilePath('src/foo.clj', workspaceRoot))
+        .toBe(path.join(workspaceRoot, 'src/foo.clj'));
     });
 
     it('returns undefined for relative path without workspace root', () => {
-      expect(fileArg.resolveFilePath('src/foo.clj', undefined)).toBeUndefined();
+      expectLib.expect(fileArg.resolveFilePath('src/foo.clj', undefined)).toBeUndefined();
     });
   });
 
   describe('string array arguments', () => {
     it('joins and returns absolute segments', () => {
-      expect(fileArg.resolveFilePath(['/absolute', 'path', 'foo.clj'], workspaceRoot)).toBe(
-        path.join('/absolute', 'path', 'foo.clj')
-      );
+      expectLib
+        .expect(fileArg.resolveFilePath(['/absolute', 'path', 'foo.clj'], workspaceRoot))
+        .toBe(path.join('/absolute', 'path', 'foo.clj'));
     });
 
     it('joins relative segments and resolves against workspace root', () => {
-      expect(fileArg.resolveFilePath(['src', 'foo.clj'], workspaceRoot)).toBe(
-        path.join(workspaceRoot, 'src', 'foo.clj')
-      );
+      expectLib
+        .expect(fileArg.resolveFilePath(['src', 'foo.clj'], workspaceRoot))
+        .toBe(path.join(workspaceRoot, 'src', 'foo.clj'));
     });
 
     it('returns undefined for relative segments without workspace root', () => {
-      expect(fileArg.resolveFilePath(['src', 'foo.clj'], undefined)).toBeUndefined();
+      expectLib.expect(fileArg.resolveFilePath(['src', 'foo.clj'], undefined)).toBeUndefined();
     });
 
     it('rejects arrays with non-string elements', () => {
-      expect(fileArg.resolveFilePath(['src', 42 as any], workspaceRoot)).toBeUndefined();
+      expectLib.expect(fileArg.resolveFilePath(['src', 42 as any], workspaceRoot)).toBeUndefined();
     });
   });
 
   describe('unsupported argument types', () => {
     it('returns undefined for a plain object without scheme', () => {
-      expect(fileArg.resolveFilePath({ foo: 'bar' }, workspaceRoot)).toBeUndefined();
+      expectLib.expect(fileArg.resolveFilePath({ foo: 'bar' }, workspaceRoot)).toBeUndefined();
     });
 
     it('returns undefined for a number', () => {
-      expect(fileArg.resolveFilePath(42, workspaceRoot)).toBeUndefined();
+      expectLib.expect(fileArg.resolveFilePath(42, workspaceRoot)).toBeUndefined();
     });
 
     it('returns undefined for a boolean', () => {
-      expect(fileArg.resolveFilePath(true, workspaceRoot)).toBeUndefined();
+      expectLib.expect(fileArg.resolveFilePath(true, workspaceRoot)).toBeUndefined();
     });
   });
 });

--- a/src/extension-test/unit/results-output/output-test.ts
+++ b/src/extension-test/unit/results-output/output-test.ts
@@ -1,16 +1,12 @@
-import { expect } from 'expect';
-import {
-  routeEvaluatedCode,
-  type EvaluatedCodeMessage,
-  type VisibleEvaluatedCodeWrite,
-} from '../../../results-output/evaluated-code';
+import * as expectLib from 'expect';
+import * as evaluatedCode from '../../../results-output/evaluated-code';
 
 describe('routeEvaluatedCode', () => {
   it('emits one evaluatedCode message while preserving metadata', () => {
-    const messages: EvaluatedCodeMessage[] = [];
-    const visibleWrites: VisibleEvaluatedCodeWrite[] = [];
+    const messages: evaluatedCode.EvaluatedCodeMessage[] = [];
+    const visibleWrites: evaluatedCode.VisibleEvaluatedCodeWrite[] = [];
 
-    routeEvaluatedCode({
+    evaluatedCode.routeEvaluatedCode({
       code: '(inc 1)',
       didLastTerminateLine: true,
       ns: 'user',
@@ -20,7 +16,7 @@ describe('routeEvaluatedCode', () => {
       writeVisible: (write) => visibleWrites.push(write),
     });
 
-    expect(messages).toEqual([
+    expectLib.expect(messages).toEqual([
       {
         category: 'evaluatedCode',
         text: '(inc 1)',
@@ -29,7 +25,7 @@ describe('routeEvaluatedCode', () => {
         replSessionKey: 'clj',
       },
     ]);
-    expect(visibleWrites).toEqual([
+    expectLib.expect(visibleWrites).toEqual([
       {
         code: '(inc 1)',
         didLastTerminateLine: true,

--- a/src/extension-test/unit/results-output/util-test.ts
+++ b/src/extension-test/unit/results-output/util-test.ts
@@ -1,32 +1,32 @@
-import { expect } from 'expect';
-import type { ResultsBuffer } from '../../../repl-window/repl-window-doc';
+import * as expectLib from 'expect';
+import type * as replWindowDoc from '../../../repl-window/repl-window-doc';
 import * as util from '../../../results-output/util';
 
 describe('addToHistory', () => {
   it('should push text to history array', () => {
     const history = [];
     const newHistory = util.addToHistory(history, 'hello');
-    expect(newHistory[0]).toBe('hello');
+    expectLib.expect(newHistory[0]).toBe('hello');
   });
   it('should push text to history array without whitespace or eol characters', () => {
     const history = [];
     const newHistory = util.addToHistory(history, ' \t\nhello \r\n');
-    expect(newHistory[0]).toBe('hello');
+    expectLib.expect(newHistory[0]).toBe('hello');
   });
   it('should not push text to history array if empty string', () => {
     const history = [];
     const newHistory = util.addToHistory(history, '');
-    expect(newHistory.length).toBe(history.length);
+    expectLib.expect(newHistory.length).toBe(history.length);
   });
   it('should not push text to history array if same as last item in array', () => {
     const history = ['123'];
     const newHistory = util.addToHistory(history, '123');
-    expect(newHistory.length).toBe(history.length);
+    expectLib.expect(newHistory.length).toBe(history.length);
   });
   it('should not push null to history array', () => {
     const history = [];
     const newHistory = util.addToHistory(history, null);
-    expect(newHistory.length).toBe(history.length);
+    expectLib.expect(newHistory.length).toBe(history.length);
   });
 });
 
@@ -34,12 +34,12 @@ describe('formatAsLineComments', () => {
   it('should add "; " to beginning of each line that contains content', () => {
     const error = 'hello\nworld\n';
     const formattedError = util.formatAsLineComments(error);
-    expect(formattedError).toBe('; hello\n; world');
+    expectLib.expect(formattedError).toBe('; hello\n; world');
   });
   it('should account for \\r\\n line endings', () => {
     const error = 'hello\r\nworld\r\n';
     const formattedError = util.formatAsLineComments(error);
-    expect(formattedError).toBe('; hello\n; world');
+    expectLib.expect(formattedError).toBe('; hello\n; world');
   });
 });
 
@@ -47,11 +47,11 @@ describe('splitEditQueueForTextBatching', () => {
   it('handles empty queue correctly', () => {
     const queue = [];
     const [textBatch, remainingEditQueue] = util.splitEditQueueForTextBatching(queue);
-    expect(textBatch).toHaveLength(0);
-    expect(remainingEditQueue).toHaveLength(0);
+    expectLib.expect(textBatch).toHaveLength(0);
+    expectLib.expect(remainingEditQueue).toHaveLength(0);
   });
   it("doesn't perform batching if first item has callback", () => {
-    const queue: ResultsBuffer = [
+    const queue: replWindowDoc.ResultsBuffer = [
       {
         text: 'item-with-callback',
         onAppended: () => {
@@ -62,13 +62,13 @@ describe('splitEditQueueForTextBatching', () => {
       { text: 'item3' },
     ];
     const [textBatch, remainingEditQueue] = util.splitEditQueueForTextBatching(queue);
-    expect(textBatch).toHaveLength(0);
-    expect(remainingEditQueue.map((x) => x.text)).toEqual(
-      expect.arrayContaining(['item-with-callback', 'item2', 'item3'])
-    );
+    expectLib.expect(textBatch).toHaveLength(0);
+    expectLib
+      .expect(remainingEditQueue.map((x) => x.text))
+      .toEqual(expectLib.expect.arrayContaining(['item-with-callback', 'item2', 'item3']));
   });
   it('batches only leading items with no callback', () => {
-    const queue: ResultsBuffer = [
+    const queue: replWindowDoc.ResultsBuffer = [
       { text: 'item1' },
       { text: 'item2' },
       {
@@ -80,22 +80,28 @@ describe('splitEditQueueForTextBatching', () => {
       { text: 'item4' },
     ];
     const [textBatch, remainingEditQueue] = util.splitEditQueueForTextBatching(queue);
-    expect(textBatch).toEqual(expect.arrayContaining(['item1', 'item2']));
-    expect(remainingEditQueue.map((x) => x.text)).toEqual(
-      expect.arrayContaining(['item3-with-callback', 'item4'])
-    );
+    expectLib.expect(textBatch).toEqual(expectLib.expect.arrayContaining(['item1', 'item2']));
+    expectLib
+      .expect(remainingEditQueue.map((x) => x.text))
+      .toEqual(expectLib.expect.arrayContaining(['item3-with-callback', 'item4']));
   });
   it('correctly handles queue containing just items without callbacks', () => {
-    const queue: ResultsBuffer = [{ text: 'item1' }, { text: 'item2' }];
+    const queue: replWindowDoc.ResultsBuffer = [{ text: 'item1' }, { text: 'item2' }];
     const [textBatch, remainingEditQueue] = util.splitEditQueueForTextBatching(queue);
-    expect(textBatch).toEqual(expect.arrayContaining(['item1', 'item2']));
-    expect(remainingEditQueue).toHaveLength(0);
+    expectLib.expect(textBatch).toEqual(expectLib.expect.arrayContaining(['item1', 'item2']));
+    expectLib.expect(remainingEditQueue).toHaveLength(0);
   });
   it('respects maxBatchSize', () => {
-    const queue: ResultsBuffer = [{ text: 'item1' }, { text: 'item2' }, { text: 'item3' }];
+    const queue: replWindowDoc.ResultsBuffer = [
+      { text: 'item1' },
+      { text: 'item2' },
+      { text: 'item3' },
+    ];
 
     const [textBatch, remainingEditQueue] = util.splitEditQueueForTextBatching(queue, 2);
-    expect(textBatch).toEqual(expect.arrayContaining(['item1', 'item2']));
-    expect(remainingEditQueue.map((x) => x.text)).toEqual(expect.arrayContaining(['item3']));
+    expectLib.expect(textBatch).toEqual(expectLib.expect.arrayContaining(['item1', 'item2']));
+    expectLib
+      .expect(remainingEditQueue.map((x) => x.text))
+      .toEqual(expectLib.expect.arrayContaining(['item3']));
   });
 });

--- a/src/extension-test/unit/session-name-resolver-test.ts
+++ b/src/extension-test/unit/session-name-resolver-test.ts
@@ -1,5 +1,5 @@
-import { expect } from 'expect';
-import type { NReplClient, NReplSession } from '../../nrepl';
+import * as expectLib from 'expect';
+import type * as nrepl from '../../nrepl';
 import * as sessionNameResolver from '../../nrepl/session-name-resolver';
 import * as sessionRegistry from '../../nrepl/session-registry';
 import * as clientRegistry from '../../nrepl/client-registry';
@@ -13,10 +13,10 @@ describe('session-name-resolver', () => {
     nameSuffix.resetPool();
   });
 
-  const createSession = (clientKey: string): NReplSession =>
-    ({ client: { clientKey } } as unknown as NReplSession);
+  const createSession = (clientKey: string): nrepl.NReplSession =>
+    ({ client: { clientKey } } as unknown as nrepl.NReplSession);
 
-  const createMockClient = (clientKey: string) => ({ clientKey } as unknown as NReplClient);
+  const createMockClient = (clientKey: string) => ({ clientKey } as unknown as nrepl.NReplClient);
 
   describe('resolveSessionNames', () => {
     describe('no conflict scenario', () => {
@@ -30,9 +30,9 @@ describe('session-name-resolver', () => {
           1234
         );
 
-        expect(resolution.finalNames).toEqual(baseNames);
-        expect(resolution.suffix).toBeUndefined();
-        expect(resolution.reconnectClientKey).toBeUndefined();
+        expectLib.expect(resolution.finalNames).toEqual(baseNames);
+        expectLib.expect(resolution.suffix).toBeUndefined();
+        expectLib.expect(resolution.reconnectClientKey).toBeUndefined();
       });
 
       it('returns base names when existing sessions have different keys', () => {
@@ -46,8 +46,8 @@ describe('session-name-resolver', () => {
           1234
         );
 
-        expect(resolution.finalNames).toEqual(baseNames);
-        expect(resolution.suffix).toBeUndefined();
+        expectLib.expect(resolution.finalNames).toEqual(baseNames);
+        expectLib.expect(resolution.suffix).toBeUndefined();
       });
 
       it('handles primary-only sessions', () => {
@@ -60,8 +60,8 @@ describe('session-name-resolver', () => {
           1234
         );
 
-        expect(resolution.finalNames).toEqual({ primary: 'bb' });
-        expect(resolution.suffix).toBeUndefined();
+        expectLib.expect(resolution.finalNames).toEqual({ primary: 'bb' });
+        expectLib.expect(resolution.suffix).toBeUndefined();
       });
     });
 
@@ -77,9 +77,9 @@ describe('session-name-resolver', () => {
           1234
         );
 
-        expect(resolution.finalNames.primary).toMatch(/^clj:\w+$/);
-        expect(resolution.finalNames.secondary).toMatch(/^cljs:\w+$/);
-        expect(resolution.suffix).toBeDefined();
+        expectLib.expect(resolution.finalNames.primary).toMatch(/^clj:\w+$/);
+        expectLib.expect(resolution.finalNames.secondary).toMatch(/^cljs:\w+$/);
+        expectLib.expect(resolution.suffix).toBeDefined();
       });
 
       it('applies suffix when secondary key conflicts', () => {
@@ -93,9 +93,9 @@ describe('session-name-resolver', () => {
           1234
         );
 
-        expect(resolution.finalNames.primary).toMatch(/^clj:\w+$/);
-        expect(resolution.finalNames.secondary).toMatch(/^cljs:\w+$/);
-        expect(resolution.suffix).toBeDefined();
+        expectLib.expect(resolution.finalNames.primary).toMatch(/^clj:\w+$/);
+        expectLib.expect(resolution.finalNames.secondary).toMatch(/^cljs:\w+$/);
+        expectLib.expect(resolution.suffix).toBeDefined();
       });
 
       it('applies same suffix to both primary and secondary', () => {
@@ -110,8 +110,8 @@ describe('session-name-resolver', () => {
         );
 
         const suffix = resolution.suffix;
-        expect(resolution.finalNames.primary).toBe(`clj:${suffix}`);
-        expect(resolution.finalNames.secondary).toBe(`cljs:${suffix}`);
+        expectLib.expect(resolution.finalNames.primary).toBe(`clj:${suffix}`);
+        expectLib.expect(resolution.finalNames.secondary).toBe(`cljs:${suffix}`);
       });
 
       it('acquires different suffixes for successive conflicts', () => {
@@ -139,7 +139,7 @@ describe('session-name-resolver', () => {
           1234
         );
 
-        expect(resolution1.suffix).not.toBe(resolution2.suffix);
+        expectLib.expect(resolution1.suffix).not.toBe(resolution2.suffix);
       });
     });
 
@@ -164,9 +164,9 @@ describe('session-name-resolver', () => {
           1234
         );
 
-        expect(resolution.reconnectClientKey).toBe('client-a');
-        expect(resolution.finalNames).toEqual(baseNames);
-        expect(resolution.suffix).toBeUndefined();
+        expectLib.expect(resolution.reconnectClientKey).toBe('client-a');
+        expectLib.expect(resolution.finalNames).toEqual(baseNames);
+        expectLib.expect(resolution.suffix).toBeUndefined();
       });
 
       it('preserves suffix on reconnection', () => {
@@ -190,9 +190,9 @@ describe('session-name-resolver', () => {
           1234
         );
 
-        expect(resolution.reconnectClientKey).toBe('client-a');
-        expect(resolution.finalNames).toEqual({ primary: 'clj:2', secondary: 'cljs:2' });
-        expect(resolution.suffix).toBe('2');
+        expectLib.expect(resolution.reconnectClientKey).toBe('client-a');
+        expectLib.expect(resolution.finalNames).toEqual({ primary: 'clj:2', secondary: 'cljs:2' });
+        expectLib.expect(resolution.suffix).toBe('2');
       });
 
       it('detects reconnection even when projectRoot differs (matches on host:port)', () => {
@@ -214,7 +214,7 @@ describe('session-name-resolver', () => {
           1234
         );
 
-        expect(resolution.reconnectClientKey).toBe('client-a');
+        expectLib.expect(resolution.reconnectClientKey).toBe('client-a');
       });
 
       it('does not detect reconnection when baseNames differ', () => {
@@ -234,8 +234,8 @@ describe('session-name-resolver', () => {
           1234
         );
 
-        expect(resolution.reconnectClientKey).toBeUndefined();
-        expect(resolution.finalNames).toEqual({ primary: 'bb' });
+        expectLib.expect(resolution.reconnectClientKey).toBeUndefined();
+        expectLib.expect(resolution.finalNames).toEqual({ primary: 'bb' });
       });
 
       it('does not detect reconnection when host differs', () => {
@@ -258,7 +258,7 @@ describe('session-name-resolver', () => {
           1234
         );
 
-        expect(resolution.reconnectClientKey).toBeUndefined();
+        expectLib.expect(resolution.reconnectClientKey).toBeUndefined();
       });
 
       it('does not detect reconnection when port differs', () => {
@@ -281,7 +281,7 @@ describe('session-name-resolver', () => {
           5678
         );
 
-        expect(resolution.reconnectClientKey).toBeUndefined();
+        expectLib.expect(resolution.reconnectClientKey).toBeUndefined();
       });
     });
 
@@ -307,7 +307,7 @@ describe('session-name-resolver', () => {
           null
         );
 
-        expect(resolution.reconnectClientKey).toBe('client-a');
+        expectLib.expect(resolution.reconnectClientKey).toBe('client-a');
       });
 
       it('does not detect reconnection when projectRoot differs', () => {
@@ -329,7 +329,7 @@ describe('session-name-resolver', () => {
           null
         );
 
-        expect(resolution.reconnectClientKey).toBeUndefined();
+        expectLib.expect(resolution.reconnectClientKey).toBeUndefined();
       });
 
       it('reserves suffix on reconnection so other connections cannot steal it', () => {
@@ -353,10 +353,10 @@ describe('session-name-resolver', () => {
           1234
         );
 
-        expect(resolution.reconnectClientKey).toBe('client-a');
-        expect(resolution.suffix).toBe('apple');
+        expectLib.expect(resolution.reconnectClientKey).toBe('client-a');
+        expectLib.expect(resolution.suffix).toBe('apple');
 
-        expect(nameSuffix.getUsedSuffixes()).toContain('apple');
+        expectLib.expect(nameSuffix.getUsedSuffixes()).toContain('apple');
       });
     });
 
@@ -372,9 +372,11 @@ describe('session-name-resolver', () => {
 
         const baseNames = { primary: 'clj', secondary: 'cljs' };
 
-        expect(() => {
-          sessionNameResolver.resolveSessionNames(baseNames, '/project-b', 'localhost', 1234);
-        }).toThrow(/too many REPLs/);
+        expectLib
+          .expect(() => {
+            sessionNameResolver.resolveSessionNames(baseNames, '/project-b', 'localhost', 1234);
+          })
+          .toThrow(/too many REPLs/);
       });
     });
   });
@@ -393,7 +395,9 @@ describe('session-name-resolver', () => {
         },
       });
 
-      expect(sessionNameResolver.hasMatchingBaseConnection(baseNames, projectRoot)).toBe(true);
+      expectLib
+        .expect(sessionNameResolver.hasMatchingBaseConnection(baseNames, projectRoot))
+        .toBe(true);
     });
 
     it('returns true regardless of host/port', () => {
@@ -409,7 +413,9 @@ describe('session-name-resolver', () => {
         },
       });
 
-      expect(sessionNameResolver.hasMatchingBaseConnection(baseNames, projectRoot)).toBe(true);
+      expectLib
+        .expect(sessionNameResolver.hasMatchingBaseConnection(baseNames, projectRoot))
+        .toBe(true);
     });
 
     it('returns false when projectRoot differs', () => {
@@ -420,12 +426,14 @@ describe('session-name-resolver', () => {
         },
       });
 
-      expect(
-        sessionNameResolver.hasMatchingBaseConnection(
-          { primary: 'clj', secondary: 'cljs' },
-          '/project-b'
+      expectLib
+        .expect(
+          sessionNameResolver.hasMatchingBaseConnection(
+            { primary: 'clj', secondary: 'cljs' },
+            '/project-b'
+          )
         )
-      ).toBe(false);
+        .toBe(false);
     });
 
     it('returns false when baseNames differ', () => {
@@ -436,15 +444,15 @@ describe('session-name-resolver', () => {
         },
       });
 
-      expect(sessionNameResolver.hasMatchingBaseConnection({ primary: 'bb' }, '/project-a')).toBe(
-        false
-      );
+      expectLib
+        .expect(sessionNameResolver.hasMatchingBaseConnection({ primary: 'bb' }, '/project-a'))
+        .toBe(false);
     });
 
     it('returns false when no clients registered', () => {
-      expect(sessionNameResolver.hasMatchingBaseConnection({ primary: 'clj' }, '/project-a')).toBe(
-        false
-      );
+      expectLib
+        .expect(sessionNameResolver.hasMatchingBaseConnection({ primary: 'clj' }, '/project-a'))
+        .toBe(false);
     });
   });
 });

--- a/src/extension-test/unit/shadow-cljs-runtime-core-test.ts
+++ b/src/extension-test/unit/shadow-cljs-runtime-core-test.ts
@@ -1,6 +1,6 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as shadowRuntimeCore from '../../../src/shadow-cljs-runtime-core';
-import type { ConnectionState } from '../../../src/nrepl/client-registry';
+import type * as clientRegistry from '../../../src/nrepl/client-registry';
 
 describe('shadow-cljs-runtime-core', () => {
   describe('normalizeRuntimeInfo', () => {
@@ -17,11 +17,11 @@ describe('shadow-cljs-runtime-core', () => {
 
       const result = shadowRuntimeCore.normalizeRuntimeInfo(apiInfo);
 
-      expect(result.clientId).toBe(42);
-      expect(result.buildId).toBe(':app');
-      expect(result.host).toBe('localhost');
-      expect(result.workerId).toBe(1);
-      expect(result.description).toBe('Test Browser');
+      expectLib.expect(result.clientId).toBe(42);
+      expectLib.expect(result.buildId).toBe(':app');
+      expectLib.expect(result.host).toBe('localhost');
+      expectLib.expect(result.workerId).toBe(1);
+      expectLib.expect(result.description).toBe('Test Browser');
     });
 
     it('falls back to user-agent when desc is missing', () => {
@@ -36,7 +36,7 @@ describe('shadow-cljs-runtime-core', () => {
       };
 
       const result = shadowRuntimeCore.normalizeRuntimeInfo(apiInfo);
-      expect(result.description).toBe('Mozilla/5.0');
+      expectLib.expect(result.description).toBe('Mozilla/5.0');
     });
 
     it('uses "No description" when neither desc nor user-agent exists', () => {
@@ -50,7 +50,7 @@ describe('shadow-cljs-runtime-core', () => {
       };
 
       const result = shadowRuntimeCore.normalizeRuntimeInfo(apiInfo);
-      expect(result.description).toBe('No description');
+      expectLib.expect(result.description).toBe('No description');
     });
 
     it('computes sinceInst from since Date', () => {
@@ -66,7 +66,7 @@ describe('shadow-cljs-runtime-core', () => {
       };
 
       const result = shadowRuntimeCore.normalizeRuntimeInfo(apiInfo);
-      expect(result.sinceInst).toBe(testDate.getTime());
+      expectLib.expect(result.sinceInst).toBe(testDate.getTime());
     });
   });
 
@@ -75,14 +75,14 @@ describe('shadow-cljs-runtime-core', () => {
       const data: shadowRuntimeCore.NotifyMessageData = { op: 'other' };
       const result = shadowRuntimeCore.decideMessageAction(data, undefined);
 
-      expect(result.type).toBe('no-action');
+      expectLib.expect(result.type).toBe('no-action');
     });
 
     it('returns no-action for notify without client-id', () => {
       const data: shadowRuntimeCore.NotifyMessageData = { op: 'notify' };
       const result = shadowRuntimeCore.decideMessageAction(data, undefined);
 
-      expect(result.type).toBe('no-action');
+      expectLib.expect(result.type).toBe('no-action');
     });
 
     it('returns runtime-disconnected when current runtime disconnects', () => {
@@ -93,7 +93,7 @@ describe('shadow-cljs-runtime-core', () => {
       };
       const result = shadowRuntimeCore.decideMessageAction(data, 42);
 
-      expect(result).toEqual({ type: 'runtime-disconnected', clientId: 42 });
+      expectLib.expect(result).toEqual({ type: 'runtime-disconnected', clientId: 42 });
     });
 
     it('returns no-action when a different runtime disconnects', () => {
@@ -104,7 +104,7 @@ describe('shadow-cljs-runtime-core', () => {
       };
       const result = shadowRuntimeCore.decideMessageAction(data, 42);
 
-      expect(result.type).toBe('no-action');
+      expectLib.expect(result.type).toBe('no-action');
     });
 
     it('returns runtime-connected when new runtime appears while disconnected', () => {
@@ -124,11 +124,11 @@ describe('shadow-cljs-runtime-core', () => {
       };
       const result = shadowRuntimeCore.decideMessageAction(data, undefined);
 
-      expect(result.type).toBe('runtime-connected');
+      expectLib.expect(result.type).toBe('runtime-connected');
       if (result.type === 'runtime-connected') {
-        expect(result.clientId).toBe(42);
-        expect(result.runtimeInfo.description).toBe('New Browser');
-        expect(result.runtimeInfo.clientId).toBe(42); // Should be set from outer client-id
+        expectLib.expect(result.clientId).toBe(42);
+        expectLib.expect(result.runtimeInfo.description).toBe('New Browser');
+        expectLib.expect(result.runtimeInfo.clientId).toBe(42); // Should be set from outer client-id
       }
     });
 
@@ -148,7 +148,7 @@ describe('shadow-cljs-runtime-core', () => {
       };
       const result = shadowRuntimeCore.decideMessageAction(data, 42);
 
-      expect(result.type).toBe('no-action');
+      expectLib.expect(result.type).toBe('no-action');
     });
 
     it('returns no-action when client-connect lacks client-info', () => {
@@ -159,13 +159,13 @@ describe('shadow-cljs-runtime-core', () => {
       };
       const result = shadowRuntimeCore.decideMessageAction(data, undefined);
 
-      expect(result.type).toBe('no-action');
+      expectLib.expect(result.type).toBe('no-action');
     });
   });
 
   describe('formatSinceDescription', () => {
     it('returns "Unknown time" for undefined', () => {
-      expect(shadowRuntimeCore.formatSinceDescription(undefined)).toBe('Unknown time');
+      expectLib.expect(shadowRuntimeCore.formatSinceDescription(undefined)).toBe('Unknown time');
     });
 
     it('formats date to locale string', () => {
@@ -173,8 +173,8 @@ describe('shadow-cljs-runtime-core', () => {
       const result = shadowRuntimeCore.formatSinceDescription(date);
 
       // Just verify it produces some non-empty string (locale-dependent)
-      expect(result.length).toBeGreaterThan(0);
-      expect(result).not.toBe('Unknown time');
+      expectLib.expect(result.length).toBeGreaterThan(0);
+      expectLib.expect(result).not.toBe('Unknown time');
     });
   });
 });

--- a/src/extension-test/unit/test-runner-test.ts
+++ b/src/extension-test/unit/test-runner-test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as cider from '../../nrepl/cider';
 
 describe('test result processing', () => {
@@ -12,68 +12,80 @@ describe('test result processing', () => {
       message: '',
     };
 
-    expect(cider.lineInformation(result)).toBe('');
+    expectLib.expect(cider.lineInformation(result)).toBe('');
 
-    expect(
-      cider.lineInformation({
-        ...result,
-        file: 'socks.clj',
-      })
-    ).toBe(' (socks.clj)');
+    expectLib
+      .expect(
+        cider.lineInformation({
+          ...result,
+          file: 'socks.clj',
+        })
+      )
+      .toBe(' (socks.clj)');
 
-    expect(
-      cider.lineInformation({
-        ...result,
-        line: 19,
-      })
-    ).toBe(' (line 19)');
+    expectLib
+      .expect(
+        cider.lineInformation({
+          ...result,
+          line: 19,
+        })
+      )
+      .toBe(' (line 19)');
 
-    expect(
-      cider.lineInformation({
-        ...result,
-        line: 17,
-        file: 'tree.clj',
-      })
-    ).toBe(' (tree.clj:17)');
+    expectLib
+      .expect(
+        cider.lineInformation({
+          ...result,
+          line: 17,
+          file: 'tree.clj',
+        })
+      )
+      .toBe(' (tree.clj:17)');
   });
 
   it('shows a summary', () => {
-    expect(
-      cider.summaryMessage({
-        ns: 0,
-        var: 0,
-        test: 0,
-        pass: 0,
-        fail: 0,
-        error: 0,
-      })
-    ).toBe('No tests found. 😱, ns: 0, vars: 0');
+    expectLib
+      .expect(
+        cider.summaryMessage({
+          ns: 0,
+          var: 0,
+          test: 0,
+          pass: 0,
+          fail: 0,
+          error: 0,
+        })
+      )
+      .toBe('No tests found. 😱, ns: 0, vars: 0');
 
-    expect(
-      cider.summaryMessage({
-        ns: 1,
-        var: 1,
-        test: 1,
-        pass: 1,
-        fail: 0,
-        error: 0,
-      })
-    ).toBe('1 tests finished, all passing 👍, ns: 1, vars: 1');
+    expectLib
+      .expect(
+        cider.summaryMessage({
+          ns: 1,
+          var: 1,
+          test: 1,
+          pass: 1,
+          fail: 0,
+          error: 0,
+        })
+      )
+      .toBe('1 tests finished, all passing 👍, ns: 1, vars: 1');
 
-    expect(
-      cider.summaryMessage({
-        ns: 1,
-        var: 2,
-        test: 3,
-        pass: 4,
-        fail: 5,
-        error: 6,
-      })
-    ).toBe('3 tests finished, problems found. 😭 errors: 6, failures: 5, ns: 1, vars: 2');
+    expectLib
+      .expect(
+        cider.summaryMessage({
+          ns: 1,
+          var: 2,
+          test: 3,
+          pass: 4,
+          fail: 5,
+          error: 6,
+        })
+      )
+      .toBe('3 tests finished, problems found. 😭 errors: 6, failures: 5, ns: 1, vars: 2');
   });
 
   it('can merge results', () => {
-    expect(cider.totalSummary([])).toMatchObject({
+    expectLib.expect(cider.totalSummary([])).toMatchObject({
       test: 0,
       error: 0,
       ns: 0,
@@ -82,94 +94,104 @@ describe('test result processing', () => {
       pass: 0,
     });
 
-    expect(
-      cider.totalSummary([
-        { test: 0, error: 0, ns: 0, var: 0, fail: 0, pass: 0 },
-        { test: 0, error: 0, ns: 0, var: 0, fail: 0, pass: 0 },
-      ])
-    ).toMatchObject({
-      test: 0,
-      error: 0,
-      ns: 0,
-      var: 0,
-      fail: 0,
-      pass: 0,
-    });
+    expectLib
+      .expect(
+        cider.totalSummary([
+          { test: 0, error: 0, ns: 0, var: 0, fail: 0, pass: 0 },
+          { test: 0, error: 0, ns: 0, var: 0, fail: 0, pass: 0 },
+        ])
+      )
+      .toMatchObject({
+        test: 0,
+        error: 0,
+        ns: 0,
+        var: 0,
+        fail: 0,
+        pass: 0,
+      });
 
-    expect(
-      cider.totalSummary([
-        { test: 1, error: 2, ns: 3, var: 5, fail: 7, pass: 11 },
-        { test: 13, error: 17, ns: 19, var: 23, fail: 29, pass: 31 },
-      ])
-    ).toMatchObject({
-      test: 14,
-      error: 19,
-      ns: 22,
-      var: 28,
-      fail: 36,
-      pass: 42,
-    });
+    expectLib
+      .expect(
+        cider.totalSummary([
+          { test: 1, error: 2, ns: 3, var: 5, fail: 7, pass: 11 },
+          { test: 13, error: 17, ns: 19, var: 23, fail: 29, pass: 31 },
+        ])
+      )
+      .toMatchObject({
+        test: 14,
+        error: 19,
+        ns: 22,
+        var: 28,
+        fail: 36,
+        pass: 42,
+      });
   });
 
   it('can produce detailed messages', () => {
-    expect(
-      cider.detailedMessage({
-        type: 'pass',
-        ns: 'core',
-        context: 'ctx',
-        index: 0,
-        var: 'test',
-        message: '',
-      })
-    ).toBeUndefined();
+    expectLib
+      .expect(
+        cider.detailedMessage({
+          type: 'pass',
+          ns: 'core',
+          context: 'ctx',
+          index: 0,
+          var: 'test',
+          message: '',
+        })
+      )
+      .toBeUndefined();
 
-    expect(
-      cider.detailedMessage({
-        type: 'fail',
-        ns: 'core',
-        context: 'ctx',
-        index: 1,
-        expected: 'apple',
-        actual: 'orange',
-        var: 'test',
-        file: 'core.clj',
-        line: 7,
-        message: 'an extra message',
-      })
-    ).toBe(
-      `; FAIL in core/test (core.clj:7):
+    expectLib
+      .expect(
+        cider.detailedMessage({
+          type: 'fail',
+          ns: 'core',
+          context: 'ctx',
+          index: 1,
+          expected: 'apple',
+          actual: 'orange',
+          var: 'test',
+          file: 'core.clj',
+          line: 7,
+          message: 'an extra message',
+        })
+      )
+      .toBe(
+        `; FAIL in core/test (core.clj:7):
 ; ctx: an extra message
 ; expected:
 apple
 ; actual:
 orange`
-    );
+      );
 
-    expect(
-      cider.detailedMessage({
-        type: 'error',
-        ns: 'core',
-        context: 'ctx',
-        index: 1,
-        expected: 'apple',
-        actual: 'orange',
-        var: 'test',
-        error: 'shoes fell off',
-        file: 'impl.clj',
-        line: 9,
-        message: 'an extra message',
-      })
-    ).toBe(
-      `; ERROR in core/test (impl.clj:9):
+    expectLib
+      .expect(
+        cider.detailedMessage({
+          type: 'error',
+          ns: 'core',
+          context: 'ctx',
+          index: 1,
+          expected: 'apple',
+          actual: 'orange',
+          var: 'test',
+          error: 'shoes fell off',
+          file: 'impl.clj',
+          line: 9,
+          message: 'an extra message',
+        })
+      )
+      .toBe(
+        `; ERROR in core/test (impl.clj:9):
 ; ctx: an extra message
 ; error: shoes fell off (impl.clj:9)
 ; expected:
 apple`
-    );
+      );
   });
 
   it('can produce detailed messages with diffs', () => {
-    expect(
+    expectLib.expect(
       cider.detailedMessage({
         type: 'fail',
         ns: 'core',

--- a/src/extension-test/unit/util/cursor-get-text-test.ts
+++ b/src/extension-test/unit/util/cursor-get-text-test.ts
@@ -1,124 +1,137 @@
-import { expect } from 'expect';
-import { docFromTextNotation } from '../common/text-notation';
+import * as expectLib from 'expect';
+import * as textNotation from '../common/text-notation';
 import * as getText from '../../../util/cursor-get-text';
 
 describe('get text', () => {
   describe('getTopLevelFunction', () => {
     it('Finds top level function at top', () => {
-      const a = docFromTextNotation('(foo bar)•(deftest a-test•  (baz |gaz))');
-      const b = docFromTextNotation('(foo bar)•(deftest |a-test|•  (baz gaz))');
+      const a = textNotation.docFromTextNotation('(foo bar)•(deftest a-test•  (baz |gaz))');
+      const b = textNotation.docFromTextNotation('(foo bar)•(deftest |a-test|•  (baz gaz))');
       const range: [number, number] = [b.selections[0].anchor, b.selections[0].active];
-      expect(getText.currentTopLevelDefined(a, a.selections[0].active)).toEqual([
-        range,
-        b.model.getText(...range),
-      ]);
+      expectLib
+        .expect(getText.currentTopLevelDefined(a, a.selections[0].active))
+        .toEqual([range, b.model.getText(...range)]);
     });
 
     it('Finds top level function when nested', () => {
-      const a = docFromTextNotation('(foo bar)•(with-test•  (deftest a-test•    (baz |gaz)))');
-      const b = docFromTextNotation('(foo bar)•(with-test•  (deftest |a-test|•    (baz gaz)))');
+      const a = textNotation.docFromTextNotation(
+        '(foo bar)•(with-test•  (deftest a-test•    (baz |gaz)))'
+      );
+      const b = textNotation.docFromTextNotation(
+        '(foo bar)•(with-test•  (deftest |a-test|•    (baz gaz)))'
+      );
       const range: [number, number] = [b.selections[0].anchor, b.selections[0].active];
-      expect(getText.currentTopLevelDefined(a, a.selections[0].active)).toEqual([
-        range,
-        b.model.getText(...range),
-      ]);
+      expectLib
+        .expect(getText.currentTopLevelDefined(a, a.selections[0].active))
+        .toEqual([range, b.model.getText(...range)]);
     });
 
     it('Finds top level function when namespaced def-macro', () => {
       // https://github.com/BetterThanTomorrow/calva/issues/1086
-      const a = docFromTextNotation('(foo bar)•(with-test•  (t/deftest a-test•    (baz |gaz)))');
-      const b = docFromTextNotation('(foo bar)•(with-test•  (t/deftest |a-test|•    (baz gaz)))');
+      const a = textNotation.docFromTextNotation(
+        '(foo bar)•(with-test•  (t/deftest a-test•    (baz |gaz)))'
+      );
+      const b = textNotation.docFromTextNotation(
+        '(foo bar)•(with-test•  (t/deftest |a-test|•    (baz gaz)))'
+      );
       const range: [number, number] = [b.selections[0].anchor, b.selections[0].active];
-      expect(getText.currentTopLevelDefined(a, a.selections[0].active)).toEqual([
-        range,
-        b.model.getText(...range),
-      ]);
+      expectLib
+        .expect(getText.currentTopLevelDefined(a, a.selections[0].active))
+        .toEqual([range, b.model.getText(...range)]);
     });
 
     it('Finds top level function when function has metadata', () => {
-      const a = docFromTextNotation('(foo bar)•(deftest ^{:some :thing} a-test•  (baz |gaz))');
-      const b = docFromTextNotation('(foo bar)•(deftest ^{:some :thing} |a-test|•  (baz gaz))');
+      const a = textNotation.docFromTextNotation(
+        '(foo bar)•(deftest ^{:some :thing} a-test•  (baz |gaz))'
+      );
+      const b = textNotation.docFromTextNotation(
+        '(foo bar)•(deftest ^{:some :thing} |a-test|•  (baz gaz))'
+      );
       const range: [number, number] = [b.selections[0].anchor, b.selections[0].active];
-      expect(getText.currentTopLevelDefined(a, a.selections[0].active)).toEqual([
-        range,
-        b.model.getText(...range),
-      ]);
+      expectLib
+        .expect(getText.currentTopLevelDefined(a, a.selections[0].active))
+        .toEqual([range, b.model.getText(...range)]);
     });
   });
 
   describe('getTopLevelForm', () => {
     it('Finds top level form', () => {
-      const a = docFromTextNotation('(foo bar)•(deftest a-test•  (baz |gaz))');
-      const b = docFromTextNotation('(foo bar)•|(deftest a-test•  (baz gaz))|');
+      const a = textNotation.docFromTextNotation('(foo bar)•(deftest a-test•  (baz |gaz))');
+      const b = textNotation.docFromTextNotation('(foo bar)•|(deftest a-test•  (baz gaz))|');
       const range: [number, number] = [b.selections[0].anchor, b.selections[0].active];
-      expect(getText.currentTopLevelForm(a)).toEqual([range, b.model.getText(...range)]);
+      expectLib.expect(getText.currentTopLevelForm(a)).toEqual([range, b.model.getText(...range)]);
     });
   });
 
   describe('currentEnclosingFormToCursor', () => {
     it('Current enclosing form from start to cursor, then folded', () => {
-      const a = docFromTextNotation('(foo bar)•(deftest a-test•  [baz ; f|oo•     gaz])');
-      const b = docFromTextNotation('(foo bar)•(deftest a-test•  |[baz| ; foo•     gaz])');
+      const a = textNotation.docFromTextNotation(
+        '(foo bar)•(deftest a-test•  [baz ; f|oo•     gaz])'
+      );
+      const b = textNotation.docFromTextNotation(
+        '(foo bar)•(deftest a-test•  |[baz| ; foo•     gaz])'
+      );
       const range: [number, number] = [b.selections[0].anchor, b.selections[0].active];
       const trail = ']';
-      expect(getText.currentEnclosingFormToCursor(a)).toEqual([
-        range,
-        `${b.model.getText(...range)}${trail}`,
-      ]);
+      expectLib
+        .expect(getText.currentEnclosingFormToCursor(a))
+        .toEqual([range, `${b.model.getText(...range)}${trail}`]);
     });
   });
 
   describe('topLevelFormToCursor', () => {
     it('Finds top level form from start to cursor', () => {
-      const a = docFromTextNotation('(foo bar)•(deftest a-test•  [baz ; f|oo•     gaz])');
-      const b = docFromTextNotation('(foo bar)•|(deftest a-test•  [baz| ; foo•     gaz])');
+      const a = textNotation.docFromTextNotation(
+        '(foo bar)•(deftest a-test•  [baz ; f|oo•     gaz])'
+      );
+      const b = textNotation.docFromTextNotation(
+        '(foo bar)•|(deftest a-test•  [baz| ; foo•     gaz])'
+      );
       const range: [number, number] = [b.selections[0].anchor, b.selections[0].active];
       const trail = '])';
-      expect(getText.currentTopLevelFormToCursor(a)).toEqual([
-        range,
-        `${b.model.getText(...range)}${trail}`,
-      ]);
+      expectLib
+        .expect(getText.currentTopLevelFormToCursor(a))
+        .toEqual([range, `${b.model.getText(...range)}${trail}`]);
     });
   });
 
   describe('startOfFileToCursor', () => {
     it('Builds form from start of file to cursor, when cursor in line comment', () => {
-      const a = docFromTextNotation('(foo bar)•(deftest a-test•  [baz ; f|oo•     gaz])•(bar baz)');
-      const b = docFromTextNotation(
+      const a = textNotation.docFromTextNotation(
+        '(foo bar)•(deftest a-test•  [baz ; f|oo•     gaz])•(bar baz)'
+      );
+      const b = textNotation.docFromTextNotation(
         '|(foo bar)•(deftest a-test•  [baz| ; foo•     gaz])•(bar baz)'
       );
       const range: [number, number] = [b.selections[0].anchor, b.selections[0].active];
       const trail = '])';
-      expect(getText.startOfFileToCursor(a)).toEqual([
-        range,
-        `${b.model.getText(...range)}${trail}`,
-      ]);
+      expectLib
+        .expect(getText.startOfFileToCursor(a))
+        .toEqual([range, `${b.model.getText(...range)}${trail}`]);
     });
     it('Builds form from start of file to cursor, when cursor in comment macro', () => {
-      const a = docFromTextNotation(
+      const a = textNotation.docFromTextNotation(
         '(foo bar)(comment• (deftest a-test•  [baz ; f|oo•     gaz])•(bar baz))'
       );
-      const b = docFromTextNotation(
+      const b = textNotation.docFromTextNotation(
         '|(foo bar)(comment• (deftest a-test•  [baz| ; foo•     gaz])•(bar baz))'
       );
       const range: [number, number] = [b.selections[0].anchor, b.selections[0].active];
       const trail = ']))';
-      expect(getText.startOfFileToCursor(a)).toEqual([
-        range,
-        `${b.model.getText(...range)}${trail}`,
-      ]);
+      expectLib
+        .expect(getText.startOfFileToCursor(a))
+        .toEqual([range, `${b.model.getText(...range)}${trail}`]);
     });
   });
 
   describe('selectionAddingBrackets', () => {
     it('Folds the missing brackets of the selection with brackets from the text behind the selection', () => {
-      const doc = docFromTextNotation('(a b) |(c {:d [1 2 3|] :e :f} d) [4 5 6]');
+      const doc = textNotation.docFromTextNotation('(a b) |(c {:d [1 2 3|] :e :f} d) [4 5 6]');
       const range: [number, number] = [doc.selections[0].anchor, doc.selections[0].active];
       const trail = ']})';
-      expect(getText.selectionAddingBrackets(doc)).toEqual([
-        range,
-        `${doc.model.getText(...range)}${trail}`,
-      ]);
+      expectLib
+        .expect(getText.selectionAddingBrackets(doc))
+        .toEqual([range, `${doc.model.getText(...range)}${trail}`]);
     });
   });
 });

--- a/src/extension-test/unit/util/fiddle-files-test.ts
+++ b/src/extension-test/unit/util/fiddle-files-test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'expect';
+import * as expectLib from 'expect';
 import * as fiddleFiles from '../../../util/fiddle-files';
 import * as path from 'path';
 
@@ -6,590 +6,690 @@ describe('fiddle files', () => {
   describe('mapping', () => {
     describe('source->fiddle', () => {
       it('finds mapping', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [{ source: ['src'], fiddle: ['dev'] }],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'src', 'a', 'b', 'c_d.clj'),
-            'source'
-          ).fiddle
-        ).toEqual(['dev']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [{ source: ['src'], fiddle: ['dev'] }],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'src', 'a', 'b', 'c_d.clj'),
+              'source'
+            ).fiddle
+          )
+          .toEqual(['dev']);
       });
       it('finds first matching mapping', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['no-src'], fiddle: ['no-dev'] },
-              { source: ['src'], fiddle: ['first-dev'] },
-              { source: ['src'], fiddle: ['second-dev'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'src', 'a', 'b', 'c_d.clj'),
-            'source'
-          ).fiddle
-        ).toEqual(['first-dev']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['no-src'], fiddle: ['no-dev'] },
+                { source: ['src'], fiddle: ['first-dev'] },
+                { source: ['src'], fiddle: ['second-dev'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'src', 'a', 'b', 'c_d.clj'),
+              'source'
+            ).fiddle
+          )
+          .toEqual(['first-dev']);
       });
       it('finds first matching mapping, considering full path segments', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['no-src'], fiddle: ['no-dev'] },
-              { source: ['src'], fiddle: ['not-first-dev'] },
-              { source: ['src2'], fiddle: ['first-dev'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'src2', 'a', 'b', 'c_d.clj'),
-            'source'
-          ).fiddle
-        ).toEqual(['first-dev']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['no-src'], fiddle: ['no-dev'] },
+                { source: ['src'], fiddle: ['not-first-dev'] },
+                { source: ['src2'], fiddle: ['first-dev'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'src2', 'a', 'b', 'c_d.clj'),
+              'source'
+            ).fiddle
+          )
+          .toEqual(['first-dev']);
       });
       it('prioritizes the longest source mapping, when overlapping', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['src'], fiddle: ['not-prio'] },
-              { source: ['src', 'a'], fiddle: ['prio'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'src/a/b.cljs'),
-            'source'
-          ).fiddle
-        ).toEqual(['prio']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['src'], fiddle: ['not-prio'] },
+                { source: ['src', 'a'], fiddle: ['prio'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'src/a/b.cljs'),
+              'source'
+            ).fiddle
+          )
+          .toEqual(['prio']);
       });
       it('prioritizes the longest source mapping, when overlapping, even if the shorter is an dedicated fiddle', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['src'], fiddle: ['a.fiddle'] },
-              { source: ['src', 'a'], fiddle: ['prio'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'src/a/b.cljs'),
-            'source'
-          ).fiddle
-        ).toEqual(['prio']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['src'], fiddle: ['a.fiddle'] },
+                { source: ['src', 'a'], fiddle: ['prio'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'src/a/b.cljs'),
+              'source'
+            ).fiddle
+          )
+          .toEqual(['prio']);
       });
       it('only considers matching path', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['src'], fiddle: ['a.fiddle'] },
-              { source: ['src', 'a'], fiddle: ['not-matching'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'src', 'b', 'b.cljs'),
-            'source'
-          ).fiddle
-        ).toEqual(['a.fiddle']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['src'], fiddle: ['a.fiddle'] },
+                { source: ['src', 'a'], fiddle: ['not-matching'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'src', 'b', 'b.cljs'),
+              'source'
+            ).fiddle
+          )
+          .toEqual(['a.fiddle']);
       });
       it('prioritizes dedicated fiddle when equal length from mappings', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['src'], fiddle: ['dev'] },
-              { source: ['src'], fiddle: ['dev', 'a.ext'] },
-              { source: ['src'], fiddle: ['dev', 'b'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'src', 'a', 'b', 'c.clj'),
-            'source'
-          ).fiddle
-        ).toEqual(['dev', 'a.ext']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['src'], fiddle: ['dev'] },
+                { source: ['src'], fiddle: ['dev', 'a.ext'] },
+                { source: ['src'], fiddle: ['dev', 'b'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'src', 'a', 'b', 'c.clj'),
+              'source'
+            ).fiddle
+          )
+          .toEqual(['dev', 'a.ext']);
       });
       it('prioritizes first dedicated fiddle when equal length from mappings', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['no-match'], fiddle: ['no-fiddle'] },
-              { source: ['src'], fiddle: ['no-fiddle'] },
-              { source: ['src2'], fiddle: ['first.ext'] },
-              { source: ['src2'], fiddle: ['second.ext'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'src2', 'a', 'b', 'c.clj'),
-            'source'
-          ).fiddle
-        ).toEqual(['first.ext']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['no-match'], fiddle: ['no-fiddle'] },
+                { source: ['src'], fiddle: ['no-fiddle'] },
+                { source: ['src2'], fiddle: ['first.ext'] },
+                { source: ['src2'], fiddle: ['second.ext'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'src2', 'a', 'b', 'c.clj'),
+              'source'
+            ).fiddle
+          )
+          .toEqual(['first.ext']);
       });
       it('prioritizes first dedicated fiddle when equal length from mappings', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['no-match'], fiddle: ['no-fiddle'] },
-              { source: ['src'], fiddle: ['first'] },
-              { source: ['src'], fiddle: ['second.ext'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'src', 'a', 'b', 'c.clj'),
-            'source'
-          ).fiddle
-        ).toEqual(['second.ext']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['no-match'], fiddle: ['no-fiddle'] },
+                { source: ['src'], fiddle: ['first'] },
+                { source: ['src'], fiddle: ['second.ext'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'src', 'a', 'b', 'c.clj'),
+              'source'
+            ).fiddle
+          )
+          .toEqual(['second.ext']);
       });
       it('prioritizes dedicated fiddle match with the same file extension', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['not-prio'], fiddle: ['dev'] },
-              { source: ['src'], fiddle: ['dev', 'a.clj'] },
-              { source: ['src'], fiddle: ['dev', 'a.cljc'] },
-              { source: ['src'], fiddle: ['dev', 'a.cljs'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'src', 'a', 'b', 'c.cljs'),
-            'source'
-          ).fiddle
-        ).toEqual(['dev', 'a.cljs']);
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['not-prio'], fiddle: ['dev'] },
-              { source: ['src'], fiddle: ['dev', 'a.clj'] },
-              { source: ['src'], fiddle: ['dev', 'a.cljc'] },
-              { source: ['src'], fiddle: ['dev', 'a.cljs'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'src', 'a', 'b', 'c.clj'),
-            'source'
-          ).fiddle
-        ).toEqual(['dev', 'a.clj']);
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['not-prio'], fiddle: ['dev'] },
-              { source: ['src'], fiddle: ['dev', 'a.clj'] },
-              { source: ['src'], fiddle: ['dev', 'a.cljc'] },
-              { source: ['src'], fiddle: ['dev', 'a.cljs'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'src', 'a', 'b', 'c.cljc'),
-            'source'
-          ).fiddle
-        ).toEqual(['dev', 'a.cljc']);
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['not-prio'], fiddle: ['dev'] },
-              { source: ['src'], fiddle: ['dev', 'a.clj'] },
-              { source: ['src'], fiddle: ['dev', 'a.cljc'] },
-              { source: ['src'], fiddle: ['dev', 'a.cljs'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'src', 'a', 'b', 'c.bb'),
-            'source'
-          ).fiddle
-        ).toEqual(['dev', 'a.clj']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['not-prio'], fiddle: ['dev'] },
+                { source: ['src'], fiddle: ['dev', 'a.clj'] },
+                { source: ['src'], fiddle: ['dev', 'a.cljc'] },
+                { source: ['src'], fiddle: ['dev', 'a.cljs'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'src', 'a', 'b', 'c.cljs'),
+              'source'
+            ).fiddle
+          )
+          .toEqual(['dev', 'a.cljs']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['not-prio'], fiddle: ['dev'] },
+                { source: ['src'], fiddle: ['dev', 'a.clj'] },
+                { source: ['src'], fiddle: ['dev', 'a.cljc'] },
+                { source: ['src'], fiddle: ['dev', 'a.cljs'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'src', 'a', 'b', 'c.clj'),
+              'source'
+            ).fiddle
+          )
+          .toEqual(['dev', 'a.clj']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['not-prio'], fiddle: ['dev'] },
+                { source: ['src'], fiddle: ['dev', 'a.clj'] },
+                { source: ['src'], fiddle: ['dev', 'a.cljc'] },
+                { source: ['src'], fiddle: ['dev', 'a.cljs'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'src', 'a', 'b', 'c.cljc'),
+              'source'
+            ).fiddle
+          )
+          .toEqual(['dev', 'a.cljc']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['not-prio'], fiddle: ['dev'] },
+                { source: ['src'], fiddle: ['dev', 'a.clj'] },
+                { source: ['src'], fiddle: ['dev', 'a.cljc'] },
+                { source: ['src'], fiddle: ['dev', 'a.cljs'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'src', 'a', 'b', 'c.bb'),
+              'source'
+            ).fiddle
+          )
+          .toEqual(['dev', 'a.clj']);
       });
     });
 
     describe('fiddle->source', () => {
       it('finds mapping', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [{ source: ['src'], fiddle: ['dev'] }],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'dev', 'a', 'b', 'c_d.fiddle'),
-            'fiddle'
-          ).source
-        ).toEqual(['src']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [{ source: ['src'], fiddle: ['dev'] }],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'dev', 'a', 'b', 'c_d.fiddle'),
+              'fiddle'
+            ).source
+          )
+          .toEqual(['src']);
       });
       it('finds first mapping', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['no-src'], fiddle: ['no-dev'] },
-              { source: ['first-src'], fiddle: ['dev'] },
-              { source: ['second-src'], fiddle: ['dev'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'dev', 'a', 'b', 'c_d.fiddle'),
-            'fiddle'
-          ).source
-        ).toEqual(['first-src']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['no-src'], fiddle: ['no-dev'] },
+                { source: ['first-src'], fiddle: ['dev'] },
+                { source: ['second-src'], fiddle: ['dev'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'dev', 'a', 'b', 'c_d.fiddle'),
+              'fiddle'
+            ).source
+          )
+          .toEqual(['first-src']);
       });
       it('finds first mapping, considering full path segments', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['no-src'], fiddle: ['no-dev'] },
-              { source: ['not-first-src'], fiddle: ['dev'] },
-              { source: ['first-src'], fiddle: ['dev2'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'dev2', 'a', 'b', 'c_d.fiddle'),
-            'fiddle'
-          ).source
-        ).toEqual(['first-src']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['no-src'], fiddle: ['no-dev'] },
+                { source: ['not-first-src'], fiddle: ['dev'] },
+                { source: ['first-src'], fiddle: ['dev2'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'dev2', 'a', 'b', 'c_d.fiddle'),
+              'fiddle'
+            ).source
+          )
+          .toEqual(['first-src']);
       });
       it('prioritizes the longest fiddle mapping, when overlapping', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['src'], fiddle: ['dev', 'fiddles'] },
-              { source: ['prio'], fiddle: ['dev', 'fiddles', 'a'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'dev', 'fiddles', 'a', 'b.cljs'),
-            'fiddle'
-          ).source
-        ).toEqual(['prio']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['src'], fiddle: ['dev', 'fiddles'] },
+                { source: ['prio'], fiddle: ['dev', 'fiddles', 'a'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'dev', 'fiddles', 'a', 'b.cljs'),
+              'fiddle'
+            ).source
+          )
+          .toEqual(['prio']);
       });
       it('prioritizes dedicated fiddle match', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['not-prio'], fiddle: ['dev'] },
-              { source: ['first-src'], fiddle: ['dev', 'a.ext'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'dev', 'a.ext'),
-            'fiddle'
-          ).source
-        ).toEqual(['first-src']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['not-prio'], fiddle: ['dev'] },
+                { source: ['first-src'], fiddle: ['dev', 'a.ext'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'dev', 'a.ext'),
+              'fiddle'
+            ).source
+          )
+          .toEqual(['first-src']);
       });
       it('prioritizes dedicated fiddle match with the same file extension', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['not-prio'], fiddle: ['dev'] },
-              { source: ['clj'], fiddle: ['dev', 'a.clj'] },
-              { source: ['cljc'], fiddle: ['dev', 'a.cljc'] },
-              { source: ['cljs'], fiddle: ['dev', 'a.cljs'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'dev', 'a.cljs'),
-            'fiddle'
-          ).source
-        ).toEqual(['cljs']);
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['not-prio'], fiddle: ['dev'] },
-              { source: ['clj'], fiddle: ['dev', 'a.clj'] },
-              { source: ['cljc'], fiddle: ['dev', 'a.cljc'] },
-              { source: ['cljs'], fiddle: ['dev', 'a.cljs'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'dev', 'a.clj'),
-            'fiddle'
-          ).source
-        ).toEqual(['clj']);
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['not-prio'], fiddle: ['dev'] },
-              { source: ['clj'], fiddle: ['dev', 'a.clj'] },
-              { source: ['cljc'], fiddle: ['dev', 'a.cljc'] },
-              { source: ['cljs'], fiddle: ['dev', 'a.cljs'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'dev', 'a.cljc'),
-            'fiddle'
-          ).source
-        ).toEqual(['cljc']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['not-prio'], fiddle: ['dev'] },
+                { source: ['clj'], fiddle: ['dev', 'a.clj'] },
+                { source: ['cljc'], fiddle: ['dev', 'a.cljc'] },
+                { source: ['cljs'], fiddle: ['dev', 'a.cljs'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'dev', 'a.cljs'),
+              'fiddle'
+            ).source
+          )
+          .toEqual(['cljs']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['not-prio'], fiddle: ['dev'] },
+                { source: ['clj'], fiddle: ['dev', 'a.clj'] },
+                { source: ['cljc'], fiddle: ['dev', 'a.cljc'] },
+                { source: ['cljs'], fiddle: ['dev', 'a.cljs'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'dev', 'a.clj'),
+              'fiddle'
+            ).source
+          )
+          .toEqual(['clj']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['not-prio'], fiddle: ['dev'] },
+                { source: ['clj'], fiddle: ['dev', 'a.clj'] },
+                { source: ['cljc'], fiddle: ['dev', 'a.cljc'] },
+                { source: ['cljs'], fiddle: ['dev', 'a.cljs'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'dev', 'a.cljc'),
+              'fiddle'
+            ).source
+          )
+          .toEqual(['cljc']);
       });
       it('prioritizes longest from mapping, even when the shorter is an dedicated fiddle', function () {
-        expect(
-          fiddleFiles._internal_getMapping(
-            [
-              { source: ['not-prio'], fiddle: ['dev'] },
-              { source: ['dedicated'], fiddle: ['dev', 'a', 'a.ext'] },
-              { source: ['prio'], fiddle: ['dev', 'a', 'b'] },
-            ],
-            path.join('u', 'p'),
-            path.join('u', 'p', 'dev', 'a', 'b', 'c.clj'),
-            'fiddle'
-          ).source
-        ).toEqual(['prio']);
+        expectLib
+          .expect(
+            fiddleFiles._internal_getMapping(
+              [
+                { source: ['not-prio'], fiddle: ['dev'] },
+                { source: ['dedicated'], fiddle: ['dev', 'a', 'a.ext'] },
+                { source: ['prio'], fiddle: ['dev', 'a', 'b'] },
+              ],
+              path.join('u', 'p'),
+              path.join('u', 'p', 'dev', 'a', 'b', 'c.clj'),
+              'fiddle'
+            ).source
+          )
+          .toEqual(['prio']);
       });
     });
   });
 
   describe('context', () => {
     it('without source->fiddle map, a .fiddle files is fiddle file', function () {
-      expect(
-        fiddleFiles.isFiddleFile(
-          path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'),
-          path.join('u', 'p'),
-          null
+      expectLib
+        .expect(
+          fiddleFiles.isFiddleFile(
+            path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'),
+            path.join('u', 'p'),
+            null
+          )
         )
-      ).toBeTruthy();
+        .toBeTruthy();
     });
     it('without source->fiddle map, all .fiddle files are fiddle files, also outside the project root', function () {
-      expect(
-        fiddleFiles.isFiddleFile(
-          path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'),
-          path.join('z', 'p'),
-          null
+      expectLib
+        .expect(
+          fiddleFiles.isFiddleFile(
+            path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'),
+            path.join('z', 'p'),
+            null
+          )
         )
-      ).toBeTruthy();
+        .toBeTruthy();
     });
     it('with fiddle->source map, a .cljc file in the fiddle path is fiddle file', function () {
-      expect(
-        fiddleFiles.isFiddleFile(
-          path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.cljc'),
-          path.join('u', 'p'),
-          [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+      expectLib
+        .expect(
+          fiddleFiles.isFiddleFile(
+            path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.cljc'),
+            path.join('u', 'p'),
+            [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+          )
         )
-      ).toBeTruthy();
+        .toBeTruthy();
     });
     it('with fiddle->source map, a .fiddle file in the fiddle path is a fiddle file', function () {
-      expect(
-        fiddleFiles.isFiddleFile(
-          path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.fiddle'),
-          path.join('u', 'p'),
-          [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+      expectLib
+        .expect(
+          fiddleFiles.isFiddleFile(
+            path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.fiddle'),
+            path.join('u', 'p'),
+            [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+          )
         )
-      ).toBeTruthy();
+        .toBeTruthy();
     });
     it('with fiddle->source map, a .fiddle file in the source path is a fiddle file', function () {
-      expect(
-        fiddleFiles.isFiddleFile(
-          path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'),
-          path.join('u', 'p'),
-          [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+      expectLib
+        .expect(
+          fiddleFiles.isFiddleFile(
+            path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'),
+            path.join('u', 'p'),
+            [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+          )
         )
-      ).toBeTruthy();
+        .toBeTruthy();
     });
     it('with fiddle->source map, any file fiddle path is a fiddle file', function () {
-      expect(
-        fiddleFiles.isFiddleFile(
-          path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c', 'd.anything'),
-          path.join('u', 'p'),
-          [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+      expectLib
+        .expect(
+          fiddleFiles.isFiddleFile(
+            path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c', 'd.anything'),
+            path.join('u', 'p'),
+            [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+          )
         )
-      ).toBeTruthy();
+        .toBeTruthy();
     });
     it('with fiddle->source map, a .cljc file not in the fiddle path is not a fiddle file', function () {
-      expect(
-        fiddleFiles.isFiddleFile(
-          path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
-          path.join('u', 'p'),
-          [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+      expectLib
+        .expect(
+          fiddleFiles.isFiddleFile(
+            path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
+            path.join('u', 'p'),
+            [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+          )
         )
-      ).toBeFalsy();
+        .toBeFalsy();
     });
     it('with fiddle->source map ending with a file extension, the exact match is a dedicated fiddle file', function () {
-      expect(
-        fiddleFiles.isFiddleFile(
-          path.join('u', 'p', 'dev', 'fiddles', 'a.ext'),
-          path.join('u', 'p'),
-          [{ source: ['src'], fiddle: ['dev', 'fiddles', 'a.ext'] }]
+      expectLib
+        .expect(
+          fiddleFiles.isFiddleFile(
+            path.join('u', 'p', 'dev', 'fiddles', 'a.ext'),
+            path.join('u', 'p'),
+            [{ source: ['src'], fiddle: ['dev', 'fiddles', 'a.ext'] }]
+          )
         )
-      ).toBeTruthy();
+        .toBeTruthy();
     });
     it('with multiple fiddle->source mappings, a file in any of the fiddle paths is a fiddle file', function () {
-      expect(
-        fiddleFiles.isFiddleFile(
-          path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.cljc'),
-          path.join('u', 'p'),
-          [
-            { source: ['no-match'], fiddle: ['no-fiddle'] },
-            { source: ['src'], fiddle: ['dev', 'fiddles'] },
-            { source: ['src'], fiddle: ['second'] },
-          ]
+      expectLib
+        .expect(
+          fiddleFiles.isFiddleFile(
+            path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.cljc'),
+            path.join('u', 'p'),
+            [
+              { source: ['no-match'], fiddle: ['no-fiddle'] },
+              { source: ['src'], fiddle: ['dev', 'fiddles'] },
+              { source: ['src'], fiddle: ['second'] },
+            ]
+          )
         )
-      ).toBeTruthy();
+        .toBeTruthy();
     });
     it('with fiddle->source map ending with a file extension,  a non-matching file is not a fiddle file', function () {
-      expect(
-        fiddleFiles.isFiddleFile(
-          path.join('u', 'p', 'dev', 'fiddles', 'b.ext'),
-          path.join('u', 'p'),
-          [{ source: ['src'], fiddle: ['dev', 'fiddles', 'a.ext'] }]
+      expectLib
+        .expect(
+          fiddleFiles.isFiddleFile(
+            path.join('u', 'p', 'dev', 'fiddles', 'b.ext'),
+            path.join('u', 'p'),
+            [{ source: ['src'], fiddle: ['dev', 'fiddles', 'a.ext'] }]
+          )
         )
-      ).toBeFalsy();
-      expect(
-        fiddleFiles.isFiddleFile(
-          path.join('u', 'p', 'src', 'a', 'b', 'c.clj'),
-          path.join('u', 'p'),
-          [{ source: ['src'], fiddle: ['dev', 'fiddles', 'a.ext'] }]
+        .toBeFalsy();
+      expectLib
+        .expect(
+          fiddleFiles.isFiddleFile(
+            path.join('u', 'p', 'src', 'a', 'b', 'c.clj'),
+            path.join('u', 'p'),
+            [{ source: ['src'], fiddle: ['dev', 'fiddles', 'a.ext'] }]
+          )
         )
-      ).toBeFalsy();
+        .toBeFalsy();
     });
   });
 
   describe('fiddle file for source', () => {
     it('without source->fiddle map, gets fiddle file for cljc file', function () {
-      expect(
-        fiddleFiles.getFiddleForSourceFile(
-          path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
-          path.join('u', 'p'),
-          null
+      expectLib
+        .expect(
+          fiddleFiles.getFiddleForSourceFile(
+            path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
+            path.join('u', 'p'),
+            null
+          )
         )
-      ).toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'));
+        .toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'));
     });
     it('with source->fiddle map, gets fiddle file for cljc file', function () {
-      expect(
-        fiddleFiles.getFiddleForSourceFile(
-          path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
-          path.join('u', 'p'),
-          [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+      expectLib
+        .expect(
+          fiddleFiles.getFiddleForSourceFile(
+            path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
+            path.join('u', 'p'),
+            [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+          )
         )
-      ).toBe(path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.cljc'));
+        .toBe(path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.cljc'));
     });
     it('with source->fiddle map with several matching source mappings, gets fiddle file for first', function () {
-      expect(
-        fiddleFiles.getFiddleForSourceFile(
-          path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
-          path.join('u', 'p'),
-          [
-            { source: ['no-match'], fiddle: ['no-fiddle'] },
-            { source: ['src'], fiddle: ['first'] },
-            { source: ['src'], fiddle: ['second'] },
-          ]
+      expectLib
+        .expect(
+          fiddleFiles.getFiddleForSourceFile(
+            path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
+            path.join('u', 'p'),
+            [
+              { source: ['no-match'], fiddle: ['no-fiddle'] },
+              { source: ['src'], fiddle: ['first'] },
+              { source: ['src'], fiddle: ['second'] },
+            ]
+          )
         )
-      ).toBe(path.join('u', 'p', 'first', 'a', 'b', 'c_d.cljc'));
+        .toBe(path.join('u', 'p', 'first', 'a', 'b', 'c_d.cljc'));
     });
     it('with source->fiddle map with fiddle path ending in a file extension, finds that file for any source file', function () {
-      expect(
-        fiddleFiles.getFiddleForSourceFile(
-          path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
-          path.join('u', 'p'),
-          [{ source: ['src'], fiddle: ['dev', 'fiddles', 'a.ext'] }]
+      expectLib
+        .expect(
+          fiddleFiles.getFiddleForSourceFile(
+            path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
+            path.join('u', 'p'),
+            [{ source: ['src'], fiddle: ['dev', 'fiddles', 'a.ext'] }]
+          )
         )
-      ).toBe(path.join('u', 'p', 'dev', 'fiddles', 'a.ext'));
-      expect(
-        fiddleFiles.getFiddleForSourceFile(
-          path.join('u', 'p', 'src', 'a', 'b.cljc'),
-          path.join('u', 'p'),
-          [{ source: ['src'], fiddle: ['dev', 'fiddles', 'a.ext'] }]
+        .toBe(path.join('u', 'p', 'dev', 'fiddles', 'a.ext'));
+      expectLib
+        .expect(
+          fiddleFiles.getFiddleForSourceFile(
+            path.join('u', 'p', 'src', 'a', 'b.cljc'),
+            path.join('u', 'p'),
+            [{ source: ['src'], fiddle: ['dev', 'fiddles', 'a.ext'] }]
+          )
         )
-      ).toBe(path.join('u', 'p', 'dev', 'fiddles', 'a.ext'));
+        .toBe(path.join('u', 'p', 'dev', 'fiddles', 'a.ext'));
     });
     it('with source->fiddle map with several matching source mappings, gets fiddle file for first, also if it is an dedicated fiddle', function () {
-      expect(
-        fiddleFiles.getFiddleForSourceFile(
-          path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
-          path.join('u', 'p'),
-          [
-            { source: ['no-match'], fiddle: ['no-fiddle'] },
-            { source: ['src'], fiddle: ['first.ext'] },
-            { source: ['src'], fiddle: ['second'] },
-          ]
+      expectLib
+        .expect(
+          fiddleFiles.getFiddleForSourceFile(
+            path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
+            path.join('u', 'p'),
+            [
+              { source: ['no-match'], fiddle: ['no-fiddle'] },
+              { source: ['src'], fiddle: ['first.ext'] },
+              { source: ['src'], fiddle: ['second'] },
+            ]
+          )
         )
-      ).toBe(path.join('u', 'p', 'first.ext'));
-      expect(
-        fiddleFiles.getFiddleForSourceFile(
-          path.join('u', 'p', 'src2', 'a', 'b', 'c_d.cljc'),
-          path.join('u', 'p'),
-          [
-            { source: ['no-match'], fiddle: ['no-fiddle'] },
-            { source: ['src'], fiddle: ['no-fiddle'] },
-            { source: ['src2'], fiddle: ['first.ext'] },
-            { source: ['src2'], fiddle: ['second.ext'] },
-          ]
+        .toBe(path.join('u', 'p', 'first.ext'));
+      expectLib
+        .expect(
+          fiddleFiles.getFiddleForSourceFile(
+            path.join('u', 'p', 'src2', 'a', 'b', 'c_d.cljc'),
+            path.join('u', 'p'),
+            [
+              { source: ['no-match'], fiddle: ['no-fiddle'] },
+              { source: ['src'], fiddle: ['no-fiddle'] },
+              { source: ['src2'], fiddle: ['first.ext'] },
+              { source: ['src2'], fiddle: ['second.ext'] },
+            ]
+          )
         )
-      ).toBe(path.join('u', 'p', 'first.ext'));
+        .toBe(path.join('u', 'p', 'first.ext'));
     });
     it('with source->fiddle map with several matching source mappings, gets dedicated', function () {
-      expect(
-        fiddleFiles.getFiddleForSourceFile(
-          path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
-          path.join('u', 'p'),
-          [
-            { source: ['no-match'], fiddle: ['no-fiddle'] },
-            { source: ['src'], fiddle: ['first'] },
-            { source: ['src'], fiddle: ['second.ext'] },
-          ]
+      expectLib
+        .expect(
+          fiddleFiles.getFiddleForSourceFile(
+            path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
+            path.join('u', 'p'),
+            [
+              { source: ['no-match'], fiddle: ['no-fiddle'] },
+              { source: ['src'], fiddle: ['first'] },
+              { source: ['src'], fiddle: ['second.ext'] },
+            ]
+          )
         )
-      ).toBe(path.join('u', 'p', 'second.ext'));
+        .toBe(path.join('u', 'p', 'second.ext'));
     });
     it('throws when no source mapping', function () {
-      expect(() =>
-        fiddleFiles.getFiddleForSourceFile(
-          path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
-          path.join('u', 'p'),
-          [{ source: ['no-match'], fiddle: ['no-fiddle'] }]
+      expectLib
+        .expect(() =>
+          fiddleFiles.getFiddleForSourceFile(
+            path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
+            path.join('u', 'p'),
+            [{ source: ['no-match'], fiddle: ['no-fiddle'] }]
+          )
         )
-      ).toThrow(fiddleFiles.FiddleMappingException);
+        .toThrow(fiddleFiles.FiddleMappingException);
     });
     it('throws when project root does not match', function () {
-      expect(() =>
-        fiddleFiles.getFiddleForSourceFile(
-          path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
-          path.join('u', 'p-no'),
-          [
-            { source: ['no-match'], fiddle: ['no-fiddle'] },
-            { source: ['src'], fiddle: ['first'] },
-            { source: ['src'], fiddle: ['second'] },
-          ]
+      expectLib
+        .expect(() =>
+          fiddleFiles.getFiddleForSourceFile(
+            path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'),
+            path.join('u', 'p-no'),
+            [
+              { source: ['no-match'], fiddle: ['no-fiddle'] },
+              { source: ['src'], fiddle: ['first'] },
+              { source: ['src'], fiddle: ['second'] },
+            ]
+          )
         )
-      ).toThrow(fiddleFiles.FiddleMappingException);
+        .toThrow(fiddleFiles.FiddleMappingException);
     });
   });
 
   describe('source for fiddle file', () => {
     describe('source base', () => {
       it('without fiddle->source map, gets source base for fiddle file', function () {
-        expect(
-          fiddleFiles.getSourceBaseForFiddleFile(
-            path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'),
-            path.join('u', 'p'),
-            null
+        expectLib
+          .expect(
+            fiddleFiles.getSourceBaseForFiddleFile(
+              path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'),
+              path.join('u', 'p'),
+              null
+            )
           )
-        ).toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d'));
+          .toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d'));
       });
       it('with fiddle->source map, gets source base for fiddle file', function () {
-        expect(
-          fiddleFiles.getSourceBaseForFiddleFile(
-            path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.clj'),
-            path.join('u', 'p'),
-            [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+        expectLib
+          .expect(
+            fiddleFiles.getSourceBaseForFiddleFile(
+              path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.clj'),
+              path.join('u', 'p'),
+              [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+            )
           )
-        ).toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d'));
+          .toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d'));
       });
       it('with fiddle->source map and a .fiddle file, gets source base as sibling', function () {
-        expect(
-          fiddleFiles.getSourceBaseForFiddleFile(
-            path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'),
-            path.join('u', 'p'),
-            [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+        expectLib
+          .expect(
+            fiddleFiles.getSourceBaseForFiddleFile(
+              path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'),
+              path.join('u', 'p'),
+              [{ source: ['src'], fiddle: ['dev', 'fiddles'] }]
+            )
           )
-        ).toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d'));
+          .toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d'));
       });
       it('with fiddle->source map with several matching source mappings, gets fiddle file for first', function () {
-        expect(
-          fiddleFiles.getSourceBaseForFiddleFile(
-            path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.cljc'),
-            path.join('u', 'p'),
-            [
-              { source: ['no-source'], fiddle: ['no-match'] },
-              { source: ['first'], fiddle: ['dev', 'fiddles'] },
-              { source: ['second'], fiddle: ['dev', 'fiddles'] },
-            ]
+        expectLib
+          .expect(
+            fiddleFiles.getSourceBaseForFiddleFile(
+              path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.cljc'),
+              path.join('u', 'p'),
+              [
+                { source: ['no-source'], fiddle: ['no-match'] },
+                { source: ['first'], fiddle: ['dev', 'fiddles'] },
+                { source: ['second'], fiddle: ['dev', 'fiddles'] },
+              ]
+            )
           )
-        ).toBe(path.join('u', 'p', 'first', 'a', 'b', 'c_d'));
+          .toBe(path.join('u', 'p', 'first', 'a', 'b', 'c_d'));
       });
       it('returns sibling base for .fiddle file', function () {
-        expect(
-          fiddleFiles.getSourceBaseForFiddleFile(
-            path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.fiddle'),
-            path.join('u', 'p'),
-            [{ source: ['no-source'], fiddle: ['no-match'] }]
+        expectLib
+          .expect(
+            fiddleFiles.getSourceBaseForFiddleFile(
+              path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.fiddle'),
+              path.join('u', 'p'),
+              [{ source: ['no-source'], fiddle: ['no-match'] }]
+            )
           )
-        ).toBe(path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d'));
+          .toBe(path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d'));
       });
       it('returns undefined for dedicated fiddle file match', function () {
-        expect(
-          fiddleFiles.getSourceBaseForFiddleFile(
-            path.join('u', 'p', 'dev', 'fiddles', 'a.ext'),
-            path.join('u', 'p'),
-            [{ source: ['src'], fiddle: ['dev', 'fiddles', 'a.ext'] }]
+        expectLib
+          .expect(
+            fiddleFiles.getSourceBaseForFiddleFile(
+              path.join('u', 'p', 'dev', 'fiddles', 'a.ext'),
+              path.join('u', 'p'),
+              [{ source: ['src'], fiddle: ['dev', 'fiddles', 'a.ext'] }]
+            )
           )
-        ).toBeUndefined();
+          .toBeUndefined();
       });
       it('throws when project root does not match', function () {
-        expect(() =>
-          fiddleFiles.getSourceBaseForFiddleFile(
-            path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.cljc'),
-            path.join('u', 'p-no'),
-            [
-              { source: ['no-source'], fiddle: ['no-match'] },
-              { source: ['first'], fiddle: ['dev', 'fiddles'] },
-              { source: ['second'], fiddle: ['dev', 'fiddles'] },
-            ]
+        expectLib
+          .expect(() =>
+            fiddleFiles.getSourceBaseForFiddleFile(
+              path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.cljc'),
+              path.join('u', 'p-no'),
+              [
+                { source: ['no-source'], fiddle: ['no-match'] },
+                { source: ['first'], fiddle: ['dev', 'fiddles'] },
+                { source: ['second'], fiddle: ['dev', 'fiddles'] },
+              ]
+            )
           )
-        ).toThrow(fiddleFiles.FiddleMappingException);
+          .toThrow(fiddleFiles.FiddleMappingException);
       });
     });
 
@@ -606,56 +706,66 @@ describe('fiddle files', () => {
         },
       };
       it('without fiddle->source map, gets cljc source file for fiddle file', async function () {
-        expect(
-          await fiddleFiles.getSourceForFiddleFile(
-            path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'),
-            path.join('u', 'p'),
-            null,
-            mockWorkspace,
-            ['cljc', 'clj']
+        expectLib
+          .expect(
+            await fiddleFiles.getSourceForFiddleFile(
+              path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'),
+              path.join('u', 'p'),
+              null,
+              mockWorkspace,
+              ['cljc', 'clj']
+            )
           )
-        ).toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'));
+          .toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'));
       });
       it('with fiddle->source map, gets source clj for clj fiddle file', async function () {
-        expect(
-          await fiddleFiles.getSourceForFiddleFile(
-            path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.clj'),
-            path.join('u', 'p'),
-            [{ source: ['src'], fiddle: ['dev', 'fiddles'] }],
-            mockWorkspace
+        expectLib
+          .expect(
+            await fiddleFiles.getSourceForFiddleFile(
+              path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.clj'),
+              path.join('u', 'p'),
+              [{ source: ['src'], fiddle: ['dev', 'fiddles'] }],
+              mockWorkspace
+            )
           )
-        ).toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d.clj'));
+          .toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d.clj'));
       });
       it('with fiddle->source map, gets sibling source clj for .fiddle file', async function () {
-        expect(
-          await fiddleFiles.getSourceForFiddleFile(
-            path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'),
-            path.join('u', 'p'),
-            [{ source: ['src'], fiddle: ['dev', 'fiddles'] }],
-            mockWorkspace,
-            ['cljc', 'clj']
+        expectLib
+          .expect(
+            await fiddleFiles.getSourceForFiddleFile(
+              path.join('u', 'p', 'src', 'a', 'b', 'c_d.fiddle'),
+              path.join('u', 'p'),
+              [{ source: ['src'], fiddle: ['dev', 'fiddles'] }],
+              mockWorkspace,
+              ['cljc', 'clj']
+            )
           )
-        ).toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'));
+          .toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d.cljc'));
       });
       it('with fiddle->source map, gets source bb for bb fiddle file', async function () {
-        expect(
-          await fiddleFiles.getSourceForFiddleFile(
-            path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.bb'),
-            path.join('u', 'p'),
-            [{ source: ['src'], fiddle: ['dev', 'fiddles'] }],
-            mockWorkspace
+        expectLib
+          .expect(
+            await fiddleFiles.getSourceForFiddleFile(
+              path.join('u', 'p', 'dev', 'fiddles', 'a', 'b', 'c_d.bb'),
+              path.join('u', 'p'),
+              [{ source: ['src'], fiddle: ['dev', 'fiddles'] }],
+              mockWorkspace
+            )
           )
-        ).toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d.bb'));
+          .toBe(path.join('u', 'p', 'src', 'a', 'b', 'c_d.bb'));
       });
       it('returns undefined for dedicated matching fiddle file', async function () {
-        expect(
-          await fiddleFiles.getSourceForFiddleFile(
-            path.join('u', 'p', 'dev', 'fiddles', 'a.ext'),
-            path.join('u', 'p'),
-            [{ source: ['src'], fiddle: ['dev', 'fiddles', 'a.ext'] }],
-            mockWorkspace
+        expectLib
+          .expect(
+            await fiddleFiles.getSourceForFiddleFile(
+              path.join('u', 'p', 'dev', 'fiddles', 'a.ext'),
+              path.join('u', 'p'),
+              [{ source: ['src'], fiddle: ['dev', 'fiddles', 'a.ext'] }],
+              mockWorkspace
+            )
           )
-        ).toBeUndefined();
+          .toBeUndefined();
       });
     });
   });

--- a/src/extension-test/unit/util/ns-form-test.ts
+++ b/src/extension-test/unit/util/ns-form-test.ts
@@ -1,239 +1,346 @@
-import { expect } from 'expect';
-import { docFromTextNotation } from '../common/text-notation';
+import * as expectLib from 'expect';
+import * as textNotation from '../common/text-notation';
 import * as nsFormUtil from '../../../util/ns-form';
-import { resolveNsName, pathToNs, isPrefix } from '../../../util/ns-form';
-import { fail } from 'assert';
+import * as assert from 'assert';
 
 describe('ns-form util', () => {
   describe('isPrefix', function () {
     it('/app/src is prefix', function () {
-      expect(true).toBe(isPrefix('/app/src', '/app/src/app/file.clj'));
+      expectLib.expect(true).toBe(nsFormUtil.isPrefix('/app/src', '/app/src/app/file.clj'));
     });
     it('/app/resource is not prefix', function () {
-      expect(false).toBe(isPrefix('/app/resource', '/app/src/app/file.clj'));
+      expectLib.expect(false).toBe(nsFormUtil.isPrefix('/app/resource', '/app/src/app/file.clj'));
     });
   });
 
   describe('pathToNs', function () {
     it('test_file.clj', function () {
-      expect('test-file').toBe(pathToNs('test_file.clj'));
+      expectLib.expect('test-file').toBe(nsFormUtil.pathToNs('test_file.clj'));
     });
     it('foo/bar/baz/test_file.clj', function () {
-      expect('foo.bar.baz.test-file').toBe(pathToNs('foo/bar/baz/test_file.clj'));
+      expectLib
+        .expect('foo.bar.baz.test-file')
+        .toBe(nsFormUtil.pathToNs('foo/bar/baz/test_file.clj'));
     });
     it('foo_bar_baz/test_file.clj', function () {
-      expect('foo-bar-baz.test-file').toBe(pathToNs('foo_bar_baz/test_file.clj'));
+      expectLib
+        .expect('foo-bar-baz.test-file')
+        .toBe(nsFormUtil.pathToNs('foo_bar_baz/test_file.clj'));
     });
   });
 
   describe('resolveNsName', function () {
     it('with source paths', function () {
-      expect('app.file').toBe(resolveNsName(['/app/src'], '/app/src/app/file.clj'));
+      expectLib
+        .expect('app.file')
+        .toBe(nsFormUtil.resolveNsName(['/app/src'], '/app/src/app/file.clj'));
     });
     it('with empty source paths', function () {
-      expect('empty-src').toBe(resolveNsName([], '/app/src/app/empty_src.clj'));
+      expectLib
+        .expect('empty-src')
+        .toBe(nsFormUtil.resolveNsName([], '/app/src/app/empty_src.clj'));
     });
     it('with source paths (not found)', function () {
-      expect('file-test').toBe(resolveNsName(['/app/src'], '/app/test/app/file_test.clj'));
+      expectLib
+        .expect('file-test')
+        .toBe(nsFormUtil.resolveNsName(['/app/src'], '/app/test/app/file_test.clj'));
     });
   });
 
   describe('nsFromCursorDoc', function () {
     it('defaults to `null`', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(no-ns a-b.c-d)\nfoo|'))).toBe(null);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(textNotation.docFromTextNotation('(no-ns a-b.c-d)\nfoo|'))
+        )
+        .toBe(null);
     });
     it('finds ns', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-d) (a b c)|'))
-      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(textNotation.docFromTextNotation('(ns a-b.c-d) (a b c)|'))
+        )
+        .toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
     });
     it('finds in-ns', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation("(in-ns 'a-b.c-d) (a b c)|"))
-      ).toStrictEqual(['a-b.c-d', "(in-ns 'a-b.c-d)"]);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(textNotation.docFromTextNotation("(in-ns 'a-b.c-d) (a b c)|"))
+        )
+        .toStrictEqual(['a-b.c-d', "(in-ns 'a-b.c-d)"]);
     });
     it('returns `null` if ns form does not contain a namespace symbol', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns) (a b c)|'))).toBe(null);
+      expectLib
+        .expect(nsFormUtil.nsFromCursorDoc(textNotation.docFromTextNotation('(ns) (a b c)|')))
+        .toBe(null);
     });
     it('returns `null` if ns form does contains non-symbol', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns [a]) (a b c)|'))).toBe(null);
+      expectLib
+        .expect(nsFormUtil.nsFromCursorDoc(textNotation.docFromTextNotation('(ns [a]) (a b c)|')))
+        .toBe(null);
     });
     it('finds ns in form with line comment', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-d ; comment\n)|'))
-      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d ; comment\n)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(textNotation.docFromTextNotation('(ns a-b.c-d ; comment\n)|'))
+        )
+        .toStrictEqual(['a-b.c-d', '(ns a-b.c-d ; comment\n)']);
     });
     it('finds ns in form after line comments', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation('; comment\n(ns a-b.c-d)|'))
-      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(textNotation.docFromTextNotation('; comment\n(ns a-b.c-d)|'))
+        )
+        .toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
     });
 
     it('Closest ns at top level wins', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(
-          docFromTextNotation('(ns a) (fn [] {:rcf (comment\n(ns a-b.c-d))}|)')
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation('(ns a) (fn [] {:rcf (comment\n(ns a-b.c-d))}|)')
+          )
         )
-      ).toStrictEqual(['a', '(ns a)']);
-      expect(
-        nsFormUtil.nsFromCursorDoc(
-          docFromTextNotation('(ns a) (ns b) (fn [] {:rcf (comment\n(ns a-b.c-d))|})')
+        .toStrictEqual(['a', '(ns a)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation(
+              '(ns a) (ns b) (fn [] {:rcf (comment\n(ns a-b.c-d))|})'
+            )
+          )
         )
-      ).toStrictEqual(['b', '(ns b)']);
-      expect(
-        nsFormUtil.nsFromCursorDoc(
-          docFromTextNotation('(ns a) (ns b) (fn [] {:rcf (comment\n(ns a-b.c-d)|)})')
+        .toStrictEqual(['b', '(ns b)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation(
+              '(ns a) (ns b) (fn [] {:rcf (comment\n(ns a-b.c-d)|)})'
+            )
+          )
         )
-      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
-      expect(
-        nsFormUtil.nsFromCursorDoc(
-          docFromTextNotation('(fn [] {:rcf (comment\n(ns a-b.c-d))}) (ns a)|')
+        .toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation('(fn [] {:rcf (comment\n(ns a-b.c-d))}) (ns a)|')
+          )
         )
-      ).toStrictEqual(['a', '(ns a)']);
-      expect(
-        nsFormUtil.nsFromCursorDoc(
-          docFromTextNotation('(fn [] {:rcf (comment\n(ns a-b.c-d))}) (ns a|)')
+        .toStrictEqual(['a', '(ns a)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation('(fn [] {:rcf (comment\n(ns a-b.c-d))}) (ns a|)')
+          )
         )
-      ).toStrictEqual(['a', '(ns a)']);
+        .toStrictEqual(['a', '(ns a)']);
     });
 
     it('Closest ns or in-ns at top level wins', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(
-          docFromTextNotation("(ns a) (in-ns 'b) (fn [] {:rcf (comment\n(ns a-b.c-d))}|)")
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation(
+              "(ns a) (in-ns 'b) (fn [] {:rcf (comment\n(ns a-b.c-d))}|)"
+            )
+          )
         )
-      ).toStrictEqual(['b', "(in-ns 'b)"]);
-      expect(
-        nsFormUtil.nsFromCursorDoc(
-          docFromTextNotation("(in-ns 'a) (ns b) (fn [] {:rcf (comment\n(ns a-b.c-d))|})")
+        .toStrictEqual(['b', "(in-ns 'b)"]);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation(
+              "(in-ns 'a) (ns b) (fn [] {:rcf (comment\n(ns a-b.c-d))|})"
+            )
+          )
         )
-      ).toStrictEqual(['b', '(ns b)']);
-      expect(
-        nsFormUtil.nsFromCursorDoc(
-          docFromTextNotation("(ns a) (ns b) (fn [] {:rcf (comment\n(ns c) x (in-ns 'a-b.c-d)|)})")
+        .toStrictEqual(['b', '(ns b)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation(
+              "(ns a) (ns b) (fn [] {:rcf (comment\n(ns c) x (in-ns 'a-b.c-d)|)})"
+            )
+          )
         )
-      ).toStrictEqual(['a-b.c-d', "(in-ns 'a-b.c-d)"]);
-      expect(
-        nsFormUtil.nsFromCursorDoc(
-          docFromTextNotation("(fn [] {:rcf (comment\n(ns a-b.c-d))}) (in-ns 'a)|")
+        .toStrictEqual(['a-b.c-d', "(in-ns 'a-b.c-d)"]);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation("(fn [] {:rcf (comment\n(ns a-b.c-d))}) (in-ns 'a)|")
+          )
         )
-      ).toStrictEqual(['a', "(in-ns 'a)"]);
-      expect(
-        nsFormUtil.nsFromCursorDoc(
-          docFromTextNotation("(fn [] {:rcf (comment\n(ns a-b.c-d))}) (in-ns 'a|)")
+        .toStrictEqual(['a', "(in-ns 'a)"]);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation("(fn [] {:rcf (comment\n(ns a-b.c-d))}) (in-ns 'a|)")
+          )
         )
-      ).toStrictEqual(['a', "(in-ns 'a)"]);
+        .toStrictEqual(['a', "(in-ns 'a)"]);
     });
 
     it('Does not find ns in top level ignored form', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('#_ (ns a-b.c-d)|'))).toStrictEqual(
-        null
-      );
+      expectLib
+        .expect(nsFormUtil.nsFromCursorDoc(textNotation.docFromTextNotation('#_ (ns a-b.c-d)|')))
+        .toStrictEqual(null);
     });
     it('Finds ns in ignored rich comments', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation('#_ (comment\n(ns a-b.c-d)|)'))
-      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation('#_ (comment\n(ns a-b.c-d)|)')
+          )
+        )
+        .toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
     });
 
     it('finds ns past top level id tokens', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-d) (a b c) d e (f)|'))
-      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation('(ns a-b.c-d) (a b c) d e (f)|')
+          )
+        )
+        .toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
     });
     it('finds ns past top level id tokens from nested form', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a-b.c-d) (a b c) d e (f|)'))
-      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation('(ns a-b.c-d) (a b c) d e (f|)')
+          )
+        )
+        .toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
     });
     it('finds ns also when not first form', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(foo bar)\n\n(ns a-b.c-d)|'))
-      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(textNotation.docFromTextNotation('(foo bar)\n\n(ns a-b.c-d)|'))
+        )
+        .toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
     });
     it('finds ns in rich comments', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a) (comment\n(ns b) (d e)|)'))
-      ).toStrictEqual(['b', '(ns b)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation('(ns a) (comment\n(ns b) (d e)|)')
+          )
+        )
+        .toStrictEqual(['b', '(ns b)']);
     });
     it('finds ns in nested rich comments', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(
-          docFromTextNotation('(ns a) (fn [] {:rcf (comment\n(ns b) (c| d))})')
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation('(ns a) (fn [] {:rcf (comment\n(ns b) (c| d))})')
+          )
         )
-      ).toStrictEqual(['b', '(ns b)']);
+        .toStrictEqual(['b', '(ns b)']);
     });
     it('finds first ns form if at start of document', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation('|(ns a) (a b c) (ns b)'))
-      ).toStrictEqual(['a', '(ns a)']);
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation('|(no-ns a) (a b c) (ns b) x (ns c) y'))
-      ).toStrictEqual(['b', '(ns b)']);
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation(' |(ns a) (a b c) (ns b)'))
-      ).toStrictEqual(['a', '(ns a)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(textNotation.docFromTextNotation('|(ns a) (a b c) (ns b)'))
+        )
+        .toStrictEqual(['a', '(ns a)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation('|(no-ns a) (a b c) (ns b) x (ns c) y')
+          )
+        )
+        .toStrictEqual(['b', '(ns b)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(textNotation.docFromTextNotation(' |(ns a) (a b c) (ns b)'))
+        )
+        .toStrictEqual(['a', '(ns a)']);
     });
     it('returns `null` if at start of document without ns form', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('|(no-ns a) (a b c) (no-ns b)'))).toBe(
-        null
-      );
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation('|(no-ns a) (a b c) (no-ns b)')
+          )
+        )
+        .toBe(null);
     });
 
     // https://github.com/BetterThanTomorrow/calva/issues/2249
     it('returns outer ns if rich comment lacks ns', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns a) (a b c) (comment b|)'))
-      ).toStrictEqual(['a', '(ns a)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation('(ns a) (a b c) (comment b|)')
+          )
+        )
+        .toStrictEqual(['a', '(ns a)']);
     });
     // https://github.com/BetterThanTomorrow/calva/issues/2266
     it('finds ns when symbol has metadata', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns ^:no-doc a-b.c-d) (a b c)|'))
-      ).toStrictEqual(['a-b.c-d', '(ns ^:no-doc a-b.c-d)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(
+            textNotation.docFromTextNotation('(ns ^:no-doc a-b.c-d) (a b c)|')
+          )
+        )
+        .toStrictEqual(['a-b.c-d', '(ns ^:no-doc a-b.c-d)']);
     });
     // https://github.com/BetterThanTomorrow/calva/issues/2309
     it('finds ns from inside ns form', function () {
-      expect(
-        nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns |a-b.c-d) (a b c)'))
-      ).toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
+      expectLib
+        .expect(
+          nsFormUtil.nsFromCursorDoc(textNotation.docFromTextNotation('(ns |a-b.c-d) (a b c)'))
+        )
+        .toStrictEqual(['a-b.c-d', '(ns a-b.c-d)']);
     });
     // https://github.com/BetterThanTomorrow/calva/issues/2299
     it('finds ns from unbalanced form, lacking opening brackets', function () {
       try {
-        expect(
-          nsFormUtil.nsFromCursorDoc(
-            docFromTextNotation(
-              '(ns xxx)•(def xxx|•{()"#"\\$" #"(?!\\w)"))))))))))))))))))))))))))))))))))))))))'
+        expectLib
+          .expect(
+            nsFormUtil.nsFromCursorDoc(
+              textNotation.docFromTextNotation(
+                '(ns xxx)•(def xxx|•{()"#"\\$" #"(?!\\w)"))))))))))))))))))))))))))))))))))))))))'
+              )
             )
           )
-        ).toStrictEqual(['xxx', '(ns xxx)']);
+          .toStrictEqual(['xxx', '(ns xxx)']);
       } catch (error) {
-        fail(`Expected no error to be thrown, but got ${error}`);
+        assert.fail(`Expected no error to be thrown, but got ${error}`);
       }
     });
     it('finds ns from unbalanced form lacking closing brackets', function () {
       try {
-        expect(
-          nsFormUtil.nsFromCursorDoc(docFromTextNotation('(ns xxx]))]]]]]])))•(def xxx|•{})'))
-        ).toStrictEqual(['xxx', '(ns xxx]']);
+        expectLib
+          .expect(
+            nsFormUtil.nsFromCursorDoc(
+              textNotation.docFromTextNotation('(ns xxx]))]]]]]])))•(def xxx|•{})')
+            )
+          )
+          .toStrictEqual(['xxx', '(ns xxx]']);
       } catch (error) {
-        fail(`Expected no error to be thrown, but got ${error}`);
+        assert.fail(`Expected no error to be thrown, but got ${error}`);
       }
     });
     // https://github.com/BetterThanTomorrow/calva/issues/2523
     // (This wasn't the bug it seems, but it is a good test case.)
     it('returns null when no text in the document', function () {
-      expect(nsFormUtil.nsFromCursorDoc(docFromTextNotation('|'))).toBe(null);
+      expectLib
+        .expect(nsFormUtil.nsFromCursorDoc(textNotation.docFromTextNotation('|')))
+        .toBe(null);
     });
   });
 
   describe('nsFromText', function () {
     it('defaults to `null`', function () {
-      expect(nsFormUtil.nsFromText('(no-ns a-b.c-d)\nfoo')).toBe(null);
+      expectLib.expect(nsFormUtil.nsFromText('(no-ns a-b.c-d)\nfoo')).toBe(null);
     });
     it('defaults to start from end', function () {
-      expect(nsFormUtil.nsFromText('(ns a)\nfoo (ns b) bar')).toStrictEqual(['b', '(ns b)']);
+      expectLib
+        .expect(nsFormUtil.nsFromText('(ns a)\nfoo (ns b) bar'))
+        .toStrictEqual(['b', '(ns b)']);
     });
   });
 });

--- a/src/extension-test/unit/util/regex-test.ts
+++ b/src/extension-test/unit/util/regex-test.ts
@@ -1,16 +1,16 @@
-import { expect } from 'expect';
-import { testCljOrJsRegex } from '../../../util/regex';
+import * as expectLib from 'expect';
+import * as regex from '../../../util/regex';
 
 describe('regex', () => {
   describe('testCljOrJsRegex', () => {
     it('works with the clojure regex string', () => {
-      expect(testCljOrJsRegex('#"^\\w"', 'function1')).toBeTruthy();
+      expectLib.expect(regex.testCljOrJsRegex('#"^\\w"', 'function1')).toBeTruthy();
     });
     it('works with the js regex string', () => {
-      expect(testCljOrJsRegex('/^\\w/', 'function1')).toBeTruthy();
+      expectLib.expect(regex.testCljOrJsRegex('/^\\w/', 'function1')).toBeTruthy();
     });
     it('works with the plain text', () => {
-      expect(testCljOrJsRegex('ANY', 'ANY')).toBeTruthy();
+      expectLib.expect(regex.testCljOrJsRegex('ANY', 'ANY')).toBeTruthy();
     });
   });
 });

--- a/src/extension-test/unit/util/string-test.ts
+++ b/src/extension-test/unit/util/string-test.ts
@@ -1,92 +1,90 @@
-import { expect } from 'expect';
-import {
-  keywordize,
-  unKeywordize,
-  getIndexAfterLastNonWhitespace,
-  getTextAfterLastOccurrenceOfSubstring,
-  testNameSearchPattern,
-} from '../../../util/string';
+import * as expectLib from 'expect';
+import * as string from '../../../util/string';
 
 describe('string', () => {
   describe('keywordize', function () {
     it('keywordizes non-keywords', function () {
-      expect(':test').toBe(keywordize('test'));
+      expectLib.expect(':test').toBe(string.keywordize('test'));
     });
     it('leaves keywords alone', function () {
-      expect(':test').toBe(keywordize(':test'));
+      expectLib.expect(':test').toBe(string.keywordize(':test'));
     });
   });
 
   describe('unKeywordize', function () {
     it('un-keywordizes keywords', function () {
-      expect('test').toBe(unKeywordize(':test'));
+      expectLib.expect('test').toBe(string.unKeywordize(':test'));
     });
     it('leaves non-keywords alone', function () {
-      expect('test').toBe(unKeywordize('test'));
+      expectLib.expect('test').toBe(string.unKeywordize('test'));
     });
   });
 
   describe('getIndexAfterLastNonWhitespace', () => {
     it('returns correct index of end of string', () => {
-      expect(3).toBe(getIndexAfterLastNonWhitespace('123'));
+      expectLib.expect(3).toBe(string.getIndexAfterLastNonWhitespace('123'));
     });
     it('ignores whitespace at end of string', () => {
-      expect(1).toBe(getIndexAfterLastNonWhitespace('> '));
+      expectLib.expect(1).toBe(string.getIndexAfterLastNonWhitespace('> '));
     });
     it('ignores tab characters at end of string', () => {
-      expect(1).toBe(getIndexAfterLastNonWhitespace('>\t\t'));
+      expectLib.expect(1).toBe(string.getIndexAfterLastNonWhitespace('>\t\t'));
     });
     it('ignores eol characters at end of string', () => {
-      expect(1).toBe(getIndexAfterLastNonWhitespace('>\n\r\n'));
+      expectLib.expect(1).toBe(string.getIndexAfterLastNonWhitespace('>\n\r\n'));
     });
   });
 
   describe('testNameSearchPattern', () => {
     it('matches the exact test name in a namespace-qualified var', () => {
-      const pattern = new RegExp(testNameSearchPattern('a-test'));
-      expect(pattern.test('my.ns/a-test')).toBe(true);
+      const pattern = new RegExp(string.testNameSearchPattern('a-test'));
+      expectLib.expect(pattern.test('my.ns/a-test')).toBe(true);
     });
     it('does not match a test name that is a substring prefix', () => {
-      const pattern = new RegExp(testNameSearchPattern('a-test'));
-      expect(pattern.test('my.ns/a-test-b')).toBe(false);
+      const pattern = new RegExp(string.testNameSearchPattern('a-test'));
+      expectLib.expect(pattern.test('my.ns/a-test-b')).toBe(false);
     });
     it('does not match a test name that is a substring suffix', () => {
-      const pattern = new RegExp(testNameSearchPattern('a-test'));
-      expect(pattern.test('my.ns/b-a-test')).toBe(false);
+      const pattern = new RegExp(string.testNameSearchPattern('a-test'));
+      expectLib.expect(pattern.test('my.ns/b-a-test')).toBe(false);
     });
     it('matches when the test name contains regex special characters', () => {
-      const pattern = new RegExp(testNameSearchPattern('test.name+1'));
-      expect(pattern.test('my.ns/test.name+1')).toBe(true);
+      const pattern = new RegExp(string.testNameSearchPattern('test.name+1'));
+      expectLib.expect(pattern.test('my.ns/test.name+1')).toBe(true);
     });
     it('does not match partial with regex special characters', () => {
-      const pattern = new RegExp(testNameSearchPattern('test.name+1'));
-      expect(pattern.test('my.ns/test.name+1-extra')).toBe(false);
+      const pattern = new RegExp(string.testNameSearchPattern('test.name+1'));
+      expectLib.expect(pattern.test('my.ns/test.name+1-extra')).toBe(false);
     });
     it('matches a test name ending in a question mark', () => {
-      const pattern = new RegExp(testNameSearchPattern('foo?'));
-      expect(pattern.test('my.ns/foo?')).toBe(true);
+      const pattern = new RegExp(string.testNameSearchPattern('foo?'));
+      expectLib.expect(pattern.test('my.ns/foo?')).toBe(true);
     });
     it('does not match without the question mark', () => {
-      const pattern = new RegExp(testNameSearchPattern('foo?'));
-      expect(pattern.test('my.ns/foo')).toBe(false);
+      const pattern = new RegExp(string.testNameSearchPattern('foo?'));
+      expectLib.expect(pattern.test('my.ns/foo')).toBe(false);
     });
     it('matches a test name containing an asterisk', () => {
-      const pattern = new RegExp(testNameSearchPattern('*dynamic*'));
-      expect(pattern.test('my.ns/*dynamic*')).toBe(true);
+      const pattern = new RegExp(string.testNameSearchPattern('*dynamic*'));
+      expectLib.expect(pattern.test('my.ns/*dynamic*')).toBe(true);
     });
   });
 
   describe('getTextAfterLastOccurrenceOfSubstring', () => {
     it('returns text if substring does not exist', () => {
-      expect(getTextAfterLastOccurrenceOfSubstring('hello world', '123')).toBe('hello world');
+      expectLib
+        .expect(string.getTextAfterLastOccurrenceOfSubstring('hello world', '123'))
+        .toBe('hello world');
     });
     it('returns text after last occurrence of substring', () => {
-      expect('foo').toBe(getTextAfterLastOccurrenceOfSubstring('hello > world\nprompt >foo', '>'));
+      expectLib
+        .expect('foo')
+        .toBe(string.getTextAfterLastOccurrenceOfSubstring('hello > world\nprompt >foo', '>'));
     });
     it('returns text after last occurrenc of substring without trimming whitespace or eol characters', () => {
-      expect('\n\t foo \n\t').toBe(
-        getTextAfterLastOccurrenceOfSubstring('hello > world >\n\t foo \n\t', '>')
-      );
+      expectLib
+        .expect('\n\t foo \n\t')
+        .toBe(string.getTextAfterLastOccurrenceOfSubstring('hello > world >\n\t foo \n\t', '>'));
     });
   });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,21 +8,21 @@ import * as replMenu from './nrepl/repl-menu';
 import * as replSessionsMenu from './repl-sessions-menu';
 import * as drams from './nrepl/drams';
 import * as util from './utilities';
-import { NotebookKernel, NotebookProvider } from './NotebookProvider';
+import * as notebookProvider from './NotebookProvider';
 import status from './status';
 import connector from './connector';
 import CalvaCompletionItemProvider from './providers/completion';
 import JarContentProvider from './providers/content';
 import HoverProvider from './providers/hover';
 import * as definition from './providers/definition';
-import { CalvaSignatureHelpProvider } from './providers/signature';
+import * as signature from './providers/signature';
 import testRunner from './testRunner';
 import annotations from './providers/annotations';
 import eval from './evaluate';
 import * as refresh from './refresh';
 import * as greetings from './greet';
 import Analytics from './analytics';
-import * as open from 'open';
+import open = require('open');
 import statusbar from './statusbar';
 import * as debug from './debugger/calva-debug';
 import * as model from './cursor-doc/model';
@@ -32,21 +32,15 @@ import * as replHistory from './repl-window/repl-history';
 import * as config from './config';
 import * as snippets from './custom-snippets';
 import * as whenContexts from './when-contexts';
-import {
-  setStateValue,
-  initializeCljs,
-  clearReplOutputView,
-  showReplOutputWebviewPanel,
-} from '../out/cljs-lib/cljs-lib';
+import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as edit from './edit';
 import * as nreplLogging from './nrepl/logging';
 import * as converters from './converters';
 import * as joyride from './joyride';
 import * as api from './api/index';
 import * as depsClj from './nrepl/deps-clj';
-import { refreshJackInDependencyVersions } from './nrepl/jack-in-dependency-versions';
+import * as jackInDependencyVersions from './nrepl/jack-in-dependency-versions';
 import * as clojureDocs from './clojuredocs';
-import { capitalize } from './utilities';
 import * as overrides from './overrides';
 import * as lsp from './lsp';
 import * as fiddleFiles from './fiddle-files';
@@ -71,13 +65,16 @@ function setKeybindingsEnabledContext() {
 }
 
 function initializeState() {
-  setStateValue('connected', false);
-  setStateValue('connecting', false);
+  cljsLib.setStateValue('connected', false);
+  cljsLib.setStateValue('connecting', false);
   const outputChannel = vscode.window.createOutputChannel('Calva says', 'markdown');
-  setStateValue('outputChannel', outputChannel);
+  cljsLib.setStateValue('outputChannel', outputChannel);
   output.initOutputChannel(outputChannel);
-  setStateValue('connectionLogChannel', vscode.window.createOutputChannel('Calva Connection Log'));
-  setStateValue(
+  cljsLib.setStateValue(
+    'connectionLogChannel',
+    vscode.window.createOutputChannel('Calva Connection Log')
+  );
+  cljsLib.setStateValue(
     'diagnosticCollection',
     vscode.languages.createDiagnosticCollection('calva: Evaluation errors')
   );
@@ -89,7 +86,7 @@ async function activate(context: vscode.ExtensionContext) {
   // Store a reference to the vscode API in the cljs so it can call the API using that reference,
   // because requiring the vscode API poses issues with being able to test the cljs lib.
   // We cannot run unit tests on code that imports the vscode API, because it's only available at runtime.
-  initializeCljs(vscode, context);
+  cljsLib.initializeCljs(vscode, context);
 
   initializeState();
   state.setExtensionContext(context);
@@ -134,7 +131,7 @@ async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(testController);
   testRunner.initialize(testController);
 
-  setStateValue('analytics', new Analytics(context));
+  cljsLib.setStateValue('analytics', new Analytics(context));
   void state.analytics().logGA4Pageview('/start');
 
   model.initScanner(vscode.workspace.getConfiguration('editor').get('maxTokenizationLineLength'));
@@ -189,7 +186,7 @@ async function activate(context: vscode.ExtensionContext) {
   }
 
   void depsClj.downloadDepsClj(context.extensionPath).finally(() => {
-    void refreshJackInDependencyVersions();
+    void jackInDependencyVersions.refreshJackInDependencyVersions();
   });
 
   if (cljKondoExtension) {
@@ -237,7 +234,7 @@ async function activate(context: vscode.ExtensionContext) {
   // COMMANDS
   const commands = {
     clearInlineResults: annotations.clearAllEvaluationDecorations,
-    clearReplOutputView: clearReplOutputView,
+    clearReplOutputView: cljsLib.clearReplOutputView,
     clearReplHistory: replHistory.clearHistory,
     connect: connector.connectCommand,
     connectNonProjectREPL: () => {
@@ -308,7 +305,7 @@ async function activate(context: vscode.ExtensionContext) {
     showOutputWindow: outputWindow.revealReplWindowDoc, // backwards compatibility
     showOutputChannel: output.showOutputChannel,
     showOutputTerminal: output.showOutputTerminal,
-    showReplOutputView: showReplOutputWebviewPanel,
+    showReplOutputView: cljsLib.showReplOutputWebviewPanel,
     showResultOutputDestination: output.showResultOutputDestination,
     showPreviousReplHistoryEntry: replHistory.showPreviousReplHistoryEntry,
     startJoyrideReplAndConnect: async () => {
@@ -425,14 +422,14 @@ async function activate(context: vscode.ExtensionContext) {
       provider: new HoverProvider(clientProvider),
     },
     signatureHelpProvider: {
-      provider: new CalvaSignatureHelpProvider(),
+      provider: new signature.CalvaSignatureHelpProvider(),
       registerArgs: [' '],
     },
   };
 
   function registerLangProvider([service, providers]) {
     providers = Array.isArray(providers) ? providers : [providers];
-    const register = `register${capitalize(service)}`;
+    const register = `register${util.capitalize(service)}`;
 
     providers.forEach(({ provider, registerArgs = [] }) => {
       context.subscriptions.push(
@@ -551,7 +548,7 @@ async function activate(context: vscode.ExtensionContext) {
 
   function registerOnDidEventHandler(scope) {
     return ([eventName, callback]) => {
-      const event = `onDid${capitalize(eventName)}`;
+      const event = `onDid${util.capitalize(eventName)}`;
       context.subscriptions.push(vscode[scope][event](callback));
     };
   }
@@ -576,11 +573,15 @@ async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(factory);
   }
   context.subscriptions.push(
-    vscode.workspace.registerNotebookSerializer('calva-clojure-notebook', new NotebookProvider(), {
-      transientOutputs: true,
-    })
+    vscode.workspace.registerNotebookSerializer(
+      'calva-clojure-notebook',
+      new notebookProvider.NotebookProvider(),
+      {
+        transientOutputs: true,
+      }
+    )
   );
-  context.subscriptions.push(new NotebookKernel());
+  context.subscriptions.push(new notebookProvider.NotebookKernel());
 
   void vscode.commands.executeCommand('setContext', 'calva:activated', true);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,21 +9,21 @@ import * as replSessionsMenu from './repl-sessions-menu';
 import * as drams from './nrepl/drams';
 import * as util from './utilities';
 import * as notebookProvider from './NotebookProvider';
-import * as statusModule from './status';
-import * as connectorModule from './connector';
-import * as calvaCompletionItemProviderModule from './providers/completion';
-import * as jarContentProviderModule from './providers/content';
-import * as hoverProviderModule from './providers/hover';
+import * as status from './status';
+import * as connector from './connector';
+import * as completion from './providers/completion';
+import * as content from './providers/content';
+import * as hover from './providers/hover';
 import * as definition from './providers/definition';
 import * as signature from './providers/signature';
-import * as testRunnerModule from './testRunner';
-import * as annotationsModule from './providers/annotations';
-import * as evaluateModule from './evaluate';
+import * as testRunner from './testRunner';
+import * as annotations from './providers/annotations';
+import * as evaluate from './evaluate';
 import * as refresh from './refresh';
 import * as greetings from './greet';
 import * as analyticsModule from './analytics';
 import open = require('open');
-import * as statusbarModule from './statusbar';
+import * as statusbar from './statusbar';
 import * as debug from './debugger/calva-debug';
 import * as model from './cursor-doc/model';
 import * as outputWindow from './repl-window/repl-window-doc';
@@ -48,17 +48,6 @@ import * as flareHandler from './flare-handler';
 import * as output from './results-output/output';
 import * as inspector from './providers/inspector';
 import * as shadowRuntime from './shadow-cljs-runtime';
-
-const status = statusModule.default;
-const connector = connectorModule.default;
-const CalvaCompletionItemProvider = calvaCompletionItemProviderModule.default;
-const JarContentProvider = jarContentProviderModule.default;
-const HoverProvider = hoverProviderModule.default;
-const testRunner = testRunnerModule.default;
-const annotations = annotationsModule.default;
-const evaluate = evaluateModule.default;
-const Analytics = analyticsModule.default;
-const statusbar = statusbarModule.default;
 
 function onDidChangeEditorOrSelection(editor: vscode.TextEditor) {
   replHistory.setReplHistoryCommandsActiveContext(editor);
@@ -142,7 +131,7 @@ async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(testController);
   testRunner.initialize(testController);
 
-  cljsLib.setStateValue('analytics', new Analytics(context));
+  cljsLib.setStateValue('analytics', new analyticsModule.Analytics(context));
   void state.analytics().logGA4Pageview('/start');
 
   model.initScanner(vscode.workspace.getConfiguration('editor').get('maxTokenizationLineLength'));
@@ -414,12 +403,12 @@ async function activate(context: vscode.ExtensionContext) {
 
   // PROVIDERS
   context.subscriptions.push(
-    vscode.workspace.registerTextDocumentContentProvider('jar', new JarContentProvider())
+    vscode.workspace.registerTextDocumentContentProvider('jar', new content.JarContentProvider())
   );
 
   const languageProviders = {
     completionItemProvider: {
-      provider: new CalvaCompletionItemProvider(clientProvider),
+      provider: new completion.CalvaCompletionItemProvider(clientProvider),
     },
     definitionProvider: [
       {
@@ -430,7 +419,7 @@ async function activate(context: vscode.ExtensionContext) {
       },
     ],
     hoverProvider: {
-      provider: new HoverProvider(clientProvider),
+      provider: new hover.HoverProvider(clientProvider),
     },
     signatureHelpProvider: {
       provider: new signature.CalvaSignatureHelpProvider(),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,21 +9,21 @@ import * as replSessionsMenu from './repl-sessions-menu';
 import * as drams from './nrepl/drams';
 import * as util from './utilities';
 import * as notebookProvider from './NotebookProvider';
-import status from './status';
-import connector from './connector';
-import CalvaCompletionItemProvider from './providers/completion';
-import JarContentProvider from './providers/content';
-import HoverProvider from './providers/hover';
+import * as statusModule from './status';
+import * as connectorModule from './connector';
+import * as calvaCompletionItemProviderModule from './providers/completion';
+import * as jarContentProviderModule from './providers/content';
+import * as hoverProviderModule from './providers/hover';
 import * as definition from './providers/definition';
 import * as signature from './providers/signature';
-import testRunner from './testRunner';
-import annotations from './providers/annotations';
-import eval from './evaluate';
+import * as testRunnerModule from './testRunner';
+import * as annotationsModule from './providers/annotations';
+import * as evaluateModule from './evaluate';
 import * as refresh from './refresh';
 import * as greetings from './greet';
-import Analytics from './analytics';
+import * as analyticsModule from './analytics';
 import open = require('open');
-import statusbar from './statusbar';
+import * as statusbarModule from './statusbar';
 import * as debug from './debugger/calva-debug';
 import * as model from './cursor-doc/model';
 import * as outputWindow from './repl-window/repl-window-doc';
@@ -48,6 +48,17 @@ import * as flareHandler from './flare-handler';
 import * as output from './results-output/output';
 import * as inspector from './providers/inspector';
 import * as shadowRuntime from './shadow-cljs-runtime';
+
+const status = statusModule.default;
+const connector = connectorModule.default;
+const CalvaCompletionItemProvider = calvaCompletionItemProviderModule.default;
+const JarContentProvider = jarContentProviderModule.default;
+const HoverProvider = hoverProviderModule.default;
+const testRunner = testRunnerModule.default;
+const annotations = annotationsModule.default;
+const evaluate = evaluateModule.default;
+const Analytics = analyticsModule.default;
+const statusbar = statusbarModule.default;
 
 function onDidChangeEditorOrSelection(editor: vscode.TextEditor) {
   replHistory.setReplHistoryCommandsActiveContext(editor);
@@ -94,7 +105,7 @@ async function activate(context: vscode.ExtensionContext) {
   const isDramStart = await drams.dramStartConfigExists();
   void drams.refreshDramConfigs();
 
-  const inspectorDataProvider = eval.initInspectorDataProvider();
+  const inspectorDataProvider = evaluate.initInspectorDataProvider();
   const inspectorTreeView = vscode.window.createTreeView('calva.inspector', {
     treeDataProvider: inspectorDataProvider,
   });
@@ -249,27 +260,27 @@ async function activate(context: vscode.ExtensionContext) {
     copyHtmlAsHiccup: converters.copyHtmlAsHiccup,
     copyAnnotationHoverText: annotations.copyHoverTextCommand,
     copyJackInCommandToClipboard: jackIn.copyJackInCommandToClipboard,
-    copyLastResults: eval.copyLastResultCommand,
-    'debug.instrument': eval.instrumentTopLevelForm,
+    copyLastResults: evaluate.copyLastResultCommand,
+    'debug.instrument': evaluate.instrumentTopLevelForm,
     'diagnostics.toggleNreplLoggingEnabled': nreplLogging.toggleEnabled,
     disconnect: jackIn.calvaDisconnect,
-    evaluateCurrentTopLevelForm: eval.evaluateTopLevelForm,
-    evaluateEnclosingForm: eval.evaluateEnclosingForm,
-    evaluateReplWindowForm: eval.evaluateReplWindowForm,
-    evaluateSelection: eval.evaluateCurrentForm,
-    evaluateSelectionAsComment: eval.evaluateSelectionAsComment,
-    evaluateSelectionReplace: eval.evaluateSelectionReplace,
-    evaluateSelectionToSelectionEnd: eval.evaluateToCursor,
-    evaluateStartOfFileToCursor: eval.evaluateStartOfFileToCursor,
-    evaluateToCursor: eval.evaluateToCursor,
-    evaluateTopLevelFormAsComment: eval.evaluateTopLevelFormAsComment,
-    evaluateTopLevelFormToCursor: eval.evaluateTopLevelFormToCursor,
-    evaluateUser: eval.evaluateUser,
-    interruptAllEvaluations: eval.interruptAllEvaluations,
+    evaluateCurrentTopLevelForm: evaluate.evaluateTopLevelForm,
+    evaluateEnclosingForm: evaluate.evaluateEnclosingForm,
+    evaluateReplWindowForm: evaluate.evaluateReplWindowForm,
+    evaluateSelection: evaluate.evaluateCurrentForm,
+    evaluateSelectionAsComment: evaluate.evaluateSelectionAsComment,
+    evaluateSelectionReplace: evaluate.evaluateSelectionReplace,
+    evaluateSelectionToSelectionEnd: evaluate.evaluateToCursor,
+    evaluateStartOfFileToCursor: evaluate.evaluateStartOfFileToCursor,
+    evaluateToCursor: evaluate.evaluateToCursor,
+    evaluateTopLevelFormAsComment: evaluate.evaluateTopLevelFormAsComment,
+    evaluateTopLevelFormToCursor: evaluate.evaluateTopLevelFormToCursor,
+    evaluateUser: evaluate.evaluateUser,
+    interruptAllEvaluations: evaluate.interruptAllEvaluations,
     jackIn: jackIn.jackInCommand,
     jackOut: jackIn.jackOutCommand,
     reJackIn: jackIn.reJackInCommand,
-    loadFile: eval.loadFileCommand,
+    loadFile: evaluate.loadFileCommand,
     openCalvaDocs: async () => {
       await context.globalState.update(VIEWED_CALVA_DOCS, true);
       return open(CALVA_DOCS_URL).catch((e) => {
@@ -285,7 +296,7 @@ async function activate(context: vscode.ExtensionContext) {
     printTextToRichCommentCommand: clojureDocs.printTextToRichCommentCommand,
     refresh: refresh.refresh,
     refreshAll: refresh.refreshAll,
-    requireREPLUtilities: eval.requireREPLUtilitiesCommand,
+    requireREPLUtilities: evaluate.requireREPLUtilitiesCommand,
     rereadUserConfigEdn: config.updateCalvaConfigFromUserConfigEdn,
     rerunTests: () => testRunner.rerunTestsCommand(testController),
     runAllTests: () => testRunner.runAllTestsCommand(testController),
@@ -341,7 +352,7 @@ async function activate(context: vscode.ExtensionContext) {
     },
     toggleCLJCSession: connector.toggleCLJCSession,
     selectCljcTarget: connector.selectCljcTarget,
-    toggleEvaluationSendCodeToOutputWindow: eval.toggleEvaluationSendCodeToOutputWindow,
+    toggleEvaluationSendCodeToOutputWindow: evaluate.toggleEvaluationSendCodeToOutputWindow,
     toggleKeybindingsEnabled: () => {
       const keybindingsEnabled = vscode.workspace
         .getConfiguration()
@@ -354,7 +365,7 @@ async function activate(context: vscode.ExtensionContext) {
           vscode.ConfigurationTarget.Global
         );
     },
-    togglePrettyPrint: eval.togglePrettyPrint,
+    togglePrettyPrint: evaluate.togglePrettyPrint,
     activateCalva: () => {
       return new Promise((resolve, _reject) => {
         resolve(true);
@@ -503,7 +514,7 @@ async function activate(context: vscode.ExtensionContext) {
 
         if (evalOnSave) {
           if (!outputWindow.isReplWindowDoc(document)) {
-            await eval.loadDocument(document, config.getConfig().prettyPrintingOptions, false);
+            await evaluate.loadDocument(document, config.getConfig().prettyPrintingOptions, false);
             void output.replWindowAppendPrompt();
           }
         }

--- a/src/fiddle-files.ts
+++ b/src/fiddle-files.ts
@@ -3,13 +3,11 @@ import * as fiddleFilesUtil from './util/fiddle-files';
 import * as state from './state';
 import * as config from './config';
 import * as nsUtil from './util/ns-form';
-import * as evaluateModule from './evaluate';
+import * as evaluate from './evaluate';
 import * as namespace from './namespace';
 import * as replSession from './nrepl/repl-session';
 import * as output from './results-output/output';
 import * as sessionRegistry from './nrepl/session-registry';
-
-const evaluate = evaluateModule.default;
 
 // TODO: This viewColumn memory could probably be a shared thing for all of Calva.
 //       At least the REPL window has similar functionality an could benefit from this more general approach.

--- a/src/fiddle-files.ts
+++ b/src/fiddle-files.ts
@@ -3,11 +3,13 @@ import * as fiddleFilesUtil from './util/fiddle-files';
 import * as state from './state';
 import * as config from './config';
 import * as nsUtil from './util/ns-form';
-import eval from './evaluate';
+import * as evaluateModule from './evaluate';
 import * as namespace from './namespace';
 import * as replSession from './nrepl/repl-session';
 import * as output from './results-output/output';
 import * as sessionRegistry from './nrepl/session-registry';
+
+const evaluate = evaluateModule.default;
 
 // TODO: This viewColumn memory could probably be a shared thing for all of Calva.
 //       At least the REPL window has similar functionality an could benefit from this more general approach.
@@ -146,7 +148,7 @@ export async function evaluateFiddleForSourceFile() {
     output.appendLineOtherOut(`Evaluating fiddle: ${relativeFiddleFilePath}`);
     const session = replSession.getSession();
     const sessionKey = sessionRegistry.resolveSessionKey(session);
-    await eval.evaluateInOutputWindow(code, sessionKey, ns, {
+    await evaluate.evaluateInOutputWindow(code, sessionKey, ns, {
       nsForm,
     });
     await output.replWindowAppendPrompt();

--- a/src/file-switcher/file-switcher.ts
+++ b/src/file-switcher/file-switcher.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as util from './util';
 import * as projectRoot from '../project-root';
-import { getActiveTextEditor } from '../utilities';
+import * as utilities from '../utilities';
 
 function openFile(file: string | vscode.Uri) {
   const fileUri: vscode.Uri = file instanceof vscode.Uri ? file : vscode.Uri.file(file);
@@ -34,7 +34,7 @@ function askToCreateANewFile(dir: vscode.Uri, filename: string) {
 }
 
 export async function toggleBetweenImplAndTest() {
-  const activeFile = getActiveTextEditor();
+  const activeFile = utilities.getActiveTextEditor();
   const openedFilename = activeFile.document.fileName;
   const projectRootUri = projectRoot.findClosestParent(
     vscode.window.activeTextEditor?.document.uri,

--- a/src/flare-handler.ts
+++ b/src/flare-handler.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { parseEdn } from '../out/cljs-lib/cljs-lib';
+import * as cljsLib from '../out/cljs-lib/cljs-lib';
 
 type EvaluateFunction = (code: string) => Promise<string | null>;
 
@@ -33,7 +33,7 @@ export function inspect(edn: string, evaluate: EvaluateFunction): any {
       const match = edn.match(/^#(?:flare|cursive)\/(\w+)\s*(\{.*})\s*$/s);
       if (match) {
         const tag = match[1];
-        const flare = parseEdn(match[2]);
+        const flare = cljsLib.parseEdn(match[2]);
         const handler = actHandlers[tag];
         if (handler) {
           handler(flare, evaluate);

--- a/src/highlight/src/extension.ts
+++ b/src/highlight/src/extension.ts
@@ -1,23 +1,22 @@
 import * as vscode from 'vscode';
-import { Position, Range } from 'vscode';
 import * as isEqual from 'lodash.isequal';
-import { isArray } from 'util';
+import * as nodeUtil from 'util';
 import * as docMirror from '../../doc-mirror/index';
-import { Token, validPair } from '../../cursor-doc/clojure-lexer';
-import { LispTokenCursor } from '../../cursor-doc/token-cursor';
-import { tryToGetActiveTextEditor, getActiveTextEditor } from '../../utilities';
-import { isCommentFormHead } from '../../cursor-doc/paredit-config';
-import { getConfig } from '../../config';
+import * as clojureLexer from '../../cursor-doc/clojure-lexer';
+import * as tokenCursor from '../../cursor-doc/token-cursor';
+import * as utilities from '../../utilities';
+import * as pareditConfig from '../../cursor-doc/paredit-config';
+import * as config from '../../config';
 
 type StackItem = {
   char: string;
-  start: Position;
-  end: Position;
+  start: vscode.Position;
+  end: vscode.Position;
   pair_idx: number;
   opens_comment_form?: boolean;
 };
 
-function position_str(pos: Position) {
+function position_str(pos: vscode.Position) {
   return '' + pos.line + ':' + pos.character;
 }
 function is_clojure(editor) {
@@ -46,8 +45,8 @@ let lastHighlightedEditor,
   enableBracketColors,
   useRainbowIndentGuides,
   highlightActiveIndent,
-  pairsBack: Map<string, [Range, Range]> = new Map(),
-  pairsForward: Map<string, [Range, Range]> = new Map(),
+  pairsBack: Map<string, [vscode.Range, vscode.Range]> = new Map(),
+  pairsForward: Map<string, [vscode.Range, vscode.Range]> = new Map(),
   placedGuidesColor: Map<string, number> = new Map(),
   rainbowTimer = undefined,
   matchTimer = undefined,
@@ -61,7 +60,7 @@ function decorationType(opts) {
 }
 
 function colorDecorationType(color) {
-  if (isArray(color)) {
+  if (nodeUtil.isArray(color)) {
     return decorationType({
       light: { color: color[0] },
       dark: { color: color[1] },
@@ -72,7 +71,7 @@ function colorDecorationType(color) {
 }
 
 function guidesDecorationType_(color, isActive: boolean): vscode.TextEditorDecorationType {
-  if (isArray(color)) {
+  if (nodeUtil.isArray(color)) {
     return decorationType({
       light: {
         borderWidth: `0; border-right-width: ${
@@ -270,15 +269,15 @@ function updateRainbowBrackets() {
   pairsBack = new Map();
   pairsForward = new Map();
   placedGuidesColor = new Map();
-  const { customCommentForms, aliasMap } = getConfig();
+  const { customCommentForms, aliasMap } = config.getConfig();
   const commentFormConfig = { customCommentForms, aliasMap };
   activeEditor.visibleRanges.forEach((range) => {
     // Find the visible forms
     const startOffset = doc.offsetAt(range.start);
     const endOffset = doc.offsetAt(range.end);
-    const startCursor: LispTokenCursor = mirrorDoc.getTokenCursor(0);
+    const startCursor: tokenCursor.LispTokenCursor = mirrorDoc.getTokenCursor(0);
     const startRange = startCursor.rangeForDefun(startOffset, false);
-    const endCursor: LispTokenCursor = mirrorDoc.getTokenCursor(endOffset);
+    const endCursor: tokenCursor.LispTokenCursor = mirrorDoc.getTokenCursor(endOffset);
     const endRange = endCursor.rangeForDefun(endOffset, false);
     const rangeStart = startRange ? startRange[0] : startOffset;
     const rangeEnd = endRange ? endRange[1] : endOffset;
@@ -298,12 +297,12 @@ function updateRainbowBrackets() {
       }
     }
     // Start painting!
-    const cursor: LispTokenCursor = mirrorDoc.getTokenCursor(startPaintingFrom);
+    const cursor: tokenCursor.LispTokenCursor = mirrorDoc.getTokenCursor(startPaintingFrom);
     do {
       cursor.forwardWhitespace();
       {
         // Skip pass strings and literals, and highlight ignored forms.
-        const token: Token = cursor.getToken();
+        const token: clojureLexer.Token = cursor.getToken();
         if (token.type === 'str-inside' || token.raw.includes('"')) {
           continue;
         } else if (token.type === 'lit') {
@@ -322,9 +321,9 @@ function updateRainbowBrackets() {
           }
           const ignore_end = activeEditor.document.positionAt(ignoreCursor.offsetStart);
           if (cursor.atTopLevel()) {
-            topLevelIgnores.push(new Range(ignore_start, ignore_end));
+            topLevelIgnores.push(new vscode.Range(ignore_start, ignore_end));
           } else {
-            ignores.push(new Range(ignore_start, ignore_end));
+            ignores.push(new vscode.Range(ignore_start, ignore_end));
           }
         }
       }
@@ -332,7 +331,7 @@ function updateRainbowBrackets() {
         char = token.raw,
         charLength = char.length;
       // Highlight (comment ...) forms
-      if (!in_comment_form && isCommentFormHead(char, commentFormConfig)) {
+      if (!in_comment_form && pareditConfig.isCommentFormHead(char, commentFormConfig)) {
         const peekCursor = cursor.clone();
         peekCursor.backwardWhitespace();
         if (peekCursor.getPrevToken().raw === '(') {
@@ -346,7 +345,7 @@ function updateRainbowBrackets() {
         readerCursor.backwardThroughAnyReader();
         const start = activeEditor.document.positionAt(readerCursor.offsetStart),
           end = activeEditor.document.positionAt(cursor.offsetEnd),
-          openRange = new Range(start, end),
+          openRange = new vscode.Range(start, end),
           openString = activeEditor.document.getText(openRange);
         if (colorsEnabled) {
           const decoration = { range: openRange };
@@ -363,19 +362,23 @@ function updateRainbowBrackets() {
         continue;
       } else if (token.type === 'close') {
         const pos = activeEditor.document.positionAt(cursor.offsetStart),
-          decoration = { range: new Range(pos, pos.translate(0, 1)) };
+          decoration = { range: new vscode.Range(pos, pos.translate(0, 1)) };
         let pair_idx = stack.length - 1;
         while (pair_idx >= 0 && stack[pair_idx].pair_idx !== undefined) {
           pair_idx = stack[pair_idx].pair_idx - 1;
         }
-        if (pair_idx === undefined || pair_idx < 0 || !validPair(stack[pair_idx].char, char)) {
+        if (
+          pair_idx === undefined ||
+          pair_idx < 0 ||
+          !clojureLexer.validPair(stack[pair_idx].char, char)
+        ) {
           misplaced.push(decoration);
         } else {
           const pair = stack[pair_idx],
-            closing = new Range(pos, pos.translate(0, charLength)),
-            opening = new Range(pair.end.translate(0, -1), pair.end);
+            closing = new vscode.Range(pos, pos.translate(0, charLength)),
+            opening = new vscode.Range(pair.end.translate(0, -1), pair.end);
           if (in_comment_form && pair.opens_comment_form) {
-            comment_forms.push(new Range(pair.start, pos.translate(0, charLength)));
+            comment_forms.push(new vscode.Range(pair.start, pos.translate(0, charLength)));
             in_comment_form = false;
           }
           stack.push({
@@ -481,7 +484,7 @@ function decorateGuide(
   for (let lineDelta = 1; lineDelta <= endPos.line - startPos.line; lineDelta++) {
     const guidePos = startPos.translate(lineDelta, 0);
     if (doc.lineAt(guidePos).text.match(/^ */)[0].length >= startPos.character) {
-      const guidesDecoration = { range: new Range(guidePos, guidePos) };
+      const guidesDecoration = { range: new vscode.Range(guidePos, guidePos) };
       guides.push(guidesDecoration);
       guideLength++;
     }
@@ -491,7 +494,7 @@ function decorateGuide(
 
 function decorateActiveGuides() {
   const activeGuides = [];
-  activeEditor = getActiveTextEditor();
+  activeEditor = utilities.getActiveTextEditor();
   if (activeGuidesTypes) {
     activeGuidesTypes.forEach((type) => activeEditor.setDecorations(type, []));
   }
@@ -532,7 +535,7 @@ function decorateActiveGuides() {
 }
 
 export function activate(context: vscode.ExtensionContext) {
-  activeEditor = tryToGetActiveTextEditor();
+  activeEditor = utilities.tryToGetActiveTextEditor();
 
   vscode.window.onDidChangeActiveTextEditor(
     (editor) => {
@@ -547,7 +550,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   vscode.window.onDidChangeTextEditorSelection(
     (event) => {
-      const activeEditor = tryToGetActiveTextEditor();
+      const activeEditor = utilities.tryToGetActiveTextEditor();
       if (activeEditor && event.textEditor === activeEditor && is_clojure(event.textEditor)) {
         if (lastHighlightedEditor !== event.textEditor) {
           scheduleRainbowBrackets();
@@ -558,7 +561,7 @@ export function activate(context: vscode.ExtensionContext) {
           matchTimer = setTimeout(() => {
             matchPairs();
             if (highlightActiveIndent && rainbowTypes.length) {
-              const activeEditor = tryToGetActiveTextEditor();
+              const activeEditor = utilities.tryToGetActiveTextEditor();
               if (activeEditor) {
                 decorateActiveGuides();
               }

--- a/src/joyride.ts
+++ b/src/joyride.ts
@@ -6,7 +6,7 @@ import * as connectSequences from './nrepl/connectSequence';
 import * as open from 'open';
 import * as outputWindow from './repl-window/repl-window-doc';
 import * as utilities from './utilities';
-import { ConnectType } from './nrepl/connect-types';
+import * as connectTypes from './nrepl/connect-types';
 import * as output from './results-output/output';
 import * as inspector from './providers/inspector';
 
@@ -47,7 +47,7 @@ export function isJoyrideNReplServerRunning() {
 }
 
 export async function prepareForJackInOrConnect() {
-  await state.initProjectDir(ConnectType.JackIn, undefined, false).catch((e) => {
+  await state.initProjectDir(connectTypes.ConnectType.JackIn, undefined, false).catch((e) => {
     void vscode.window.showErrorMessage('Failed initializing project root directory: ', e);
   });
   inspector.revealOnConnect();

--- a/src/live-share.ts
+++ b/src/live-share.ts
@@ -1,4 +1,4 @@
-import { Disposable } from 'vscode';
+import * as vscode from 'vscode';
 import * as vsls from 'vsls';
 import * as config from './config';
 
@@ -6,11 +6,11 @@ import * as config from './config';
 let liveShare: vsls.LiveShare = null;
 
 // Keeps hold of the LiveShare listener, to prevent it from being disposed immediately.
-let liveShareListener: Disposable = null;
+let liveShareListener: vscode.Disposable = null;
 
 let connectedPort: number = null;
 let jackedIn = false;
-const sharedPorts: Map<number, Disposable> = new Map();
+const sharedPorts: Map<number, vscode.Disposable> = new Map();
 
 export async function setupLiveShareListener() {
   if (liveShareListener !== null) {

--- a/src/lsp/api.ts
+++ b/src/lsp/api.ts
@@ -1,4 +1,4 @@
-import { LanguageClient } from 'vscode-languageclient/node';
+import * as vscodeLsp from 'vscode-languageclient/node';
 import * as defs from './definitions';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
@@ -75,7 +75,7 @@ export type ServerInfo = {
   'semantic-tokens': string[];
 };
 
-export const getServerInfo = async (client: LanguageClient) => {
+export const getServerInfo = async (client: vscodeLsp.LanguageClient) => {
   try {
     return await client.sendRequest<ServerInfo>('clojure/serverInfo/raw');
   } catch (err) {
@@ -87,7 +87,10 @@ type GetClojureDocsParams = {
   symName: string;
   symNs: string;
 };
-export const getClojureDocs = async (client: LanguageClient, params: GetClojureDocsParams) => {
+export const getClojureDocs = async (
+  client: vscodeLsp.LanguageClient,
+  params: GetClojureDocsParams
+) => {
   const server_info = await getServerInfo(client);
   if (server_info['server-version'] <= '2021.10.20-16.49.47') {
     return;
@@ -99,18 +102,18 @@ export const getClojureDocs = async (client: LanguageClient, params: GetClojureD
   });
 };
 
-export async function getCljFmtConfig(client: LanguageClient) {
+export async function getCljFmtConfig(client: vscodeLsp.LanguageClient) {
   const server_info = await getServerInfo(client);
   return server_info?.['cljfmt-raw'];
 }
 
-export async function getSemanticTokens(client: LanguageClient) {
+export async function getSemanticTokens(client: vscodeLsp.LanguageClient) {
   const server_info = await getServerInfo(client);
   return server_info?.['semantic-tokens'];
 }
 
 export function getReferences(
-  client: LanguageClient,
+  client: vscodeLsp.LanguageClient,
   documentUri: vscode.Uri,
   position: vscode.Position | defs.Position,
   includeDeclaration = true
@@ -126,7 +129,7 @@ export function getReferences(
   });
 }
 
-export function getDocumentSymbols(lspClient: LanguageClient, documentUri: vscode.Uri) {
+export function getDocumentSymbols(lspClient: vscodeLsp.LanguageClient, documentUri: vscode.Uri) {
   return lspClient.sendRequest<vscode.DocumentSymbol[]>('textDocument/documentSymbol', {
     textDocument: {
       uri: documentUri.toString(),
@@ -135,7 +138,7 @@ export function getDocumentSymbols(lspClient: LanguageClient, documentUri: vscod
 }
 
 export function getCursorInfo(
-  client: LanguageClient,
+  client: vscodeLsp.LanguageClient,
   textDocument: vscode.TextDocument,
   position: vscode.Position
 ) {

--- a/src/lsp/client/client.ts
+++ b/src/lsp/client/client.ts
@@ -1,14 +1,14 @@
 import * as messages from './messages';
-import { provideSignatureHelp } from '../../providers/signature';
-import { provideHover } from '../../providers/hover';
-import { isReplWindowDoc } from '../../repl-window/repl-window-doc';
+import * as signature from '../../providers/signature';
+import * as hover from '../../providers/hover';
+import * as replWindowDoc from '../../repl-window/repl-window-doc';
 import * as vscode_lsp from 'vscode-languageclient/node';
 import * as defs from '../definitions';
 import * as config from '../../config';
 import * as utils from '../utils';
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { getClientProvider } from '../state';
+import * as lspState from '../state';
 import * as tokenFilter from './semantic-token-filter';
 import * as api from '../api';
 
@@ -158,19 +158,19 @@ export const createClient = (params: CreateClientParams): defs.LspClient => {
       },
       middleware: {
         didOpen: (document, next) => {
-          if (isReplWindowDoc(document)) {
+          if (replWindowDoc.isReplWindowDoc(document)) {
             return Promise.resolve();
           }
           return next(document);
         },
         didSave: (document, next) => {
-          if (isReplWindowDoc(document)) {
+          if (replWindowDoc.isReplWindowDoc(document)) {
             return Promise.resolve();
           }
           return next(document);
         },
         didChange: (change, next) => {
-          if (isReplWindowDoc(change.document)) {
+          if (replWindowDoc.isReplWindowDoc(change.document)) {
             return Promise.resolve();
           }
           return next(change);
@@ -179,7 +179,7 @@ export const createClient = (params: CreateClientParams): defs.LspClient => {
           return null;
         },
         async provideHover(document, position, token, next) {
-          const hovers = await provideHover(getClientProvider(), document, position);
+          const hovers = await hover.provideHover(lspState.getClientProvider(), document, position);
           if (hovers) {
             return null;
           } else {
@@ -245,7 +245,7 @@ export const createClient = (params: CreateClientParams): defs.LspClient => {
           return filterTokens(result);
         },
         async provideSignatureHelp(document, position, context, token, next) {
-          const help = await provideSignatureHelp(document, position, token);
+          const help = await signature.provideSignatureHelp(document, position, token);
           if (help) {
             return null;
           } else {

--- a/src/lsp/client/downloader.ts
+++ b/src/lsp/client/downloader.ts
@@ -1,11 +1,11 @@
 import * as extractZip from 'extract-zip';
-import { https } from 'follow-redirects';
+import * as followRedirects from 'follow-redirects';
 import * as util from '../../utilities';
 import * as config from '../../config';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import * as fs from 'node:fs';
-import { downloadWithBackupRecovery } from './downloader-utils';
+import * as downloaderUtils from './downloader-utils';
 
 const DOWNLOAD_TIMEOUT_MS = 120_000;
 
@@ -60,7 +60,7 @@ export async function readVersionFile(extensionPath: string) {
 function downloadArtifact(url: string, filePath: string): Promise<void> {
   console.log('Downloading clojure-lsp from', url);
   return new Promise((resolve, reject) => {
-    const request = https
+    const request = followRedirects.https
       .get(url, (response) => {
         if (response.statusCode === 200) {
           const writeStream = fs.createWriteStream(filePath);
@@ -110,7 +110,7 @@ async function downloadClojureLsp(extensionPath: string, version: string): Promi
   const downloadPath = path.join(extensionPath, artifactName);
   const clojureLspPath = getClojureLspPath(extensionPath);
 
-  const result = await downloadWithBackupRecovery(clojureLspPath, async () => {
+  const result = await downloaderUtils.downloadWithBackupRecovery(clojureLspPath, async () => {
     await downloadArtifact(url, downloadPath);
     if (path.extname(downloadPath) === '.zip') {
       await unzipFile(downloadPath, extensionPath);

--- a/src/lsp/provider.ts
+++ b/src/lsp/provider.ts
@@ -10,7 +10,7 @@ import * as lsp_client from './client';
 import * as commands from './commands';
 import * as config from './config';
 import * as defs from './definitions';
-import { ProjectTreeExplorer } from './project-tree';
+import * as projectTree from './project-tree';
 import * as status_bar from './status-bar';
 import * as utils from './utils';
 
@@ -149,7 +149,7 @@ export const createClientProvider = (params: CreateClientProviderParams) => {
           calvaSaysChannel.appendLine(`clj-kondo version used: ${serverInfo['clj-kondo-version']}`);
         }
 
-        new ProjectTreeExplorer(client.client);
+        new projectTree.ProjectTreeExplorer(client.client);
       }
     });
 

--- a/src/lsp/state.ts
+++ b/src/lsp/state.ts
@@ -1,13 +1,13 @@
 import * as state from '../../out/cljs-lib/cljs-lib';
-import { ClientProvider } from './provider';
+import type * as provider from './provider';
 
 const STATE_KEY = 'LSP_CLIENT_PROVIDER';
 
-export const registerGlobally = (provider: ClientProvider) => {
+export const registerGlobally = (provider: provider.ClientProvider) => {
   state.setStateValue(STATE_KEY, provider);
 };
 
-export const getClientProvider = (): ClientProvider => {
+export const getClientProvider = (): provider.ClientProvider => {
   const provider = state.getStateValue(STATE_KEY);
   if (!provider) {
     throw new Error('Failed to get LSP ClientProvider from global state');

--- a/src/lsp/status-bar.ts
+++ b/src/lsp/status-bar.ts
@@ -1,29 +1,29 @@
-import { LspStatus } from './definitions';
+import * as definitions from './definitions';
 import * as vscode from 'vscode';
 
-export const updateStatusBar = (item: vscode.StatusBarItem, status: LspStatus) => {
+export const updateStatusBar = (item: vscode.StatusBarItem, status: definitions.LspStatus) => {
   switch (status) {
-    case LspStatus.Stopped: {
+    case definitions.LspStatus.Stopped: {
       item.text = '$(circle-outline) clojure-lsp';
       item.tooltip = 'Clojure-lsp is not active, click to get a menu';
       break;
     }
-    case LspStatus.Starting: {
+    case definitions.LspStatus.Starting: {
       item.text = '$(sync~spin) clojure-lsp';
       item.tooltip = 'Clojure-lsp is starting';
       break;
     }
-    case LspStatus.Running: {
+    case definitions.LspStatus.Running: {
       item.text = '$(circle-filled) clojure-lsp';
       item.tooltip = 'Clojure-lsp is active';
       break;
     }
-    case LspStatus.Failed: {
+    case definitions.LspStatus.Failed: {
       item.text = '$(error) clojure-lsp';
       item.tooltip = 'Clojure-lsp failed to start';
       break;
     }
-    case LspStatus.Unknown: {
+    case definitions.LspStatus.Unknown: {
       item.text = 'clojure-lsp';
       item.tooltip = 'Open a clojure file to see the server status';
       break;

--- a/src/lsp/utils.ts
+++ b/src/lsp/utils.ts
@@ -1,5 +1,5 @@
 import * as vscode_lsp from 'vscode-languageclient/node';
-import { LspStatus, LspClient } from './definitions';
+import * as definitions from './definitions';
 import * as roots from '../project-root';
 import * as vscode from 'vscode';
 
@@ -41,16 +41,16 @@ export const findClojureProjectRootForUri = async (
   return vscode.workspace.getWorkspaceFolder(uri)?.uri;
 };
 
-export const lspClientStateToStatus = (state: vscode_lsp.State): LspStatus => {
+export const lspClientStateToStatus = (state: vscode_lsp.State): definitions.LspStatus => {
   switch (state) {
     case vscode_lsp.State.Stopped: {
-      return LspStatus.Stopped;
+      return definitions.LspStatus.Stopped;
     }
     case vscode_lsp.State.Starting: {
-      return LspStatus.Starting;
+      return definitions.LspStatus.Starting;
     }
     case vscode_lsp.State.Running: {
-      return LspStatus.Running;
+      return definitions.LspStatus.Running;
     }
   }
 };

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -4,7 +4,7 @@ import * as docMirror from './doc-mirror/index';
 import * as outputWindow from './repl-window/repl-window-doc';
 import * as utilities from './utilities';
 import * as replSession from './nrepl/repl-session';
-import { NReplSession } from './nrepl';
+import type * as nrepl from './nrepl';
 import * as nsUtil from './util/ns-form';
 
 export type NsAndNsForm = [string, string];
@@ -74,7 +74,10 @@ export function getDocumentNamespace(document = {}) {
   return getNamespace(doc);
 }
 
-export async function getUriForNamespace(session: NReplSession, ns: string): Promise<vscode.Uri> {
+export async function getUriForNamespace(
+  session: nrepl.NReplSession,
+  ns: string
+): Promise<vscode.Uri> {
   const info = await session.info(ns, ns);
   return vscode.Uri.parse(info.file, true);
 }

--- a/src/nrepl/bencode.ts
+++ b/src/nrepl/bencode.ts
@@ -4,7 +4,7 @@
  * Author: Matt Seddon
  */
 import * as stream from 'stream';
-import { Buffer } from 'buffer';
+import * as buffer from 'buffer';
 
 /** Bencode the given JSON object */
 const bencode = (value) => {
@@ -18,7 +18,7 @@ const bencode = (value) => {
     return 'i' + value + 'e';
   }
   if (typeof value == 'string') {
-    return Buffer.byteLength(value, 'utf8') + ':' + value;
+    return buffer.Buffer.byteLength(value, 'utf8') + ':' + value;
   }
   if (value instanceof Array) {
     return 'l' + value.map(bencode).join('') + 'e';
@@ -184,7 +184,7 @@ class BIncrementalDecoder {
     } else if (this.state.id == 'string-body') {
       this.state.accum.push(byte);
       if (this.state.accum.length >= this.state.length) {
-        return this.complete(Buffer.from(this.state.accum).toString('utf8'));
+        return this.complete(buffer.Buffer.from(this.state.accum).toString('utf8'));
       }
     } else if (this.state.id == 'list') {
       return this.complete(this.state.accum);

--- a/src/nrepl/client-registry.ts
+++ b/src/nrepl/client-registry.ts
@@ -1,6 +1,6 @@
-import type { NReplClient } from './index';
-import type { SessionRoleKeys, SessionGlobMap } from './session-role-utils';
-import type { ReplConnectSequence } from './connectSequence';
+import type * as connectSequence from './connectSequence';
+import type * as nrepl from './index';
+import type * as sessionRoleUtils from './session-role-utils';
 
 export type CljcTargetRole = 'primary' | 'secondary';
 
@@ -12,13 +12,13 @@ export interface ConnectionState {
   cljsBuild: string | null;
   cljsTypeName: string | null;
   hasBuilds: boolean;
-  sessionRoleKeys?: SessionRoleKeys;
-  sessionGlobMap?: SessionGlobMap;
-  connectSequence?: ReplConnectSequence;
+  sessionRoleKeys?: sessionRoleUtils.SessionRoleKeys;
+  sessionGlobMap?: sessionRoleUtils.SessionGlobMap;
+  connectSequence?: connectSequence.ReplConnectSequence;
   shadowCljsRuntimeId?: number;
   shadowCljsRuntimeInfo?: any;
   /** Base session names before any suffix was applied */
-  baseSessionNames?: SessionRoleKeys;
+  baseSessionNames?: sessionRoleUtils.SessionRoleKeys;
   /** The suffix applied to this connection, if any */
   suffix?: string;
   /** Which session role should handle .cljc files for this connection */
@@ -27,7 +27,7 @@ export interface ConnectionState {
 
 export interface RegisteredClient {
   key: string;
-  client: NReplClient;
+  client: nrepl.NReplClient;
   connectSequenceName?: string;
   projectRoot?: string;
   host?: string;
@@ -45,7 +45,7 @@ const defaultConnectionState: ConnectionState = {
 };
 
 export function registerClient(
-  client: NReplClient,
+  client: nrepl.NReplClient,
   metadata: Omit<RegisteredClient, 'key' | 'client' | 'connectedAt' | 'connectionState'> & {
     connectionState?: Partial<ConnectionState>;
   } = {}
@@ -79,7 +79,7 @@ export function listClients(): RegisteredClient[] {
   return Array.from(registeredClients.values()).sort((a, b) => a.connectedAt - b.connectedAt);
 }
 
-export function getClient(clientKey: string): NReplClient | undefined {
+export function getClient(clientKey: string): nrepl.NReplClient | undefined {
   return registeredClients.get(clientKey)?.client;
 }
 

--- a/src/nrepl/connect-sequence-inheritance.ts
+++ b/src/nrepl/connect-sequence-inheritance.ts
@@ -1,4 +1,4 @@
-import type { ReplConnectSequence, SelectedPortBehaviour } from './connect-sequence-types';
+import type * as connectSequenceTypes from './connect-sequence-types';
 
 export interface ConnectSequenceProjectTypeDefaults {
   defaultNReplPortFile?: string[];
@@ -6,7 +6,7 @@ export interface ConnectSequenceProjectTypeDefaults {
 }
 
 export function effectiveNReplPortFileSegments(
-  sequence: Pick<ReplConnectSequence, 'nReplPortFile'>,
+  sequence: Pick<connectSequenceTypes.ReplConnectSequence, 'nReplPortFile'>,
   projectTypeDefaults?: ConnectSequenceProjectTypeDefaults
 ): string[] | undefined {
   const portFileSegments = sequence.nReplPortFile ?? projectTypeDefaults?.defaultNReplPortFile;
@@ -14,15 +14,15 @@ export function effectiveNReplPortFileSegments(
 }
 
 export function effectiveFallbackPort(
-  sequence: Pick<ReplConnectSequence, 'fallbackPort'>,
+  sequence: Pick<connectSequenceTypes.ReplConnectSequence, 'fallbackPort'>,
   projectTypeDefaults?: ConnectSequenceProjectTypeDefaults
 ): number | undefined {
   return sequence.fallbackPort ?? projectTypeDefaults?.defaultFallbackPort;
 }
 
 export function effectiveSelectedPortBehaviour(
-  sequence: Pick<ReplConnectSequence, 'selectedPortBehaviour'>,
-  defaultBehaviour: SelectedPortBehaviour
-): SelectedPortBehaviour {
+  sequence: Pick<connectSequenceTypes.ReplConnectSequence, 'selectedPortBehaviour'>,
+  defaultBehaviour: connectSequenceTypes.SelectedPortBehaviour
+): connectSequenceTypes.SelectedPortBehaviour {
   return sequence.selectedPortBehaviour ?? defaultBehaviour;
 }

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -4,7 +4,7 @@ import * as state from '../state';
 import * as utilities from '../utilities';
 import * as fileArg from '../util/resolve-file-arg';
 import * as config from '../config';
-import { ConnectType } from './connect-types';
+import * as connectTypes from './connect-types';
 import * as output from '../results-output/output';
 import * as projectRoot from '../project-root';
 import * as csTypes from './connect-sequence-types';
@@ -397,13 +397,15 @@ function getDefaultCljsType(cljsType: string): csTypes.CljsTypeConfig {
 
 async function getUserSpecifiedSequence(
   sequences: csTypes.ReplConnectSequence[],
-  connectType: ConnectType,
+  connectType: connectTypes.ConnectType,
   disableAutoSelect: boolean
 ): Promise<csTypes.ReplConnectSequence | undefined> {
   const autoSelectedSequences = disableAutoSelect
     ? []
     : sequences.filter((s) =>
-        connectType === ConnectType.Connect ? s.autoSelectForConnect : s.autoSelectForJackIn
+        connectType === connectTypes.ConnectType.Connect
+          ? s.autoSelectForConnect
+          : s.autoSelectForJackIn
       );
   const candidatePaths = await projectRoot.findProjectRoots();
   const active_uri = vscode.window.activeTextEditor?.document.uri;
@@ -446,11 +448,11 @@ async function getUserSpecifiedSequence(
 
 async function askForConnectSequence(
   cljTypes: string[],
-  connectType: ConnectType,
+  connectType: connectTypes.ConnectType,
   disableAutoSelect: boolean
 ): Promise<csTypes.ReplConnectSequence> {
   const [saveAs, logLabel, menuTitleType] =
-    connectType === ConnectType.Connect
+    connectType === connectTypes.ConnectType.Connect
       ? ['connect-type', 'ConnectInterrupted', 'Connect']
       : ['jack-in-type', 'JackInInterrupted', 'Jack-in'];
   const sequences: csTypes.ReplConnectSequence[] = getConnectSequences(cljTypes);
@@ -464,7 +466,7 @@ async function askForConnectSequence(
 
   if (!projectConnectSequenceName) {
     const filteredSequences =
-      connectType === ConnectType.JackIn
+      connectType === connectTypes.ConnectType.JackIn
         ? sequences.filter((s) => {
             // Allow sequences that define their own jack-in command
             if (s.customJackInCommandLine) {

--- a/src/nrepl/deps-clj.ts
+++ b/src/nrepl/deps-clj.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as util from '../utilities';
 import * as fs from 'fs';
-import { https } from 'follow-redirects';
+import * as followRedirects from 'follow-redirects';
 
 const DEPS_CLJ_FILE = 'deps.clj.jar';
 const DEPS_CLJ_VERSION_FILE = 'deps-clj-version';
@@ -33,7 +33,7 @@ function restoreBackupFile(depsCljPath: string, backupPath: string): string {
 function downloadArtifact(url: string, filePath: string): Promise<void> {
   console.log('Downloading deps.clj.jar from', url);
   return new Promise((resolve, reject) => {
-    https
+    followRedirects.https
       .get(url, (response) => {
         if (response.statusCode === 200) {
           const writeStream = fs.createWriteStream(filePath);

--- a/src/nrepl/drams.ts
+++ b/src/nrepl/drams.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as state from '../state';
 import * as utilities from '../utilities';
 import * as cljsLib from '../../out/cljs-lib/cljs-lib';
-import { ConnectType } from './connect-types';
+import * as connectTypes from './connect-types';
 import * as dramManifest from './dram-manifest';
 import * as dramStaging from './dram-staging';
 import * as replMenu from './repl-menu';
@@ -359,7 +359,7 @@ export async function startDram() {
   const config = (await deserializeDramStartConfig(state.getProjectRootUri())).config;
   console.debug('Dram start config:', config);
   void vscode.workspace.fs.delete(ARGS_FILE_PATH(state.getProjectRootUri()));
-  await state.initProjectDir(ConnectType.JackIn, null, false);
+  await state.initProjectDir(connectTypes.ConnectType.JackIn, null, false);
   const projectRootUri = state.getProjectRootUri();
   const openPaths = dramManifest.resolveDramOpenPaths(config);
 

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -6,7 +6,7 @@ import * as util from '../utilities';
 import * as printer from '../printer';
 import * as debug from '../debugger/calva-debug';
 import * as vscode from 'vscode';
-import debugDecorations from '../debugger/decorations';
+import * as debugDecorationsModule from '../debugger/decorations';
 import * as outputWindow from '../repl-window/repl-window-doc';
 import * as resultsOutputUtil from '../results-output/util';
 import * as cljsLib from '../../out/cljs-lib/cljs-lib';
@@ -16,6 +16,8 @@ import * as string from '../util/string';
 import * as output from '../results-output/output';
 import * as shadowCljsRuntime from '../shadow-cljs-runtime';
 import * as whoTracking from '../api/who-tracking';
+
+const debugDecorations = debugDecorationsModule.default;
 
 type PrettyPrintingOptions = printer.PrettyPrintingOptions;
 type ReplSessionType = config.ReplSessionType;

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -1,27 +1,40 @@
 import * as net from 'net';
-import { BEncoderStream, BDecoderStream } from './bencode';
+import * as bencode from './bencode';
 import * as cider from './cider';
 import * as state from './../state';
 import * as util from '../utilities';
-import {
-  PrettyPrintingOptions,
-  disabledPrettyPrinter,
-  getServerSidePrinter,
-  prettyPrint,
-} from '../printer';
+import * as printer from '../printer';
 import * as debug from '../debugger/calva-debug';
 import * as vscode from 'vscode';
 import debugDecorations from '../debugger/decorations';
 import * as outputWindow from '../repl-window/repl-window-doc';
-import { formatAsLineComments } from '../results-output/util';
-import type { ReplSessionType } from '../config';
-import { getStateValue } from '../../out/cljs-lib/cljs-lib';
-import { getConfig } from '../config';
-import { log, Direction } from './logging';
+import * as resultsOutputUtil from '../results-output/util';
+import * as cljsLib from '../../out/cljs-lib/cljs-lib';
+import * as config from '../config';
+import * as logging from './logging';
 import * as string from '../util/string';
 import * as output from '../results-output/output';
-import { handleShadowRemoteMessage } from '../shadow-cljs-runtime';
+import * as shadowCljsRuntime from '../shadow-cljs-runtime';
 import * as whoTracking from '../api/who-tracking';
+
+type PrettyPrintingOptions = printer.PrettyPrintingOptions;
+type ReplSessionType = config.ReplSessionType;
+
+const BEncoderStream = bencode.BEncoderStream;
+const BDecoderStream = bencode.BDecoderStream;
+const disabledPrettyPrinter = printer.disabledPrettyPrinter;
+const getServerSidePrinter = printer.getServerSidePrinter;
+const prettyPrint = printer.prettyPrint;
+const formatAsLineComments = resultsOutputUtil.formatAsLineComments;
+const getStateValue = cljsLib.getStateValue;
+const getConfig = config.getConfig;
+const log = logging.log;
+const Direction = {
+  ClientToServer: logging.Direction.ClientToServer,
+  ServerToClient: logging.Direction.ServerToClient,
+  ClientToServerNotSupported: logging.Direction.ClientToServerNotSupported,
+} as const;
+const handleShadowRemoteMessage = shadowCljsRuntime.handleShadowRemoteMessage;
 
 function hasStatus(res: any, status: string): boolean {
   return res.status && res.status.indexOf(status) > -1;

--- a/src/nrepl/index.ts
+++ b/src/nrepl/index.ts
@@ -6,7 +6,7 @@ import * as util from '../utilities';
 import * as printer from '../printer';
 import * as debug from '../debugger/calva-debug';
 import * as vscode from 'vscode';
-import * as debugDecorationsModule from '../debugger/decorations';
+import * as debugDecorations from '../debugger/decorations';
 import * as outputWindow from '../repl-window/repl-window-doc';
 import * as resultsOutputUtil from '../results-output/util';
 import * as cljsLib from '../../out/cljs-lib/cljs-lib';
@@ -16,8 +16,6 @@ import * as string from '../util/string';
 import * as output from '../results-output/output';
 import * as shadowCljsRuntime from '../shadow-cljs-runtime';
 import * as whoTracking from '../api/who-tracking';
-
-const debugDecorations = debugDecorationsModule.default;
 
 type PrettyPrintingOptions = printer.PrettyPrintingOptions;
 type ReplSessionType = config.ReplSessionType;

--- a/src/nrepl/jack-in-dependency-versions.ts
+++ b/src/nrepl/jack-in-dependency-versions.ts
@@ -3,17 +3,14 @@ import * as vscode from 'vscode';
 import * as child from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
-import { parseEdn } from '../../out/cljs-lib/cljs-lib';
-import {
-  selectLatestStableAndPrerelease,
-  type JackInLatestVersionInfo,
-} from './jack-in-version-resolution';
+import * as cljsLib from '../../out/cljs-lib/cljs-lib';
+import * as jackInVersionResolution from './jack-in-version-resolution';
 
 export type JackInDependencyKey = 'nrepl' | 'cider-nrepl' | 'cider/piggieback';
 
 export type JackInDependencyVersions = Partial<Record<JackInDependencyKey, string>>;
 export type JackInDependencyLatestVersions = Partial<
-  Record<JackInDependencyKey, JackInLatestVersionInfo>
+  Record<JackInDependencyKey, jackInVersionResolution.JackInLatestVersionInfo>
 >;
 
 const JACK_IN_DEPENDENCY_LIBRARIES: Record<JackInDependencyKey, string> = {
@@ -59,7 +56,7 @@ function parseFindVersionsOutput(output: string): string[] {
     .filter((line) => line.length > 0)
     .map((line) => {
       try {
-        return parseEdn(line);
+        return cljsLib.parseEdn(line);
       } catch (error) {
         console.warn('[Calva] Failed to parse find-versions output line', line, error);
         return undefined;
@@ -80,14 +77,16 @@ function getDepsCljJarPath(): string | undefined {
   return fs.existsSync(jarPath) ? jarPath : undefined;
 }
 
-async function fetchLatestVersion(library: string): Promise<JackInLatestVersionInfo> {
+async function fetchLatestVersion(
+  library: string
+): Promise<jackInVersionResolution.JackInLatestVersionInfo> {
   const args = ['-X:deps', 'find-versions', ':lib', library, ':n', FIND_VERSIONS_COUNT];
   const errors: string[] = [];
 
   try {
     const { stdout } = await execFileAsync('clojure', args);
     const versions = parseFindVersionsOutput(stdout);
-    const latest = selectLatestStableAndPrerelease(versions);
+    const latest = jackInVersionResolution.selectLatestStableAndPrerelease(versions);
     if (latest.stable || latest.prerelease) {
       return latest;
     }
@@ -101,7 +100,7 @@ async function fetchLatestVersion(library: string): Promise<JackInLatestVersionI
     try {
       const { stdout } = await execFileAsync('java', ['-jar', depsCljJarPath, ...args]);
       const versions = parseFindVersionsOutput(stdout);
-      const latest = selectLatestStableAndPrerelease(versions);
+      const latest = jackInVersionResolution.selectLatestStableAndPrerelease(versions);
       if (latest.stable || latest.prerelease) {
         return latest;
       }
@@ -116,9 +115,11 @@ async function fetchLatestVersion(library: string): Promise<JackInLatestVersionI
   throw new Error(errors.join(' | '));
 }
 
-function normalizeStoredLatestVersionValue(value: unknown): JackInLatestVersionInfo | undefined {
+function normalizeStoredLatestVersionValue(
+  value: unknown
+): jackInVersionResolution.JackInLatestVersionInfo | undefined {
   if (typeof value === 'string') {
-    const normalized = selectLatestStableAndPrerelease([value]);
+    const normalized = jackInVersionResolution.selectLatestStableAndPrerelease([value]);
     if (normalized.stable || normalized.prerelease) {
       return normalized;
     }

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -4,28 +4,18 @@ import * as _ from 'lodash';
 import * as state from '../state';
 import * as connector from '../connector';
 import statusbar from '../statusbar';
-import {
-  askForConnectSequence,
-  ReplConnectSequence,
-  CljsTypes,
-  getConnectSequences,
-} from './connectSequence';
+import * as connectSequences from './connectSequence';
 import * as connectSequenceInheritance from './connect-sequence-inheritance';
 import * as projectTypes from './project-types';
 import * as outputWindow from '../repl-window/repl-window-doc';
-import {
-  JackInPTY as JackInPTY,
-  JackInPTYOptions as JackInPTYOptions,
-  createCommandLine,
-} from './jack-in-terminal';
+import * as jackInTerminal from './jack-in-terminal';
 import * as liveShareSupport from '../live-share';
-import { getConfig } from '../config';
+import * as config from '../config';
 import * as joyride from '../joyride';
-import { ConnectType } from './connect-types';
+import * as connectTypes from './connect-types';
 import * as output from '../results-output/output';
 import * as inspector from '../providers/inspector';
 import * as clientRegistry from './client-registry';
-import type { RegisteredClient } from './client-registry';
 
 function resolveEnvVariables(entry: any): any {
   if (typeof entry === 'string') {
@@ -43,15 +33,15 @@ function processEnvObject(env: any) {
 function getGlobalJackInEnv() {
   return {
     ...process.env,
-    ...processEnvObject(getConfig().jackInEnv as object),
+    ...processEnvObject(config.getConfig().jackInEnv as object),
   };
 }
 
 type JackInProcessEntry = {
   id: number;
-  pty: JackInPTY;
+  pty: jackInTerminal.JackInPTY;
   terminal: vscode.Terminal;
-  connectSequence: ReplConnectSequence;
+  connectSequence: connectSequences.ReplConnectSequence;
   disposables: vscode.Disposable[];
   connected: boolean;
   clientKey?: string;
@@ -80,7 +70,7 @@ function matchesProjectRoot(entry: JackInProcessEntry, targetRootUri: string | u
 
 function matchesConnectSequence(
   entry: JackInProcessEntry,
-  connectSequence: ReplConnectSequence,
+  connectSequence: connectSequences.ReplConnectSequence,
   targetRootUri: string | undefined
 ): boolean {
   if (!connectSequence) {
@@ -102,7 +92,9 @@ function matchesConnectSequence(
  * Find jack-in processes that would be replaced by a new jack-in.
  * Matches by both sequence name AND current project root.
  */
-function findProcessesForReconnection(connectSequence: ReplConnectSequence): JackInProcessEntry[] {
+function findProcessesForReconnection(
+  connectSequence: connectSequences.ReplConnectSequence
+): JackInProcessEntry[] {
   const targetRootUri = getProjectRootUriString();
   return listJackInProcesses().filter((entry) =>
     matchesConnectSequence(entry, connectSequence, targetRootUri)
@@ -171,7 +163,9 @@ export async function stopJackInProcessesByClientKey(
  * Stop jack-in processes that would be replaced by a new jack-in.
  * Only affects processes matching both sequence name AND current project root.
  */
-async function stopProcessesForReconnection(connectSequence: ReplConnectSequence): Promise<void> {
+async function stopProcessesForReconnection(
+  connectSequence: connectSequences.ReplConnectSequence
+): Promise<void> {
   const matching = findProcessesForReconnection(connectSequence);
   if (matching.length === 0) {
     return;
@@ -186,7 +180,9 @@ async function stopProcessesForReconnection(connectSequence: ReplConnectSequence
  * Clients with the same sequence but different project roots are left alone
  * (name conflicts are handled via suffixes in connector.connectToHost()).
  */
-function findClientsForReconnection(connectSequence: ReplConnectSequence): RegisteredClient[] {
+function findClientsForReconnection(
+  connectSequence: connectSequences.ReplConnectSequence
+): clientRegistry.RegisteredClient[] {
   const targetRootUri = getProjectRootUriString();
 
   return clientRegistry.listClients().filter((client) => {
@@ -207,7 +203,9 @@ function findClientsForReconnection(connectSequence: ReplConnectSequence): Regis
  * Disconnect clients that would be replaced by a new connection.
  * Only affects clients matching both sequence name AND current project root.
  */
-async function stopClientsForReconnection(connectSequence: ReplConnectSequence): Promise<void> {
+async function stopClientsForReconnection(
+  connectSequence: connectSequences.ReplConnectSequence
+): Promise<void> {
   const clients = findClientsForReconnection(connectSequence);
   for (const client of clients) {
     await connector.default.disconnect({ clientKey: client.key });
@@ -222,14 +220,18 @@ function refreshJackedInState() {
   statusbar.update();
 }
 
-function registerJackInProcess(connectSequence: ReplConnectSequence): JackInProcessEntry {
-  const pty = new JackInPTY();
+function registerJackInProcess(
+  connectSequence: connectSequences.ReplConnectSequence
+): JackInProcessEntry {
+  const pty = new jackInTerminal.JackInPTY();
   const terminal = (<any>vscode.window).createTerminal({
     name: `Calva Jack-in: ${connectSequence.name}`,
     pty,
   });
   const selectedSequenceName =
-    state.extensionContext.workspaceState.get<ReplConnectSequence>('selectedConnectSequence')?.name;
+    state.extensionContext.workspaceState.get<connectSequences.ReplConnectSequence>(
+      'selectedConnectSequence'
+    )?.name;
   const entry: JackInProcessEntry = {
     id: nextJackInProcessId++,
     pty,
@@ -266,15 +268,15 @@ function handleJackInProcessExit(processId: number) {
 }
 
 async function executeJackInTask(
-  terminalOptions: JackInPTYOptions,
-  connectSequence: ReplConnectSequence,
+  terminalOptions: jackInTerminal.JackInPTYOptions,
+  connectSequence: connectSequences.ReplConnectSequence,
   cb?: () => unknown
 ) {
   utilities.setLaunchingState(connectSequence.name);
   statusbar.update();
   const jackInProcess = registerJackInProcess(connectSequence);
 
-  if (getConfig().autoOpenJackInTerminal) {
+  if (config.getConfig().autoOpenJackInTerminal) {
     jackInProcess.terminal.show();
   }
 
@@ -379,22 +381,22 @@ export function revealJackInTerminal() {
 }
 
 export async function copyJackInCommandToClipboard(options?: {
-  connectSequence?: ReplConnectSequence | string;
+  connectSequence?: connectSequences.ReplConnectSequence | string;
   disableAutoSelect?: boolean;
 }): Promise<void> {
-  let providedSequence: ReplConnectSequence | undefined;
+  let providedSequence: connectSequences.ReplConnectSequence | undefined;
 
   if (options && typeof options.connectSequence === 'string') {
-    providedSequence = getConnectSequences(projectTypes.getAllProjectTypes()).find(
-      (s) => s.name === options.connectSequence
-    );
+    providedSequence = connectSequences
+      .getConnectSequences(projectTypes.getAllProjectTypes())
+      .find((s) => s.name === options.connectSequence);
   } else if (options?.connectSequence) {
-    providedSequence = options.connectSequence as ReplConnectSequence;
+    providedSequence = options.connectSequence as connectSequences.ReplConnectSequence;
   }
 
   try {
     await state.initProjectDir(
-      ConnectType.JackIn,
+      connectTypes.ConnectType.JackIn,
       providedSequence,
       options?.disableAutoSelect ?? false
     );
@@ -403,7 +405,7 @@ export async function copyJackInCommandToClipboard(options?: {
     return;
   }
 
-  let projectConnectSequence: ReplConnectSequence;
+  let projectConnectSequence: connectSequences.ReplConnectSequence;
   try {
     projectConnectSequence =
       providedSequence ?? (await getProjectConnectSequence(options?.disableAutoSelect ?? false));
@@ -414,7 +416,7 @@ export async function copyJackInCommandToClipboard(options?: {
     try {
       const options = await getJackInTerminalOptions(projectConnectSequence);
       if (options) {
-        await vscode.env.clipboard.writeText(createCommandLine(options));
+        await vscode.env.clipboard.writeText(jackInTerminal.createCommandLine(options));
         const message = `Jack-in command line copied to the clipboard.${
           projectTypes.isWin ? ' It is tailored for cmd.exe and may not work in other shells.' : ''
         }`;
@@ -450,14 +452,14 @@ function substituteCustomCommandLinePlaceholders(
 }
 
 async function getJackInTerminalOptions(
-  projectConnectSequence: ReplConnectSequence
-): Promise<JackInPTYOptions> {
+  projectConnectSequence: connectSequences.ReplConnectSequence
+): Promise<jackInTerminal.JackInPTYOptions> {
   const projectTypeName: string = projectConnectSequence.projectType;
-  let selectedCljsType: CljsTypes;
+  let selectedCljsType: connectSequences.CljsTypes;
 
   if (
     typeof projectConnectSequence.cljsType == 'string' &&
-    projectConnectSequence.cljsType != CljsTypes.none
+    projectConnectSequence.cljsType != connectSequences.CljsTypes.none
   ) {
     selectedCljsType = projectConnectSequence.cljsType;
   } else if (
@@ -504,7 +506,7 @@ async function getJackInTerminalOptions(
     : cmd[0];
   args = projectConnectSequence.customJackInCommandLine ? [] : [...cmd.slice(1), ...args];
 
-  const terminalOptions: JackInPTYOptions = {
+  const terminalOptions: jackInTerminal.JackInPTYOptions = {
     name: `Calva Jack-in: ${projectConnectSequence.name}`,
     executable,
     args,
@@ -522,23 +524,25 @@ async function getJackInTerminalOptions(
   return terminalOptions;
 }
 
-async function getProjectConnectSequence(disableAutoSelect: boolean): Promise<ReplConnectSequence> {
+async function getProjectConnectSequence(
+  disableAutoSelect: boolean
+): Promise<connectSequences.ReplConnectSequence> {
   const cljTypes: string[] = await projectTypes.detectProjectTypes();
   const excludes = ['generic', 'cljs-only'];
   if (joyride.isJoyrideExtensionActive() && joyride.isJoyrideNReplServerRunning()) {
     excludes.push('joyride');
   }
   if (cljTypes.length >= 1) {
-    return askForConnectSequence(
+    return connectSequences.askForConnectSequence(
       cljTypes.filter((t) => !excludes.includes(t)),
-      ConnectType.JackIn,
+      connectTypes.ConnectType.JackIn,
       disableAutoSelect
     );
   }
 }
 
 async function executeJackIn(
-  connectSequence: ReplConnectSequence,
+  connectSequence: connectSequences.ReplConnectSequence,
   disableAutoSelect: boolean,
   cb?: () => unknown
 ) {
@@ -562,7 +566,7 @@ async function executeJackIn(
   output.appendLineOtherOut('Jacking in...');
   await outputWindow.openReplWindowDoc();
 
-  let projectConnectSequence: ReplConnectSequence = connectSequence;
+  let projectConnectSequence: connectSequences.ReplConnectSequence = connectSequence;
   if (!projectConnectSequence) {
     try {
       projectConnectSequence = await getProjectConnectSequence(disableAutoSelect);
@@ -605,7 +609,7 @@ async function executeJackIn(
 }
 
 export function jackIn(
-  connectSequence: ReplConnectSequence,
+  connectSequence: connectSequences.ReplConnectSequence,
   disableAutoSelect: boolean,
   cb?: () => unknown
 ): Promise<unknown> {
@@ -622,7 +626,7 @@ export async function reJackInCommand() {
     void vscode.window.showInformationMessage('No active Jack-in process to restart.');
     return;
   }
-  let connectSequence: ReplConnectSequence;
+  let connectSequence: connectSequences.ReplConnectSequence;
   if (processes.length === 1) {
     connectSequence = processes[0].connectSequence;
   } else {
@@ -642,19 +646,23 @@ export async function reJackInCommand() {
 }
 
 export async function jackInCommand(options: {
-  connectSequence?: ReplConnectSequence | string;
+  connectSequence?: connectSequences.ReplConnectSequence | string;
   disableAutoSelect?: boolean;
 }) {
-  let connectSequence: ReplConnectSequence;
+  let connectSequence: connectSequences.ReplConnectSequence;
   if (options && typeof options.connectSequence === 'string') {
-    connectSequence = getConnectSequences(projectTypes.getAllProjectTypes()).find(
-      (s) => s.name === options.connectSequence
-    );
+    connectSequence = connectSequences
+      .getConnectSequences(projectTypes.getAllProjectTypes())
+      .find((s) => s.name === options.connectSequence);
   } else if (options && options.connectSequence) {
-    connectSequence = options.connectSequence as ReplConnectSequence;
+    connectSequence = options.connectSequence as connectSequences.ReplConnectSequence;
   }
   try {
-    await state.initProjectDir(ConnectType.JackIn, connectSequence, options?.disableAutoSelect);
+    await state.initProjectDir(
+      connectTypes.ConnectType.JackIn,
+      connectSequence,
+      options?.disableAutoSelect
+    );
   } catch (e) {
     console.error('An error occurred while initializing project directory.', e);
     return;

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -3,7 +3,7 @@ import * as utilities from '../utilities';
 import * as _ from 'lodash';
 import * as state from '../state';
 import * as connector from '../connector';
-import statusbar from '../statusbar';
+import * as statusbarModule from '../statusbar';
 import * as connectSequences from './connectSequence';
 import * as connectSequenceInheritance from './connect-sequence-inheritance';
 import * as projectTypes from './project-types';
@@ -16,6 +16,8 @@ import * as connectTypes from './connect-types';
 import * as output from '../results-output/output';
 import * as inspector from '../providers/inspector';
 import * as clientRegistry from './client-registry';
+
+const statusbar = statusbarModule.default;
 
 function resolveEnvVariables(entry: any): any {
   if (typeof entry === 'string') {

--- a/src/nrepl/jack-in.ts
+++ b/src/nrepl/jack-in.ts
@@ -3,7 +3,7 @@ import * as utilities from '../utilities';
 import * as _ from 'lodash';
 import * as state from '../state';
 import * as connector from '../connector';
-import * as statusbarModule from '../statusbar';
+import * as statusbar from '../statusbar';
 import * as connectSequences from './connectSequence';
 import * as connectSequenceInheritance from './connect-sequence-inheritance';
 import * as projectTypes from './project-types';
@@ -16,8 +16,6 @@ import * as connectTypes from './connect-types';
 import * as output from '../results-output/output';
 import * as inspector from '../providers/inspector';
 import * as clientRegistry from './client-registry';
-
-const statusbar = statusbarModule.default;
 
 function resolveEnvVariables(entry: any): any {
   if (typeof entry === 'string') {
@@ -111,7 +109,7 @@ async function stopJackInProcess(
 
   if (entry.clientKey) {
     try {
-      await connector.default.disconnect({
+      await connector.disconnect({
         clientKey: entry.clientKey,
         preserveSuffix: options.preserveSuffix,
       });
@@ -210,7 +208,7 @@ async function stopClientsForReconnection(
 ): Promise<void> {
   const clients = findClientsForReconnection(connectSequence);
   for (const client of clients) {
-    await connector.default.disconnect({ clientKey: client.key });
+    await connector.disconnect({ clientKey: client.key });
   }
 }
 
@@ -674,7 +672,7 @@ export async function jackInCommand(options: {
 
 export function calvaDisconnect() {
   if (utilities.getConnectedState()) {
-    void connector.default.disconnect();
+    void connector.disconnect();
     return;
   } else if (utilities.getConnectingState() || utilities.getLaunchingState()) {
     void vscode.window
@@ -686,7 +684,7 @@ export function calvaDisconnect() {
       .then((value) => {
         if (value == 'Ok') {
           void calvaJackout();
-          void connector.default.disconnect();
+          void connector.disconnect();
           utilities.setLaunchingState(null);
           utilities.setConnectingState(false);
           statusbar.update();

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -1,19 +1,16 @@
 import * as state from '../state';
 import * as vscode from 'vscode';
 import * as path from 'path';
-import * as getPort from 'get-port';
+import getPort = require('get-port');
 import * as utilities from '../utilities';
 import * as pprint from '../printer';
-import { getConfig } from '../config';
-import { keywordize, unKeywordize } from '../util/string';
-import {
-  getEffectiveJackInDependencyVersions,
-  type JackInDependencyKey,
-} from './jack-in-dependency-versions';
+import * as config from '../config';
+import * as stringUtil from '../util/string';
+import * as jackInDependencyVersions from './jack-in-dependency-versions';
 import * as connectSequenceInheritance from './connect-sequence-inheritance';
 import * as connectSequences from './connectSequence';
-import { getStateValue, parseForms, parseEdn } from '../../out/cljs-lib/cljs-lib';
 import * as joyride from '../joyride';
+import * as cljsLib from '../../out/cljs-lib/cljs-lib';
 
 export const isWin = /^win/.test(process.platform);
 
@@ -103,7 +100,7 @@ export function shadowConfigFile(projectRootUri?: vscode.Uri): vscode.Uri {
 
 export async function shadowBuilds(projectRootUri?: vscode.Uri): Promise<string[]> {
   const data = await vscode.workspace.fs.readFile(shadowConfigFile(projectRootUri));
-  const parsed = parseEdn(new TextDecoder('utf-8').decode(data));
+  const parsed = cljsLib.parseEdn(new TextDecoder('utf-8').decode(data));
   return [
     ...(parsed.builds
       ? Object.keys(parsed.builds).map((key: string) => {
@@ -185,7 +182,9 @@ async function selectShadowBuilds(
     selectedBuilds = selectedBuildItems.map((item) => item.label);
   }
   const aliases: string[] =
-    menuSelections && menuSelections.cljAliases ? menuSelections.cljAliases.map(keywordize) : [];
+    menuSelections && menuSelections.cljAliases
+      ? menuSelections.cljAliases.map(stringUtil.keywordize)
+      : [];
   const aliasesOption = aliases.length > 0 ? ['-A', aliases.join('')] : [];
   const args: string[] = [];
   if (aliasesOption && aliasesOption.length) {
@@ -203,7 +202,7 @@ async function leinDefProject(): Promise<any> {
   );
   const data = new TextDecoder('utf-8').decode(bytes);
   try {
-    const parsed = parseForms(data);
+    const parsed = cljsLib.parseForms(data);
     return parsed.find((x) => x[0] == 'defproject');
   } catch (e) {
     void vscode.window.showErrorMessage(
@@ -227,7 +226,7 @@ async function leinProfilesAndAlias(
         const menuSelections = connectSequence.menuSelections,
           leinAlias = menuSelections ? menuSelections.leinAlias : undefined;
         if (leinAlias) {
-          alias = unKeywordize(leinAlias);
+          alias = stringUtil.unKeywordize(leinAlias);
         } else if (leinAlias === null) {
           alias = undefined;
         } else {
@@ -255,15 +254,15 @@ async function leinProfilesAndAlias(
       menuSelections = connectSequence.menuSelections,
       launchProfiles = menuSelections ? menuSelections.leinProfiles : undefined;
     if (launchProfiles) {
-      profiles = launchProfiles.map(keywordize);
+      profiles = launchProfiles.map(stringUtil.keywordize);
     } else {
       let projectProfiles = profilesIndex > -1 ? Object.keys(defproject[profilesIndex + 1]) : [];
-      const myProfiles = getConfig().myLeinProfiles;
+      const myProfiles = config.getConfig().myLeinProfiles;
       if (myProfiles && myProfiles.length) {
         projectProfiles = [...projectProfiles, ...myProfiles];
       }
       if (projectProfiles.length) {
-        profiles = projectProfiles.map(keywordize);
+        profiles = projectProfiles.map(stringUtil.keywordize);
         if (profiles.length) {
           const profilItems = await utilities.quickPickMulti({
             values: profiles.map((a) => ({ label: a })),
@@ -284,7 +283,8 @@ export enum JackInDependency {
   'cider/piggieback' = 'cider/piggieback',
 }
 
-const jackInVersionFor = (key: JackInDependencyKey) => getEffectiveJackInDependencyVersions()[key];
+const jackInVersionFor = (key: jackInDependencyVersions.JackInDependencyKey) =>
+  jackInDependencyVersions.getEffectiveJackInDependencyVersions()[key];
 
 const NREPL_VERSION = () => jackInVersionFor('nrepl'),
   CIDER_NREPL_VERSION = () => jackInVersionFor('cider-nrepl'),
@@ -382,9 +382,9 @@ function depsCljWindowsPath() {
 
 const clojureCmdFn = () => {
   const configuredCmd =
-    getConfig().depsEdnJackInExecutable === 'clojure or deps.clj'
-      ? getStateValue('depsEdnJackInDefaultExecutable') ?? 'deps.clj'
-      : getConfig().depsEdnJackInExecutable;
+    config.getConfig().depsEdnJackInExecutable === 'clojure or deps.clj'
+      ? cljsLib.getStateValue('depsEdnJackInDefaultExecutable') ?? 'deps.clj'
+      : config.getConfig().depsEdnJackInExecutable;
   return configuredCmd === 'deps.clj'
     ? ['java', '-jar', `"${path.join(state.extensionContext.extensionPath, 'deps.clj.jar')}"`]
     : ['clojure'];
@@ -684,10 +684,10 @@ const projectTypes: { [id: string]: ProjectType } = {
   basilisp: {
     name: 'basilisp',
     cmd: () => {
-      return [getConfig().basilispPath];
+      return [config.getConfig().basilispPath];
     },
     winCmd: () => {
-      return [getConfig().basilispPath];
+      return [config.getConfig().basilispPath];
     },
     processShellUnix: true,
     processShellWin: false,
@@ -852,7 +852,7 @@ async function cljCommandLine(
     const bytes = await vscode.workspace.fs.readFile(depsUri);
     const data = new TextDecoder('utf-8').decode(bytes);
     try {
-      parsed = parseEdn(data);
+      parsed = cljsLib.parseEdn(data);
     } catch (e) {
       void vscode.window.showErrorMessage('Could not parse deps.edn');
       throw e;
@@ -865,7 +865,7 @@ async function cljCommandLine(
   const aliasesWithMain: string[] = [];
   let projectAliases = parsed && parsed.aliases != undefined ? Object.keys(parsed.aliases) : [];
   for (const projectAlias of projectAliases) {
-    const aliasKey = unKeywordize(projectAlias);
+    const aliasKey = stringUtil.unKeywordize(projectAlias);
     if (parsed && parsed.aliases) {
       const alias = parsed.aliases[aliasKey];
       if (alias && alias['main-opts'] != undefined && alias['main-opts'].length > 0) {
@@ -874,16 +874,16 @@ async function cljCommandLine(
     }
   }
   if (launchAliases) {
-    aliases = launchAliases.map(keywordize);
+    aliases = launchAliases.map(stringUtil.keywordize);
   } else {
-    const myAliases = getConfig().myCljAliases;
+    const myAliases = config.getConfig().myCljAliases;
     if (myAliases && myAliases.length) {
       projectAliases = [...projectAliases, ...myAliases];
     }
     if (projectAliases.length) {
       const aliasItems = await utilities.quickPickMulti({
         values: projectAliases
-          .map(keywordize)
+          .map(stringUtil.keywordize)
           .sort()
           .map((a) =>
             aliasesWithMain.includes(a)
@@ -913,7 +913,9 @@ async function cljCommandLine(
     ...(connectSequence.extraNReplMiddleware || []),
   ];
 
-  const aliasesFlag = getStateValue('isClojureCLIVersionAncient') ? ['-A', ''] : ['-M', '-M'];
+  const aliasesFlag = cljsLib.getStateValue('isClojureCLIVersionAncient')
+    ? ['-A', '']
+    : ['-M', '-M'];
   const aliasesOption =
     aliases.length > 0 ? `${aliasesFlag[0]}${aliases.join('')}` : aliasesFlag[1];
   const q = isWin ? '"' : "'";
@@ -999,7 +1001,7 @@ async function leinCommandLine(
     );
   }
   if (profiles.length) {
-    args.push('with-profile', profiles.map((x) => `+${unKeywordize(x)}`).join(','));
+    args.push('with-profile', profiles.map((x) => `+${stringUtil.unKeywordize(x)}`).join(','));
   }
 
   args.push(...command);
@@ -1013,7 +1015,7 @@ async function leinCommandLine(
         ...cljsDependencies()[cljsType],
         ...serverPrinterDependencies,
       }),
-      'LEIN-PROFILES': profiles.map((x) => unKeywordize(x)).join(','),
+      'LEIN-PROFILES': profiles.map((x) => stringUtil.unKeywordize(x)).join(','),
       ...(alias ? { 'LEIN-LAUNCH-ALIAS': alias } : {}),
       'CLJ-MIDDLEWARE': middleware.join(','),
       ...(cljsType ? { 'CLJS-MIDDLEWARE': cljsMiddleware[cljsType].join(',') } : {}),

--- a/src/nrepl/repl-session.ts
+++ b/src/nrepl/repl-session.ts
@@ -1,14 +1,13 @@
 import * as vscode from 'vscode';
 import * as minimatchLib from 'minimatch';
-import { NReplSession } from '.';
-import { cljsLib, tryToGetDocument, getFileType } from '../utilities';
+import type * as globs from './globs';
+import type * as nrepl from '.';
+import * as utilities from '../utilities';
 import * as outputWindow from '../repl-window/repl-window-doc';
 import * as sessionRegistry from './session-registry';
 import * as sessionRouting from './session-routing';
 import * as clientRegistry from './client-registry';
-import type { WorkspaceFolderInfo } from './glob-paths';
 import * as globPaths from './glob-paths';
-import type { SessionGlobTier } from './globs';
 import * as sessionLabel from './session-label';
 
 // Re-export for consumers
@@ -20,7 +19,7 @@ export { formatSessionLabel, type SessionLabelContext } from './session-label';
 export type RoutingReason =
   | { type: 'pinned' }
   | { type: 'repl-window' }
-  | { type: 'glob-match'; tier: SessionGlobTier; matchingPattern?: string }
+  | { type: 'glob-match'; tier: globs.SessionGlobTier; matchingPattern?: string }
   | { type: 'cljc-within-connection' } // TODO: Find a better name
   | { type: 'first-available' };
 
@@ -37,7 +36,7 @@ function buildCandidatePaths(doc: vscode.TextDocument): string[] {
   }
 
   const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
-  const folders: WorkspaceFolderInfo[] = [];
+  const folders: globPaths.WorkspaceFolderInfo[] = [];
 
   if (workspaceFolder) {
     folders.push({ fsPath: workspaceFolder.uri.fsPath, name: workspaceFolder.name });
@@ -55,7 +54,7 @@ function buildCandidatePaths(doc: vscode.TextDocument): string[] {
 
 interface GlobMatchResult {
   sessionKey: string;
-  tier: SessionGlobTier;
+  tier: globs.SessionGlobTier;
   matchingPattern: string;
   score: number;
   order: number;
@@ -63,7 +62,7 @@ interface GlobMatchResult {
 
 function findSessionKeyForDocument(
   doc?: vscode.TextDocument
-): { sessionKey: string; tier: SessionGlobTier; matchingPattern: string } | undefined {
+): { sessionKey: string; tier: globs.SessionGlobTier; matchingPattern: string } | undefined {
   if (!doc) {
     return undefined;
   }
@@ -202,7 +201,7 @@ function resolveCljcWithinConnection(
  * Returns detailed routing information for UI display.
  */
 function getRoutingInfo(): RoutingResult | undefined {
-  const doc = tryToGetDocument({});
+  const doc = utilities.tryToGetDocument({});
 
   // 1. Pinned session takes priority
   const pinnedSession = sessionRouting.resolvePinnedSession();
@@ -265,7 +264,7 @@ function getSessionKey(): string | undefined {
   return getRoutingInfo()?.sessionKey;
 }
 
-function getSession(): NReplSession {
+function getSession(): nrepl.NReplSession {
   const sessionKey = getSessionKey();
 
   // Try getting from registry first
@@ -277,7 +276,7 @@ function getSession(): NReplSession {
   }
 
   // Fallback for REPL window session
-  if (outputWindow.isReplWindowDoc(tryToGetDocument({}))) {
+  if (outputWindow.isReplWindowDoc(utilities.tryToGetDocument({}))) {
     return outputWindow.getSession();
   }
 
@@ -286,11 +285,11 @@ function getSession(): NReplSession {
 
 function updateReplSessionType() {
   const replSessionType = getSessionKey();
-  cljsLib.setStateValue('current-session-type', replSessionType);
+  utilities.cljsLib.setStateValue('current-session-type', replSessionType);
 }
 
 function getReplSessionTypeFromState() {
-  return cljsLib.getStateValue('current-session-type');
+  return utilities.cljsLib.getStateValue('current-session-type');
 }
 
 /**
@@ -305,9 +304,9 @@ function getSessionLabelContext(options?: {
   isPinned?: boolean;
   doc?: vscode.TextDocument;
 }): sessionLabel.SessionLabelContext {
-  const { isPinned = false, doc = tryToGetDocument({}) } = options ?? {};
+  const { isPinned = false, doc = utilities.tryToGetDocument({}) } = options ?? {};
   const routingInfo = getRoutingInfo();
-  const fileType = getFileType(doc);
+  const fileType = utilities.getFileType(doc);
 
   return sessionLabel.determineSessionLabelContext({
     isPinned,

--- a/src/nrepl/session-name-resolver.ts
+++ b/src/nrepl/session-name-resolver.ts
@@ -5,14 +5,14 @@
  * when conflicts are detected, while preserving names for reconnection scenarios.
  */
 
-import type { SessionRoleKeys } from './session-role-utils';
 import * as clientRegistry from './client-registry';
 import * as sessionRegistry from './session-registry';
 import * as nameSuffix from './session-name-suffix';
+import type * as sessionRoleUtils from './session-role-utils';
 
 export interface SessionNameResolution {
   /** Final session names to use */
-  finalNames: SessionRoleKeys;
+  finalNames: sessionRoleUtils.SessionRoleKeys;
 
   /** Name suffix applied, if any */
   suffix?: string;
@@ -24,7 +24,10 @@ export interface SessionNameResolution {
 /**
  * Check if two SessionRoleKeys have the same base names.
  */
-function sameBaseNames(a: SessionRoleKeys, b: SessionRoleKeys): boolean {
+function sameBaseNames(
+  a: sessionRoleUtils.SessionRoleKeys,
+  b: sessionRoleUtils.SessionRoleKeys
+): boolean {
   return a.primary === b.primary && a.secondary === b.secondary;
 }
 
@@ -38,7 +41,7 @@ function sameBaseNames(a: SessionRoleKeys, b: SessionRoleKeys): boolean {
  * know the port yet — e.g. jack-in starts a new server on a new port).
  */
 function findReconnectionCandidate(
-  baseNames: SessionRoleKeys,
+  baseNames: sessionRoleUtils.SessionRoleKeys,
   projectRoot: string,
   host: string,
   port: number | null
@@ -69,7 +72,7 @@ function findReconnectionCandidate(
  * regardless of host:port.
  */
 export function hasMatchingBaseConnection(
-  baseNames: SessionRoleKeys,
+  baseNames: sessionRoleUtils.SessionRoleKeys,
   projectRoot: string
 ): boolean {
   const clients = clientRegistry.listClients();
@@ -85,7 +88,7 @@ export function hasMatchingBaseConnection(
  * Check if any of the requested session keys conflict with existing sessions.
  * A conflict means the session exists and is owned by a different client.
  */
-function hasConflict(keys: SessionRoleKeys): boolean {
+function hasConflict(keys: sessionRoleUtils.SessionRoleKeys): boolean {
   const keysToCheck = [keys.primary];
   if (keys.secondary) {
     keysToCheck.push(keys.secondary);
@@ -103,8 +106,11 @@ function hasConflict(keys: SessionRoleKeys): boolean {
 /**
  * Apply a suffix to both primary and secondary session names.
  */
-function applySuffixToNames(baseNames: SessionRoleKeys, suffix: string): SessionRoleKeys {
-  const result: SessionRoleKeys = {
+function applySuffixToNames(
+  baseNames: sessionRoleUtils.SessionRoleKeys,
+  suffix: string
+): sessionRoleUtils.SessionRoleKeys {
+  const result: sessionRoleUtils.SessionRoleKeys = {
     primary: nameSuffix.applySuffix(baseNames.primary, suffix),
   };
   if (baseNames.secondary) {
@@ -129,7 +135,7 @@ function applySuffixToNames(baseNames: SessionRoleKeys, suffix: string): Session
  * @throws Error if suffix pool is exhausted when suffix is needed
  */
 export function resolveSessionNames(
-  baseNames: SessionRoleKeys,
+  baseNames: sessionRoleUtils.SessionRoleKeys,
   projectRoot: string,
   host: string,
   port: number | null

--- a/src/nrepl/session-registry.ts
+++ b/src/nrepl/session-registry.ts
@@ -1,23 +1,22 @@
-import { NReplSession } from './index';
-import type { SessionGlobSpec } from './globs';
+import type * as globs from './globs';
+import type * as nrepl from './index';
 import * as clientRegistry from './client-registry';
-import type { ConnectionState } from './client-registry';
 
 export interface SessionMetadata {
   key: string;
   projectRoot?: string;
   globs?: string[];
-  globSpecs?: SessionGlobSpec[];
+  globSpecs?: globs.SessionGlobSpec[];
   connectionOwnerId?: string;
   isSecondary?: boolean;
   lastActivity?: number;
 }
 
-const registeredSessions = new Map<string, NReplSession>();
+const registeredSessions = new Map<string, nrepl.NReplSession>();
 
 export function registerSession(
   key: string,
-  session: NReplSession,
+  session: nrepl.NReplSession,
   metadata: Omit<SessionMetadata, 'key'> = {}
 ): void {
   const computedOwnerId = metadata.connectionOwnerId ?? session?.client?.clientKey;
@@ -32,7 +31,7 @@ export function registerSession(
   (session as any)._calvaSessionMetadata = fullMetadata;
 }
 
-export function getSession(key: string): NReplSession | undefined {
+export function getSession(key: string): nrepl.NReplSession | undefined {
   return registeredSessions.get(key);
 }
 
@@ -51,7 +50,7 @@ export function getSessionMetadata(key: string): SessionMetadata | undefined {
   return (session as any)?._calvaSessionMetadata;
 }
 
-export function updateSessionActivity(sessionOrkey: string | NReplSession): void {
+export function updateSessionActivity(sessionOrkey: string | nrepl.NReplSession): void {
   const session = typeof sessionOrkey === 'string' ? getSession(sessionOrkey) : sessionOrkey;
   if (session) {
     const metadata = (session as any)?._calvaSessionMetadata;
@@ -66,7 +65,7 @@ export function isSessionSecondary(key: string): boolean {
   return Boolean(metadata?.isSecondary);
 }
 
-export function resolveSessionKey(session?: NReplSession, fallback: string = 'clj'): string {
+export function resolveSessionKey(session?: nrepl.NReplSession, fallback: string = 'clj'): string {
   return (session as any)?._calvaSessionMetadata?.key ?? fallback;
 }
 
@@ -87,7 +86,9 @@ export function listSessionsByClient(targetClientKey: string): SessionMetadata[]
  * Find the primary (non-secondary) session for the same connection as the given session.
  * Used when we need to evaluate CLJ code for a feature related to a CLJS session.
  */
-export function findPrimarySessionForConnection(sessionKey: string): NReplSession | undefined {
+export function findPrimarySessionForConnection(
+  sessionKey: string
+): nrepl.NReplSession | undefined {
   const metadata = getSessionMetadata(sessionKey);
   if (!metadata?.connectionOwnerId) {
     return undefined;
@@ -102,7 +103,7 @@ export function findPrimarySessionForConnection(sessionKey: string): NReplSessio
  * Extended connection state that includes client info.
  * Used by code that needs both connection state AND client-level info.
  */
-export interface ConnectionContext extends ConnectionState {
+export interface ConnectionContext extends clientRegistry.ConnectionState {
   clientKey: string;
   projectRoot?: string;
 }
@@ -143,7 +144,7 @@ export function getClientKeyForSession(sessionKey: string): string | undefined {
 /**
  * Get the primary (non-secondary) session for a given client.
  */
-export function getPrimarySessionForClient(clientKey: string): NReplSession | undefined {
+export function getPrimarySessionForClient(clientKey: string): nrepl.NReplSession | undefined {
   const sessions = listSessionsByClient(clientKey);
   const primaryMeta = sessions.find((m) => !m.isSecondary);
   if (!primaryMeta) {
@@ -192,7 +193,7 @@ export function getClojureDocsSessionKey(): string | null {
 /**
  * Get the session currently designated for ClojureDocs lookups.
  */
-export function getClojureDocsSession(): NReplSession | undefined {
+export function getClojureDocsSession(): nrepl.NReplSession | undefined {
   const key = getClojureDocsSessionKey();
   return key ? getSession(key) : undefined;
 }

--- a/src/nrepl/session-role-utils.ts
+++ b/src/nrepl/session-role-utils.ts
@@ -1,12 +1,7 @@
-import {
-  ReplConnectSequence,
-  SessionFilePatternsConfig,
-  SessionFilePatternsRulesConfig,
-} from './connect-sequence-types';
-import type { SessionGlobTiers, SessionGlobSpec } from './globs';
+import type * as connectSequenceTypes from './connect-sequence-types';
 import * as globs from './globs';
 import * as secondarySession from './secondary-session';
-import { getProjectTypeForName } from './project-types';
+import * as projectTypes from './project-types';
 
 export type SessionRole = 'primary' | 'secondary';
 
@@ -15,7 +10,7 @@ export interface SessionRoleKeys {
   secondary?: string;
 }
 
-export type SessionGlobMap = Record<string, SessionGlobSpec[]>;
+export type SessionGlobMap = Record<string, globs.SessionGlobSpec[]>;
 
 const DEFAULT_SESSION_ROLE_KEYS: SessionRoleKeys = {
   primary: 'clj',
@@ -27,7 +22,7 @@ const DEFAULT_SESSION_ROLE_KEYS: SessionRoleKeys = {
  * These are simple patterns like `*.clj` that get combined with the project root
  * to form full globs like `/path/to/project/**\/*.clj`.
  */
-const DEFAULT_SESSION_ROLE_FILE_PATTERNS: Record<SessionRole, SessionGlobTiers> = {
+const DEFAULT_SESSION_ROLE_FILE_PATTERNS: Record<SessionRole, globs.SessionGlobTiers> = {
   primary: { 'always-claim': ['*.clj', '*.edn'], 'is-fallback-for': [] },
   secondary: { 'always-claim': ['*.cljs'], 'is-fallback-for': [] },
 };
@@ -43,8 +38,8 @@ function normalizeTierConfig(value?: string | string[]): string[] {
 }
 
 function normalizePatternEntry(
-  value: string | string[] | SessionFilePatternsRulesConfig | undefined
-): SessionGlobTiers {
+  value: string | string[] | connectSequenceTypes.SessionFilePatternsRulesConfig | undefined
+): globs.SessionGlobTiers {
   if (value === undefined) {
     return { 'always-claim': [], 'is-fallback-for': [] };
   }
@@ -66,7 +61,9 @@ function normalizePatternEntry(
  *
  * This is a pure function that does NOT set any global state.
  */
-export function deriveSessionRoleKeys(sequence?: ReplConnectSequence): SessionRoleKeys {
+export function deriveSessionRoleKeys(
+  sequence?: connectSequenceTypes.ReplConnectSequence
+): SessionRoleKeys {
   // Check sequence config first
   const sequenceConfig = sequence?.replSessionNames;
 
@@ -74,7 +71,7 @@ export function deriveSessionRoleKeys(sequence?: ReplConnectSequence): SessionRo
   let projectTypePrimary: string | undefined;
   let projectTypeSecondary: string | undefined;
   if (sequence?.projectType) {
-    const projectType = getProjectTypeForName(sequence.projectType);
+    const projectType = projectTypes.getProjectTypeForName(sequence.projectType);
     projectTypePrimary = projectType?.defaultReplSessionNames?.primary;
     projectTypeSecondary = projectType?.defaultReplSessionNames?.secondary;
   }
@@ -96,8 +93,8 @@ export function deriveSessionRoleKeys(sequence?: ReplConnectSequence): SessionRo
  */
 function buildGlobSpecsFromPatterns(
   projectRootPath: string,
-  patternTiers: SessionGlobTiers
-): SessionGlobSpec[] {
+  patternTiers: globs.SessionGlobTiers
+): globs.SessionGlobSpec[] {
   const alwaysClaimSpecs = globs.constructGlobsFromFilePatterns(
     projectRootPath,
     patternTiers['always-claim'],
@@ -120,8 +117,8 @@ function buildGlobSpecsFromPatterns(
  */
 function getFilePatternsForRole(
   role: SessionRole,
-  sequence: ReplConnectSequence | undefined
-): SessionGlobTiers {
+  sequence: connectSequenceTypes.ReplConnectSequence | undefined
+): globs.SessionGlobTiers {
   // 1. Check sequence's explicit replSessionFilePatterns
   const sequencePatterns = sequence?.replSessionFilePatterns?.[role];
   if (sequencePatterns) {
@@ -130,7 +127,7 @@ function getFilePatternsForRole(
 
   // 2. Check project type's defaultFilePatterns
   if (sequence?.projectType) {
-    const projectType = getProjectTypeForName(sequence.projectType);
+    const projectType = projectTypes.getProjectTypeForName(sequence.projectType);
     const projectTypePatterns = projectType?.defaultFilePatterns?.[role];
     if (projectTypePatterns) {
       return normalizePatternEntry(projectTypePatterns);
@@ -162,7 +159,7 @@ function getFilePatternsForRole(
  * @param projectRootPath - The project root as an fsPath, used to construct full globs
  */
 export function deriveSessionGlobMap(
-  sequence: ReplConnectSequence | undefined,
+  sequence: connectSequenceTypes.ReplConnectSequence | undefined,
   keys: SessionRoleKeys,
   projectRootPath: string
 ): SessionGlobMap {
@@ -192,6 +189,6 @@ export function deriveSessionGlobMap(
 /**
  * Get glob specs for a specific session key from a glob map.
  */
-export function getGlobSpecsFromMap(globMap: SessionGlobMap, key: string): SessionGlobSpec[] {
+export function getGlobSpecsFromMap(globMap: SessionGlobMap, key: string): globs.SessionGlobSpec[] {
   return globMap[key] ?? [];
 }

--- a/src/nrepl/session-routing.ts
+++ b/src/nrepl/session-routing.ts
@@ -1,4 +1,4 @@
-import { getStateValue, setStateValue } from '../../out/cljs-lib/cljs-lib';
+import * as cljsLib from '../../out/cljs-lib/cljs-lib';
 import * as sessionRegistry from './session-registry';
 
 export type SessionRoutingMode = 'auto' | 'pinned';
@@ -7,12 +7,12 @@ const ROUTING_MODE_STATE_KEY = 'session-routing-mode';
 const PINNED_SESSION_STATE_KEY = 'session-routing-pinned-session-key';
 
 function readStoredKey(stateKey: string): string | undefined {
-  const value = getStateValue(stateKey);
+  const value = cljsLib.getStateValue(stateKey);
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 function clearStateKey(stateKey: string): void {
-  setStateValue(stateKey, null);
+  cljsLib.setStateValue(stateKey, null);
 }
 
 function ensureActiveSession(key: string | undefined): string | undefined {
@@ -28,12 +28,12 @@ function ensureActiveSession(key: string | undefined): string | undefined {
 }
 
 export function getRoutingMode(): SessionRoutingMode {
-  const stored = getStateValue(ROUTING_MODE_STATE_KEY);
+  const stored = cljsLib.getStateValue(ROUTING_MODE_STATE_KEY);
   return stored === 'pinned' ? 'pinned' : 'auto';
 }
 
 function setRoutingMode(mode: SessionRoutingMode): void {
-  setStateValue(ROUTING_MODE_STATE_KEY, mode);
+  cljsLib.setStateValue(ROUTING_MODE_STATE_KEY, mode);
 }
 
 export function getPinnedSessionKey(): string | undefined {
@@ -54,7 +54,7 @@ export function pinSession(sessionKey: string | undefined): void {
     return;
   }
 
-  setStateValue(PINNED_SESSION_STATE_KEY, sessionKey);
+  cljsLib.setStateValue(PINNED_SESSION_STATE_KEY, sessionKey);
   setRoutingMode('pinned');
 }
 

--- a/src/nrepl/session-teardown.ts
+++ b/src/nrepl/session-teardown.ts
@@ -1,10 +1,12 @@
 import * as sessionRegistry from './session-registry';
 import * as replSession from './repl-session';
-import status from '../status';
+import * as statusModule from '../status';
 import * as util from '../utilities';
 import * as cljsLib from '../../out/cljs-lib/cljs-lib';
 import * as teardownCore from './session-teardown-core';
 import * as clojureDocs from '../clojuredocs';
+
+const status = statusModule.default;
 
 function applySideEffects(removed: string[]): void {
   if (removed.length === 0) {

--- a/src/nrepl/session-teardown.ts
+++ b/src/nrepl/session-teardown.ts
@@ -2,7 +2,7 @@ import * as sessionRegistry from './session-registry';
 import * as replSession from './repl-session';
 import status from '../status';
 import * as util from '../utilities';
-import { setStateValue } from '../../out/cljs-lib/cljs-lib';
+import * as cljsLib from '../../out/cljs-lib/cljs-lib';
 import * as teardownCore from './session-teardown-core';
 import * as clojureDocs from '../clojuredocs';
 
@@ -20,7 +20,7 @@ function applySideEffects(removed: string[]): void {
   status.update();
   if (sessionRegistry.listSessions().length === 0) {
     util.setConnectedState(false);
-    setStateValue('current-session-type', null);
+    cljsLib.setStateValue('current-session-type', null);
   }
 }
 

--- a/src/nrepl/session-teardown.ts
+++ b/src/nrepl/session-teardown.ts
@@ -1,12 +1,10 @@
 import * as sessionRegistry from './session-registry';
 import * as replSession from './repl-session';
-import * as statusModule from '../status';
+import * as status from '../status';
 import * as util from '../utilities';
 import * as cljsLib from '../../out/cljs-lib/cljs-lib';
 import * as teardownCore from './session-teardown-core';
 import * as clojureDocs from '../clojuredocs';
-
-const status = statusModule.default;
 
 function applySideEffects(removed: string[]): void {
   if (removed.length === 0) {

--- a/src/paredit/commands.ts
+++ b/src/paredit/commands.ts
@@ -1,55 +1,55 @@
-import { EditableDocument, ModelEditDirectedRange } from '../cursor-doc/model';
+import type * as model from '../cursor-doc/model';
 import * as paredit from '../cursor-doc/paredit';
-import type { PareditConfig } from '../cursor-doc/paredit-config';
+import type * as pareditConfig from '../cursor-doc/paredit-config';
 
 // MOVEMENT
 
-export function forwardSexp(doc: EditableDocument, isMulti: boolean = false) {
+export function forwardSexp(doc: model.EditableDocument, isMulti: boolean = false) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.forwardSexpRange(doc, s.end));
   paredit.moveToRangeRight(doc, ranges);
 }
-export function backwardSexp(doc: EditableDocument, isMulti: boolean = false) {
+export function backwardSexp(doc: model.EditableDocument, isMulti: boolean = false) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.backwardSexpRange(doc, s.start));
   paredit.moveToRangeLeft(doc, ranges);
 }
-export function forwardDownSexp(doc: EditableDocument, isMulti: boolean = false) {
+export function forwardDownSexp(doc: model.EditableDocument, isMulti: boolean = false) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.rangeToForwardDownList(doc, s.end));
   paredit.moveToRangeRight(doc, ranges);
 }
-export function backwardDownSexp(doc: EditableDocument, isMulti: boolean = false) {
+export function backwardDownSexp(doc: model.EditableDocument, isMulti: boolean = false) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.rangeToBackwardDownList(doc, s.start));
   paredit.moveToRangeLeft(doc, ranges);
 }
-export function forwardUpSexp(doc: EditableDocument, isMulti: boolean = false) {
+export function forwardUpSexp(doc: model.EditableDocument, isMulti: boolean = false) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.rangeToForwardUpList(doc, s.end));
   paredit.moveToRangeRight(doc, ranges);
 }
-export function backwardUpSexp(doc: EditableDocument, isMulti: boolean = false) {
+export function backwardUpSexp(doc: model.EditableDocument, isMulti: boolean = false) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.rangeToBackwardUpList(doc, s.start));
   paredit.moveToRangeLeft(doc, ranges);
 }
-export function forwardSexpOrUp(doc: EditableDocument, isMulti: boolean = false) {
+export function forwardSexpOrUp(doc: model.EditableDocument, isMulti: boolean = false) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.forwardSexpOrUpRange(doc, s.end));
   paredit.moveToRangeRight(doc, ranges);
 }
-export function backwardSexpOrUp(doc: EditableDocument, isMulti: boolean = false) {
+export function backwardSexpOrUp(doc: model.EditableDocument, isMulti: boolean = false) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.backwardSexpOrUpRange(doc, s.end));
   paredit.moveToRangeLeft(doc, ranges);
 }
-export function closeList(doc: EditableDocument, isMulti: boolean = false) {
+export function closeList(doc: model.EditableDocument, isMulti: boolean = false) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.rangeToForwardList(doc, s.end));
   paredit.moveToRangeRight(doc, ranges);
 }
-export function openList(doc: EditableDocument, isMulti: boolean = false) {
+export function openList(doc: model.EditableDocument, isMulti: boolean = false) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.rangeToBackwardList(doc, s.start));
   paredit.moveToRangeLeft(doc, ranges);
@@ -57,67 +57,67 @@ export function openList(doc: EditableDocument, isMulti: boolean = false) {
 
 // SELECTION
 
-export function selectCurrentForm(doc: EditableDocument, isMulti: boolean = false) {
+export function selectCurrentForm(doc: model.EditableDocument, isMulti: boolean = false) {
   paredit.selectCurrentForm(doc, false, isMulti ? doc.selections : [doc.selections[0]]);
 }
-export function rangeForDefun(doc: EditableDocument, isMulti: boolean) {
+export function rangeForDefun(doc: model.EditableDocument, isMulti: boolean) {
   const selections = isMulti ? doc.selections : [doc.selections[0]];
   const ranges = selections.map((s) => paredit.rangeForDefun(doc, s.active));
   paredit.selectRange(doc, ranges);
 }
 export function sexpRangeExpansion(
-  doc: EditableDocument,
+  doc: model.EditableDocument,
   isMulti: boolean,
-  config?: PareditConfig
+  config?: pareditConfig.PareditConfig
 ) {
   paredit.growSelection(doc, isMulti ? doc.selections : [doc.selections[0]], config);
 }
-export function sexpRangeContraction(doc: EditableDocument, isMulti: boolean) {
+export function sexpRangeContraction(doc: model.EditableDocument, isMulti: boolean) {
   paredit.shrinkSelection(doc, isMulti ? doc.selections : [doc.selections[0]]);
 }
-export function selectForwardSexp(doc: EditableDocument, isMulti: boolean) {
+export function selectForwardSexp(doc: model.EditableDocument, isMulti: boolean) {
   paredit.selectForwardSexp(doc, isMulti ? doc.selections : [doc.selections[0]]);
 }
-export function selectRight(doc: EditableDocument, isMulti: boolean) {
+export function selectRight(doc: model.EditableDocument, isMulti: boolean) {
   paredit.selectRight(doc, isMulti ? doc.selections : [doc.selections[0]]);
 }
 /* export function selectLeft(doc: EditableDocument, isMulti: boolean) {
   paredit.selectLeft(doc, isMulti ? doc.selections : [doc.selections[0]]);
 } */
-export function selectBackwardSexp(doc: EditableDocument, isMulti: boolean) {
+export function selectBackwardSexp(doc: model.EditableDocument, isMulti: boolean) {
   paredit.selectBackwardSexp(doc, isMulti ? doc.selections : [doc.selections[0]]);
 }
-export function selectForwardDownSexp(doc: EditableDocument, isMulti: boolean) {
+export function selectForwardDownSexp(doc: model.EditableDocument, isMulti: boolean) {
   paredit.selectForwardDownSexp(doc, isMulti ? doc.selections : [doc.selections[0]]);
 }
-export function selectBackwardDownSexp(doc: EditableDocument, isMulti: boolean) {
+export function selectBackwardDownSexp(doc: model.EditableDocument, isMulti: boolean) {
   paredit.selectBackwardDownSexp(doc, isMulti ? doc.selections : [doc.selections[0]]);
 }
-export function selectForwardUpSexp(doc: EditableDocument, isMulti: boolean) {
+export function selectForwardUpSexp(doc: model.EditableDocument, isMulti: boolean) {
   paredit.selectForwardUpSexp(doc, isMulti ? doc.selections : [doc.selections[0]]);
 }
-export function selectForwardSexpOrUp(doc: EditableDocument, isMulti: boolean) {
+export function selectForwardSexpOrUp(doc: model.EditableDocument, isMulti: boolean) {
   paredit.selectForwardSexpOrUp(doc, isMulti ? doc.selections : [doc.selections[0]]);
 }
-export function selectBackwardSexpOrUp(doc: EditableDocument, isMulti: boolean) {
+export function selectBackwardSexpOrUp(doc: model.EditableDocument, isMulti: boolean) {
   paredit.selectBackwardSexpOrUp(doc, isMulti ? doc.selections : [doc.selections[0]]);
 }
-export function selectBackwardUpSexp(doc: EditableDocument, isMulti: boolean) {
+export function selectBackwardUpSexp(doc: model.EditableDocument, isMulti: boolean) {
   paredit.selectBackwardUpSexp(doc, isMulti ? doc.selections : [doc.selections[0]]);
 }
-export function selectCloseList(doc: EditableDocument, isMulti: boolean) {
+export function selectCloseList(doc: model.EditableDocument, isMulti: boolean) {
   paredit.selectCloseList(doc, isMulti ? doc.selections : [doc.selections[0]]);
 }
-export function selectOpenList(doc: EditableDocument, isMulti: boolean) {
+export function selectOpenList(doc: model.EditableDocument, isMulti: boolean) {
   paredit.selectOpenList(doc, isMulti ? doc.selections : [doc.selections[0]]);
 }
 
 // DELETION
 
 export async function killLeft(
-  doc: EditableDocument,
+  doc: model.EditableDocument,
   isMulti: boolean,
-  onRange?: (doc: EditableDocument, range: ModelEditDirectedRange) => Promise<void>
+  onRange?: (doc: model.EditableDocument, range: model.ModelEditDirectedRange) => Promise<void>
 ) {
   // TODO: support multi-cursor
   const result = paredit.backwardHybridSexpRange(doc);
@@ -133,22 +133,22 @@ export async function killLeft(
 
 // REWRAP
 
-export function rewrapQuote(doc: EditableDocument, isMulti: boolean) {
+export function rewrapQuote(doc: model.EditableDocument, isMulti: boolean) {
   return paredit.rewrapSexpr(doc, '"', '"', isMulti ? doc.selections : [doc.selections[0]]);
 }
 
-export function rewrapSet(doc: EditableDocument, isMulti: boolean) {
+export function rewrapSet(doc: model.EditableDocument, isMulti: boolean) {
   return paredit.rewrapSexpr(doc, '#{', '}', isMulti ? doc.selections : [doc.selections[0]]);
 }
 
-export function rewrapCurly(doc: EditableDocument, isMulti: boolean) {
+export function rewrapCurly(doc: model.EditableDocument, isMulti: boolean) {
   return paredit.rewrapSexpr(doc, '{', '}', isMulti ? doc.selections : [doc.selections[0]]);
 }
 
-export function rewrapSquare(doc: EditableDocument, isMulti: boolean) {
+export function rewrapSquare(doc: model.EditableDocument, isMulti: boolean) {
   return paredit.rewrapSexpr(doc, '[', ']', isMulti ? doc.selections : [doc.selections[0]]);
 }
 
-export function rewrapParens(doc: EditableDocument, isMulti: boolean) {
+export function rewrapParens(doc: model.EditableDocument, isMulti: boolean) {
   return paredit.rewrapSexpr(doc, '(', ')', isMulti ? doc.selections : [doc.selections[0]]);
 }

--- a/src/paredit/extension.ts
+++ b/src/paredit/extension.ts
@@ -1,27 +1,27 @@
-import { StatusBar } from './statusbar';
 import * as vscode from 'vscode';
-import {
-  commands,
-  window,
-  Event,
-  EventEmitter,
-  ExtensionContext,
-  workspace,
-  ConfigurationChangeEvent,
-} from 'vscode';
+import * as statusbar from './statusbar';
 import * as paredit from '../cursor-doc/paredit';
 import * as handlers from './commands';
 import * as docMirror from '../doc-mirror/index';
-import { EditableDocument } from '../cursor-doc/model';
-import { assertIsDefined } from '../utilities';
+import type * as model from '../cursor-doc/model';
+import * as utilities from '../utilities';
 import * as config from '../formatter-config';
 import * as mainConfig from '../config';
 import * as textNotation from '../extension-test/unit/common/text-notation';
 import * as calvaState from '../state';
-import { createPareditConfig, defaultBindingForms } from '../cursor-doc/paredit-config';
-import type { PareditConfig } from '../cursor-doc/paredit-config';
+import * as pareditConfig from '../cursor-doc/paredit-config';
 
-const onPareditKeyMapChangedEmitter = new EventEmitter<string>();
+type EditableDocument = model.EditableDocument;
+type PareditConfig = pareditConfig.PareditConfig;
+type Event<T> = vscode.Event<T>;
+type ExtensionContext = vscode.ExtensionContext;
+type ConfigurationChangeEvent = vscode.ConfigurationChangeEvent;
+
+const commands = vscode.commands;
+const window = vscode.window;
+const workspace = vscode.workspace;
+
+const onPareditKeyMapChangedEmitter = new vscode.EventEmitter<string>();
 
 const languages = new Set(['clojure', 'lisp', 'scheme']);
 const enabled = true;
@@ -58,7 +58,7 @@ let pareditConfigCache: PareditConfig | null = null;
 export function getPareditConfig(): PareditConfig {
   if (!pareditConfigCache) {
     const cfg = mainConfig.getConfig();
-    pareditConfigCache = createPareditConfig(
+    pareditConfigCache = pareditConfig.createPareditConfig(
       cfg.customPairForms,
       cfg.customThreadingMacros,
       cfg.aliasMap
@@ -535,7 +535,7 @@ function wrapPareditCommand<C extends PareditCommand>(command: C) {
     try {
       const textEditor = window.activeTextEditor;
 
-      assertIsDefined(textEditor, 'Expected window to have an activeTextEditor!');
+      utilities.assertIsDefined(textEditor, 'Expected window to have an activeTextEditor!');
 
       const mDoc: EditableDocument = docMirror.getDocument(textEditor.document);
       if (!enabled || !languages.has(textEditor.document.languageId)) {
@@ -585,7 +585,7 @@ function setKeyMapConf() {
 setKeyMapConf();
 
 export function activate(context: ExtensionContext) {
-  const statusBar = new StatusBar(getKeyMapConf());
+  const statusBar = new statusbar.StatusBar(getKeyMapConf());
 
   context.subscriptions.push(
     statusBar,

--- a/src/paredit/statusbar.ts
+++ b/src/paredit/statusbar.ts
@@ -1,7 +1,9 @@
 'use strict';
 import * as vscode from 'vscode';
-import statusbar from '../statusbar';
+import * as statusbarModule from '../statusbar';
 import * as paredit from './extension';
+
+const statusbar = statusbarModule.default;
 
 export class StatusBar {
   private _visible: boolean;

--- a/src/paredit/statusbar.ts
+++ b/src/paredit/statusbar.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { window, StatusBarAlignment, StatusBarItem } from 'vscode';
+import * as vscode from 'vscode';
 import statusbar from '../statusbar';
 import * as paredit from './extension';
 
@@ -7,10 +7,14 @@ export class StatusBar {
   private _visible: boolean;
   private _keyMap: string;
 
-  private _toggleBarItem: StatusBarItem;
+  private _toggleBarItem: vscode.StatusBarItem;
 
   constructor(keymap: string) {
-    this._toggleBarItem = window.createStatusBarItem('paredit', StatusBarAlignment.Right, null);
+    this._toggleBarItem = vscode.window.createStatusBarItem(
+      'paredit',
+      vscode.StatusBarAlignment.Right,
+      null
+    );
     this._toggleBarItem.text = '(λ)';
     this._toggleBarItem.tooltip = '';
     this._toggleBarItem.command = 'paredit.togglemode';

--- a/src/paredit/statusbar.ts
+++ b/src/paredit/statusbar.ts
@@ -1,9 +1,7 @@
 'use strict';
 import * as vscode from 'vscode';
-import * as statusbarModule from '../statusbar';
+import * as statusbar from '../statusbar';
 import * as paredit from './extension';
-
-const statusbar = statusbarModule.default;
 
 export class StatusBar {
   private _visible: boolean;

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1,5 +1,5 @@
-import { getConfig } from './config';
-import { assertIsDefined } from './utilities';
+import * as config from './config';
+import * as utilities from './utilities';
 import * as calvaLib from '../out/cljs-lib/cljs-lib';
 
 export type PrintFnOptions = {
@@ -110,7 +110,7 @@ export function getServerSidePrinter(pprintOptions: PrettyPrintingOptions) {
 }
 
 export function prettyPrintingOptions(): PrettyPrintingOptions | undefined {
-  return getConfig().prettyPrintingOptions;
+  return config.getConfig().prettyPrintingOptions;
 }
 
 export const zprintDependencies = {
@@ -119,7 +119,7 @@ export const zprintDependencies = {
 
 export function getServerSidePrinterDependencies() {
   const options = prettyPrintingOptions();
-  assertIsDefined(options, 'Expected prettyPrintingOptions to be defined!');
+  utilities.assertIsDefined(options, 'Expected prettyPrintingOptions to be defined!');
 
   if (options.printEngine === 'zprint') {
     return zprintDependencies;

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -2,7 +2,7 @@ import * as config from './config';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as _ from 'lodash';
-import { ConnectType } from './nrepl/connect-types';
+import * as connectTypes from './nrepl/connect-types';
 
 export type ProjectRoot = {
   uri: vscode.Uri;
@@ -278,14 +278,14 @@ function sortPreSelectedFirst(groups: vscode.Uri[][], selected: vscode.Uri) {
 export async function pickProjectRoot(
   uris: vscode.Uri[],
   selected: vscode.Uri,
-  connectType?: ConnectType
+  connectType?: connectTypes.ConnectType
 ) {
   let menuTitle: string;
   switch (connectType) {
-    case ConnectType.Connect:
+    case connectTypes.ConnectType.Connect:
       menuTitle = 'Connect: Project Root';
       break;
-    case ConnectType.JackIn:
+    case connectTypes.ConnectType.JackIn:
       menuTitle = 'Jack-in: Project Root';
       break;
     default:

--- a/src/providers/annotations.ts
+++ b/src/providers/annotations.ts
@@ -204,7 +204,7 @@ function _getEvalSelectionDecorationTypes(status: AnnotationStatus) {
 
 // ------------------------------------------------------------------------------
 
-export default {
+export {
   _getDecorateSelectionHeader,
   _getEvalSelectionDecorationTypes,
   AnnotationStatus,

--- a/src/providers/completion-util.ts
+++ b/src/providers/completion-util.ts
@@ -1,8 +1,8 @@
-import { CompletionItemKind, CompletionItemLabel } from 'vscode';
+import * as vscode from 'vscode';
 
 type CompletionObject = {
-  label: string | CompletionItemLabel;
-  kind: CompletionItemKind | number;
+  label: string | vscode.CompletionItemLabel;
+  kind: vscode.CompletionItemKind | number;
   [key: string]: any;
 };
 

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -7,12 +7,8 @@ import * as namespace from '../namespace';
 import * as replSession from '../nrepl/repl-session';
 import * as vscodeLanguageserverProtocol from 'vscode-languageserver-protocol';
 import * as protocolConverter from 'vscode-languageclient/lib/common/protocolConverter';
-import * as protocolCompletionItemModule from 'vscode-languageclient/lib/common/protocolCompletionItem';
 import * as lsp from '../lsp';
 import * as completionUtil from './completion-util';
-
-const ProtocolCompletionItem = protocolCompletionItemModule.default;
-type ProtocolCompletionItemInstance = InstanceType<typeof ProtocolCompletionItem>;
 
 const mappings = {
   nil: vscode.CompletionItemKind.Value,
@@ -66,14 +62,12 @@ async function provideCompletionItems(
     }
   }
 
-  const completionItems: ProtocolCompletionItemInstance[] = results.map((completion) =>
-    converter.asCompletionItem(completion)
-  );
+  const completionItems = results.map((completion) => converter.asCompletionItem(completion));
 
   return new vscode.CompletionList(completionItems, true);
 }
 
-export default class CalvaCompletionItemProvider implements vscode.CompletionItemProvider {
+export class CalvaCompletionItemProvider implements vscode.CompletionItemProvider {
   constructor(private readonly clientProvider: lsp.ClientProvider) {}
 
   async provideCompletionItems(

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -1,42 +1,30 @@
-import {
-  TextDocument,
-  Position,
-  CancellationToken,
-  CompletionContext,
-  CompletionItemKind,
-  window,
-  CompletionList,
-  CompletionItemProvider,
-  CompletionItem,
-  Uri,
-  MarkdownString,
-} from 'vscode';
+import * as vscode from 'vscode';
 import * as util from '../utilities';
 import * as select from '../select';
 import * as docMirror from '../doc-mirror/index';
 import * as infoparser from './infoparser';
 import * as namespace from '../namespace';
 import * as replSession from '../nrepl/repl-session';
-import { CompletionRequest, CompletionResolveRequest } from 'vscode-languageserver-protocol';
-import { createConverter } from 'vscode-languageclient/lib/common/protocolConverter';
+import * as vscodeLanguageserverProtocol from 'vscode-languageserver-protocol';
+import * as protocolConverter from 'vscode-languageclient/lib/common/protocolConverter';
 import ProtocolCompletionItem from 'vscode-languageclient/lib/common/protocolCompletionItem';
 import * as lsp from '../lsp';
-import { mergeCompletions } from './completion-util';
+import * as completionUtil from './completion-util';
 
 const mappings = {
-  nil: CompletionItemKind.Value,
-  macro: CompletionItemKind.Value,
-  class: CompletionItemKind.Class,
-  keyword: CompletionItemKind.Keyword,
-  namespace: CompletionItemKind.Module,
-  function: CompletionItemKind.Function,
-  'special-form': CompletionItemKind.Keyword,
-  var: CompletionItemKind.Variable,
-  local: CompletionItemKind.Variable,
-  method: CompletionItemKind.Method,
+  nil: vscode.CompletionItemKind.Value,
+  macro: vscode.CompletionItemKind.Value,
+  class: vscode.CompletionItemKind.Class,
+  keyword: vscode.CompletionItemKind.Keyword,
+  namespace: vscode.CompletionItemKind.Module,
+  function: vscode.CompletionItemKind.Function,
+  'special-form': vscode.CompletionItemKind.Keyword,
+  var: vscode.CompletionItemKind.Variable,
+  local: vscode.CompletionItemKind.Variable,
+  method: vscode.CompletionItemKind.Method,
 };
 
-const converter = createConverter(undefined, undefined, true);
+const converter = protocolConverter.createConverter(undefined, undefined, true);
 
 const completionProviderOptions = { priority: ['lsp', 'repl'], merge: true };
 
@@ -50,10 +38,10 @@ async function provideCompletions(provider: string) {
 
 async function provideCompletionItems(
   clientProvider: lsp.ClientProvider,
-  document: TextDocument,
-  position: Position,
-  token: CancellationToken,
-  context: CompletionContext
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  token: vscode.CancellationToken,
+  context: vscode.CompletionContext
 ) {
   let results = [];
   for (const provider of completionProviderOptions.priority) {
@@ -71,7 +59,7 @@ async function provideCompletionItems(
       console.log(`Failed to get results from completions provider '${provider}'`, err);
     });
     if (completions) {
-      results = mergeCompletions(results, completions);
+      results = completionUtil.mergeCompletions(results, completions);
     }
   }
 
@@ -79,24 +67,24 @@ async function provideCompletionItems(
     converter.asCompletionItem(completion)
   );
 
-  return new CompletionList(completionItems, true);
+  return new vscode.CompletionList(completionItems, true);
 }
 
-export default class CalvaCompletionItemProvider implements CompletionItemProvider {
+export default class CalvaCompletionItemProvider implements vscode.CompletionItemProvider {
   constructor(private readonly clientProvider: lsp.ClientProvider) {}
 
   async provideCompletionItems(
-    document: TextDocument,
-    position: Position,
-    token: CancellationToken,
-    context: CompletionContext
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken,
+    context: vscode.CompletionContext
   ) {
     return provideCompletionItems(this.clientProvider, document, position, token, context);
   }
 
-  async resolveCompletionItem(item: CompletionItem, token: CancellationToken) {
+  async resolveCompletionItem(item: vscode.CompletionItem, token: vscode.CancellationToken) {
     if (util.getConnectedState() && item['data']?.provider === 'repl') {
-      const activeTextEditor = window.activeTextEditor;
+      const activeTextEditor = vscode.window.activeTextEditor;
 
       util.assertIsDefined(activeTextEditor, 'Expected window to have activeTextEditor defined!');
 
@@ -112,7 +100,7 @@ export default class CalvaCompletionItemProvider implements CompletionItemProvid
         const docFromCider = item['data']?.['completion-doc'];
 
         item.documentation =
-          doc || docFromCider ? new MarkdownString(docFromCider, true) : undefined;
+          doc || docFromCider ? new vscode.MarkdownString(docFromCider, true) : undefined;
         item.detail = details;
       }
 
@@ -120,7 +108,7 @@ export default class CalvaCompletionItemProvider implements CompletionItemProvid
     } else {
       const res = await lspResolveCompletions(
         this.clientProvider,
-        window.activeTextEditor.document.uri,
+        vscode.window.activeTextEditor.document.uri,
         item,
         token
       );
@@ -132,15 +120,15 @@ export default class CalvaCompletionItemProvider implements CompletionItemProvid
 
 function lspCompletions(
   clientProvider: lsp.ClientProvider,
-  document: TextDocument,
-  position: Position,
-  token: CancellationToken,
-  context: CompletionContext
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  token: vscode.CancellationToken,
+  context: vscode.CompletionContext
 ) {
   const client = clientProvider.getClientForDocumentUri(document.uri);
   if (client) {
     return client.sendRequest(
-      CompletionRequest.type,
+      vscodeLanguageserverProtocol.CompletionRequest.type,
       client.code2ProtocolConverter.asCompletionParams(document, position, context),
       token
     );
@@ -151,13 +139,13 @@ function lspCompletions(
 
 async function lspResolveCompletions(
   clientProvider: lsp.ClientProvider,
-  uri: Uri,
-  item: CompletionItem,
-  token: CancellationToken
+  uri: vscode.Uri,
+  item: vscode.CompletionItem,
+  token: vscode.CancellationToken
 ) {
   const client = clientProvider.getClientForDocumentUri(uri);
   return await client?.sendRequest(
-    CompletionResolveRequest.type,
+    vscodeLanguageserverProtocol.CompletionResolveRequest.type,
     client.code2ProtocolConverter.asCompletionItem(item),
     token
   );
@@ -165,11 +153,11 @@ async function lspResolveCompletions(
 
 async function replCompletions(
   clientProvider: lsp.ClientProvider,
-  document: TextDocument,
-  position: Position,
-  _token: CancellationToken,
-  _context: CompletionContext
-): Promise<CompletionItem[]> {
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  _token: vscode.CancellationToken,
+  _context: vscode.CompletionContext
+): Promise<vscode.CompletionItem[]> {
   if (!util.getConnectedState()) {
     return [];
   }
@@ -205,11 +193,11 @@ async function replCompletions(
     }
   });
   return results.map((item) => {
-    const result = new CompletionItem(
+    const result = new vscode.CompletionItem(
       item.candidate,
       // +1 because the LSP CompletionItemKind enum starts at 1
       // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemKind
-      (mappings[item.type] || CompletionItemKind.Text) + 1
+      (mappings[item.type] || vscode.CompletionItemKind.Text) + 1
     );
     const data = item[0] === '.' ? item.slice(1) : item;
     data['provider'] = 'repl';

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -7,9 +7,12 @@ import * as namespace from '../namespace';
 import * as replSession from '../nrepl/repl-session';
 import * as vscodeLanguageserverProtocol from 'vscode-languageserver-protocol';
 import * as protocolConverter from 'vscode-languageclient/lib/common/protocolConverter';
-import ProtocolCompletionItem from 'vscode-languageclient/lib/common/protocolCompletionItem';
+import * as protocolCompletionItemModule from 'vscode-languageclient/lib/common/protocolCompletionItem';
 import * as lsp from '../lsp';
 import * as completionUtil from './completion-util';
+
+const ProtocolCompletionItem = protocolCompletionItemModule.default;
+type ProtocolCompletionItemInstance = InstanceType<typeof ProtocolCompletionItem>;
 
 const mappings = {
   nil: vscode.CompletionItemKind.Value,
@@ -63,7 +66,7 @@ async function provideCompletionItems(
     }
   }
 
-  const completionItems: ProtocolCompletionItem[] = results.map((completion) =>
+  const completionItems: ProtocolCompletionItemInstance[] = results.map((completion) =>
     converter.asCompletionItem(completion)
   );
 

--- a/src/providers/content.ts
+++ b/src/providers/content.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as state from '../state';
 import * as util from '../utilities';
 
-export default class JarContentProvider implements vscode.TextDocumentContentProvider {
+export class JarContentProvider implements vscode.TextDocumentContentProvider {
   state: any;
 
   constructor() {

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -6,11 +6,11 @@ import * as namespace from '../namespace';
 import * as outputWindow from '../repl-window/repl-window-doc';
 import * as replSession from '../nrepl/repl-session';
 import * as config from '../config';
-import { createConverter } from 'vscode-languageclient/lib/common/protocolConverter';
-import { DefinitionRequest } from 'vscode-languageclient';
+import * as protocolConverter from 'vscode-languageclient/lib/common/protocolConverter';
+import * as vscodeLanguageclient from 'vscode-languageclient';
 import * as lsp from '../lsp';
 
-const converter = createConverter(undefined, undefined, true);
+const converter = protocolConverter.createConverter(undefined, undefined, true);
 
 const definitionFunctions = { lsp: lspDefinition, repl: provideClojureDefinition };
 
@@ -52,7 +52,7 @@ function lspDefinition(
 ) {
   const client = clientProvider.getClientForDocumentUri(document.uri);
   return client?.sendRequest(
-    DefinitionRequest.type,
+    vscodeLanguageclient.DefinitionRequest.type,
     client?.code2ProtocolConverter.asTextDocumentPositionParams(document, position),
     token
   );

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as state from '../state';
 import * as util from '../utilities';
-import * as annotationsModule from './annotations';
+import * as annotations from './annotations';
 import * as namespace from '../namespace';
 import * as outputWindow from '../repl-window/repl-window-doc';
 import * as replSession from '../nrepl/repl-session';
@@ -9,8 +9,6 @@ import * as config from '../config';
 import * as protocolConverter from 'vscode-languageclient/lib/common/protocolConverter';
 import * as vscodeLanguageclient from 'vscode-languageclient';
 import * as lsp from '../lsp';
-
-const annotations = annotationsModule.default;
 
 const converter = protocolConverter.createConverter(undefined, undefined, true);
 

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as state from '../state';
 import * as util from '../utilities';
-import annotations from './annotations';
+import * as annotationsModule from './annotations';
 import * as namespace from '../namespace';
 import * as outputWindow from '../repl-window/repl-window-doc';
 import * as replSession from '../nrepl/repl-session';
@@ -9,6 +9,8 @@ import * as config from '../config';
 import * as protocolConverter from 'vscode-languageclient/lib/common/protocolConverter';
 import * as vscodeLanguageclient from 'vscode-languageclient';
 import * as lsp from '../lsp';
+
+const annotations = annotationsModule.default;
 
 const converter = protocolConverter.createConverter(undefined, undefined, true);
 

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -4,8 +4,8 @@ import * as infoparser from './infoparser';
 import * as namespace from '../namespace';
 import * as replSession from '../nrepl/repl-session';
 import * as clojureDocs from '../clojuredocs';
-import { getConfig } from '../config';
-import { evaluateSnippet } from '../custom-snippets';
+import * as config from '../config';
+import * as customSnippets from '../custom-snippets';
 import * as getText from '../util/get-text';
 import * as lsp from '../lsp';
 import _ = require('lodash');
@@ -22,7 +22,7 @@ export async function provideHover(
     if (client && client.supports('info')) {
       await namespace.createNamespaceFromDocumentIfNotExists(document);
       const res = await client.info(ns, text);
-      const customREPLHoverSnippets = getConfig().customREPLHoverSnippets;
+      const customREPLHoverSnippets = config.getConfig().customREPLHoverSnippets;
       const hovers: vscode.MarkdownString[] = [];
       if (!res.status.includes('error') && !res.status.includes('no-info')) {
         const docsMd = infoparser.getHover(res);
@@ -61,7 +61,7 @@ export async function provideHover(
       await Promise.all(
         customREPLHoverSnippets.map(async (snippet) => {
           try {
-            const text = await evaluateSnippet(editor, snippet.snippet, context, {
+            const text = await customSnippets.evaluateSnippet(editor, snippet.snippet, context, {
               evaluationSendCodeToOutputWindow: false,
               showErrorMessage: false,
               showResult: false,

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -90,7 +90,7 @@ export async function provideHover(
   }
 }
 
-export default class HoverProvider implements vscode.HoverProvider {
+export class HoverProvider implements vscode.HoverProvider {
   constructor(private readonly clientProvider: lsp.ClientProvider) {}
 
   async provideHover(document, position, _) {

--- a/src/providers/infoparser.ts
+++ b/src/providers/infoparser.ts
@@ -1,10 +1,10 @@
-import { SignatureInformation, ParameterInformation, MarkdownString } from 'vscode';
+import * as vscode from 'vscode';
 import * as tokenCursor from '../cursor-doc/token-cursor';
-import { getConfig } from '../config';
+import * as config from '../config';
 
 export type Completion =
   | [string, string]
-  | [MarkdownString, string | undefined]
+  | [vscode.MarkdownString, string | undefined]
   | [undefined, undefined];
 
 export class REPLInfoParser {
@@ -53,11 +53,14 @@ export class REPLInfoParser {
     }
   }
 
-  private getParameters(symbol: string, argList: string): ParameterInformation[] | undefined {
+  private getParameters(
+    symbol: string,
+    argList: string
+  ): vscode.ParameterInformation[] | undefined {
     const offsets = this.getParameterOffsets(symbol, argList);
     if (offsets !== undefined) {
       return offsets.map((o) => {
-        return new ParameterInformation(o);
+        return new vscode.ParameterInformation(o);
       });
     }
   }
@@ -97,8 +100,8 @@ export class REPLInfoParser {
     }
   }
 
-  getHover(): MarkdownString {
-    const hover = new MarkdownString();
+  getHover(): vscode.MarkdownString {
+    const hover = new vscode.MarkdownString();
     if (this._name !== '') {
       if (!this._specialForm || this._isMacro) {
         hover.appendCodeblock(this._name, 'clojure');
@@ -133,7 +136,7 @@ export class REPLInfoParser {
   }
 
   getCompletion(): Completion {
-    const name = new MarkdownString(this._docString);
+    const name = new vscode.MarkdownString(this._docString);
     if (this._name !== '') {
       if (this._specialForm) {
         return [name, this._formsString];
@@ -144,7 +147,7 @@ export class REPLInfoParser {
     return [undefined, undefined];
   }
 
-  getSignatures(symbol: string): SignatureInformation[] | undefined {
+  getSignatures(symbol: string): vscode.SignatureInformation[] | undefined {
     if (this._name !== '') {
       const argLists = this._arglist ? this._arglist : this._formsString;
       if (argLists) {
@@ -153,13 +156,13 @@ export class REPLInfoParser {
           .map((argList) => argList.trim())
           .map((argList) => {
             if (argList !== '') {
-              const signature = new SignatureInformation(`(${symbol} ${argList})`);
+              const signature = new vscode.SignatureInformation(`(${symbol} ${argList})`);
               // Skip parameter help on special forms and forms with optional arguments, for now
               if (this._arglist && !argList.match(/\?/)) {
                 signature.parameters = this.getParameters(symbol, argList);
               }
-              if (this._docString && getConfig().showDocstringInParameterHelp) {
-                signature.documentation = new MarkdownString(this._docString);
+              if (this._docString && config.getConfig().showDocstringInParameterHelp) {
+                signature.documentation = new vscode.MarkdownString(this._docString);
               }
               return signature;
             } else {
@@ -172,7 +175,7 @@ export class REPLInfoParser {
   }
 }
 
-export function getHover(msg: any): MarkdownString {
+export function getHover(msg: any): vscode.MarkdownString {
   return new REPLInfoParser(msg).getHover();
 }
 
@@ -184,6 +187,6 @@ export function getCompletion(msg: any): Completion {
   return new REPLInfoParser(msg).getCompletion();
 }
 
-export function getSignatures(msg: any, symbol: string): SignatureInformation[] | undefined {
+export function getSignatures(msg: any, symbol: string): vscode.SignatureInformation[] | undefined {
   return new REPLInfoParser(msg).getSignatures(symbol);
 }

--- a/src/providers/signature.ts
+++ b/src/providers/signature.ts
@@ -1,34 +1,26 @@
-import {
-  TextDocument,
-  Position,
-  Range,
-  CancellationToken,
-  SignatureHelp,
-  SignatureHelpProvider,
-  SignatureInformation,
-} from 'vscode';
+import * as vscode from 'vscode';
 import * as util from '../utilities';
 import * as infoparser from './infoparser';
-import { LispTokenCursor } from '../cursor-doc/token-cursor';
+import * as tokenCursor from '../cursor-doc/token-cursor';
 import * as docMirror from '../doc-mirror/index';
 import * as namespace from '../namespace';
 import * as replSession from '../nrepl/repl-session';
 
-export class CalvaSignatureHelpProvider implements SignatureHelpProvider {
+export class CalvaSignatureHelpProvider implements vscode.SignatureHelpProvider {
   async provideSignatureHelp(
-    document: TextDocument,
-    position: Position,
-    token: CancellationToken
-  ): Promise<SignatureHelp | undefined> {
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken
+  ): Promise<vscode.SignatureHelp | undefined> {
     return provideSignatureHelp(document, position, token);
   }
 }
 
 export async function provideSignatureHelp(
-  document: TextDocument,
-  position: Position,
-  _token: CancellationToken
-): Promise<SignatureHelp | undefined> {
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  _token: vscode.CancellationToken
+): Promise<vscode.SignatureHelp | undefined> {
   if (util.getConnectedState()) {
     const [ns, _] = namespace.getNamespace(document, position),
       idx = document.offsetAt(position),
@@ -40,7 +32,7 @@ export async function provideSignatureHelp(
         const res = await client.info(ns, symbol),
           signatures = infoparser.getSignatures(res, symbol);
         if (signatures) {
-          const help = new SignatureHelp(),
+          const help = new vscode.SignatureHelp(),
             currentArgsRanges = getCurrentArgsRanges(document, idx);
           help.signatures = signatures;
           help.activeSignature = getActiveSignatureIdx(signatures, currentArgsRanges.length);
@@ -61,8 +53,11 @@ export async function provideSignatureHelp(
   return undefined;
 }
 
-function getCurrentArgsRanges(document: TextDocument, idx: number): Range[] | undefined {
-  const cursor: LispTokenCursor = docMirror.getDocument(document).getTokenCursor(idx),
+function getCurrentArgsRanges(
+  document: vscode.TextDocument,
+  idx: number
+): vscode.Range[] | undefined {
+  const cursor: tokenCursor.LispTokenCursor = docMirror.getDocument(document).getTokenCursor(idx),
     allRanges = cursor.rowColRangesForSexpsInList('(');
 
   // Are we in a function that gets a threaded first parameter?
@@ -76,24 +71,29 @@ function getCurrentArgsRanges(document: TextDocument, idx: number): Range[] | un
   }
 }
 
-function getActiveSignatureIdx(signatures: SignatureInformation[], currentArgsCount): number {
+function getActiveSignatureIdx(
+  signatures: vscode.SignatureInformation[],
+  currentArgsCount
+): number {
   const activeSignatureIdx = signatures.findIndex(
     (signature) => signature.parameters && signature.parameters.length >= currentArgsCount
   );
   return activeSignatureIdx !== -1 ? activeSignatureIdx : signatures.length - 1;
 }
 
-function getSymbol(document: TextDocument, idx: number): string {
-  const cursor: LispTokenCursor = docMirror.getDocument(document).getTokenCursor(idx);
+function getSymbol(document: vscode.TextDocument, idx: number): string {
+  const cursor: tokenCursor.LispTokenCursor = docMirror.getDocument(document).getTokenCursor(idx);
   return cursor.getFunctionName();
 }
 
-function coordsToRange(coords: [[number, number], [number, number]]): Range {
-  return new Range(new Position(...coords[0]), new Position(...coords[1]));
+function coordsToRange(coords: [[number, number], [number, number]]): vscode.Range {
+  return new vscode.Range(new vscode.Position(...coords[0]), new vscode.Position(...coords[1]));
 }
 
-function getPreviousRangeIndexAndFunction(document: TextDocument, idx: number) {
-  const peekBehindCursor: LispTokenCursor = docMirror.getDocument(document).getTokenCursor(idx);
+function getPreviousRangeIndexAndFunction(document: vscode.TextDocument, idx: number) {
+  const peekBehindCursor: tokenCursor.LispTokenCursor = docMirror
+    .getDocument(document)
+    .getTokenCursor(idx);
   peekBehindCursor.backwardFunction(1);
   const previousFunction = peekBehindCursor.getFunctionName(0),
     previousRanges = peekBehindCursor.rowColRangesForSexpsInList('(').map(coordsToRange),

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as util from './utilities';
 import * as state from './state';
-import { NReplSession } from './nrepl';
+import * as nrepl from './nrepl';
 import * as replSession from './nrepl/repl-session';
 import * as output from './results-output/output';
 import * as config from './config';
@@ -40,7 +40,7 @@ export function refresh(opts: Record<string, unknown> = {}) {
   initRefreshOptions(opts);
 
   const doc = util.tryToGetDocument({}),
-    client: NReplSession = replSession.getSession();
+    client: nrepl.NReplSession = replSession.getSession();
 
   if (client != undefined) {
     const sessionKey = sessionRegistry.resolveSessionKey(client);
@@ -59,7 +59,7 @@ export function refreshAll(opts: Record<string, unknown> = {}) {
   initRefreshOptions(opts);
 
   const doc = util.tryToGetDocument({}),
-    client: NReplSession = replSession.getSession();
+    client: nrepl.NReplSession = replSession.getSession();
 
   if (client != undefined) {
     const sessionKey = sessionRegistry.resolveSessionKey(client);

--- a/src/repl-sessions-menu.ts
+++ b/src/repl-sessions-menu.ts
@@ -3,12 +3,14 @@ import * as sessionRegistry from './nrepl/session-registry';
 import * as sessionRouting from './nrepl/session-routing';
 import * as replSession from './nrepl/repl-session';
 import * as clientRegistry from './nrepl/client-registry';
-import status from './status';
+import * as statusModule from './status';
 import * as projectRootUtil from './project-root';
 import * as utilities from './utilities';
 import * as outputWindow from './repl-window/repl-window-doc';
 import * as output from './results-output/output';
 import * as state from './state';
+
+const status = statusModule.default;
 
 const OUTPUT_SESSION_MENU_SAVE_KEY = 'repl-sessions-menu-output';
 

--- a/src/repl-sessions-menu.ts
+++ b/src/repl-sessions-menu.ts
@@ -4,7 +4,7 @@ import * as sessionRouting from './nrepl/session-routing';
 import * as replSession from './nrepl/repl-session';
 import * as clientRegistry from './nrepl/client-registry';
 import status from './status';
-import { getPathRelativeToWorkspace } from './project-root';
+import * as projectRootUtil from './project-root';
 import * as utilities from './utilities';
 import * as outputWindow from './repl-window/repl-window-doc';
 import * as output from './results-output/output';
@@ -28,7 +28,7 @@ function formatRelativeProjectRoot(projectRoot?: string): string | undefined {
   }
   try {
     const uri = vscode.Uri.parse(projectRoot);
-    return getPathRelativeToWorkspace(uri);
+    return projectRootUtil.getPathRelativeToWorkspace(uri);
   } catch {
     return projectRoot;
   }
@@ -476,7 +476,9 @@ export async function showReplSessionsMenu(): Promise<void> {
 
   // Build placeholder with active file path if available
   const activeDoc = vscode.window.activeTextEditor?.document;
-  const activeFilePath = activeDoc ? getPathRelativeToWorkspace(activeDoc.uri) : undefined;
+  const activeFilePath = activeDoc
+    ? projectRootUtil.getPathRelativeToWorkspace(activeDoc.uri)
+    : undefined;
   const placeHolder = activeFilePath
     ? `Selecting a session pins it. ${activeFilePath}`
     : 'Selecting a session pins it';

--- a/src/repl-sessions-menu.ts
+++ b/src/repl-sessions-menu.ts
@@ -3,14 +3,12 @@ import * as sessionRegistry from './nrepl/session-registry';
 import * as sessionRouting from './nrepl/session-routing';
 import * as replSession from './nrepl/repl-session';
 import * as clientRegistry from './nrepl/client-registry';
-import * as statusModule from './status';
+import * as status from './status';
 import * as projectRootUtil from './project-root';
 import * as utilities from './utilities';
 import * as outputWindow from './repl-window/repl-window-doc';
 import * as output from './results-output/output';
 import * as state from './state';
-
-const status = statusModule.default;
 
 const OUTPUT_SESSION_MENU_SAVE_KEY = 'repl-sessions-menu-output';
 

--- a/src/repl-window/repl-history.ts
+++ b/src/repl-window/repl-history.ts
@@ -1,25 +1,22 @@
 import * as vscode from 'vscode';
 import * as state from '../state';
 import * as util from '../utilities';
-import {
-  getIndexAfterLastNonWhitespace,
-  getTextAfterLastOccurrenceOfSubstring,
-} from '../util/string';
-import type { ReplSessionType } from '../config';
-import { isReplWindowDoc, getSessionType, getPrompt, append } from './repl-window-doc';
-import { addToHistory } from '../results-output/util';
-import { isUndefined } from 'lodash';
+import * as _ from 'lodash';
+import * as stringUtil from '../util/string';
+import type * as configTypes from '../config';
+import * as replWindowDoc from './repl-window-doc';
+import * as resultsOutputUtil from '../results-output/util';
 
 const replHistoryCommandsActiveContext = 'calva:replHistoryCommandsActive';
 let historyIndex: number | undefined = undefined;
 let lastTextAtPrompt: string | undefined = undefined;
 
 function setReplHistoryCommandsActiveContext(editor: vscode.TextEditor): void {
-  if (editor && util.getConnectedState() && isReplWindowDoc(editor.document)) {
+  if (editor && util.getConnectedState() && replWindowDoc.isReplWindowDoc(editor.document)) {
     const document = editor.document;
     const selection = editor.selections[0];
     const positionAtEndOfContent = document.positionAt(
-      getIndexAfterLastNonWhitespace(document.getText())
+      stringUtil.getIndexAfterLastNonWhitespace(document.getText())
     );
     if (selection.start.isAfterOrEqual(positionAtEndOfContent)) {
       void vscode.commands.executeCommand('setContext', replHistoryCommandsActiveContext, true);
@@ -34,18 +31,18 @@ function resetState(): void {
   lastTextAtPrompt = undefined;
 }
 
-function getHistoryKey(replSessionType: ReplSessionType): string {
+function getHistoryKey(replSessionType: configTypes.ReplSessionType): string {
   return `calva-repl-${replSessionType}-history`;
 }
 
-function getHistory(replSessionType: ReplSessionType): Array<string> {
+function getHistory(replSessionType: configTypes.ReplSessionType): Array<string> {
   const key = getHistoryKey(replSessionType);
   const history = state.extensionContext.workspaceState.get(key, []);
   return history;
 }
 
 function updateReplHistory(
-  replSessionType: ReplSessionType,
+  replSessionType: configTypes.ReplSessionType,
   history: string[],
   content: string,
   index: number
@@ -55,18 +52,18 @@ function updateReplHistory(
   void state.extensionContext.workspaceState.update(getHistoryKey(replSessionType), newHistory);
 }
 
-function addToReplHistory(replSessionType: ReplSessionType, content: string) {
-  const newHistory = addToHistory(getHistory(replSessionType), content);
+function addToReplHistory(replSessionType: configTypes.ReplSessionType, content: string) {
+  const newHistory = resultsOutputUtil.addToHistory(getHistory(replSessionType), content);
   void state.extensionContext.workspaceState.update(getHistoryKey(replSessionType), newHistory);
 }
 
 function clearHistory() {
-  const replType = getSessionType();
+  const replType = replWindowDoc.getSessionType();
   const key = getHistoryKey(replType);
   void state.extensionContext.workspaceState.update(key, []);
   resetState();
-  append('; REPL history cleared');
-  append(getPrompt());
+  replWindowDoc.append('; REPL history cleared');
+  replWindowDoc.append(replWindowDoc.getPrompt());
 }
 
 function showReplHistoryEntry(
@@ -90,19 +87,22 @@ function showReplHistoryEntry(
 }
 
 function promptLine() {
-  return `${getPrompt()}\n`;
+  return `${replWindowDoc.getPrompt()}\n`;
 }
 
 function showPreviousReplHistoryEntry(): void {
   const editor = util.getActiveTextEditor();
   const doc = editor.document;
-  const replSessionType = getSessionType();
+  const replSessionType = replWindowDoc.getSessionType();
   const history = getHistory(replSessionType);
-  if (!isReplWindowDoc(doc) || historyIndex === 0 || history.length === 0) {
+  if (!replWindowDoc.isReplWindowDoc(doc) || historyIndex === 0 || history.length === 0) {
     return;
   }
-  const textAtPrompt = getTextAfterLastOccurrenceOfSubstring(doc.getText(), promptLine());
-  if (isUndefined(historyIndex)) {
+  const textAtPrompt = stringUtil.getTextAfterLastOccurrenceOfSubstring(
+    doc.getText(),
+    promptLine()
+  );
+  if (_.isUndefined(historyIndex)) {
     historyIndex = history.length;
     lastTextAtPrompt = textAtPrompt;
   } else {
@@ -116,16 +116,19 @@ function showPreviousReplHistoryEntry(): void {
 function showNextReplHistoryEntry(): void {
   const editor = util.getActiveTextEditor();
   const doc = editor.document;
-  const replSessionType = getSessionType();
+  const replSessionType = replWindowDoc.getSessionType();
   const history = getHistory(replSessionType);
-  if (!isReplWindowDoc(doc) || historyIndex === null) {
+  if (!replWindowDoc.isReplWindowDoc(doc) || historyIndex === null) {
     return;
   }
   if (historyIndex === history.length - 1) {
     historyIndex = undefined;
     showReplHistoryEntry(lastTextAtPrompt, editor);
   } else {
-    const textAtPrompt = getTextAfterLastOccurrenceOfSubstring(doc.getText(), promptLine());
+    const textAtPrompt = stringUtil.getTextAfterLastOccurrenceOfSubstring(
+      doc.getText(),
+      promptLine()
+    );
     util.assertIsDefined(textAtPrompt, 'Expected to find text at the prompt!');
     util.assertIsDefined(historyIndex, 'Expected a value for historyIndex!');
     updateReplHistory(replSessionType, history, textAtPrompt, historyIndex);
@@ -136,7 +139,6 @@ function showNextReplHistoryEntry(): void {
 }
 
 export {
-  addToHistory,
   addToReplHistory,
   showPreviousReplHistoryEntry,
   showNextReplHistoryEntry,
@@ -144,3 +146,5 @@ export {
   clearHistory,
   setReplHistoryCommandsActiveContext,
 };
+
+export const addToHistory = resultsOutputUtil.addToHistory;

--- a/src/repl-window/repl-window-doc.ts
+++ b/src/repl-window/repl-window-doc.ts
@@ -1,21 +1,21 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as state from '../state';
-import { highlight } from '../highlight/src/extension';
-import { NReplSession } from '../nrepl';
+import * as highlightExtension from '../highlight/src/extension';
+import * as nrepl from '../nrepl';
 import * as util from '../utilities';
 import * as select from '../select';
-import { formatCode } from '../calva-fmt/src/format';
+import * as formatter from '../calva-fmt/src/format';
 import * as namespace from '../namespace';
 import * as config from '../config';
-import type { ReplSessionType } from '../config';
+import type * as configTypes from '../config';
 import * as replHistory from './repl-history';
 import * as docMirror from '../doc-mirror/index';
-import { PrintStackTraceCodelensProvider } from '../providers/codelense';
+import * as codelense from '../providers/codelense';
 import * as replSession from '../nrepl/repl-session';
-import { formatAsLineComments, splitEditQueueForTextBatching } from '../results-output/util';
+import * as resultsOutputUtil from '../results-output/util';
 import * as output from '../results-output/output';
-import { normalizeDestinations } from '../results-output/output-destinations';
+import * as outputDestinations from '../results-output/output-destinations';
 
 const REPL_DOC_NAME = `repl.${config.REPL_FILE_EXT}`;
 
@@ -40,9 +40,9 @@ You can configure this with the setting:
 function outputDestinationSettingMessage() {
   const destinations = config.getConfig().outputDestinations;
   if (
-    normalizeDestinations(destinations.evalResults).includes('repl-window') ||
-    normalizeDestinations(destinations.evalOutput).includes('repl-window') ||
-    normalizeDestinations(destinations.otherOutput).includes('repl-window')
+    outputDestinations.normalizeDestinations(destinations.evalResults).includes('repl-window') ||
+    outputDestinations.normalizeDestinations(destinations.evalOutput).includes('repl-window') ||
+    outputDestinations.normalizeDestinations(destinations.otherOutput).includes('repl-window')
   ) {
     return OUTPUT_DESTINATION_SETTINGS_MESSAGE;
   }
@@ -91,10 +91,10 @@ function getDocDir(): vscode.Uri {
 
 type SessionInfo = {
   ns?: string;
-  session?: NReplSession;
+  session?: nrepl.NReplSession;
 };
 
-let _sessionType: ReplSessionType = 'clj';
+let _sessionType: configTypes.ReplSessionType = 'clj';
 const _sessionInfo: Record<string, SessionInfo> = {
   clj: {},
   cljs: {},
@@ -113,7 +113,10 @@ function ensureSessionEntries(sessionType: string) {
   }
 }
 
-function resolveSessionType(session?: NReplSession, override?: string): ReplSessionType {
+function resolveSessionType(
+  session?: nrepl.NReplSession,
+  override?: string
+): configTypes.ReplSessionType {
   if (override) {
     return override;
   }
@@ -133,7 +136,7 @@ export function getPrompt(): string {
   let prompt = `${_sessionType}꞉${getNs()}꞉> `;
   if (showPrompt[_sessionType]) {
     showPrompt[_sessionType] = false;
-    prompt = `${prompt} ${formatAsLineComments(PROMPT_HINT)}`;
+    prompt = `${prompt} ${resultsOutputUtil.formatAsLineComments(PROMPT_HINT)}`;
   }
   return prompt;
 }
@@ -143,16 +146,16 @@ export function getNs(): string | undefined {
   return _sessionInfo[_sessionType].ns;
 }
 
-export function getSessionType(): ReplSessionType {
+export function getSessionType(): configTypes.ReplSessionType {
   return _sessionType;
 }
 
-export function getSession(): NReplSession | undefined {
+export function getSession(): nrepl.NReplSession | undefined {
   ensureSessionEntries(_sessionType);
   return _sessionInfo[_sessionType].session;
 }
 
-export function setSession(session: NReplSession, newNs?: string, sessionKey?: string): void {
+export function setSession(session: nrepl.NReplSession, newNs?: string, sessionKey?: string): void {
   const resolvedType = resolveSessionType(session, sessionKey);
   ensureSessionEntries(resolvedType);
   _sessionType = resolvedType;
@@ -228,7 +231,9 @@ let havePrintedResultsElsewhereMessage = false;
  */
 export function maybePrintResultsInOtherDestinationMessage(): void {
   if (
-    normalizeDestinations(output.getDestinationConfiguration().evalResults).includes('repl-window')
+    outputDestinations
+      .normalizeDestinations(output.getDestinationConfiguration().evalResults)
+      .includes('repl-window')
   ) {
     return;
   }
@@ -237,7 +242,9 @@ export function maybePrintResultsInOtherDestinationMessage(): void {
   }
   havePrintedResultsElsewhereMessage = true;
 
-  const destinations = normalizeDestinations(output.getDestinationConfiguration().evalResults);
+  const destinations = outputDestinations.normalizeDestinations(
+    output.getDestinationConfiguration().evalResults
+  );
   const destinationNames: Record<output.OutputDestination, string> = {
     'repl-window': 'REPL Window',
     'output-channel': 'Output Channel',
@@ -251,7 +258,7 @@ export function maybePrintResultsInOtherDestinationMessage(): void {
 To reveal the output, use the command:
 > Calva: Show/Open the result output destination`;
   appendLine();
-  appendLine(formatAsLineComments(message));
+  appendLine(resultsOutputUtil.formatAsLineComments(message));
 }
 
 function getViewColumn(): vscode.ViewColumn {
@@ -365,7 +372,9 @@ export async function initReplWindowDoc(): Promise<vscode.TextDocument> {
     return doc;
   }
 
-  const greetings = `${formatAsLineComments(START_GREETINGS)}\n\n${formatAsLineComments(
+  const greetings = `${resultsOutputUtil.formatAsLineComments(
+    START_GREETINGS
+  )}\n\n${resultsOutputUtil.formatAsLineComments(
     CLJ_CONNECT_GREETINGS
   )}${outputDestinationSettingMessage()}\n\n`;
   const edit = new vscode.WorkspaceEdit();
@@ -378,7 +387,7 @@ export async function initReplWindowDoc(): Promise<vscode.TextDocument> {
 
   vscode.languages.registerCodeLensProvider(
     config.documentSelector,
-    new PrintStackTraceCodelensProvider()
+    new codelense.PrintStackTraceCodelensProvider()
   );
 
   replHistory.resetState();
@@ -428,9 +437,9 @@ function appendFormGrabbingSessionAndNS(topLevel: boolean): void {
   let code = '';
   if (selection.isEmpty) {
     const formSelection = select.getFormSelection(doc, selection.active, topLevel);
-    code = formatCode(doc.getText(formSelection), doc.eol);
+    code = formatter.formatCode(doc.getText(formSelection), doc.eol);
   } else {
-    code = formatCode(doc.getText(selection), doc.eol);
+    code = formatter.formatCode(doc.getText(selection), doc.eol);
   }
   if (code != '') {
     setSession(session, ns);
@@ -491,7 +500,7 @@ async function writeToReplWindowDoc({ text, onAppended }: ResultsBufferEntry): P
   const editors = visibleReplWindowEditors();
   editors.forEach((editor) => {
     util.scrollToBottom(editor);
-    highlight(editor);
+    highlightExtension.highlight(editor);
   });
 }
 
@@ -518,7 +527,7 @@ async function writeNextOutputBatch() {
     return await writeToReplWindowDoc(resultsBuffer.shift());
   }
   // Batch all remaining entries up until another onAppended callback.
-  const [nextText, remaining] = splitEditQueueForTextBatching(resultsBuffer);
+  const [nextText, remaining] = resultsOutputUtil.splitEditQueueForTextBatching(resultsBuffer);
   resultsBuffer = remaining;
   await writeToReplWindowDoc({ text: nextText.join('') });
 }

--- a/src/results-output/file-output.ts
+++ b/src/results-output/file-output.ts
@@ -7,7 +7,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { resolveFilePath } from '../util/resolve-file-arg';
+import * as resolveFileArg from '../util/resolve-file-arg';
 
 /**
  * Returns true if the destination string looks like a file path.
@@ -41,11 +41,11 @@ export function resolveOutputFilePath(
   workspaceRoot: string | undefined
 ): string | undefined {
   if (typeof destination === 'string') {
-    return resolveFilePath(expandTilde(destination), workspaceRoot);
+    return resolveFileArg.resolveFilePath(expandTilde(destination), workspaceRoot);
   }
   // Array of path segments — join first, then expand + resolve
   const joined = path.join(...destination);
-  return resolveFilePath(expandTilde(joined), workspaceRoot);
+  return resolveFileArg.resolveFilePath(expandTilde(joined), workspaceRoot);
 }
 
 /**

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -5,16 +5,12 @@ import * as util from '../utilities';
 import * as model from '../cursor-doc/model';
 import * as cursorUtil from '../cursor-doc/utilities';
 import * as chalk from 'chalk';
-import * as ansiRegex from 'ansi-regex';
+import ansiRegex = require('ansi-regex');
 import * as printer from '../printer';
-import {
-  appendToReplOutputWebview,
-  showReplOutputWebviewPanel,
-  appendStackTraceToReplOutputWebview,
-} from '../../out/cljs-lib/cljs-lib';
+import * as cljsLib from '../../out/cljs-lib/cljs-lib';
 import * as replSession from '../nrepl/repl-session';
 import * as jackInVersions from '../nrepl/jack-in-dependency-versions';
-import { routeEvaluatedCode } from './evaluated-code';
+import * as evaluatedCode from './evaluated-code';
 
 const customChalk = new chalk.Instance({ level: 3 });
 
@@ -110,17 +106,17 @@ export interface AfterAppendCallback {
   (insertLocation: vscode.Location, newPosition?: vscode.Location): any;
 }
 
-import {
-  normalizeDestinations,
-  type OutputDestination,
-  type OutputDestinationValue,
-} from './output-destinations';
-import {
-  isFilePathDestination,
-  resolveOutputFilePath,
-  appendToOutputFile,
-  reportFileOutputError,
-} from './file-output';
+import * as outputDestinations from './output-destinations';
+import * as fileOutput from './file-output';
+
+type OutputDestination = outputDestinations.OutputDestination;
+type OutputDestinationValue = outputDestinations.OutputDestinationValue;
+
+const normalizeDestinations = outputDestinations.normalizeDestinations;
+const isFilePathDestination = fileOutput.isFilePathDestination;
+const resolveOutputFilePath = fileOutput.resolveOutputFilePath;
+const appendToOutputFile = fileOutput.appendToOutputFile;
+const reportFileOutputError = fileOutput.reportFileOutputError;
 
 export type { OutputDestination, OutputDestinationValue };
 export { normalizeDestinations };
@@ -229,7 +225,7 @@ export function showResultOutputDestination(preserveFocus = true) {
     return showOutputTerminal(preserveFocus);
   }
   if (first === 'output-view') {
-    return showReplOutputWebviewPanel(preserveFocus);
+    return cljsLib.showReplOutputWebviewPanel(preserveFocus);
   }
   return outputWindow.revealReplWindowDoc(preserveFocus);
 }
@@ -394,7 +390,7 @@ function writeClojure(
       after(undefined, undefined);
     }
   } else if (destination === 'output-view') {
-    appendToReplOutputWebview(options, message);
+    cljsLib.appendToReplOutputWebview(options, message);
     if (after) {
       after(undefined, undefined);
     }
@@ -461,7 +457,7 @@ export function appendEvaluatedCode(
     didLastOutputTerminateLine.set(sinkFirst, true);
   }
 
-  routeEvaluatedCode({
+  evaluatedCode.routeEvaluatedCode({
     code,
     didLastTerminateLine: sinkDidLastTerminateLine,
     who: metadataOptions.who,
@@ -608,7 +604,7 @@ function writeAppend(options: AppendOptions, message: string, after?: AfterAppen
     return;
   }
   if (destination === 'output-view') {
-    appendToReplOutputWebview(options, message);
+    cljsLib.appendToReplOutputWebview(options, message);
   }
 }
 
@@ -862,7 +858,7 @@ function writeAppendLine(options: AppendOptions, message: string, after?: AfterA
     return;
   }
   if (destination === 'output-view') {
-    appendToReplOutputWebview(options, '\n\n' + message);
+    cljsLib.appendToReplOutputWebview(options, '\n\n' + message);
   }
 }
 
@@ -1095,7 +1091,7 @@ function printStackTrace(stacktrace: any[]) {
         void replWindowAppendPrompt();
         break;
       case 'output-view':
-        appendStackTraceToReplOutputWebview(stacktrace);
+        cljsLib.appendStackTraceToReplOutputWebview(stacktrace);
         break;
       case 'output-channel':
         outputChannel.appendLine('');

--- a/src/results-output/util.ts
+++ b/src/results-output/util.ts
@@ -1,5 +1,5 @@
-import { takeWhile } from 'lodash';
-import type { ResultsBuffer } from '../repl-window/repl-window-doc';
+import * as _ from 'lodash';
+import type * as replWindowDoc from '../repl-window/repl-window-doc';
 
 function addToHistory(history: string[], content?: string): string[] {
   if (content) {
@@ -18,10 +18,10 @@ function formatAsLineComments(str: string): string {
 }
 
 function splitEditQueueForTextBatching(
-  editQueue: ResultsBuffer,
+  editQueue: replWindowDoc.ResultsBuffer,
   maxBatchSize: number = 1000
-): [string[], ResultsBuffer] {
-  const nextBatch = takeWhile(editQueue, (value, index) => {
+): [string[], replWindowDoc.ResultsBuffer] {
+  const nextBatch = _.takeWhile(editQueue, (value, index) => {
     return index < maxBatchSize && !value.onAppended;
   }).map((x) => x.text);
   const remainingEditQueue = [...editQueue].slice(nextBatch.length);

--- a/src/shadow-cljs-runtime-core.ts
+++ b/src/shadow-cljs-runtime-core.ts
@@ -5,8 +5,6 @@
  * This module is VS Code-free and operates solely on data structures.
  */
 
-import type { ConnectionState } from './nrepl/client-registry';
-
 export interface RuntimeInfo {
   clientId: number;
   description: string;

--- a/src/shadow-cljs-runtime.ts
+++ b/src/shadow-cljs-runtime.ts
@@ -5,8 +5,10 @@ import * as clientRegistry from './nrepl/client-registry';
 import * as util from './utilities';
 import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as output from './results-output/output';
-import status from './status';
+import * as statusModule from './status';
 import * as shadowRuntimeCore from './shadow-cljs-runtime-core';
+
+const status = statusModule.default;
 
 interface RuntimeQuickPickItem extends vscode.QuickPickItem {
   runtimeInfo: shadowRuntimeCore.RuntimeInfo;

--- a/src/shadow-cljs-runtime.ts
+++ b/src/shadow-cljs-runtime.ts
@@ -3,7 +3,7 @@ import * as replSession from './nrepl/repl-session';
 import * as sessionRegistry from './nrepl/session-registry';
 import * as clientRegistry from './nrepl/client-registry';
 import * as util from './utilities';
-import { parseEdn, parseEdnWithInst } from '../out/cljs-lib/cljs-lib';
+import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as output from './results-output/output';
 import status from './status';
 import * as shadowRuntimeCore from './shadow-cljs-runtime-core';
@@ -103,7 +103,8 @@ async function getShadowRuntimesForClient(
 
     // Parse the EDN data structure returned by shadow-cljs
     try {
-      const apiRuntimes: shadowRuntimeCore.ShadowApiRuntimeInfo[] = parseEdnWithInst(result);
+      const apiRuntimes: shadowRuntimeCore.ShadowApiRuntimeInfo[] =
+        cljsLib.parseEdnWithInst(result);
       return apiRuntimes.map(shadowRuntimeCore.normalizeRuntimeInfo);
     } catch (parseError) {
       output.appendLineOtherErr(`Error parsing runtime information: ${parseError}`);
@@ -144,7 +145,8 @@ export async function getShadowRuntimes(): Promise<shadowRuntimeCore.RuntimeInfo
 
     // Parse the EDN data structure returned by shadow-cljs
     try {
-      const apiRuntimes: shadowRuntimeCore.ShadowApiRuntimeInfo[] = parseEdnWithInst(result);
+      const apiRuntimes: shadowRuntimeCore.ShadowApiRuntimeInfo[] =
+        cljsLib.parseEdnWithInst(result);
       return apiRuntimes.map(shadowRuntimeCore.normalizeRuntimeInfo);
     } catch (parseError) {
       output.appendLineOtherErr(`Error parsing runtime information: ${parseError}`);
@@ -398,7 +400,7 @@ export function clearRuntimeState(clientKey?: string): void {
 export async function handleShadowRemoteMessage(msgData: any, clientKey: string): Promise<void> {
   try {
     if (msgData.data) {
-      const data = parseEdn(msgData.data);
+      const data = cljsLib.parseEdn(msgData.data);
       const currentRuntimeId = getSelectedRuntimeId(clientKey);
       const action = shadowRuntimeCore.decideMessageAction(data, currentRuntimeId);
 

--- a/src/shadow-cljs-runtime.ts
+++ b/src/shadow-cljs-runtime.ts
@@ -5,10 +5,8 @@ import * as clientRegistry from './nrepl/client-registry';
 import * as util from './utilities';
 import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as output from './results-output/output';
-import * as statusModule from './status';
+import * as status from './status';
 import * as shadowRuntimeCore from './shadow-cljs-runtime-core';
-
-const status = statusModule.default;
 
 interface RuntimeQuickPickItem extends vscode.QuickPickItem {
   runtimeInfo: shadowRuntimeCore.RuntimeInfo;

--- a/src/state.ts
+++ b/src/state.ts
@@ -10,9 +10,6 @@ import * as projectRoot from './project-root';
 import * as connectSequences from './nrepl/connectSequence';
 import * as connectTypes from './nrepl/connect-types';
 
-const Analytics = analyticsModule.default;
-type AnalyticsInstance = InstanceType<typeof Analytics>;
-
 let extensionContext: vscode.ExtensionContext;
 export function setExtensionContext(context: vscode.ExtensionContext) {
   extensionContext = context;
@@ -88,7 +85,7 @@ function connectionLogChannel(): vscode.OutputChannel {
   return _outputChannel('connectionLogChannel');
 }
 
-function analytics(): AnalyticsInstance {
+function analytics(): analyticsModule.Analytics {
   const analytics = cljsLib.getStateValue('analytics');
   if (analytics.toJS !== undefined) {
     return analytics.toJS();

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as semver from 'semver';
-import Analytics from './analytics';
+import * as analyticsModule from './analytics';
 import * as util from './utilities';
 import * as path from 'path';
 import * as fileArg from './util/resolve-file-arg';
@@ -9,6 +9,9 @@ import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as projectRoot from './project-root';
 import * as connectSequences from './nrepl/connectSequence';
 import * as connectTypes from './nrepl/connect-types';
+
+const Analytics = analyticsModule.default;
+type AnalyticsInstance = InstanceType<typeof Analytics>;
 
 let extensionContext: vscode.ExtensionContext;
 export function setExtensionContext(context: vscode.ExtensionContext) {
@@ -85,7 +88,7 @@ function connectionLogChannel(): vscode.OutputChannel {
   return _outputChannel('connectionLogChannel');
 }
 
-function analytics(): Analytics {
+function analytics(): AnalyticsInstance {
   const analytics = cljsLib.getStateValue('analytics');
   if (analytics.toJS !== undefined) {
     return analytics.toJS();

--- a/src/state.ts
+++ b/src/state.ts
@@ -5,10 +5,10 @@ import * as util from './utilities';
 import * as path from 'path';
 import * as fileArg from './util/resolve-file-arg';
 import * as child from 'child_process';
-import { getStateValue, setStateValue } from '../out/cljs-lib/cljs-lib';
+import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as projectRoot from './project-root';
-import { getCustomConnectSequences, ReplConnectSequence } from './nrepl/connectSequence';
-import { ConnectType } from './nrepl/connect-types';
+import * as connectSequences from './nrepl/connectSequence';
+import * as connectTypes from './nrepl/connect-types';
 
 let extensionContext: vscode.ExtensionContext;
 export function setExtensionContext(context: vscode.ExtensionContext) {
@@ -38,14 +38,14 @@ export function initDepsEdnJackInExecutable() {
       console.warn(
         `deps.edn launcher check: '${launcherCheckCommand}' command failed, using 'deps.clj'`
       );
-      setStateValue('depsEdnJackInDefaultExecutable', 'deps.clj');
+      cljsLib.setStateValue('depsEdnJackInDefaultExecutable', 'deps.clj');
       return;
     }
     if (stdout.match('version')) {
       console.info(
         `deps.edn launcher check: '${launcherCheckCommand}' command works, using 'clojure'`
       );
-      setStateValue('depsEdnJackInDefaultExecutable', 'clojure');
+      cljsLib.setStateValue('depsEdnJackInDefaultExecutable', 'clojure');
       const version = stdout.match(/version\s+([\d.]+)/)[1];
       console.info(`clojure version: ${version}`);
       ancientCLICheck(version);
@@ -53,7 +53,7 @@ export function initDepsEdnJackInExecutable() {
       console.warn(
         `deps.edn launcher check: '${launcherCheckCommand}' command not returning expected output, using 'deps.clj'`
       );
-      setStateValue('depsEdnJackInDefaultExecutable', 'deps.clj');
+      cljsLib.setStateValue('depsEdnJackInDefaultExecutable', 'deps.clj');
     }
   });
 }
@@ -62,14 +62,14 @@ function ancientCLICheck(version: string) {
   const ancientVersion = '1.10.697';
   if (semver.lt(semver.coerce(version), ancientVersion)) {
     console.warn(`The installed 'clojure' version is ancient, even lower than ${ancientVersion}.`);
-    setStateValue('isClojureCLIVersionAncient', true);
+    cljsLib.setStateValue('isClojureCLIVersionAncient', true);
   }
 }
 
 // Super-quick fix for: https://github.com/BetterThanTomorrow/calva/issues/144
 // TODO: Revisit the whole state management business.
 function _outputChannel(name: string): vscode.OutputChannel {
-  const channel = getStateValue(name);
+  const channel = cljsLib.getStateValue(name);
   if (channel.toJS !== undefined) {
     return channel.toJS();
   } else {
@@ -86,7 +86,7 @@ function connectionLogChannel(): vscode.OutputChannel {
 }
 
 function analytics(): Analytics {
-  const analytics = getStateValue('analytics');
+  const analytics = cljsLib.getStateValue('analytics');
   if (analytics.toJS !== undefined) {
     return analytics.toJS();
   } else {
@@ -100,23 +100,23 @@ const PROJECT_CONFIG_MAP = 'config';
 
 export function getProjectRootLocal(useCache = true): string | undefined {
   if (useCache) {
-    return getStateValue(PROJECT_DIR_KEY);
+    return cljsLib.getStateValue(PROJECT_DIR_KEY);
   }
 }
 
 export function getProjectConfig(useCache = true) {
   if (useCache) {
-    return getStateValue(PROJECT_CONFIG_MAP);
+    return cljsLib.getStateValue(PROJECT_CONFIG_MAP);
   }
 }
 
 export function setProjectConfig(config) {
-  return setStateValue(PROJECT_CONFIG_MAP, config);
+  return cljsLib.setStateValue(PROJECT_CONFIG_MAP, config);
 }
 
 export function getProjectRootUri(useCache = true): vscode.Uri | undefined {
   if (useCache) {
-    const res = getStateValue(PROJECT_DIR_URI_KEY);
+    const res = cljsLib.getStateValue(PROJECT_DIR_URI_KEY);
     if (res) {
       return res;
     }
@@ -140,8 +140,8 @@ export async function setOrCreateNonProjectRoot(
     const subDir = util.randomSlug();
     root = vscode.Uri.file(path.join(util.calvaTmpDir(), subDir));
   }
-  await setStateValue(PROJECT_DIR_KEY, path.resolve(root.fsPath ? root.fsPath : root.path));
-  await setStateValue(PROJECT_DIR_URI_KEY, root);
+  await cljsLib.setStateValue(PROJECT_DIR_KEY, path.resolve(root.fsPath ? root.fsPath : root.path));
+  await cljsLib.setStateValue(PROJECT_DIR_URI_KEY, root);
   return root;
 }
 
@@ -163,8 +163,8 @@ function getProjectWsFolder(): vscode.WorkspaceFolder | undefined {
  * Figures out the current clojure project root, and stores it in Calva state
  */
 export async function initProjectDir(
-  connectType: ConnectType,
-  connectSequence: ReplConnectSequence,
+  connectType: connectTypes.ConnectType,
+  connectSequence: connectSequences.ReplConnectSequence,
   disableAutoSelect = false
 ) {
   // When a connectSequence with projectRootPath is explicitly provided, use it directly
@@ -181,8 +181,8 @@ export async function initProjectDir(
         'calva:projectRoot',
         projectRootPath.fsPath
       );
-      await setStateValue(PROJECT_DIR_KEY, projectRootPath.fsPath);
-      await setStateValue(PROJECT_DIR_URI_KEY, projectRootPath);
+      await cljsLib.setStateValue(PROJECT_DIR_KEY, projectRootPath.fsPath);
+      await cljsLib.setStateValue(PROJECT_DIR_URI_KEY, projectRootPath);
       return projectRootPath;
     }
   }
@@ -194,12 +194,15 @@ export async function initProjectDir(
     ? projectRoot.findClosestParent(active_uri, candidatePaths)
     : undefined;
 
-  const sequences: ReplConnectSequence[] = getCustomConnectSequences();
+  const sequences: connectSequences.ReplConnectSequence[] =
+    connectSequences.getCustomConnectSequences();
 
   const defaultSequences = disableAutoSelect
     ? [connectSequence]
     : sequences.filter((s) =>
-        connectType === ConnectType.Connect ? s.autoSelectForConnect : s.autoSelectForJackIn
+        connectType === connectTypes.ConnectType.Connect
+          ? s.autoSelectForConnect
+          : s.autoSelectForJackIn
       );
   const defaultSequence =
     defaultSequences.find(
@@ -225,8 +228,8 @@ export async function initProjectDir(
   if (projectRootPath) {
     console.log('Setting project root to: ', projectRootPath.fsPath);
     void vscode.commands.executeCommand('setContext', 'calva:projectRoot', projectRootPath.fsPath);
-    await setStateValue(PROJECT_DIR_KEY, projectRootPath.fsPath);
-    await setStateValue(PROJECT_DIR_URI_KEY, projectRootPath);
+    await cljsLib.setStateValue(PROJECT_DIR_KEY, projectRootPath.fsPath);
+    await cljsLib.setStateValue(PROJECT_DIR_URI_KEY, projectRootPath);
     return projectRootPath;
   }
   return setOrCreateNonProjectRoot(extensionContext, true);

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,6 +1,8 @@
-import statusbar from './statusbar';
+import * as statusbarModule from './statusbar';
 import * as replSession from './nrepl/repl-session';
 import * as whenContexts from './when-contexts';
+
+const statusbar = statusbarModule.default;
 
 function update() {
   replSession.updateReplSessionType();

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,8 +1,6 @@
-import * as statusbarModule from './statusbar';
+import * as statusbar from './statusbar';
 import * as replSession from './nrepl/repl-session';
 import * as whenContexts from './when-contexts';
-
-const statusbar = statusbarModule.default;
 
 function update() {
   replSession.updateReplSessionType();
@@ -10,6 +8,4 @@ function update() {
   whenContexts.setCljsTypeContext();
 }
 
-export default {
-  update,
-};
+export { update };

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,11 +1,11 @@
 import statusbar from './statusbar';
-import { updateReplSessionType } from './nrepl/repl-session';
-import { setCljsTypeContext } from './when-contexts';
+import * as replSession from './nrepl/repl-session';
+import * as whenContexts from './when-contexts';
 
 function update() {
-  updateReplSessionType();
+  replSession.updateReplSessionType();
   statusbar.update();
-  setCljsTypeContext();
+  whenContexts.setCljsTypeContext();
 }
 
 export default {

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as util from './utilities';
 import * as config from './config';
 import * as shadowRuntimes from './shadow-cljs-runtime';
-import { getStateValue } from '../out/cljs-lib/cljs-lib';
+import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as replSession from './nrepl/repl-session';
 import * as sessionLabel from './nrepl/session-label';
 import * as sessionRouting from './nrepl/session-routing';
@@ -105,10 +105,10 @@ function update() {
   shadowRuntimeStatus.command = 'calva.selectShadowCljsRuntime';
   shadowRuntimeStatus.tooltip = undefined;
 
-  if (!getStateValue('connected')) {
+  if (!cljsLib.getStateValue('connected')) {
     typeStatus.hide();
   }
-  if (getStateValue('connected')) {
+  if (cljsLib.getStateValue('connected')) {
     connectionStatus.text = 'REPL $(zap)';
     connectionStatus.color = colorValue('connectedStatusColor', currentConf);
 
@@ -219,7 +219,7 @@ function update() {
     ? sessionRegistry.getConnectionStateForSession(replType)
     : undefined;
   if (
-    getStateValue('connected') &&
+    cljsLib.getStateValue('connected') &&
     isRoutedSessionSecondary &&
     routedConnectionState?.cljsTypeName === 'shadow-cljs' &&
     shadowRuntimeStatus.text

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -232,7 +232,4 @@ function update() {
   prettyPrintToggle.show();
 }
 
-export default {
-  update,
-  color,
-};
+export { update, color };

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -2,15 +2,15 @@ import * as vscode from 'vscode';
 import * as util from './utilities';
 import * as string from './util/string';
 import * as outputWindow from './repl-window/repl-window-doc';
-import { NReplSession } from './nrepl';
+import * as nrepl from './nrepl';
 import * as cider from './nrepl/cider';
 import * as lsp from './lsp/definitions';
 import * as namespace from './namespace';
-import { getSession, updateReplSessionType } from './nrepl/repl-session';
+import * as replSession from './nrepl/repl-session';
 import * as getText from './util/get-text';
 import * as output from './results-output/output';
-import { appendStackTraceToReplOutputWebview } from '../out/cljs-lib/cljs-lib';
-import { normalizeDestinations } from './results-output/output-destinations';
+import * as cljsLib from '../out/cljs-lib/cljs-lib';
+import * as outputDestinations from './results-output/output-destinations';
 
 const diagnosticCollection = vscode.languages.createDiagnosticCollection('calva');
 
@@ -82,7 +82,7 @@ function existingUriForNameSpace(
 
 async function onTestResult(
   controller: vscode.TestController,
-  session: NReplSession,
+  session: nrepl.NReplSession,
   run: vscode.TestRun,
   nsName: string,
   varName: string,
@@ -161,7 +161,7 @@ async function onTestResult(
 
 async function onTestResults(
   controller: vscode.TestController,
-  session: NReplSession,
+  session: nrepl.NReplSession,
   results: cider.TestResults[]
 ) {
   const run = controller.createTestRun(new vscode.TestRunRequest(), 'Clojure', false);
@@ -182,7 +182,7 @@ function useTestExplorer(): boolean | undefined {
 
 async function reportTests(
   controller: vscode.TestController,
-  session: NReplSession,
+  session: nrepl.NReplSession,
   possibleResults: cider.TestResults[]
 ) {
   // Results can sometimes not be actual test results, such as when a namespace is not found: https://github.com/BetterThanTomorrow/calva/issues/1516.
@@ -229,12 +229,20 @@ async function reportTests(
               outputWindow.markLastStacktraceRange(afterResultLocation);
             });
             const otherOutputDestination = output.getDestinationConfiguration().otherOutput;
-            if (!normalizeDestinations(otherOutputDestination).includes('repl-window')) {
+            if (
+              !outputDestinations
+                .normalizeDestinations(otherOutputDestination)
+                .includes('repl-window')
+            ) {
               // We don't want to prepend lines with `; ` in output destinations other than the repl-window.
               // This is just a quick fix to avoid refactoring for now.
               output.appendLineOtherOut(message.replace(/; /gi, ''));
-              if (normalizeDestinations(otherOutputDestination).includes('output-view')) {
-                appendStackTraceToReplOutputWebview(stacktrace.stacktrace);
+              if (
+                outputDestinations
+                  .normalizeDestinations(otherOutputDestination)
+                  .includes('output-view')
+              ) {
+                cljsLib.appendStackTraceToReplOutputWebview(stacktrace.stacktrace);
               }
             }
           } else if (message) {
@@ -263,14 +271,14 @@ async function reportTests(
 
 // FIXME: use cljs session where necessary
 async function runAllTests(controller: vscode.TestController, document = {}) {
-  const session = getSession();
+  const session = replSession.getSession();
   output.appendLineOtherOut('Running all project tests…');
   try {
     await reportTests(controller, session, [await session.testAll()]);
   } catch (e) {
     output.appendLineOtherErr(e);
   }
-  updateReplSessionType();
+  replSession.updateReplSessionType();
   void output.replWindowAppendPrompt();
 }
 
@@ -288,7 +296,7 @@ function runAllTestsCommand(controller: vscode.TestController) {
 
 async function loadTestNS() {
   const document = util.getActiveTextEditor().document;
-  const session = getSession();
+  const session = replSession.getSession();
   const doc = util.tryToGetDocument(document);
 
   const [ns, _] = namespace.getNamespace(
@@ -323,7 +331,7 @@ async function runNamespaceTestsImpl(
     return;
   }
 
-  const session = getSession();
+  const session = replSession.getSession();
 
   output.appendLineOtherOut(
     `Running tests for the following namespaces:\n${
@@ -341,7 +349,7 @@ async function runNamespaceTestsImpl(
   }
 
   outputWindow.setSession(session, nss[0]);
-  updateReplSessionType();
+  replSession.updateReplSessionType();
   void output.replWindowAppendPrompt();
 }
 
@@ -370,7 +378,7 @@ function getTestUnderCursor() {
 
 async function runTestUnderCursor(controller: vscode.TestController) {
   const doc = util.tryToGetDocument({});
-  const session = getSession();
+  const session = replSession.getSession();
   const [ns, _] = namespace.getNamespace(
     doc,
     vscode.window.activeTextEditor?.selections[0]?.active
@@ -416,7 +424,7 @@ function runNamespaceTestsCommand(controller: vscode.TestController) {
 }
 
 async function rerunTests(controller: vscode.TestController, document = {}) {
-  const session = getSession();
+  const session = replSession.getSession();
   output.appendLineOtherOut('Running previously failed tests…');
   try {
     await reportTests(controller, session, [await session.retest()]);

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -525,7 +525,7 @@ function onTestTree(controller: vscode.TestController, testTree: lsp.TestTreePar
   }
 }
 
-export default {
+export {
   initialize,
   runNamespaceTests,
   runNamespaceTestsCommand,

--- a/src/util/cursor-get-text.ts
+++ b/src/util/cursor-get-text.ts
@@ -2,12 +2,12 @@
  * Can be unit tested since vscode and stuff is not imported
  */
 
-import { EditableDocument, StringDocument } from '../cursor-doc/model';
+import * as model from '../cursor-doc/model';
 
 export type RangeAndText = [[number, number], string] | [undefined, ''];
 
 export function currentTopLevelDefined(
-  doc: EditableDocument,
+  doc: model.EditableDocument,
   active: number = doc.selections[0].active
 ): RangeAndText {
   const defunCursor = doc.getTokenCursor(active);
@@ -33,14 +33,14 @@ export function currentTopLevelDefined(
   return [undefined, ''];
 }
 
-export function currentTopLevelForm(doc: EditableDocument): RangeAndText {
+export function currentTopLevelForm(doc: model.EditableDocument): RangeAndText {
   const defunCursor = doc.getTokenCursor(doc.selections[0].active);
   const defunRange = defunCursor.rangeForDefun(doc.selections[0].active);
   return defunRange ? [defunRange, doc.model.getText(...defunRange)] : [undefined, ''];
 }
 
 function rangeToCursor(
-  doc: EditableDocument,
+  doc: model.EditableDocument,
   foldRange: [number, number],
   startFrom: number,
   active: number
@@ -63,25 +63,25 @@ function rangeToCursor(
   return [undefined, ''];
 }
 
-export function currentEnclosingFormToCursor(doc: EditableDocument): RangeAndText {
+export function currentEnclosingFormToCursor(doc: model.EditableDocument): RangeAndText {
   const cursor = doc.getTokenCursor(doc.selections[0].active);
   const enclosingRange = cursor.rangeForList(1);
   return rangeToCursor(doc, enclosingRange, enclosingRange[0], doc.selections[0].active);
 }
 
-export function currentTopLevelFormToCursor(doc: EditableDocument): RangeAndText {
+export function currentTopLevelFormToCursor(doc: model.EditableDocument): RangeAndText {
   const cursor = doc.getTokenCursor(doc.selections[0].active);
   const defunRange = cursor.rangeForDefun(doc.selections[0].active);
   return rangeToCursor(doc, defunRange, defunRange[0], doc.selections[0].active);
 }
 
-export function startOfFileToCursor(doc: EditableDocument): RangeAndText {
+export function startOfFileToCursor(doc: model.EditableDocument): RangeAndText {
   const cursor = doc.getTokenCursor(doc.selections[0].active);
   const defunRange = cursor.rangeForDefun(doc.selections[0].active, false);
   return rangeToCursor(doc, defunRange, 0, doc.selections[0].active);
 }
 
-export function selectionAddingBrackets(doc: EditableDocument): RangeAndText {
+export function selectionAddingBrackets(doc: model.EditableDocument): RangeAndText {
   const [left, right] = [doc.selections[0].anchor, doc.selections[0].active].sort((a, b) => a - b);
   const cursor = doc.getTokenCursor(left);
   cursor.forwardSexp(true, true, true);

--- a/src/util/get-text.ts
+++ b/src/util/get-text.ts
@@ -3,8 +3,8 @@ import * as select from '../select';
 import * as paredit from '../cursor-doc/paredit';
 import * as docMirror from '../doc-mirror/index';
 import * as cursorTextGetter from './cursor-get-text';
-import { EditableDocument } from '../cursor-doc/model';
-import { getPareditConfig } from '../paredit/extension';
+import type * as model from '../cursor-doc/model';
+import * as pareditExtension from '../paredit/extension';
 
 export type SelectionAndText = [vscode.Selection | undefined, string];
 
@@ -35,7 +35,7 @@ export function currentPairText(doc: vscode.TextDocument, pos: vscode.Position):
   const cursorDoc = docMirror.getDocument(doc);
   const cursorPos = doc.offsetAt(pos);
   const cursor = cursorDoc.getTokenCursor(cursorPos);
-  const pareditConfig = getPareditConfig();
+  const pareditConfig = pareditExtension.getPareditConfig();
   if (paredit.isInPairsList(cursor, pareditConfig)) {
     const range = paredit.currentSexpsRange(cursorDoc, cursor, cursorPos, true, pareditConfig);
     const selection = select.selectionFromOffsetRange(doc, range);
@@ -95,7 +95,7 @@ export function currentTopLevelFunction(doc: vscode.TextDocument): SelectionAndT
 
 function selectionAndText(
   doc: vscode.TextDocument,
-  textGetter: (doc: EditableDocument, active: number) => cursorTextGetter.RangeAndText,
+  textGetter: (doc: model.EditableDocument, active: number) => cursorTextGetter.RangeAndText,
   pos: vscode.Position
 ): SelectionAndText {
   if (doc) {
@@ -145,7 +145,7 @@ export function startOFileToCursor(
 
 function fromFn(
   doc: vscode.TextDocument,
-  cursorDocFn: (doc: EditableDocument, offset?: number) => [number, number]
+  cursorDocFn: (doc: model.EditableDocument, offset?: number) => [number, number]
 ): SelectionAndText {
   if (doc) {
     const cursorDoc = docMirror.getDocument(doc);

--- a/src/util/regex.ts
+++ b/src/util/regex.ts
@@ -1,4 +1,4 @@
-import { trim } from 'lodash';
+import _ = require('lodash');
 
 export const isCljOrJsRegex = (regexp: string) => {
   return regexp.startsWith('#"') || regexp.startsWith('/');
@@ -12,6 +12,6 @@ export const testCljOrJsRegex = (regexp: string, str: string) => {
   }
   const clojureReMatches = regexp.match(/^#"(.*)"$/);
   const normalizedRe =
-    (clojureReMatches && RegExp(clojureReMatches[1])) || RegExp(trim(regexp, '/'));
+    (clojureReMatches && RegExp(clojureReMatches[1])) || RegExp(_.trim(regexp, '/'));
   return normalizedRe.test(str.replace(/^.*\//, ''));
 };

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { https } from 'follow-redirects';
+import * as followRedirects from 'follow-redirects';
 import * as _ from 'lodash';
 import * as state from './state';
 import * as path from 'path';
@@ -9,15 +9,11 @@ import JSZip = require('jszip');
 import * as outputWindow from './repl-window/repl-window-doc';
 import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as url from 'url';
-import { isUndefined } from 'lodash';
 import * as fiddleFiles from './fiddle-files';
 import * as output from './results-output/output';
-import { getConfig } from './config';
+import * as config from './config';
 import * as fileArg from './util/resolve-file-arg';
-import {
-  isCommentFormHead as _isCommentFormHead,
-  CommentFormConfig,
-} from './cursor-doc/paredit-config';
+import * as pareditConfig from './cursor-doc/paredit-config';
 
 const specialWords = ['-', '+', '/', '*']; //TODO: Add more here
 const syntaxQuoteSymbol = '`';
@@ -248,7 +244,7 @@ function tryToGetDocument(
 function getDocument(document: vscode.TextDocument | Record<string, never>): vscode.TextDocument {
   const doc = tryToGetDocument(document);
 
-  if (isUndefined(doc)) {
+  if (_.isUndefined(doc)) {
     throw new Error('Expected an activeTextEditor with a document!');
   }
 
@@ -549,7 +545,7 @@ async function downloadFromUrl(fileUrl: string, savePath: string) {
         });
       });
     } else {
-      https.get(fileUrl, (res) => {
+      followRedirects.https.get(fileUrl, (res) => {
         if (res.statusCode === 200) {
           res.pipe(saveFile);
         } else {
@@ -572,7 +568,7 @@ async function downloadFromUrl(fileUrl: string, savePath: string) {
 function getLatestGitHubReleaseTag(ownerRepo: string, timeoutMs = 10_000): Promise<string> {
   const releaseUrl = `https://github.com/${ownerRepo}/releases/latest`;
   return new Promise((resolve) => {
-    const request = https
+    const request = followRedirects.https
       .get(releaseUrl, (response) => {
         response.resume();
         const finalUrl = response.responseUrl ?? '';
@@ -603,7 +599,7 @@ async function fetchFromUrl(fullUrl: string): Promise<string> {
         resolve(data);
       });
     } else {
-      https
+      followRedirects.https
         .get(
           {
             host: q.hostname,
@@ -665,7 +661,7 @@ function tryToGetActiveTextEditor(): vscode.TextEditor | undefined {
 function getActiveTextEditor(): vscode.TextEditor {
   const editor = tryToGetActiveTextEditor();
 
-  if (isUndefined(editor)) {
+  if (_.isUndefined(editor)) {
     throw new Error('Expected active text editor!');
   }
 
@@ -699,12 +695,15 @@ function pathExists(path: string): boolean {
  * Convenience wrapper around paredit-config's isCommentFormHead that
  * automatically reads VS Code config when no config is supplied.
  */
-function isCommentFormHead(symbol: string, config?: CommentFormConfig): boolean {
-  if (!config) {
-    const { customCommentForms, aliasMap } = getConfig();
-    return _isCommentFormHead(symbol, { customCommentForms, aliasMap });
+function isCommentFormHead(
+  symbol: string,
+  commentFormConfig?: pareditConfig.CommentFormConfig
+): boolean {
+  if (!commentFormConfig) {
+    const { customCommentForms, aliasMap } = config.getConfig();
+    return pareditConfig.isCommentFormHead(symbol, { customCommentForms, aliasMap });
   }
-  return _isCommentFormHead(symbol, config);
+  return pareditConfig.isCommentFormHead(symbol, commentFormConfig);
 }
 
 export function lastLineIsEmpty(

--- a/src/when-contexts.ts
+++ b/src/when-contexts.ts
@@ -1,12 +1,11 @@
 import * as vscode from 'vscode';
-import { deepEqual } from './util/object';
+import * as objectUtil from './util/object';
 import * as docMirror from './doc-mirror';
 import * as context from './cursor-doc/cursor-context';
 import * as util from './utilities';
 import * as namespace from './namespace';
 import * as session from './nrepl/repl-session';
 import * as state from './state';
-import { cljsLib } from './utilities';
 
 /* Determining the "calva:ns" cursor context takes time,
 so figure it out after x milliseconds of quiet. */


### PR DESCRIPTION
## What has changed?

Pretty much what the title says. Now all imports are namespace imporrs and access to module variables is always fully qualified.

Also cleaned up all those icky `export default` aliases, so now it is named exprts thoughout as well.

Ironically changing from namespace import to require in some few places where the TS linter complained.

Now the compiler, the built in TS linter, our ES Lint config, all are happy.

## My Calva PR Checklist

<!--
Strike out items (using `~`) if they do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- ~[ ] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).~
- [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

