### PR TITLE
3191 repl log api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Add a `repl.log()` to the API, for other extensions to log to the Calva output sink](https://github.com/BetterThanTomorrow/calva/issues/3191)
+
 ## [2.0.579] - 2026-04-28
 
 - internal-dev: Update TypeScript codebase to use namespace imports throughout

--- a/docs/site/api.md
+++ b/docs/site/api.md
@@ -277,6 +277,37 @@ An example:
     }
     ```
 
+### `repl.log()`
+
+Log a message to Calva's output subscriber bus without writing to Calva's own UI destinations (output channel, REPL window, terminal). This is intended for other extensions that have their own output UI but want their messages to appear in the Calva output subscriber stream — for example, so that [Backseat Driver](https://marketplace.visualstudio.com/items?itemName=BetterThanTomorrow.calva-backseat-driver) can query them.
+
+The signature in TypeScript:
+
+```typescript
+export function log(message: OutputMessage): void;
+```
+
+The `OutputMessage` interface is the same one used by [`onOutputLogged()`](#replonoutputlogged).
+
+#### Validation
+
+* `text` must be a non-empty string
+* `category` must be a valid `OutputCategory`
+* `who` follows the same rules as [`evaluate()`](#replevaluate) — the reserved values `"ui"` and `"api"` are rejected
+
+#### Example
+
+```typescript
+const calvaApi = vscode.extensions.getExtension("betterthantomorrow.calva")?.exports;
+
+calvaApi.v1.repl.log({
+  category: "evaluatedCode",
+  text: "(+ 1 2)",
+  who: "my-extension",
+  ns: "user",
+});
+```
+
 ### `repl.onOutputLogged()`
 
 Subscribe to Calva REPL output messages. Returns a `vscode.Disposable` that you should dispose when you no longer need updates. (For fire-and-forget convenience, push it onto your extension’s `context.subscriptions`).

--- a/src/api/log-util.ts
+++ b/src/api/log-util.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure validation and mapping logic for the repl API log() function.
+ * Separated from repl-v1.ts to enable unit testing without vscode dependency.
+ */
+
+export type ApiOutputCategory =
+  | 'evaluationResults'
+  | 'evaluatedCode'
+  | 'evaluationOutput'
+  | 'evaluationErrorOutput'
+  | 'otherOutput'
+  | 'otherErrorOutput';
+
+export type InternalOutputCategory =
+  | 'evalResults'
+  | 'evaluatedCode'
+  | 'evalOut'
+  | 'evalErr'
+  | 'otherOut'
+  | 'otherErr';
+
+export const apiCategoryToOutputCategory: Record<ApiOutputCategory, InternalOutputCategory> = {
+  evaluationResults: 'evalResults',
+  evaluatedCode: 'evaluatedCode',
+  evaluationOutput: 'evalOut',
+  evaluationErrorOutput: 'evalErr',
+  otherOutput: 'otherOut',
+  otherErrorOutput: 'otherErr',
+};
+
+const reservedWhos = ['ui', 'api'];
+
+export function validateLogMessage(message: {
+  category: string;
+  text: unknown;
+  who?: string;
+}): InternalOutputCategory {
+  if (message.who && reservedWhos.includes(message.who)) {
+    throw new Error(`The who value '${message.who}' is reserved for Calva's internal use`);
+  }
+  if (!message.text || typeof message.text !== 'string') {
+    throw new Error('log() requires a non-empty text string');
+  }
+  const internalCategory = apiCategoryToOutputCategory[message.category as ApiOutputCategory];
+  if (!internalCategory) {
+    throw new Error(
+      `Unknown category '${message.category}'. Must be one of: ${Object.keys(
+        apiCategoryToOutputCategory
+      ).join(', ')}`
+    );
+  }
+  return internalCategory;
+}

--- a/src/api/repl-v1.ts
+++ b/src/api/repl-v1.ts
@@ -7,6 +7,7 @@ import * as config from '../config';
 import * as sessionRegistry from '../nrepl/session-registry';
 import * as whoTracking from './who-tracking';
 import * as outputDestinations from '../results-output/output-destinations';
+import { validateLogMessage, apiCategoryToOutputCategory } from './log-util';
 
 type Result = {
   result: string;
@@ -311,6 +312,17 @@ const outputCategoryToApiCategory: Record<string, OutputCategory> = {
   otherOut: 'otherOutput',
   otherErr: 'otherErrorOutput',
 };
+
+export function log(message: OutputMessage): void {
+  const internalCategory = validateLogMessage(message);
+  resultOutput.emitExternal({
+    category: internalCategory,
+    text: message.text,
+    who: message.who,
+    ns: message.ns,
+    replSessionKey: message.replSessionKey,
+  });
+}
 
 export function onOutputLogged(callback: (msg: OutputMessage) => void): vscode.Disposable {
   const unsubscribe = resultOutput.subscribe((m: resultOutput.SubscriberOutputMessage) => {

--- a/src/api/repl-v1.ts
+++ b/src/api/repl-v1.ts
@@ -7,7 +7,7 @@ import * as config from '../config';
 import * as sessionRegistry from '../nrepl/session-registry';
 import * as whoTracking from './who-tracking';
 import * as outputDestinations from '../results-output/output-destinations';
-import { validateLogMessage, apiCategoryToOutputCategory } from './log-util';
+import * as logUtil from './log-util';
 
 type Result = {
   result: string;
@@ -314,7 +314,7 @@ const outputCategoryToApiCategory: Record<string, OutputCategory> = {
 };
 
 export function log(message: OutputMessage): void {
-  const internalCategory = validateLogMessage(message);
+  const internalCategory = logUtil.validateLogMessage(message);
   resultOutput.emitExternal({
     category: internalCategory,
     text: message.text,

--- a/src/extension-test/unit/repl-v1-log-test.ts
+++ b/src/extension-test/unit/repl-v1-log-test.ts
@@ -1,9 +1,9 @@
 import * as expectLib from 'expect';
-import { validateLogMessage, apiCategoryToOutputCategory } from '../../api/log-util';
+import * as logUtil from '../../api/log-util';
 
 describe('repl-v1 log() validation', () => {
   it('maps evaluatedCode to evaluatedCode (same name)', () => {
-    const result = validateLogMessage({
+    const result = logUtil.validateLogMessage({
       category: 'evaluatedCode',
       text: '(+ 1 2)',
       who: 'test-agent',
@@ -12,7 +12,7 @@ describe('repl-v1 log() validation', () => {
   });
 
   it('maps evaluationResults to evalResults', () => {
-    const result = validateLogMessage({
+    const result = logUtil.validateLogMessage({
       category: 'evaluationResults',
       text: '3',
       who: 'test-agent',
@@ -21,7 +21,7 @@ describe('repl-v1 log() validation', () => {
   });
 
   it('maps evaluationOutput to evalOut', () => {
-    const result = validateLogMessage({
+    const result = logUtil.validateLogMessage({
       category: 'evaluationOutput',
       text: 'hello',
       who: 'test-agent',
@@ -30,7 +30,7 @@ describe('repl-v1 log() validation', () => {
   });
 
   it('maps evaluationErrorOutput to evalErr', () => {
-    const result = validateLogMessage({
+    const result = logUtil.validateLogMessage({
       category: 'evaluationErrorOutput',
       text: 'boom',
       who: 'test-agent',
@@ -39,7 +39,7 @@ describe('repl-v1 log() validation', () => {
   });
 
   it('maps otherOutput to otherOut', () => {
-    const result = validateLogMessage({
+    const result = logUtil.validateLogMessage({
       category: 'otherOutput',
       text: 'info',
       who: 'test-agent',
@@ -48,7 +48,7 @@ describe('repl-v1 log() validation', () => {
   });
 
   it('maps otherErrorOutput to otherErr', () => {
-    const result = validateLogMessage({
+    const result = logUtil.validateLogMessage({
       category: 'otherErrorOutput',
       text: 'warn',
       who: 'test-agent',
@@ -59,7 +59,7 @@ describe('repl-v1 log() validation', () => {
   it('throws on reserved who value "ui"', () => {
     expectLib
       .expect(() => {
-        validateLogMessage({ category: 'otherOutput', text: 'test', who: 'ui' });
+        logUtil.validateLogMessage({ category: 'otherOutput', text: 'test', who: 'ui' });
       })
       .toThrow(/reserved/);
   });
@@ -67,7 +67,7 @@ describe('repl-v1 log() validation', () => {
   it('throws on reserved who value "api"', () => {
     expectLib
       .expect(() => {
-        validateLogMessage({ category: 'otherOutput', text: 'test', who: 'api' });
+        logUtil.validateLogMessage({ category: 'otherOutput', text: 'test', who: 'api' });
       })
       .toThrow(/reserved/);
   });
@@ -75,7 +75,7 @@ describe('repl-v1 log() validation', () => {
   it('throws on empty text', () => {
     expectLib
       .expect(() => {
-        validateLogMessage({ category: 'otherOutput', text: '', who: 'test-agent' });
+        logUtil.validateLogMessage({ category: 'otherOutput', text: '', who: 'test-agent' });
       })
       .toThrow(/non-empty text/);
   });
@@ -83,17 +83,17 @@ describe('repl-v1 log() validation', () => {
   it('throws on unknown category', () => {
     expectLib
       .expect(() => {
-        validateLogMessage({ category: 'bogus', text: 'test', who: 'test-agent' });
+        logUtil.validateLogMessage({ category: 'bogus', text: 'test', who: 'test-agent' });
       })
       .toThrow(/Unknown category/);
   });
 
   it('allows who to be omitted', () => {
-    const result = validateLogMessage({ category: 'otherOutput', text: 'no who' });
+    const result = logUtil.validateLogMessage({ category: 'otherOutput', text: 'no who' });
     expectLib.expect(result).toBe('otherOut');
   });
 
   it('apiCategoryToOutputCategory covers all 6 categories', () => {
-    expectLib.expect(Object.keys(apiCategoryToOutputCategory)).toHaveLength(6);
+    expectLib.expect(Object.keys(logUtil.apiCategoryToOutputCategory)).toHaveLength(6);
   });
 });

--- a/src/extension-test/unit/repl-v1-log-test.ts
+++ b/src/extension-test/unit/repl-v1-log-test.ts
@@ -1,0 +1,99 @@
+import * as expectLib from 'expect';
+import { validateLogMessage, apiCategoryToOutputCategory } from '../../api/log-util';
+
+describe('repl-v1 log() validation', () => {
+  it('maps evaluatedCode to evaluatedCode (same name)', () => {
+    const result = validateLogMessage({
+      category: 'evaluatedCode',
+      text: '(+ 1 2)',
+      who: 'test-agent',
+    });
+    expectLib.expect(result).toBe('evaluatedCode');
+  });
+
+  it('maps evaluationResults to evalResults', () => {
+    const result = validateLogMessage({
+      category: 'evaluationResults',
+      text: '3',
+      who: 'test-agent',
+    });
+    expectLib.expect(result).toBe('evalResults');
+  });
+
+  it('maps evaluationOutput to evalOut', () => {
+    const result = validateLogMessage({
+      category: 'evaluationOutput',
+      text: 'hello',
+      who: 'test-agent',
+    });
+    expectLib.expect(result).toBe('evalOut');
+  });
+
+  it('maps evaluationErrorOutput to evalErr', () => {
+    const result = validateLogMessage({
+      category: 'evaluationErrorOutput',
+      text: 'boom',
+      who: 'test-agent',
+    });
+    expectLib.expect(result).toBe('evalErr');
+  });
+
+  it('maps otherOutput to otherOut', () => {
+    const result = validateLogMessage({
+      category: 'otherOutput',
+      text: 'info',
+      who: 'test-agent',
+    });
+    expectLib.expect(result).toBe('otherOut');
+  });
+
+  it('maps otherErrorOutput to otherErr', () => {
+    const result = validateLogMessage({
+      category: 'otherErrorOutput',
+      text: 'warn',
+      who: 'test-agent',
+    });
+    expectLib.expect(result).toBe('otherErr');
+  });
+
+  it('throws on reserved who value "ui"', () => {
+    expectLib
+      .expect(() => {
+        validateLogMessage({ category: 'otherOutput', text: 'test', who: 'ui' });
+      })
+      .toThrow(/reserved/);
+  });
+
+  it('throws on reserved who value "api"', () => {
+    expectLib
+      .expect(() => {
+        validateLogMessage({ category: 'otherOutput', text: 'test', who: 'api' });
+      })
+      .toThrow(/reserved/);
+  });
+
+  it('throws on empty text', () => {
+    expectLib
+      .expect(() => {
+        validateLogMessage({ category: 'otherOutput', text: '', who: 'test-agent' });
+      })
+      .toThrow(/non-empty text/);
+  });
+
+  it('throws on unknown category', () => {
+    expectLib
+      .expect(() => {
+        validateLogMessage({ category: 'bogus', text: 'test', who: 'test-agent' });
+      })
+      .toThrow(/Unknown category/);
+  });
+
+  it('allows who to be omitted', () => {
+    const result = validateLogMessage({ category: 'otherOutput', text: 'no who' });
+    expectLib.expect(result).toBe('otherOut');
+  });
+
+  it('apiCategoryToOutputCategory covers all 6 categories', () => {
+    expectLib.expect(Object.keys(apiCategoryToOutputCategory)).toHaveLength(6);
+  });
+});

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -39,6 +39,14 @@ function emit(msg: SubscriberOutputMessage) {
   }
 }
 
+/**
+ * Emit a message to subscribers only, without writing to any UI destinations.
+ * Used by the API `log()` function for external extensions.
+ */
+export function emitExternal(msg: SubscriberOutputMessage) {
+  emit(msg);
+}
+
 export type OutputCategory =
   | 'evalResults'
   | 'evaluatedCode'


### PR DESCRIPTION
* Fixes #3191

## What has changed?

Adding a log() API utility

## My Calva PR Checklist

<!--
Strike out items (using `~`) if they do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

