### PR TITLE
Don't tear down connection on reuse of same websocket sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Calva disconnects and closed the WebSocket server when connecting a websocket REPL configured for the same port](https://github.com/BetterThanTomorrow/calva/issues/3198)
+
 ## [2.0.582] - 2026-05-03
 
 - [Make Orphaned/dicsonnected WebSocket servers closable](https://github.com/BetterThanTomorrow/calva/issues/3195)

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -103,29 +103,17 @@ async function connectViaWebSocket(
   const projectRoot = state.getProjectRootUri().toString();
   const useSecondarySession = secondarySession.shouldUseSecondarySession(connectSequence);
 
+  // WebSocket connections skip reconnection candidate detection entirely.
+  // Each WS server is single-client, so multiple browser tabs require separate
+  // servers on different ports. The port-in-use prompt handles conflicts naturally.
   const resolution = sessionNameResolver.resolveSessionNames(
     baseSessionNames,
     projectRoot,
     wsHost,
-    isJackIn ? null : wsPort
+    wsPort,
+    { skipReconnect: true }
   );
   const sessionRoleKeys = resolution.finalNames;
-
-  if (resolution.reconnectClientKey) {
-    output.appendLineOtherOut(
-      `Reconnecting: disconnecting existing client for sessions: ${Object.values(sessionRoleKeys)
-        .filter(Boolean)
-        .join(', ')}`
-    );
-    if (isJackIn) {
-      await jackIn.stopJackInProcessesByClientKey(resolution.reconnectClientKey, {
-        preserveSuffix: true,
-      });
-    }
-    if (clientRegistry.getClient(resolution.reconnectClientKey)) {
-      await disconnectClientByKey(resolution.reconnectClientKey, { preserveSuffix: true });
-    }
-  }
 
   const sessionGlobMap = sessionRoleUtils.deriveSessionGlobMap(
     connectSequence,

--- a/src/extension-test/unit/session-name-resolver-test.ts
+++ b/src/extension-test/unit/session-name-resolver-test.ts
@@ -285,6 +285,61 @@ describe('session-name-resolver', () => {
       });
     });
 
+    describe('skipReconnect option', () => {
+      it('skips reconnection and treats as conflict when skipReconnect is true', () => {
+        const baseNames = { primary: 'clj', secondary: 'cljs' };
+        const projectRoot = '/project-a';
+
+        // Register existing client that would normally trigger reconnection
+        clientRegistry.registerClient(createMockClient('client-a'), {
+          projectRoot,
+          host: 'localhost',
+          port: 3340,
+          connectionState: {
+            baseSessionNames: baseNames,
+          },
+        });
+        sessionRegistry.registerSession('clj', createSession('client-a'), {});
+
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          projectRoot,
+          'localhost',
+          3340,
+          { skipReconnect: true }
+        );
+
+        expectLib.expect(resolution.reconnectClientKey).toBeUndefined();
+        expectLib.expect(resolution.suffix).toBeDefined();
+        expectLib.expect(resolution.finalNames.primary).toMatch(/^clj:\w+$/);
+        expectLib.expect(resolution.finalNames.secondary).toMatch(/^cljs:\w+$/);
+      });
+
+      it('still finds reconnection candidate when skipReconnect is false', () => {
+        const baseNames = { primary: 'clj', secondary: 'cljs' };
+        const projectRoot = '/project-a';
+
+        clientRegistry.registerClient(createMockClient('client-a'), {
+          projectRoot,
+          host: 'localhost',
+          port: 3340,
+          connectionState: {
+            baseSessionNames: baseNames,
+          },
+        });
+
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          projectRoot,
+          'localhost',
+          3340,
+          { skipReconnect: false }
+        );
+
+        expectLib.expect(resolution.reconnectClientKey).toBe('client-a');
+      });
+    });
+
     describe('reconnection scenario (port-unaware, e.g. jack-in)', () => {
       it('detects reconnection when baseNames and projectRoot match (port is null)', () => {
         const baseNames = { primary: 'bb' };

--- a/src/nrepl/session-name-resolver.ts
+++ b/src/nrepl/session-name-resolver.ts
@@ -138,9 +138,12 @@ export function resolveSessionNames(
   baseNames: sessionRoleUtils.SessionRoleKeys,
   projectRoot: string,
   host: string,
-  port: number | null
+  port: number | null,
+  options?: { skipReconnect?: boolean }
 ): SessionNameResolution {
-  const reconnectClientKey = findReconnectionCandidate(baseNames, projectRoot, host, port);
+  const reconnectClientKey = options?.skipReconnect
+    ? undefined
+    : findReconnectionCandidate(baseNames, projectRoot, host, port);
   if (reconnectClientKey) {
     const existingState = clientRegistry.getConnectionState(reconnectClientKey);
     const existingSuffix = existingState?.suffix;


### PR DESCRIPTION
* Fixes #3198

## What has changed?

Yeah, so what the title says. =)

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

