### PR TITLE
3197 rename sessions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,35 @@
+## Design Context
+
+### Users
+
+VS Code developers adopting or practicing Clojure/ClojureScript. The audience spans from **complete Clojure beginners** (the explicit growth mission) to **experienced Clojurians** who chose VS Code as their editor. They arrive with VS Code muscle memory and expectations — syntax highlighting, command palette, familiar keybindings — and need the REPL to feel like a natural extension of that, not a foreign system bolted on.
+
+The context of use is deep-focus programming: long sessions, high cognitive load, frequent context-switching between code and REPL output. The interface must never compete for attention with the code itself.
+
+### Brand Personality
+
+**Approachable, precise, alive.**
+
+Calva is named after Calvados — a spirit that gains its character from what it's distilled from (CIDER/nREPL) and what it matures in (VS Code). The brand voice is that of a master distiller: confident but unhurried, opinionated but welcoming, spartan but *not* poor. As the Tao states: "VS Code and Clojure brought together has the capacity to create something amazingly rich and luxurious."
+
+The emotional goals are **confidence** (I know what's happening), **flow** (nothing breaks my concentration), and **precision** (sharp, exact, professional). The anti-reference is GitLens — invasive, attention-grabbing, too much visual presence in the editor.
+
+### Aesthetic Direction
+
+- **Theme**: Native VS Code. Custom surfaces (webviews, output panels) should feel like they belong to the user's chosen VS Code theme, not to Calva's own visual system. Use `var(--vscode-*)` CSS custom properties as the primary palette.
+- **Brand color**: Golden amber `#db9550` — core brand accent. Use sparingly: status indicators, the Calva logo, moments of identity. Never as a dominant surface color.
+- **Font**: Fira Code is the bundled code font for webviews. Body/UI text inherits from VS Code's editor font family.
+- **Tone**: Quiet competence. The interface should feel like a well-made tool — present when needed, invisible when not. Spartan in the Halloway sense: few features, each done right.
+- **Anti-patterns**: Invasive decorations, unsolicited overlays, attention-competing UI, feature clutter. Calva should never make the user aware of Calva when they're trying to think about Clojure.
+
+### Design Principles
+
+1. **The VS Code way is Calva's way.** Leverage existing VS Code patterns and conventions. What's old is old; what's new should be as easy as possible to pick up. Don't invent new interaction patterns when VS Code already has one.
+
+2. **Remove obstacles to the REPL.** Every UI decision should be evaluated by: does this help or hinder the developer's path to evaluating code and understanding results? The REPL connection is the critical moment; evaluation results are the critical data.
+
+3. **Spartan, not poor.** Resist feature creep. Few knobs, sane defaults. But the knobs that exist should feel luxurious — well-considered, well-placed, well-documented. Quality over quantity.
+
+4. **Simplify the complex.** Calva has organic complexity (multiple output destinations, REPL window maintenance, session routing). Design should actively work to reduce cognitive load around these areas rather than expose the underlying complexity.
+
+5. **Invisible when working, present when needed.** Status information, connection state, session routing — these should be discoverable but not intrusive. The developer's attention belongs to their code, not to Calva's UI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Enable renaming of REPL sessions](https://github.com/BetterThanTomorrow/calva/issues/3197)
 - Fix: [Calva disconnects and closed the WebSocket server when connecting a websocket REPL configured for the same port](https://github.com/BetterThanTomorrow/calva/issues/3198)
 
 ## [2.0.582] - 2026-05-03

--- a/docs/site/repl-ui.md
+++ b/docs/site/repl-ui.md
@@ -25,6 +25,8 @@ Calva keeps every nREPL connection alive until you explicitly disconnect it. Thi
 
   E.g. connect three Babashka repls and you will have one session named `bb` another named `bb:2`, and a third named `bb:3`. If you then connect two Clojure + ClojureScript repls using default session names, you will have four more sessions named: `clj`, `cljs`, `clj:4`, `cljs:4`.
 
+- You can rename any session by clicking the pencil icon next to it in the sessions menu. This lets you give sessions meaningful names like `epupp-youtube` instead of the auto-generated `epupp:2`. Renames take effect immediately for routing and evaluation, but do not persist across reconnection.
+
 ![REPL Sessions Menu](images/repl-ui/repl-sessions-menu.png)
 
 ## UI Components Overview

--- a/src/extension-test/unit/nrepl/session-registry-test.ts
+++ b/src/extension-test/unit/nrepl/session-registry-test.ts
@@ -2,12 +2,14 @@ import * as expectLib from 'expect';
 import type * as nrepl from '../../../../src/nrepl';
 import * as sessionRegistry from '../../../../src/nrepl/session-registry';
 import * as clientRegistry from '../../../../src/nrepl/client-registry';
+import * as sessionNameSuffix from '../../../../src/nrepl/session-name-suffix';
 
 describe('session registry', () => {
   afterEach(() => {
     sessionRegistry._testUtility_registeredSessions.clear();
     sessionRegistry.setClojureDocsSessionKey(null);
     clientRegistry._testUtility_registeredClients.clear();
+    sessionNameSuffix.resetPool();
   });
 
   describe('resolveSessionKey', () => {
@@ -146,6 +148,90 @@ describe('session registry', () => {
 
       expectLib.expect((mainForA as any)?._calvaSessionMetadata?.key).toBe('clj-a');
       expectLib.expect((mainForB as any)?._calvaSessionMetadata?.key).toBe('clj-b');
+    });
+  });
+
+  describe('renameSession', () => {
+    const createSession = (clientKey: string): nrepl.NReplSession =>
+      ({ client: { clientKey } } as unknown as nrepl.NReplSession);
+
+    const createMockClient = (clientKey: string) =>
+      ({ clientKey } as unknown as Parameters<typeof clientRegistry.registerClient>[0]);
+
+    it('renames session: accessible under new key, not under old', () => {
+      sessionRegistry.registerSession('epupp', createSession('client-a'), {});
+
+      const result = sessionRegistry.renameSession('epupp', 'epupp-youtube');
+
+      expectLib.expect(result).toBe(true);
+      expectLib.expect(sessionRegistry.getSession('epupp-youtube')).toBeDefined();
+      expectLib.expect(sessionRegistry.getSession('epupp')).toBeUndefined();
+    });
+
+    it('returns false if old key not found', () => {
+      const result = sessionRegistry.renameSession('nonexistent', 'new-name');
+
+      expectLib.expect(result).toBe(false);
+    });
+
+    it('returns false if new key already exists', () => {
+      sessionRegistry.registerSession('alpha', createSession('client-a'), {});
+      sessionRegistry.registerSession('beta', createSession('client-b'), {});
+
+      const result = sessionRegistry.renameSession('alpha', 'beta');
+
+      expectLib.expect(result).toBe(false);
+      expectLib.expect(sessionRegistry.getSession('alpha')).toBeDefined();
+    });
+
+    it('updates sessionRoleKeys for primary session', () => {
+      clientRegistry.registerClient(createMockClient('client-a'), {
+        connectionState: {
+          sessionRoleKeys: { primary: 'clj', secondary: 'cljs' },
+        },
+      });
+      sessionRegistry.registerSession('clj', createSession('client-a'), {});
+      sessionRegistry.registerSession('cljs', createSession('client-a'), { isSecondary: true });
+
+      sessionRegistry.renameSession('clj', 'my-clj');
+
+      const state = clientRegistry.getConnectionState('client-a');
+      expectLib.expect(state?.sessionRoleKeys?.primary).toBe('my-clj');
+      expectLib.expect(state?.sessionRoleKeys?.secondary).toBe('cljs');
+    });
+
+    it('updates sessionRoleKeys for secondary session', () => {
+      clientRegistry.registerClient(createMockClient('client-a'), {
+        connectionState: {
+          sessionRoleKeys: { primary: 'clj', secondary: 'cljs' },
+        },
+      });
+      sessionRegistry.registerSession('clj', createSession('client-a'), {});
+      sessionRegistry.registerSession('cljs', createSession('client-a'), { isSecondary: true });
+
+      sessionRegistry.renameSession('cljs', 'my-cljs');
+
+      const state = clientRegistry.getConnectionState('client-a');
+      expectLib.expect(state?.sessionRoleKeys?.primary).toBe('clj');
+      expectLib.expect(state?.sessionRoleKeys?.secondary).toBe('my-cljs');
+    });
+
+    it('releases suffix when renaming away from suffixed name', () => {
+      const suffix = sessionNameSuffix.acquireNextAvailableSuffix();
+      expectLib.expect(suffix).toBe('2');
+
+      clientRegistry.registerClient(createMockClient('client-a'), {
+        connectionState: {
+          sessionRoleKeys: { primary: 'epupp:2' },
+        },
+      });
+      sessionRegistry.registerSession('epupp:2', createSession('client-a'), {});
+
+      sessionRegistry.renameSession('epupp:2', 'epupp-youtube');
+
+      // Suffix "2" should be released back to the pool
+      const nextSuffix = sessionNameSuffix.acquireNextAvailableSuffix();
+      expectLib.expect(nextSuffix).toBe('2');
     });
   });
 });

--- a/src/nrepl/session-registry.ts
+++ b/src/nrepl/session-registry.ts
@@ -1,6 +1,7 @@
 import type * as globs from './globs';
 import type * as nrepl from './index';
 import * as clientRegistry from './client-registry';
+import * as sessionNameSuffix from './session-name-suffix';
 
 export interface SessionMetadata {
   key: string;
@@ -169,6 +170,54 @@ export function getSecondarySessionKeyForClient(clientKey: string): string | und
   const sessions = listSessionsByClient(clientKey);
   const secondaryMeta = sessions.find((m) => m.isSecondary);
   return secondaryMeta?.key;
+}
+
+// --- Session renaming ---
+
+/**
+ * Rename a registered session from oldKey to newKey.
+ * Updates the registry, metadata, connection state, routing, and suffix pool.
+ * Returns true on success, false if oldKey is not found or newKey already exists.
+ */
+export function renameSession(oldKey: string, newKey: string): boolean {
+  const session = registeredSessions.get(oldKey);
+  if (!session || registeredSessions.has(newKey)) {
+    return false;
+  }
+
+  // Re-key the registry
+  registeredSessions.delete(oldKey);
+  registeredSessions.set(newKey, session);
+
+  // Update metadata
+  const metadata = (session as any)._calvaSessionMetadata as SessionMetadata | undefined;
+  if (metadata) {
+    metadata.key = newKey;
+  }
+
+  // Update ConnectionState.sessionRoleKeys
+  const clientKey = metadata?.connectionOwnerId;
+  if (clientKey) {
+    const connState = clientRegistry.getConnectionState(clientKey);
+    if (connState?.sessionRoleKeys) {
+      const roleKeys = { ...connState.sessionRoleKeys };
+      if (roleKeys.primary === oldKey) {
+        roleKeys.primary = newKey;
+      }
+      if (roleKeys.secondary === oldKey) {
+        roleKeys.secondary = newKey;
+      }
+      clientRegistry.setConnectionState(clientKey, { sessionRoleKeys: roleKeys });
+    }
+  }
+
+  // Release suffix if old name had one
+  const suffix = sessionNameSuffix.extractSuffix(oldKey);
+  if (suffix) {
+    sessionNameSuffix.releaseSuffix(suffix);
+  }
+
+  return true;
 }
 
 // --- ClojureDocs dedicated session ---

--- a/src/repl-sessions-menu.ts
+++ b/src/repl-sessions-menu.ts
@@ -17,6 +17,11 @@ const CLJC_TARGET_BUTTON: vscode.QuickInputButton = {
   tooltip: 'Make cljc target',
 };
 
+const RENAME_BUTTON: vscode.QuickInputButton = {
+  iconPath: new vscode.ThemeIcon('edit'),
+  tooltip: 'Rename session',
+};
+
 interface SessionQuickPickItem extends vscode.QuickPickItem {
   action: 'session' | 'auto' | 'output-session';
   sessionKey?: string;
@@ -268,6 +273,7 @@ function buildSessionPickItems(options?: {
     if (hasSibling && !isCljcTarget) {
       buttons.push(CLJC_TARGET_BUTTON);
     }
+    buttons.push(RENAME_BUTTON);
 
     return {
       label,
@@ -275,7 +281,7 @@ function buildSessionPickItems(options?: {
       detail,
       action: 'session',
       sessionKey: session.key,
-      buttons: buttons.length > 0 ? buttons : undefined,
+      buttons,
     };
   });
 }
@@ -505,6 +511,10 @@ export async function showReplSessionsMenu(): Promise<void> {
           // Refresh the menu items to reflect the change
           qp.items = buildMenuItems();
         }
+      } else if (event.button === RENAME_BUTTON && item.sessionKey) {
+        const oldKey = item.sessionKey;
+        qp.hide();
+        void handleRenameSession(oldKey);
       }
     });
 
@@ -538,4 +548,51 @@ export async function showReplSessionsMenu(): Promise<void> {
 
     qp.show();
   });
+}
+
+async function handleRenameSession(oldKey: string): Promise<void> {
+  // Read pinned key BEFORE rename (getPinnedSessionKey auto-clears if key deleted from registry)
+  const pinnedKey = sessionRouting.getPinnedSessionKey();
+
+  const newKey = await vscode.window.showInputBox({
+    prompt: 'New session name',
+    value: oldKey,
+    validateInput: (value) => {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return 'Name cannot be empty';
+      }
+      if (trimmed.includes(':')) {
+        return 'Name cannot contain ":"';
+      }
+      if (trimmed !== oldKey && sessionRegistry.getSession(trimmed)) {
+        return `Session "${trimmed}" already exists`;
+      }
+      return undefined;
+    },
+  });
+
+  if (!newKey || newKey.trim() === oldKey) {
+    return;
+  }
+
+  const trimmedKey = newKey.trim();
+  const success = sessionRegistry.renameSession(oldKey, trimmedKey);
+  if (!success) {
+    return;
+  }
+
+  // Follow pinned session (handled here to avoid circular dependency in session-registry)
+  if (pinnedKey === oldKey) {
+    sessionRouting.pinSession(trimmedKey);
+  }
+
+  // Update output window binding
+  const session = sessionRegistry.getSession(trimmedKey);
+  if (session) {
+    const ns = (session as any)._calvaSessionMetadata?.ns;
+    outputWindow.setSession(session, ns ?? 'user', trimmedKey);
+  }
+
+  status.update();
 }


### PR DESCRIPTION
* Fixes #3197

## What has changed?

Adding a button to the repl session menu for renaming sessions temporarily.

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

