### PR TITLE
Preserve renamed session names through reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 Changes to Calva.
 
 ## [Unreleased]
-- enable new clojure-lsp code actions: inline function, if<->cond, extract selection to function, move to :let
+
+- [enable new clojure-lsp code actions: inline function, if<->cond, extract selection to function, move to :let](https://github.com/BetterThanTomorrow/calva/issues/3204)
+- Fix: [Calva forgets the renamed session name on disconnect->reconnect](https://github.com/BetterThanTomorrow/calva/issues/3207)
 
 ## [2.0.583] - 2026-05-04
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -98,6 +98,7 @@ async function connectViaWebSocket(
   isJackIn = false
 ): Promise<ConnectResult> {
   let activeClient: nrepl.NReplClient | undefined;
+  let preservedRenames: Partial<sessionRoleUtils.SessionRoleKeys> | undefined;
   const baseSessionNames = sessionRoleUtils.deriveSessionRoleKeys(connectSequence);
   const projectRootPath = state.getProjectRootUri().fsPath;
   const projectRoot = state.getProjectRootUri().toString();
@@ -193,6 +194,7 @@ async function connectViaWebSocket(
           connectSequence,
           baseSessionNames,
           suffix: resolution.suffix,
+          renamedSessionNames: preservedRenames,
         },
       });
 
@@ -211,11 +213,21 @@ async function connectViaWebSocket(
       });
       clientRegistry.setCljcTargetForConnection(client.clientKey, 'primary');
 
+      // Apply preserved rename from previous browser connection
+      const renamedPrimary = preservedRenames?.primary;
+      if (renamedPrimary && renamedPrimary !== mainKey) {
+        sessionRegistry.renameSession(mainKey, renamedPrimary);
+      }
+      const effectiveMainKey = renamedPrimary ?? mainKey;
+      preservedRenames = undefined;
+
       status.update();
-      output.appendLineOtherOut(`Connected session: ${mainKey}, ws://${wsHost}:${currentPort}`);
+      output.appendLineOtherOut(
+        `Connected session: ${effectiveMainKey}, ws://${wsHost}:${currentPort}`
+      );
       replSession.updateReplSessionType();
 
-      outputWindow.setSession(mainSession, client.ns, mainKey);
+      outputWindow.setSession(mainSession, client.ns, effectiveMainKey);
 
       if (config.getConfig().autoEvaluateCode.onConnect.clj) {
         output.appendLineOtherOut(
@@ -223,7 +235,7 @@ async function connectViaWebSocket(
         );
         await evaluate.evaluateInOutputWindow(
           config.getConfig().autoEvaluateCode.onConnect.clj,
-          mainKey,
+          effectiveMainKey,
           outputWindow.getNs(),
           {}
         );
@@ -234,7 +246,12 @@ async function connectViaWebSocket(
         connectSequence.afterPrimaryReplConnectedCode ?? connectSequence.afterCLJReplJackInCode;
       if (afterMainReplCode) {
         output.appendLineOtherOut(`Evaluating 'afterPrimaryReplConnectedCode'`);
-        await evaluate.evaluateInOutputWindow(afterMainReplCode, mainKey, outputWindow.getNs(), {});
+        await evaluate.evaluateInOutputWindow(
+          afterMainReplCode,
+          effectiveMainKey,
+          outputWindow.getNs(),
+          {}
+        );
       }
       if (!connectSequence.cljsType || connectSequence.cljsType === 'none') {
         output.maybePrintLegacyREPLWindowOutputMessage();
@@ -304,6 +321,9 @@ async function connectViaWebSocket(
         const clientKey = activeClient.clientKey;
         output.appendLineOtherOut('Browser REPL disconnected, waiting for reconnection...');
         state.connectionLogChannel().appendLine('Browser REPL disconnected');
+
+        // Preserve renames across browser reconnections
+        preservedRenames = clientRegistry.getConnectionState(clientKey)?.renamedSessionNames;
 
         // Clean up client and sessions but keep server alive
         clientTeardown.releaseClientSuffix(clientKey);
@@ -466,6 +486,7 @@ async function connectToHost(
         connectSequence,
         baseSessionNames,
         suffix: resolution.suffix,
+        renamedSessionNames: resolution.renamedSessionNames,
       },
     });
     localClient.addOnCloseHandler((c) => {
@@ -504,11 +525,18 @@ async function connectToHost(
     });
     clientRegistry.setCljcTargetForConnection(localClient.clientKey, 'primary');
 
+    // Apply preserved rename from previous connection
+    const renamedPrimary = resolution.renamedSessionNames?.primary;
+    if (renamedPrimary && renamedPrimary !== mainKey) {
+      sessionRegistry.renameSession(mainKey, renamedPrimary);
+    }
+    const effectivePrimaryKey = renamedPrimary ?? mainKey;
+
     status.update();
-    output.appendLineOtherOut(`Connected session: ${mainKey}, port: ${port}`);
+    output.appendLineOtherOut(`Connected session: ${effectivePrimaryKey}, port: ${port}`);
     replSession.updateReplSessionType();
 
-    outputWindow.setSession(mainSession, localClient.ns, mainKey);
+    outputWindow.setSession(mainSession, localClient.ns, effectivePrimaryKey);
 
     if (config.getConfig().autoEvaluateCode.onConnect.clj) {
       output.appendLineOtherOut(
@@ -516,7 +544,7 @@ async function connectToHost(
       );
       await evaluate.evaluateInOutputWindow(
         config.getConfig().autoEvaluateCode.onConnect.clj,
-        mainKey,
+        effectivePrimaryKey,
         outputWindow.getNs(),
         {}
       );
@@ -527,14 +555,19 @@ async function connectToHost(
       connectSequence.afterPrimaryReplConnectedCode ?? connectSequence.afterCLJReplJackInCode;
     if (afterMainReplCode) {
       output.appendLineOtherOut(`Evaluating 'afterPrimaryReplConnectedCode'`);
-      await evaluate.evaluateInOutputWindow(afterMainReplCode, mainKey, outputWindow.getNs(), {});
+      await evaluate.evaluateInOutputWindow(
+        afterMainReplCode,
+        effectivePrimaryKey,
+        outputWindow.getNs(),
+        {}
+      );
     }
     if (!connectSequence.cljsType || connectSequence.cljsType === 'none') {
       output.maybePrintLegacyREPLWindowOutputMessage();
     }
     void output.replWindowAppendPrompt();
 
-    clojureDocs.probeAndSetSession(mainSession, mainKey);
+    clojureDocs.probeAndSetSession(mainSession, effectivePrimaryKey);
 
     let cljsSession = null,
       cljsBuild = null;
@@ -700,24 +733,34 @@ async function setUpCljsRepl(
   });
   clientRegistry.setCljcTargetForConnection(clientKey, 'secondary');
 
-  clojureDocs.probeAndSetSession(session, cljsKey);
+  // Apply preserved rename from previous connection
+  const renamedSecondary =
+    clientRegistry.getConnectionState(clientKey)?.renamedSessionNames?.secondary;
+  const effectiveCljsKey =
+    renamedSecondary && renamedSecondary !== cljsKey
+      ? (sessionRegistry.renameSession(cljsKey, renamedSecondary), renamedSecondary)
+      : cljsKey;
+
+  clojureDocs.probeAndSetSession(session, effectiveCljsKey);
 
   status.update();
-  output.appendLineOtherOut(`Connected session: ${cljsKey}${build ? ', repl: ' + build : ''}`);
+  output.appendLineOtherOut(
+    `Connected session: ${effectiveCljsKey}${build ? ', repl: ' + build : ''}`
+  );
   outputWindow.appendLine(
     resultsOutputUtil.formatAsLineComments(outputWindow.CLJS_CONNECT_GREETINGS)
   );
   const description = await session.describe(true);
   const ns = description.aux?.['current-ns'] || 'user';
   await session.eval(`(in-ns '${ns})`, 'user').value;
-  outputWindow.setSession(session, ns, cljsKey);
+  outputWindow.setSession(session, ns, effectiveCljsKey);
   if (config.getConfig().autoEvaluateCode.onConnect.cljs) {
     output.appendLineOtherOut(
       `Evaluating code from settings: 'calva.autoEvaluateCode.onConnect.cljs'`
     );
     await evaluate.evaluateInOutputWindow(
       config.getConfig().autoEvaluateCode.onConnect.cljs,
-      cljsKey,
+      effectiveCljsKey,
       ns,
       {}
     );

--- a/src/extension-test/integration/suite/websocket-connect-test.ts
+++ b/src/extension-test/integration/suite/websocket-connect-test.ts
@@ -12,6 +12,7 @@ import * as docMirror from '../../../doc-mirror';
 
 const WS_PORT_EVAL = 51340;
 const WS_PORT_LOAD = 51341;
+const WS_PORT_RENAME = 51342;
 
 /**
  * Create a scittle webview via Joyride flare.
@@ -261,5 +262,103 @@ suite('WebSocket nREPL Connect suite', function () {
 
     testUtil.log(suite, `[TIMING] Test 2 complete: ${elapsed()}`);
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+  });
+
+  test('Renamed session survives browser reconnection', async function () {
+    const t0 = Date.now();
+    const elapsed = () => `${Date.now() - t0}ms`;
+    testUtil.log(suite, 'Renamed session survives browser reconnection');
+
+    const projectDir = path.join(
+      testUtil.testDataDir,
+      '..',
+      'projects',
+      'scittle-replicant-tic-tac-toe'
+    );
+
+    const connectSequence: connectSequenceTypes.ReplConnectSequence = {
+      name: 'scittle-ws-test',
+      projectType: connectSequenceTypes.ProjectTypes['scittle'],
+      cljsType: connectSequenceTypes.CljsTypes.none,
+      webSocketPort: WS_PORT_RENAME,
+      projectRootPath: [projectDir],
+    };
+
+    // 1. Connect via WebSocket
+    const connectPromise = connector.connect(connectSequence, true);
+
+    await testUtil.waitForCondition(
+      () => testUtil.canConnectToPort(WS_PORT_RENAME),
+      5_000,
+      20,
+      `WS server not listening on port ${WS_PORT_RENAME}`
+    );
+
+    await vscode.commands.executeCommand('joyride.runCode', flareCode(WS_PORT_RENAME));
+    const result = await connectPromise;
+    assert.ok(result.connected, 'Initial WS connection should succeed');
+    testUtil.log(suite, `[TIMING] Initial connection: ${elapsed()}`);
+
+    // 2. Verify original session name and rename it
+    const originalSessions = sessionRegistry.listSessions();
+    const originalKey = originalSessions[0].key;
+    testUtil.log(suite, `Original session key: ${originalKey}`);
+
+    const renamedKey = 'my-scittle';
+    const renamed = sessionRegistry.renameSession(originalKey, renamedKey);
+    assert.ok(renamed, 'Rename should succeed');
+    assert.ok(sessionRegistry.getSession(renamedKey), 'Session should exist under renamed key');
+    testUtil.log(suite, `Renamed to: ${renamedKey}, ${elapsed()}`);
+
+    // 3. Close the webview (simulates browser tab close / reload)
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    testUtil.log(suite, `[TIMING] Webview closed: ${elapsed()}`);
+
+    // Wait for disconnect to clean up sessions
+    await testUtil.waitForCondition(
+      () => sessionRegistry.listSessions().length === 0,
+      5_000,
+      20,
+      'Timed out waiting for session cleanup after webview close'
+    );
+    testUtil.log(suite, `[TIMING] Sessions cleaned up: ${elapsed()}`);
+
+    // 4. Re-open webview (browser reconnects to the still-listening WS server)
+    await vscode.commands.executeCommand('joyride.runCode', flareCode(WS_PORT_RENAME));
+    testUtil.log(suite, `[TIMING] Webview re-opened: ${elapsed()}`);
+
+    // 5. Wait for session to be re-registered
+    await testUtil.waitForCondition(
+      () => sessionRegistry.listSessions().length > 0,
+      10_000,
+      50,
+      'Timed out waiting for session after browser reconnection'
+    );
+
+    // 6. Verify the renamed key survived the reconnection
+    const reconnectedSessions = sessionRegistry.listSessions();
+    const reconnectedKeys = reconnectedSessions.map((s) => s.key);
+    testUtil.log(suite, `Reconnected session keys: ${reconnectedKeys.join(', ')}`);
+
+    assert.ok(
+      reconnectedKeys.includes(renamedKey),
+      `Renamed key '${renamedKey}' should survive browser reconnection, got: ${reconnectedKeys.join(
+        ', '
+      )}`
+    );
+    assert.ok(
+      !reconnectedKeys.includes(originalKey),
+      `Original key '${originalKey}' should not reappear after reconnection`
+    );
+
+    // 7. Verify the session is functional
+    const session = sessionRegistry.getSession(renamedKey);
+    assert.ok(session, 'Should get session by renamed key');
+    const evalResult = await session.eval('(+ 10 20)', 'user').value;
+    assert.strictEqual(evalResult, '30', 'Eval through renamed session should work');
+    testUtil.log(suite, `Eval via renamed session: (+ 10 20) => ${evalResult}`);
+
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    testUtil.log(suite, `[TIMING] Test 3 complete: ${elapsed()}`);
   });
 });

--- a/src/extension-test/unit/nrepl/session-registry-test.ts
+++ b/src/extension-test/unit/nrepl/session-registry-test.ts
@@ -233,5 +233,35 @@ describe('session registry', () => {
       const nextSuffix = sessionNameSuffix.acquireNextAvailableSuffix();
       expectLib.expect(nextSuffix).toBe('2');
     });
+
+    it('stores renamedSessionNames in ConnectionState for primary', () => {
+      clientRegistry.registerClient(createMockClient('client-a'), {
+        connectionState: {
+          sessionRoleKeys: { primary: 'clj', secondary: 'cljs' },
+        },
+      });
+      sessionRegistry.registerSession('clj', createSession('client-a'), {});
+
+      sessionRegistry.renameSession('clj', 'my-clj');
+
+      const state = clientRegistry.getConnectionState('client-a');
+      expectLib.expect(state?.renamedSessionNames).toEqual({ primary: 'my-clj' });
+    });
+
+    it('stores renamedSessionNames in ConnectionState for secondary', () => {
+      clientRegistry.registerClient(createMockClient('client-a'), {
+        connectionState: {
+          sessionRoleKeys: { primary: 'clj', secondary: 'cljs' },
+        },
+      });
+      sessionRegistry.registerSession('cljs', createSession('client-a'), {
+        isSecondary: true,
+      });
+
+      sessionRegistry.renameSession('cljs', 'my-cljs');
+
+      const state = clientRegistry.getConnectionState('client-a');
+      expectLib.expect(state?.renamedSessionNames).toEqual({ secondary: 'my-cljs' });
+    });
   });
 });

--- a/src/extension-test/unit/session-name-resolver-test.ts
+++ b/src/extension-test/unit/session-name-resolver-test.ts
@@ -195,6 +195,31 @@ describe('session-name-resolver', () => {
         expectLib.expect(resolution.suffix).toBe('2');
       });
 
+      it('passes through renamedSessionNames from previous connection', () => {
+        const baseNames = { primary: 'clj', secondary: 'cljs' };
+        const projectRoot = '/test-project';
+
+        clientRegistry.registerClient(createMockClient('client-a'), {
+          projectRoot,
+          host: 'localhost',
+          port: 1234,
+          connectionState: {
+            baseSessionNames: baseNames,
+            renamedSessionNames: { primary: 'my-clj' },
+          },
+        });
+
+        const resolution = sessionNameResolver.resolveSessionNames(
+          baseNames,
+          projectRoot,
+          'localhost',
+          1234
+        );
+
+        expectLib.expect(resolution.reconnectClientKey).toBe('client-a');
+        expectLib.expect(resolution.renamedSessionNames).toEqual({ primary: 'my-clj' });
+      });
+
       it('detects reconnection even when projectRoot differs (matches on host:port)', () => {
         const baseNames = { primary: 'clj', secondary: 'cljs' };
 

--- a/src/nrepl/client-registry.ts
+++ b/src/nrepl/client-registry.ts
@@ -23,6 +23,8 @@ export interface ConnectionState {
   suffix?: string;
   /** Which session role should handle .cljc files for this connection */
   cljcTarget?: CljcTargetRole;
+  /** User-assigned custom names per role, preserved across reconnection */
+  renamedSessionNames?: Partial<sessionRoleUtils.SessionRoleKeys>;
 }
 
 export interface RegisteredClient {

--- a/src/nrepl/session-name-resolver.ts
+++ b/src/nrepl/session-name-resolver.ts
@@ -19,6 +19,9 @@ export interface SessionNameResolution {
 
   /** Client to disconnect for reconnection, if any */
   reconnectClientKey?: string;
+
+  /** User-assigned custom names from the previous connection, if any */
+  renamedSessionNames?: Partial<sessionRoleUtils.SessionRoleKeys>;
 }
 
 /**
@@ -157,6 +160,7 @@ export function resolveSessionNames(
       finalNames,
       suffix: existingSuffix,
       reconnectClientKey,
+      renamedSessionNames: existingState?.renamedSessionNames,
     };
   }
 

--- a/src/nrepl/session-registry.ts
+++ b/src/nrepl/session-registry.ts
@@ -195,19 +195,27 @@ export function renameSession(oldKey: string, newKey: string): boolean {
     metadata.key = newKey;
   }
 
-  // Update ConnectionState.sessionRoleKeys
+  // Update ConnectionState.sessionRoleKeys and track rename for reconnection
   const clientKey = metadata?.connectionOwnerId;
   if (clientKey) {
     const connState = clientRegistry.getConnectionState(clientKey);
     if (connState?.sessionRoleKeys) {
       const roleKeys = { ...connState.sessionRoleKeys };
+      const renamedSessionNames: Partial<typeof roleKeys> = {
+        ...connState.renamedSessionNames,
+      };
       if (roleKeys.primary === oldKey) {
         roleKeys.primary = newKey;
+        renamedSessionNames.primary = newKey;
       }
       if (roleKeys.secondary === oldKey) {
         roleKeys.secondary = newKey;
+        renamedSessionNames.secondary = newKey;
       }
-      clientRegistry.setConnectionState(clientKey, { sessionRoleKeys: roleKeys });
+      clientRegistry.setConnectionState(clientKey, {
+        sessionRoleKeys: roleKeys,
+        renamedSessionNames,
+      });
     }
   }
 


### PR DESCRIPTION
* Fixes #3207


## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

