### PR TITLE
Reuse a local clojure-lsp binary when the latest version cannot be downloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Keep Calva starting reliably when the latest clojure-lsp cannot be downloaded, by falling back to a previously downloaded binary in the local backup folder or in a sibling Calva install folder](https://github.com/BetterThanTomorrow/calva/issues/3211)
+
 ## [2.0.584] - 2026-05-07
 
 - [enable new clojure-lsp code actions: inline function, if<->cond, extract selection to function, move to :let](https://github.com/BetterThanTomorrow/calva/issues/3204)

--- a/src/extension-test/unit/lsp/downloader-test.ts
+++ b/src/extension-test/unit/lsp/downloader-test.ts
@@ -49,4 +49,224 @@ describe('downloader', () => {
     expectLib.expect(fs.existsSync(binaryPath)).toBe(true);
     expectLib.expect(fs.readFileSync(binaryPath, 'utf8')).toBe(binaryContent);
   });
+
+  describe('restoreFromBackup', () => {
+    it('returns false when the backup directory exists but is empty', async () => {
+      fs.rmSync(binaryPath);
+      fs.mkdirSync(path.join(tmpDir, 'backup'), { recursive: true });
+
+      const restored = await downloaderUtils.restoreFromBackup(binaryPath);
+
+      expectLib.expect(restored).toBe(false);
+      expectLib.expect(fs.existsSync(binaryPath)).toBe(false);
+    });
+
+    it('restores backup binary to original path when main binary is missing', async () => {
+      const backupDir = path.join(tmpDir, 'backup');
+      fs.mkdirSync(backupDir, { recursive: true });
+      const backupPath = path.join(backupDir, 'clojure-lsp');
+      fs.writeFileSync(backupPath, 'backup-version');
+      fs.rmSync(binaryPath);
+
+      const restored = await downloaderUtils.restoreFromBackup(binaryPath);
+
+      expectLib.expect(restored).toBe(true);
+      expectLib.expect(fs.existsSync(binaryPath)).toBe(true);
+      expectLib.expect(fs.readFileSync(binaryPath, 'utf8')).toBe('backup-version');
+      expectLib.expect(fs.existsSync(backupPath)).toBe(false);
+    });
+  });
+
+  describe('findHighestLocalClojureLsp', () => {
+    let extensionsRoot: string;
+    let currentExtensionPath: string;
+
+    beforeEach(() => {
+      extensionsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'calva-extensions-root-'));
+      currentExtensionPath = path.join(
+        extensionsRoot,
+        'betterthantomorrow.calva-2.0.584-universal'
+      );
+      fs.mkdirSync(currentExtensionPath, { recursive: true });
+    });
+
+    afterEach(() => {
+      fs.rmSync(extensionsRoot, { recursive: true, force: true });
+    });
+
+    function seedSibling(folderName: string, opts: { binary?: string; version?: string }) {
+      const folder = path.join(extensionsRoot, folderName);
+      fs.mkdirSync(folder, { recursive: true });
+      if (opts.binary !== undefined) {
+        fs.writeFileSync(path.join(folder, 'clojure-lsp'), opts.binary);
+      }
+      if (opts.version !== undefined) {
+        fs.writeFileSync(path.join(folder, 'clojure-lsp-version'), opts.version);
+      }
+      return folder;
+    }
+
+    it('returns null when there are no sibling Calva folders', async () => {
+      const candidate = await downloaderUtils.findHighestLocalClojureLsp(
+        currentExtensionPath,
+        'clojure-lsp',
+        'clojure-lsp-version'
+      );
+
+      expectLib.expect(candidate).toBeNull();
+    });
+
+    it('returns null when sibling folders have no clojure-lsp binary', async () => {
+      seedSibling('betterthantomorrow.calva-2.0.582-universal', {
+        version: '2026.05.05-12.58.58-nightly',
+      });
+
+      const candidate = await downloaderUtils.findHighestLocalClojureLsp(
+        currentExtensionPath,
+        'clojure-lsp',
+        'clojure-lsp-version'
+      );
+
+      expectLib.expect(candidate).toBeNull();
+    });
+
+    it('skips the current extension folder even if it has a binary', async () => {
+      fs.writeFileSync(path.join(currentExtensionPath, 'clojure-lsp'), 'self');
+      fs.writeFileSync(
+        path.join(currentExtensionPath, 'clojure-lsp-version'),
+        '2026.05.05-12.58.58-nightly'
+      );
+
+      const candidate = await downloaderUtils.findHighestLocalClojureLsp(
+        currentExtensionPath,
+        'clojure-lsp',
+        'clojure-lsp-version'
+      );
+
+      expectLib.expect(candidate).toBeNull();
+    });
+
+    it('ignores unrelated extensions that share a prefix character', async () => {
+      seedSibling('someother.publisher-1.0.0', {
+        binary: 'unrelated',
+        version: '9999.12.31-23.59.59',
+      });
+
+      const candidate = await downloaderUtils.findHighestLocalClojureLsp(
+        currentExtensionPath,
+        'clojure-lsp',
+        'clojure-lsp-version'
+      );
+
+      expectLib.expect(candidate).toBeNull();
+    });
+
+    it('returns the highest-version sibling binary across the real reporter scenario', async () => {
+      fs.mkdirSync(path.join(currentExtensionPath, 'backup'), { recursive: true });
+      seedSibling('betterthantomorrow.calva-2.0.575-universal', {
+        binary: 'binary-2.0.575',
+        version: '2026.04.28-13.12.15-nightly',
+      });
+      seedSibling('betterthantomorrow.calva-2.0.578-universal', {
+        binary: 'binary-2.0.578',
+        version: '2026.04.28-13.12.15-nightly',
+      });
+      seedSibling('betterthantomorrow.calva-2.0.579-universal', {
+        binary: 'binary-2.0.579',
+        version: '2026.04.28-13.12.15-nightly',
+      });
+      seedSibling('betterthantomorrow.calva-2.0.580-universal', {});
+      const expectedFolder = seedSibling('betterthantomorrow.calva-2.0.582-universal', {
+        binary: 'binary-2.0.582',
+        version: '2026.05.05-12.58.58-nightly',
+      });
+
+      const candidate = await downloaderUtils.findHighestLocalClojureLsp(
+        currentExtensionPath,
+        'clojure-lsp',
+        'clojure-lsp-version'
+      );
+
+      expectLib.expect(candidate).not.toBeNull();
+      expectLib.expect(candidate?.binaryPath).toBe(path.join(expectedFolder, 'clojure-lsp'));
+      expectLib.expect(candidate?.version).toBe('2026.05.05-12.58.58-nightly');
+    });
+
+    it('still returns a candidate when the version file is missing, deprioritizing it', async () => {
+      const versionedFolder = seedSibling('betterthantomorrow.calva-2.0.578-universal', {
+        binary: 'versioned-binary',
+        version: '2026.04.28-13.12.15-nightly',
+      });
+      seedSibling('betterthantomorrow.calva-2.0.580-universal', {
+        binary: 'no-version-binary',
+      });
+
+      const candidate = await downloaderUtils.findHighestLocalClojureLsp(
+        currentExtensionPath,
+        'clojure-lsp',
+        'clojure-lsp-version'
+      );
+
+      expectLib.expect(candidate).not.toBeNull();
+      expectLib.expect(candidate?.binaryPath).toBe(path.join(versionedFolder, 'clojure-lsp'));
+    });
+  });
+
+  describe('adoptLocalClojureLsp', () => {
+    it('copies the sibling binary into the upgraded extension folder and writes the version file', async () => {
+      const extensionsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'calva-adopt-root-'));
+      const oldExtensionPath = path.join(
+        extensionsRoot,
+        'betterthantomorrow.calva-2.0.582-universal'
+      );
+      const newExtensionPath = path.join(
+        extensionsRoot,
+        'betterthantomorrow.calva-2.0.584-universal'
+      );
+      fs.mkdirSync(oldExtensionPath, { recursive: true });
+      fs.mkdirSync(newExtensionPath, { recursive: true });
+      fs.mkdirSync(path.join(newExtensionPath, 'backup'), { recursive: true });
+      const sourceBinary = path.join(oldExtensionPath, 'clojure-lsp');
+      fs.writeFileSync(sourceBinary, 'binary-2.0.582');
+      const targetBinary = path.join(newExtensionPath, 'clojure-lsp');
+      const targetVersionFile = path.join(newExtensionPath, 'clojure-lsp-version');
+
+      try {
+        await downloaderUtils.adoptLocalClojureLsp(
+          { binaryPath: sourceBinary, version: '2026.05.05-12.58.58-nightly' },
+          targetBinary,
+          targetVersionFile
+        );
+
+        expectLib.expect(fs.readFileSync(targetBinary, 'utf8')).toBe('binary-2.0.582');
+        expectLib
+          .expect(fs.readFileSync(targetVersionFile, 'utf8'))
+          .toBe('2026.05.05-12.58.58-nightly');
+        expectLib.expect(fs.existsSync(sourceBinary)).toBe(true);
+      } finally {
+        fs.rmSync(extensionsRoot, { recursive: true, force: true });
+      }
+    });
+
+    it('skips writing the version file when the candidate has no version', async () => {
+      const sourceFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'calva-adopt-source-'));
+      const sourceBinary = path.join(sourceFolder, 'clojure-lsp');
+      fs.writeFileSync(sourceBinary, 'source-binary');
+      fs.rmSync(binaryPath);
+      const targetVersionFile = path.join(tmpDir, 'clojure-lsp-version');
+
+      try {
+        await downloaderUtils.adoptLocalClojureLsp(
+          { binaryPath: sourceBinary, version: '' },
+          binaryPath,
+          targetVersionFile
+        );
+
+        expectLib.expect(fs.readFileSync(binaryPath, 'utf8')).toBe('source-binary');
+        expectLib.expect(fs.existsSync(targetVersionFile)).toBe(false);
+      } finally {
+        fs.rmSync(sourceFolder, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/src/lsp/client/downloader-utils.ts
+++ b/src/lsp/client/downloader-utils.ts
@@ -28,6 +28,83 @@ async function restoreFile(backupPath: string, originalPath: string): Promise<bo
   }
 }
 
+function getBackupPath(filePath: string): string {
+  return path.join(path.dirname(filePath), 'backup', path.basename(filePath));
+}
+
+export async function restoreFromBackup(filePath: string): Promise<boolean> {
+  const backupPath = getBackupPath(filePath);
+  if (!fs.existsSync(backupPath)) {
+    return false;
+  }
+  return restoreFile(backupPath, filePath);
+}
+
+export interface LocalClojureLspCandidate {
+  binaryPath: string;
+  version: string;
+}
+
+export async function findHighestLocalClojureLsp(
+  currentExtensionPath: string,
+  binaryName: string,
+  versionFileName: string
+): Promise<LocalClojureLspCandidate | null> {
+  const extensionsRoot = path.dirname(currentExtensionPath);
+  const currentName = path.basename(currentExtensionPath);
+  const prefix = currentName.split('-')[0];
+  if (!prefix) {
+    return null;
+  }
+
+  let siblings: string[];
+  try {
+    siblings = await fs.promises.readdir(extensionsRoot);
+  } catch {
+    return null;
+  }
+
+  const candidates: LocalClojureLspCandidate[] = [];
+  for (const name of siblings) {
+    if (name === currentName || !name.startsWith(`${prefix}-`)) {
+      continue;
+    }
+    const folder = path.join(extensionsRoot, name);
+    const binaryPath = path.join(folder, binaryName);
+    if (!fs.existsSync(binaryPath)) {
+      continue;
+    }
+    let version = '';
+    try {
+      version = (await fs.promises.readFile(path.join(folder, versionFileName), 'utf8')).trim();
+    } catch {
+      // ignore
+    }
+    candidates.push({ binaryPath, version });
+  }
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  candidates.sort((a, b) => b.version.localeCompare(a.version));
+  return candidates[0];
+}
+
+export async function adoptLocalClojureLsp(
+  candidate: LocalClojureLspCandidate,
+  targetBinaryPath: string,
+  targetVersionFilePath: string
+): Promise<void> {
+  await fs.promises.copyFile(candidate.binaryPath, targetBinaryPath);
+  if (path.extname(targetBinaryPath) === '') {
+    await fs.promises.chmod(targetBinaryPath, 0o775);
+  }
+  if (candidate.version) {
+    await fs.promises.writeFile(targetVersionFilePath, candidate.version);
+  }
+}
+
 export async function downloadWithBackupRecovery(
   filePath: string,
   download: () => Promise<void>

--- a/src/lsp/client/downloader.ts
+++ b/src/lsp/client/downloader.ts
@@ -163,8 +163,36 @@ export const ensureServerDownloaded = async (
     });
   console.log(`clojure-lsp binary exists: ${exists}`);
 
-  // If there's no existing clojure-lsp file, and we can't fetch the latest version, throw an error, because the download of clojure-lsp will fail
   if (downloadVersion === '' && !exists) {
+    const restored = await downloaderUtils.restoreFromBackup(clojureLspPath);
+    if (restored) {
+      const restoredVersion = currentVersion ? ` (${currentVersion})` : '';
+      void vscode.window.showWarningMessage(
+        `Could not fetch the latest clojure-lsp version. Using a previously downloaded version${restoredVersion} restored from backup.`
+      );
+      console.log(`clojure-lsp restored from backup at ${clojureLspPath}`);
+      return clojureLspPath;
+    }
+    const localFallback = await downloaderUtils.findHighestLocalClojureLsp(
+      context.extensionPath,
+      path.basename(clojureLspPath),
+      versionFileName
+    );
+    if (localFallback) {
+      await downloaderUtils.adoptLocalClojureLsp(
+        localFallback,
+        clojureLspPath,
+        getVersionFilePath(context.extensionPath)
+      );
+      const adoptedVersion = localFallback.version || 'unknown';
+      void vscode.window.showWarningMessage(
+        `Could not fetch the latest clojure-lsp version. Using ${adoptedVersion} found in another Calva install.`
+      );
+      console.log(
+        `clojure-lsp adopted from sibling install: ${localFallback.binaryPath} -> ${clojureLspPath}`
+      );
+      return clojureLspPath;
+    }
     throw 'Could not fetch latest version for clojure-lsp. Please check your internet connection and try again. You can also download clojure-lsp manually and set the path in the Calva settings. See https://calva.io/clojure-lsp/#using-a-custom-clojure-lsp for more info.';
   } else if (
     (currentVersion !== downloadVersion && downloadVersion !== '') ||


### PR DESCRIPTION
## What has changed?

When `clojure-lsp` cannot be downloaded because the GitHub `releases/latest` redirect cannot be resolved (slow network, GitHub outage, corporate proxy, redirect parsing returning empty, etc.) AND the main binary is missing in the current extension folder (e.g. right after Cursor or VS Code creates a fresh `betterthantomorrow.calva-X.Y.Z-universal/` folder during an extension upgrade), `ensureServerDownloaded` previously threw `Could not fetch latest version for clojure-lsp`. The throw is caught in `provisionClient`, so the Calva extension itself still activates, but the user sees the "Failed to download clojure-lsp server" error toast immediately on project open and all clojure-lsp features (rename, find-references, code actions, etc.) are unavailable for the session. It now tries two local fallbacks before throwing, so a usable binary that already exists somewhere on the user's machine is reused.

- **Local backup folder fallback**: First, attempt to restore the binary from the extension folder's `backup/clojure-lsp` file (or `backup/clojure-lsp.exe` / `backup/clojure-lsp-standalone.jar` per platform) if present. Covers the case where a previous in-flight download left a recovered backup behind.
- **Sibling Calva install fallback**: If no backup is found, scan sibling extension folders matching the same publisher.name prefix derived from the current folder name (e.g. `betterthantomorrow.calva-`), pick the highest recorded clojure-lsp version using lexicographic comparison (works for clojure-lsp's date-based tags such as `2026.05.05-12.58.58-nightly`), and copy the binary plus the `clojure-lsp-version` file into the current extension folder. The binary is `chmod 0o775` on Unix-like platforms.
- **User feedback**: When either fallback succeeds, a non-blocking warning toast names the reused version and clojure-lsp comes up using the reused binary so the user keeps all LSP features. The original throw is preserved for the truly hopeless case where neither fallback finds anything.

### Changes

- **`src/lsp/client/downloader.ts`**:
  - In `ensureServerDownloaded`, the `(downloadVersion === '' && !exists)` branch now tries `restoreFromBackup` and then `findHighestLocalClojureLsp` + `adoptLocalClojureLsp` before throwing.
  - Surface a non-blocking warning toast naming the reused version on either fallback.

- **`src/lsp/client/downloader-utils.ts`**:
  - Added `restoreFromBackup(filePath)` that recovers a binary from the sibling `backup/` directory next to `filePath` when present.
  - Added `findHighestLocalClojureLsp(currentExtensionPath, binaryName, versionFileName)` that scans sibling extension folders by publisher.name prefix and returns the highest-version candidate, ignoring the current folder, unrelated extensions, and folders without a binary. Siblings without a `clojure-lsp-version` file are kept as low-priority candidates (their empty version string sorts to the bottom).
  - Added `adoptLocalClojureLsp(candidate, targetBinaryPath, targetVersionFilePath)` that copies the chosen binary into the target path, chmods it on Unix-like platforms, and writes the matching version file.

- **`src/extension-test/unit/lsp/downloader-test.ts`**:
  - Added unit tests covering: empty backup directory, restored backup, no sibling folders, siblings without binary, current folder skipped, unrelated extensions ignored, the real reporter scenario (5 sibling folders including one with no binary, picking `betterthantomorrow.calva-2.0.582-universal/clojure-lsp` at `2026.05.05-12.58.58-nightly`), siblings without a version file, and the copy-and-write behavior of `adoptLocalClojureLsp`. Full unit suite (1585 tests) passes.

Fixes #3211

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).
