### PR TITLE
Prevent calva from breaking other debugging session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Prevent calva from breaking other debugging session](https://github.com/BetterThanTomorrow/calva/pull/2936)
+
 ## [2.0.585] - 2026-05-08
 
 - Fix: [clojure-lsp fails to start when the latest version cannot be downloaded](https://github.com/BetterThanTomorrow/calva/issues/3211)

--- a/src/debugger/calva-debug.ts
+++ b/src/debugger/calva-debug.ts
@@ -454,7 +454,15 @@ class CalvaDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescripto
   }
 }
 
+function calvaDebugSession(session: vscode.DebugSession) {
+  return session?.type === CALVA_DEBUG_CONFIGURATION.type;
+}
+
 function onNreplMessage(data: any): void {
+  if (!calvaDebugSession(vscode.debug.activeDebugSession)) {
+    return;
+  }
+
   if (vscode.debug.activeDebugSession && (data['value'] || data['err'])) {
     annotations.clearAllEvaluationDecorations();
     void vscode.debug.activeDebugSession.customRequest(REQUESTS.SEND_TERMINATED_EVENT);
@@ -485,7 +493,7 @@ function handleNeedDebugInput(response: any): void {
 }
 
 vscode.debug.onDidStartDebugSession((session) => {
-  if (session.type != CALVA_DEBUG_CONFIGURATION.type) {
+  if (!calvaDebugSession(session)) {
     return;
   }
 
@@ -506,6 +514,10 @@ function initializeDebugger(cljSession: nrepl.NReplSession): void {
 }
 
 function terminateDebugSession(): void {
+  if (!calvaDebugSession(vscode.debug.activeDebugSession)) {
+    return;
+  }
+
   if (vscode.debug.activeDebugSession) {
     void vscode.debug.activeDebugSession.customRequest(REQUESTS.SEND_TERMINATED_EVENT);
   }


### PR DESCRIPTION
With the recent introduction of the jank nrepl server https://github.com/jank-lang/jank/pull/698, I have ran into the same problem as I did in https://github.com/BetterThanTomorrow/calva/pull/2934 but now because I can connect to jank via Calva's nREPL client 🙌 

<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

<!-- Please start by telling us what Github issue(s) your PR is fixing. Strongly consider creating the issue if there isn't one already. -->

Fixes #2936

## What has changed?

<!-- Introduce the change(s) briefly here. The why of the change belongs in the issue, but consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- More guards around sending customRequests to other GDB clients that aren't of type calva

## My Calva PR Checklist

<!--
Strike out items (using `~`) if they do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [ ] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

