### PR TITLE
Add built-in Glojure Jack-in and Connect Sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- [Add built-in Glojure Jack-in and Connect Sequences](https://github.com/BetterThanTomorrow/calva/issues/3103)
+
 ## [2.0.585] - 2026-05-08
 
 - Fix: [clojure-lsp fails to start when the latest version cannot be downloaded](https://github.com/BetterThanTomorrow/calva/issues/3211)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5417,9 +5417,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -16420,9 +16420,9 @@
       "dev": true
     },
     "fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true
     },
     "fastest-levenshtein": {
@@ -20401,8 +20401,7 @@
       }
     },
     "strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "requires": {
         "ansi-regex": "^6.2.2"

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
           ".boot",
           ".bb",
           ".lg",
+          ".glj",
           ".ly",
           ".lpy",
           ".jank",
@@ -738,6 +739,7 @@
                   "enum": [
                     "Leiningen",
                     "deps.edn",
+                    "clj-projectless",
                     "shadow-cljs",
                     "lein-shadow",
                     "Gradle",
@@ -746,11 +748,11 @@
                     "scittle",
                     "squint",
                     "basilisp",
-                    "let-go",
                     "epupp",
                     "joyride",
+                    "let-go",
+                    "glojure",
                     "generic",
-                    "clj-projectless",
                     "custom",
                     "cljs-only"
                   ]

--- a/src/nrepl/connect-sequence-types.ts
+++ b/src/nrepl/connect-sequence-types.ts
@@ -8,6 +8,7 @@ enum ProjectTypes {
   'nbb' = 'nbb',
   'basilisp' = 'basilisp',
   'let-go' = 'let-go',
+  'glojure' = 'glojure',
   'joyride' = 'joyride',
   'scittle' = 'scittle',
   'squint' = 'squint',

--- a/src/nrepl/connectSequence.ts
+++ b/src/nrepl/connectSequence.ts
@@ -191,6 +191,14 @@ const letGoBuiltIns: csTypes.ReplConnectSequence[] = [
   },
 ];
 
+const glojureBuiltIns: csTypes.ReplConnectSequence[] = [
+  {
+    name: 'glojure',
+    projectType: csTypes.ProjectTypes['glojure'],
+    cljsType: csTypes.CljsTypes.none,
+  },
+];
+
 const epuppBuiltIns: csTypes.ReplConnectSequence[] = [
   {
     name: 'epupp',
@@ -213,6 +221,7 @@ const builtInSequences = {
   nbb: nbbBuiltIns,
   basilisp: basilispBuiltIns,
   'let-go': letGoBuiltIns,
+  glojure: glojureBuiltIns,
   joyride: joyrideBuiltIns,
   scittle: scittleBuiltIns,
   squint: squintBuiltIns,

--- a/src/nrepl/project-types.ts
+++ b/src/nrepl/project-types.ts
@@ -735,6 +735,31 @@ const projectTypes: { [id: string]: ProjectType } = {
       };
     },
   },
+  glojure: {
+    name: 'glojure',
+    cmd: ['glj'],
+    winCmd: ['glj'],
+    processShellUnix: true,
+    processShellWin: true,
+    useWhenExists: [],
+    defaultNReplPortFile: ['.glj-nrepl-port'],
+    defaultReplSessionNames: { primary: 'glj' },
+    defaultFilePatterns: {
+      primary: {
+        'always-claim': ['*.glj'],
+        'is-fallback-for': ['**/*.glj', '**/*.clj'],
+      },
+    },
+    commandLine: async (
+      _connectSequence: connectSequences.ReplConnectSequence,
+      _cljsType: connectSequences.CljsTypes
+    ) => {
+      return {
+        args: ['--nrepl'],
+        substitutions: {},
+      };
+    },
+  },
   joyride: {
     name: 'joyride',
     cmd: [],
@@ -1080,12 +1105,13 @@ export async function detectProjectTypes(): Promise<string[]> {
     'clj-projectless',
     'cljs-only',
     'babashka',
-    'let-go',
     'nbb',
     'joyride',
     'scittle',
     'squint',
     'epupp',
+    'glojure',
+    'let-go',
     'custom',
     'generic',
   ];


### PR DESCRIPTION
* Fixes #3103

## What has changed?

* Add the built-in sequence `glojure`, which create `glj` sessions
* Add `.glj` as recognized Clojure files

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

