### PR TITLE
3218 edit use passed in editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [The structural editor fails in some API usage scenarios](https://github.com/BetterThanTomorrow/calva/issues/3218)
+
 ## [2.0.586] - 2026-05-09
 
 - Fix: [Prevent calva from breaking other debugging session](https://github.com/BetterThanTomorrow/calva/pull/2936)

--- a/src/cursor-doc/model.ts
+++ b/src/cursor-doc/model.ts
@@ -250,6 +250,7 @@ export type ModelEditOptions = {
   skipFormat?: boolean;
   selections?: ModelEditSelection[];
   builder?: TextEditorEdit;
+  editor?: unknown;
 };
 
 export interface EditableModel {

--- a/src/doc-mirror/index.ts
+++ b/src/doc-mirror/index.ts
@@ -171,7 +171,7 @@ export class DocumentModel implements EditableModel {
       this.document.selections = options.selections;
     }
     if (!options.skipFormat) {
-      const editor = utilities.getActiveTextEditor();
+      const editor = (options.editor as vscode.TextEditor) ?? utilities.getActiveTextEditor();
       void formatter.scheduleFormatAsType(editor, {});
     }
   }
@@ -279,7 +279,7 @@ export class DocumentModel implements EditableModel {
         : undefined;
     // Do the edits (with undoStopAfter=false if we will reformat,
     // to include the reformatting in the same undo-unit as the edit).
-    const editor = utilities.getActiveTextEditor();
+    const editor = (options.editor as vscode.TextEditor) ?? utilities.getActiveTextEditor();
     const editCompletion = editor.edit(
       (builder) => {
         this.editNowTextOnly(modelEdits, { builder: builder, ...options });
@@ -327,8 +327,7 @@ export class DocumentModel implements EditableModel {
     oldSelection?: [number, number],
     newSelection?: [number, number]
   ) {
-    const editor = utilities.getActiveTextEditor(),
-      document = editor.document;
+    const document = this.document.document;
     builder.insert(document.positionAt(offset), text);
   }
 
@@ -340,8 +339,7 @@ export class DocumentModel implements EditableModel {
     oldSelection?: [number, number],
     newSelection?: [number, number]
   ) {
-    const editor = utilities.getActiveTextEditor(),
-      document = editor.document,
+    const document = this.document.document,
       range = new vscode.Range(document.positionAt(start), document.positionAt(end));
     builder.replace(range, text);
   }
@@ -353,8 +351,7 @@ export class DocumentModel implements EditableModel {
     oldSelection?: [number, number],
     newSelection?: [number, number]
   ) {
-    const editor = utilities.getActiveTextEditor(),
-      document = editor.document,
+    const document = this.document.document,
       range = new vscode.Range(document.positionAt(offset), document.positionAt(offset + count));
     builder.delete(range);
   }

--- a/src/edit.ts
+++ b/src/edit.ts
@@ -633,6 +633,7 @@ export function replace(
         undoStopBefore: true,
       },
       ...options,
+      editor,
     }
   );
 }

--- a/src/extension-test/integration/suite/edit-replace-test.ts
+++ b/src/extension-test/integration/suite/edit-replace-test.ts
@@ -26,9 +26,6 @@ suite(suiteName, function () {
   });
 
   test('should apply edit to the passed editor, not activeTextEditor', async function () {
-    // Open the other file in Column One first — establishes the editor group
-    await testUtil.openFile(otherFilePath);
-
     // Open the target file in Column Two — capture a fresh editor reference
     const targetDoc = await vscode.workspace.openTextDocument(vscode.Uri.file(targetFilePath));
     const targetEditor = await vscode.window.showTextDocument(targetDoc, {
@@ -51,13 +48,18 @@ suite(suiteName, function () {
       'Timed out waiting for mirror document for target file'
     );
 
-    // Focus back to Column One so activeTextEditor is the other file
-    await vscode.commands.executeCommand('workbench.action.focusFirstEditorGroup');
+    // Show the other file in Column One — explicitly setting viewColumn
+    // ensures it opens in a different group and becomes activeTextEditor
+    const otherDoc = await vscode.workspace.openTextDocument(vscode.Uri.file(otherFilePath));
+    await vscode.window.showTextDocument(otherDoc, {
+      viewColumn: vscode.ViewColumn.One,
+      preview: false,
+    });
     await testUtil.waitForCondition(
       () => vscode.window.activeTextEditor?.document.uri.fsPath === otherFilePath,
       4000,
       50,
-      'Timed out waiting for focus to return to other file'
+      'Timed out waiting for other file to become active'
     );
 
     // Confirm precondition: active editor is NOT the target file

--- a/src/extension-test/integration/suite/edit-replace-test.ts
+++ b/src/extension-test/integration/suite/edit-replace-test.ts
@@ -11,37 +11,6 @@ const targetFilePath = path.join(testUtil.testDataDir, 'edit-replace-target.clj'
 const otherFilePath = path.join(testUtil.testDataDir, 'reformattable.clj');
 
 suite(suiteName, function () {
-  let targetEditor: vscode.TextEditor;
-  let otherEditor: vscode.TextEditor;
-
-  setup(async function () {
-    // Open the target file in a second column without focusing it
-    const targetDoc = await vscode.workspace.openTextDocument(vscode.Uri.file(targetFilePath));
-    targetEditor = await vscode.window.showTextDocument(targetDoc, {
-      viewColumn: vscode.ViewColumn.Two,
-      preserveFocus: true,
-      preview: false,
-    });
-
-    // Open a different file as the active editor
-    otherEditor = await testUtil.openFile(otherFilePath);
-
-    // Wait for the mirror doc to be available for the target file
-    await testUtil.waitForCondition(
-      () => {
-        try {
-          docMirror.getDocument(targetEditor.document);
-          return true;
-        } catch {
-          return false;
-        }
-      },
-      4000,
-      50,
-      'Timed out waiting for mirror document for target file'
-    );
-  });
-
   teardown(async function () {
     // Revert target file to original content
     const targetDoc = await vscode.workspace.openTextDocument(vscode.Uri.file(targetFilePath));
@@ -57,21 +26,51 @@ suite(suiteName, function () {
   });
 
   test('should apply edit to the passed editor, not activeTextEditor', async function () {
+    // Open the other file in Column One first — establishes the editor group
+    await testUtil.openFile(otherFilePath);
+
+    // Open the target file in Column Two — capture a fresh editor reference
+    const targetDoc = await vscode.workspace.openTextDocument(vscode.Uri.file(targetFilePath));
+    const targetEditor = await vscode.window.showTextDocument(targetDoc, {
+      viewColumn: vscode.ViewColumn.Two,
+      preview: false,
+    });
+
+    // Wait for the mirror doc to be available for the target file
+    await testUtil.waitForCondition(
+      () => {
+        try {
+          docMirror.getDocument(targetDoc);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      4000,
+      50,
+      'Timed out waiting for mirror document for target file'
+    );
+
+    // Focus back to Column One so activeTextEditor is the other file
+    await vscode.commands.executeCommand('workbench.action.focusFirstEditorGroup');
+    await testUtil.waitForCondition(
+      () => vscode.window.activeTextEditor?.document.uri.fsPath === otherFilePath,
+      4000,
+      50,
+      'Timed out waiting for focus to return to other file'
+    );
+
     // Confirm precondition: active editor is NOT the target file
-    const activeFileBefore = vscode.window.activeTextEditor?.document.uri.fsPath;
+    const activeEditor = vscode.window.activeTextEditor;
+    assert.ok(activeEditor, 'There should be an active editor');
     assert.strictEqual(
-      activeFileBefore,
+      activeEditor.document.uri.fsPath,
       otherFilePath,
       'Precondition: active editor should be the other file'
     );
-    assert.notStrictEqual(
-      activeFileBefore,
-      targetFilePath,
-      'Precondition: active editor should NOT be the target file'
-    );
 
-    const targetContentBefore = targetEditor.document.getText();
-    const otherContentBefore = otherEditor.document.getText();
+    const targetContentBefore = targetDoc.getText();
+    const otherContentBefore = activeEditor.document.getText();
 
     // Call edit.replace with the target editor (which is NOT activeTextEditor)
     const range = new vscode.Range(
@@ -85,7 +84,7 @@ suite(suiteName, function () {
     assert.strictEqual(result, true, 'edit.replace should return true');
 
     // The edit should have gone to the target file
-    const targetContentAfter = targetEditor.document.getText();
+    const targetContentAfter = targetDoc.getText();
     assert.ok(
       targetContentAfter.includes('(def a 42)'),
       `Target file should contain the replacement text. Got: ${targetContentAfter}`
@@ -96,7 +95,7 @@ suite(suiteName, function () {
     );
 
     // The active editor's file should be unchanged
-    const otherContentAfter = otherEditor.document.getText();
+    const otherContentAfter = activeEditor.document.getText();
     assert.strictEqual(
       otherContentAfter,
       otherContentBefore,

--- a/src/extension-test/integration/suite/edit-replace-test.ts
+++ b/src/extension-test/integration/suite/edit-replace-test.ts
@@ -1,0 +1,106 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as testUtil from './util';
+import * as vscode from 'vscode';
+import * as edit from '../../../edit';
+import * as docMirror from '../../../doc-mirror';
+
+const suiteName = 'Edit Replace Suite';
+
+const targetFilePath = path.join(testUtil.testDataDir, 'edit-replace-target.clj');
+const otherFilePath = path.join(testUtil.testDataDir, 'reformattable.clj');
+
+suite(suiteName, function () {
+  let targetEditor: vscode.TextEditor;
+  let otherEditor: vscode.TextEditor;
+
+  setup(async function () {
+    // Open the target file in a second column without focusing it
+    const targetDoc = await vscode.workspace.openTextDocument(vscode.Uri.file(targetFilePath));
+    targetEditor = await vscode.window.showTextDocument(targetDoc, {
+      viewColumn: vscode.ViewColumn.Two,
+      preserveFocus: true,
+      preview: false,
+    });
+
+    // Open a different file as the active editor
+    otherEditor = await testUtil.openFile(otherFilePath);
+
+    // Wait for the mirror doc to be available for the target file
+    await testUtil.waitForCondition(
+      () => {
+        try {
+          docMirror.getDocument(targetEditor.document);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      4000,
+      50,
+      'Timed out waiting for mirror document for target file'
+    );
+  });
+
+  teardown(async function () {
+    // Revert target file to original content
+    const targetDoc = await vscode.workspace.openTextDocument(vscode.Uri.file(targetFilePath));
+    const fullRange = new vscode.Range(
+      new vscode.Position(0, 0),
+      targetDoc.positionAt(targetDoc.getText().length)
+    );
+    const editor = await vscode.window.showTextDocument(targetDoc);
+    await editor.edit((builder) => {
+      builder.replace(fullRange, '(ns edit-replace-target)\n\n(def a 1)\n\n(def b 2)\n');
+    });
+    await targetDoc.save();
+  });
+
+  test('should apply edit to the passed editor, not activeTextEditor', async function () {
+    // Confirm precondition: active editor is NOT the target file
+    const activeFileBefore = vscode.window.activeTextEditor?.document.uri.fsPath;
+    assert.strictEqual(
+      activeFileBefore,
+      otherFilePath,
+      'Precondition: active editor should be the other file'
+    );
+    assert.notStrictEqual(
+      activeFileBefore,
+      targetFilePath,
+      'Precondition: active editor should NOT be the target file'
+    );
+
+    const targetContentBefore = targetEditor.document.getText();
+    const otherContentBefore = otherEditor.document.getText();
+
+    // Call edit.replace with the target editor (which is NOT activeTextEditor)
+    const range = new vscode.Range(
+      new vscode.Position(2, 0),
+      new vscode.Position(2, '(def a 1)'.length)
+    );
+    const result = await edit.replace(targetEditor, range, '(def a 42)', {
+      skipFormat: true,
+    });
+
+    assert.strictEqual(result, true, 'edit.replace should return true');
+
+    // The edit should have gone to the target file
+    const targetContentAfter = targetEditor.document.getText();
+    assert.ok(
+      targetContentAfter.includes('(def a 42)'),
+      `Target file should contain the replacement text. Got: ${targetContentAfter}`
+    );
+    assert.ok(
+      !targetContentAfter.includes('(def a 1)'),
+      `Target file should no longer contain the original text. Got: ${targetContentAfter}`
+    );
+
+    // The active editor's file should be unchanged
+    const otherContentAfter = otherEditor.document.getText();
+    assert.strictEqual(
+      otherContentAfter,
+      otherContentBefore,
+      'Active editor content should be unchanged'
+    );
+  });
+});

--- a/test-data/integration-test/edit-replace-target.clj
+++ b/test-data/integration-test/edit-replace-target.clj
@@ -1,0 +1,5 @@
+(ns edit-replace-target)
+
+(def a 1)
+
+(def b 2)


### PR DESCRIPTION
* Fixes #3218

## What has changed?

Make the edit.replace function honor the editor passed in.

## My Calva PR Checklist

<!--
Strike out items (using `~`) if they do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

