### PR TITLE
Fix debug session hang while waiting for debug input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes to Calva.
 
 ## [Unreleased]
+- Fix: [debugging stops working](https://github.com/BetterThanTomorrow/calva/issues/3224)
 
 ## [2.0.588] - 2026-05-15
 

--- a/src/debugger/calva-debug.ts
+++ b/src/debugger/calva-debug.ts
@@ -459,13 +459,11 @@ function calvaDebugSession(session: vscode.DebugSession) {
 }
 
 function onNreplMessage(data: any): void {
-  if (!calvaDebugSession(vscode.debug.activeDebugSession)) {
-    return;
-  }
-
   if (vscode.debug.activeDebugSession && (data['value'] || data['err'])) {
-    annotations.clearAllEvaluationDecorations();
-    void vscode.debug.activeDebugSession.customRequest(REQUESTS.SEND_TERMINATED_EVENT);
+    if (calvaDebugSession(vscode.debug.activeDebugSession)) {
+      annotations.clearAllEvaluationDecorations();
+      void vscode.debug.activeDebugSession.customRequest(REQUESTS.SEND_TERMINATED_EVENT);
+    }
   } else if (data['status'] && data['status'].indexOf(NEED_DEBUG_INPUT_STATUS) !== -1) {
     handleNeedDebugInput(data);
   }


### PR DESCRIPTION
The change removes the early return that was blocking need-debug-input before Calva’s debug session existed. Issue is that `vscode.debug.activeDebugSession` could be not initialized that is a root cause why debug session is blocked and all REPL is not responding for next code evaluation.

<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

<!-- Please start by telling us what Github issue(s) your PR is fixing. Strongly consider creating the issue if there isn't one already. -->

Fixes #3224 

Testing was done in Linux. Was not able to do testing on Mac or Windows.

## What has changed?

<!-- Introduce the change(s) briefly here. The why of the change belongs in the issue, but consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- Removed the early return in `onNreplMessage` so need-debug-input messages are still handled before a Calva debug session exists.
- Add null check for `vscode.debug.activeDebugSession` before invoking `calvaDebugSession` by keeping the protection for non-Calva debug sessions by checking `calvaDebugSession(...)`


## My Calva PR Checklist

<!--
Strike out items (using `~`) if they do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

