### PR TITLE
Websocket orphanage fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [WebSocket nREPL servers not stopped on VS Code window reload](https://github.com/BetterThanTomorrow/calva/issues/3237)
 - Internal: Ditching `atom-language-clojure` for Clojure TextMate grammar and using (`clojure.tmLanguage.json`) as the source of truth 
-- Unit tests (and watcher) are now covering the grammar (utilizing `vscode-textmate`)
+  - Unit tests (and watcher) are now covering the grammar (utilizing `vscode-textmate`)
 
 ## [2.0.590] - 2026-06-03
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -98,6 +98,7 @@ async function connectViaWebSocket(
   isJackIn = false
 ): Promise<ConnectResult> {
   let activeClient: nrepl.NReplClient | undefined;
+  let trackedWsServer: nReplWsServer.NReplWsServer | undefined;
   let preservedRenames: Partial<sessionRoleUtils.SessionRoleKeys> | undefined;
   const baseSessionNames = sessionRoleUtils.deriveSessionRoleKeys(connectSequence);
   const projectRootPath = state.getProjectRootUri().fsPath;
@@ -160,6 +161,7 @@ async function connectViaWebSocket(
 
     const sessionKeyValues = Object.values(sessionRoleKeys).filter(Boolean) as string[];
     nReplWsServer.trackServer(server, connectSequence.name, projectRoot, sessionKeyValues);
+    trackedWsServer = server;
 
     // Track first connection to resolve the initial await
     let resolveFirstConnection: (() => void) | null = null;
@@ -394,6 +396,10 @@ async function connectViaWebSocket(
       return { connected: false };
     }
   } catch (e) {
+    if (trackedWsServer?.isListening()) {
+      nReplWsServer.untrackServer(trackedWsServer);
+      await trackedWsServer.stop();
+    }
     return cleanUpAfterError(e, {
       clientKey: activeClient?.clientKey,
       suffix: resolution.suffix,

--- a/src/extension-test/e2e/suite/websocket-connect-test.ts
+++ b/src/extension-test/e2e/suite/websocket-connect-test.ts
@@ -6,6 +6,7 @@ import * as testUtil from './util';
 import * as clientRegistry from '../../../nrepl/client-registry';
 import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as connector from '../../../connector';
+import * as nReplWsServer from '../../../nrepl/nrepl-ws-server';
 import * as connectSequenceTypes from '../../../nrepl/connect-sequence-types';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as docMirror from '../../../doc-mirror';
@@ -13,6 +14,7 @@ import * as docMirror from '../../../doc-mirror';
 const WS_PORT_EVAL = 51340;
 const WS_PORT_LOAD = 51341;
 const WS_PORT_RENAME = 51342;
+const WS_PORT_SHUTDOWN = 51343;
 
 /**
  * Create a scittle webview via Joyride flare.
@@ -360,5 +362,56 @@ suite('WebSocket nREPL Connect suite', function () {
 
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     testUtil.log(suite, `[TIMING] Test 3 complete: ${elapsed()}`);
+  });
+
+  test('WebSocket port is released on extension shutdown path', async function () {
+    const t0 = Date.now();
+    const elapsed = () => `${Date.now() - t0}ms`;
+    testUtil.log(suite, 'WebSocket port released on shutdown path');
+
+    const projectDir = path.join(
+      testUtil.testDataDir,
+      '..',
+      'projects',
+      'scittle-replicant-tic-tac-toe'
+    );
+
+    const connectSequence: connectSequenceTypes.ReplConnectSequence = {
+      name: 'scittle-ws-shutdown-test',
+      projectType: connectSequenceTypes.ProjectTypes['scittle'],
+      cljsType: connectSequenceTypes.CljsTypes.none,
+      webSocketPort: WS_PORT_SHUTDOWN,
+      projectRootPath: [projectDir],
+    };
+
+    const connectPromise = connector.connect(connectSequence, true);
+
+    await testUtil.waitForCondition(
+      () => testUtil.canConnectToPort(WS_PORT_SHUTDOWN),
+      5_000,
+      20,
+      `WS server not listening on port ${WS_PORT_SHUTDOWN}`
+    );
+    assert.ok(
+      nReplWsServer.getActiveServers().size > 0,
+      'Expected tracked WebSocket server while waiting for browser'
+    );
+    testUtil.log(suite, `[TIMING] WS server listening: ${elapsed()}`);
+
+    // Same shutdown as extension deactivate() on window reload (#3237).
+    // Full Developer: Reload Window is not automatable in @vscode/test-electron.
+    await nReplWsServer.stopAllActiveWsServers();
+
+    await testUtil.waitForCondition(
+      async () => !(await testUtil.canConnectToPort(WS_PORT_SHUTDOWN)),
+      5_000,
+      20,
+      `Port ${WS_PORT_SHUTDOWN} still bound after stopAllActiveWsServers`
+    );
+    assert.strictEqual(nReplWsServer.getActiveServers().size, 0);
+
+    const result = await connectPromise;
+    assert.ok(!result.connected, 'Connect should end after server shutdown');
+    testUtil.log(suite, `[TIMING] Shutdown path complete: ${elapsed()}`);
   });
 });

--- a/src/extension-test/unit/nrepl/ws-nrepl-server-test.ts
+++ b/src/extension-test/unit/nrepl/ws-nrepl-server-test.ts
@@ -130,4 +130,24 @@ describe('ws-nrepl-server', () => {
     await server.stop(); // second stop should not throw
     server = undefined;
   });
+
+  it('stopAllActiveWsServers stops all tracked servers', async () => {
+    const server1 = await wsServer.startNReplWsServer(0);
+    const server2 = await wsServer.startNReplWsServer(0);
+    wsServer.trackServer(server1);
+    wsServer.trackServer(server2);
+    expectLib.expect(wsServer.getActiveServers().size).toBe(2);
+
+    await wsServer.stopAllActiveWsServers();
+
+    expectLib.expect(wsServer.getActiveServers().size).toBe(0);
+    expectLib.expect(server1.isListening()).toBe(false);
+    expectLib.expect(server2.isListening()).toBe(false);
+  });
+
+  it('stopAllActiveWsServers is idempotent on empty set', async () => {
+    await wsServer.stopAllActiveWsServers();
+    await wsServer.stopAllActiveWsServers();
+    expectLib.expect(wsServer.getActiveServers().size).toBe(0);
+  });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -652,8 +652,8 @@ async function activate(context: vscode.ExtensionContext) {
 async function deactivate(): Promise<void> | undefined {
   // Use force=true during deactivation because VS Code is shutting down
   // and graceful shutdown callbacks may not fire in time
-  await jackIn.calvaJackout({ force: true });
   await nReplWsServer.stopAllActiveWsServers();
+  await jackIn.calvaJackout({ force: true });
   paredit.deactivate();
   await lsp.getClientProvider().shutdown();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as fmt from './calva-fmt/src/extension';
 import * as highlight from './highlight/src/extension';
 import * as state from './state';
 import * as jackIn from './nrepl/jack-in';
+import * as nReplWsServer from './nrepl/nrepl-ws-server';
 import * as replMenu from './nrepl/repl-menu';
 import * as replSessionsMenu from './repl-sessions-menu';
 import * as drams from './nrepl/drams';
@@ -652,6 +653,7 @@ async function deactivate(): Promise<void> | undefined {
   // Use force=true during deactivation because VS Code is shutting down
   // and graceful shutdown callbacks may not fire in time
   await jackIn.calvaJackout({ force: true });
+  await nReplWsServer.stopAllActiveWsServers();
   paredit.deactivate();
   await lsp.getClientProvider().shutdown();
 }

--- a/src/nrepl/nrepl-ws-server.ts
+++ b/src/nrepl/nrepl-ws-server.ts
@@ -208,14 +208,18 @@ export async function startNReplWsServer(port: number, host?: string): Promise<N
 const activeServers = new Set<NReplWsServer>();
 
 function updateWsServerContext() {
-  // Dynamic require to avoid breaking unit tests (vscode module unavailable outside extension host)
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const vscode = require('vscode');
-  void vscode.commands.executeCommand(
-    'setContext',
-    'calva:webSocketServerRunning',
-    activeServers.size > 0
-  );
+  // Dynamic require; vscode is unavailable outside the extension host (e.g. unit tests)
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const vscode = require('vscode');
+    void vscode.commands.executeCommand(
+      'setContext',
+      'calva:webSocketServerRunning',
+      activeServers.size > 0
+    );
+  } catch {
+    /* ignore */
+  }
 }
 
 export function trackServer(
@@ -238,4 +242,11 @@ export function untrackServer(server: NReplWsServer): void {
 
 export function getActiveServers(): ReadonlySet<NReplWsServer> {
   return activeServers;
+}
+
+export async function stopAllActiveWsServers(): Promise<void> {
+  for (const server of [...activeServers]) {
+    untrackServer(server);
+    await server.stop();
+  }
 }


### PR DESCRIPTION

* Fixes #3237 

## What has changed?

We were not ensuring nrepl websocket servers we started were properly shut down on extension host reload.

## My Calva PR Checklist

<!--
Strike out items (using `~`) if they do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

