### PR TITLE
Report clojure-lsp start up progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Add: [Add clojure-lsp startup progress in status bar](https://github.com/BetterThanTomorrow/calva/issues/1303)
+
 ## [2.0.591] - 2026-06-04
 
 - Fix: [WebSocket nREPL servers not stopped on VS Code window reload](https://github.com/BetterThanTomorrow/calva/issues/3237)
-- Internal: Ditching `atom-language-clojure` for Clojure TextMate grammar and using (`clojure.tmLanguage.json`) as the source of truth 
+- Internal: Ditching `atom-language-clojure` for Clojure TextMate grammar and using (`clojure.tmLanguage.json`) as the source of truth
   - Unit tests (and watcher) are now covering the grammar (utilizing `vscode-textmate`)
 
 ## [2.0.590] - 2026-06-03

--- a/src/lsp/client/client.ts
+++ b/src/lsp/client/client.ts
@@ -149,7 +149,7 @@ export const createClient = (params: CreateClientParams): defs.LspClient => {
           };
         },
       },
-      progressOnInitialization: false,
+      progressOnInitialization: true,
       initializationOptions: {
         'dependency-scheme': 'jar',
         'auto-add-ns-to-new-files?': true,


### PR DESCRIPTION
<!--
❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️

Please make sure to read: https://github.com/BetterThanTomorrow/calva/wiki/Contributing-Pull-requests

PLEASE NOTE:
If you want to file a Pull Request on the documentation of Calva (calva.io),
then use the Documentation PR template by adding 'template=docs.md' to the
query parameters of the URL of this page.

The rest of this template is about changes to the Calva source code.
-->

<!-- Please start by telling us what Github issue(s) your PR is fixing. Strongly consider creating the issue if there isn't one already. -->

Fixes #1303

## What has changed?

<!-- Introduce the change(s) briefly here. The why of the change belongs in the issue, but consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->

- This flips the `progressOnInitialization` LanguageClient flag to display progress messages from clojure-lsp.


## My Calva PR Checklist

<!--
Strike out items (using `~`) if they do not apply, If you want to add items, please do. -->

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- ~[ ] Added to or updated docs in this branch, if appropriate~
  - For the test repo, the progress messages are almost instantaneous. It's easy to miss.
- [x] Tests
  - [x] Tested the particular change
    - I have a screen recording of the progress messages, but I'm limited to `.mov`. I can attach if it's helpful
  - ~[ ] Figured if the change might have some side effects and tested those as well.~
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

