### PR TITLE
Only auto-start clojure-lsp in workspaces that hold Clojure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Calva adds `.lsp` and `.clj-kondo` folders to non-Clojure projects](https://github.com/BetterThanTomorrow/calva/issues/2610)
+  - Don't auto-start clojure-lsp in the first workspace root unless that folder holds a Clojure project or an open Clojure file
+  - Activate on `onDebugResolve:clojure` (was mistakenly `onDebugResolve:type`) and on `bb.edn`
 - Add: Let the Calva User Guide follow the system light/dark preference,
   with a manual theme toggle and a Calva-branded dark palette.
 

--- a/docs/site/clojure-lsp.md
+++ b/docs/site/clojure-lsp.md
@@ -23,7 +23,7 @@ Calva is able to automatically start the clojure-lsp server for you and can be c
 
 #### "always-use-first-workspace-root" [default]
 
-When set to `"always-use-first-workspace-root"` Calva will attempt to start the clojure-lsp in the root of the first workspace folder if it is a valid clojure project. If it is not a valid clojure project it will fall back to starting the [fallback server](#fallback-server).
+When set to `"always-use-first-workspace-root"` Calva will attempt to start the clojure-lsp in the root of the first workspace folder if that folder holds a Clojure project (or an open Clojure file). If it does not, Calva skips auto-start so that non-Clojure workspaces are not littered with `.lsp` and `.clj-kondo` folders.
 
 This is the default auto-start behaviour.
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "workspaceContains:**/project.clj",
     "workspaceContains:**/shadow-cljs.edn",
     "workspaceContains:**/deps.edn",
-    "onDebugResolve:type"
+    "workspaceContains:**/bb.edn",
+    "onDebugResolve:clojure"
   ],
   "main": "./out/extension",
   "capabilities": {

--- a/src/extension-test/unit/lsp/auto-start-test.ts
+++ b/src/extension-test/unit/lsp/auto-start-test.ts
@@ -1,0 +1,98 @@
+import { expect } from 'expect';
+import * as path from 'node:path';
+import { isClojureDocument, isClojureWorkspaceFolder } from '../../../lsp/auto-start';
+
+const p = (...segments: string[]) => path.resolve(path.sep, ...segments);
+
+const document = (languageId: string, scheme: string, fsPath: string) => ({
+  languageId,
+  uri: { scheme, fsPath },
+});
+
+describe('lsp auto-start', () => {
+  describe('isClojureDocument', () => {
+    it('accepts a Clojure file on disk', () => {
+      expect(isClojureDocument(document('clojure', 'file', p('ws', 'src', 'app.clj')))).toBe(true);
+    });
+
+    it('rejects a document of another language', () => {
+      expect(isClojureDocument(document('rust', 'file', p('ws', 'src', 'main.rs')))).toBe(false);
+    });
+
+    it('rejects an untitled Clojure document, which clojure-lsp does not support', () => {
+      expect(isClojureDocument(document('clojure', 'untitled', 'Untitled-1'))).toBe(false);
+    });
+  });
+
+  describe('isClojureWorkspaceFolder', () => {
+    it('is false when the folder holds neither a project root nor an open Clojure file', () => {
+      expect(
+        isClojureWorkspaceFolder({
+          folder_path: p('ws'),
+          project_root_paths: [],
+          open_clojure_document_paths: [],
+        })
+      ).toBe(false);
+    });
+
+    it('is true when the folder itself is a project root', () => {
+      expect(
+        isClojureWorkspaceFolder({
+          folder_path: p('ws'),
+          project_root_paths: [p('ws')],
+          open_clojure_document_paths: [],
+        })
+      ).toBe(true);
+    });
+
+    it('is true when a project root is nested in the folder', () => {
+      expect(
+        isClojureWorkspaceFolder({
+          folder_path: p('ws'),
+          project_root_paths: [p('ws', 'services', 'api')],
+          open_clojure_document_paths: [],
+        })
+      ).toBe(true);
+    });
+
+    it('is true when a Clojure file is open in the folder, even without a project root', () => {
+      expect(
+        isClojureWorkspaceFolder({
+          folder_path: p('ws'),
+          project_root_paths: [],
+          open_clojure_document_paths: [p('ws', 'scripts', 'build.clj')],
+        })
+      ).toBe(true);
+    });
+
+    it('is false when the only project root belongs to another workspace folder', () => {
+      expect(
+        isClojureWorkspaceFolder({
+          folder_path: p('rust-ws'),
+          project_root_paths: [p('clojure-ws')],
+          open_clojure_document_paths: [],
+        })
+      ).toBe(false);
+    });
+
+    it('is false when the only open Clojure file lives outside the folder', () => {
+      expect(
+        isClojureWorkspaceFolder({
+          folder_path: p('rust-ws'),
+          project_root_paths: [],
+          open_clojure_document_paths: [p('clojure-ws', 'src', 'app.clj')],
+        })
+      ).toBe(false);
+    });
+
+    it('is false for a sibling folder sharing a name prefix', () => {
+      expect(
+        isClojureWorkspaceFolder({
+          folder_path: p('ws'),
+          project_root_paths: [p('ws-clojure')],
+          open_clojure_document_paths: [],
+        })
+      ).toBe(false);
+    });
+  });
+});

--- a/src/lsp/auto-start.ts
+++ b/src/lsp/auto-start.ts
@@ -1,0 +1,29 @@
+import * as path from 'path';
+
+type DocumentLike = {
+  languageId: string;
+  uri: { scheme: string; fsPath: string };
+};
+
+export function isClojureDocument(document: DocumentLike) {
+  return document.languageId === 'clojure' && document.uri.scheme !== 'untitled';
+}
+
+function isWithin(parent_path: string, child_path: string) {
+  const relative = path.relative(parent_path, child_path);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+type ClojureWorkspaceFolderParams = {
+  folder_path: string;
+  project_root_paths: string[];
+  open_clojure_document_paths: string[];
+};
+
+export function isClojureWorkspaceFolder(params: ClojureWorkspaceFolderParams) {
+  const within_folder = (candidate: string) => isWithin(params.folder_path, candidate);
+  return (
+    params.project_root_paths.some(within_folder) ||
+    params.open_clojure_document_paths.some(within_folder)
+  );
+}

--- a/src/lsp/provider.ts
+++ b/src/lsp/provider.ts
@@ -6,6 +6,7 @@ import * as vscode_lsp from 'vscode-languageclient/node';
 import * as project_utils from '../project-root';
 import * as state from '../state';
 import * as api from './api';
+import * as auto_start from './auto-start';
 import * as lsp_client from './client';
 import * as commands from './commands';
 import * as config from './config';
@@ -30,9 +31,8 @@ const shutdownFallbackClientIfNeeded = async (clients: defs.LspClientStore) => {
     .map((root) => root.uri);
 
   const contains_external_files = !!vscode.workspace.textDocuments.find((doc) => {
-    const clojure_file = doc.languageId === 'clojure' && doc.uri.scheme !== 'untitled';
     const external = vscode.workspace.getWorkspaceFolder(doc.uri);
-    return clojure_file && external;
+    return auto_start.isClojureDocument(doc) && external;
   });
 
   if (non_project_folders.length === 0 && !contains_external_files) {
@@ -203,13 +203,26 @@ export const createClientProvider = (params: CreateClientProviderParams) => {
     if (!folder) {
       return;
     }
-    return provisionClient(folder.uri);
 
-    // TODO: Rather provision fallback client if not a valid clojure project:
-    // if (folder && (await project_utils.isValidClojureProject(folder.uri))) {
-    //   return provisionClient(folder.uri);
-    // }
-    // return provisionFallbackClient();
+    const roots = await project_utils.findProjectRootsWithReasons({
+      include_lsp_directories: true,
+      include_workspace_folders: false,
+    });
+    const holds_clojure = auto_start.isClojureWorkspaceFolder({
+      folder_path: folder.uri.fsPath,
+      project_root_paths: roots.map((root) => root.uri.fsPath),
+      open_clojure_document_paths: vscode.workspace.textDocuments
+        .filter(auto_start.isClojureDocument)
+        .map((doc) => doc.uri.fsPath),
+    });
+    if (!holds_clojure) {
+      console.log(
+        `Skipping clojure-lsp auto-start in ${folder.uri.path}: no Clojure project or open Clojure files`
+      );
+      return;
+    }
+
+    return provisionClient(folder.uri);
   };
 
   return {
@@ -275,8 +288,19 @@ export const createClientProvider = (params: CreateClientProviderParams) => {
 
         // Provision new LSP clients when clojure files are opened and for all already opened clojure files.
         vscode.workspace.onDidOpenTextDocument((document) => {
-          if (config.getAutoStartBehaviour() === config.AutoStartBehaviour.FileOpened) {
-            void provisionClientForOpenedDocument(document).catch((err) => console.error(err));
+          switch (config.getAutoStartBehaviour()) {
+            case config.AutoStartBehaviour.FileOpened: {
+              return void provisionClientForOpenedDocument(document).catch((err) =>
+                console.error(err)
+              );
+            }
+            case config.AutoStartBehaviour.FirstWorkspace: {
+              const folder = vscode.workspace.workspaceFolders?.[0];
+              if (folder && auto_start.isClojureDocument(document)) {
+                void provisionClient(folder.uri).catch((err) => console.error(err));
+              }
+              return;
+            }
           }
         }),
 


### PR DESCRIPTION
Fixes #2610

## What has changed?

Two things had to line up to produce the reported behaviour, and only the second one is really fixable.

Calva gets activated in workspaces that contain no Clojure. Since VS Code 1.74 activation events are auto-generated from the `languages`, `commands` and `views` contributions, so Calva wakes up whenever VS Code restores the Inspector or Flare views, whenever any extension runs a Calva command, and whenever an `.edn` file is opened. That matches the reports of this happening on extension refresh and of the Inspector showing up in an empty startup window. Short of dropping contributions, activation can't be prevented.

What can be prevented is clojure-lsp being started there. Under the default `always-use-first-workspace-root` behaviour, `provisionClientInFirstWorkspaceRoot` rooted a client in `workspaceFolders[0]` unconditionally, and clojure-lsp writes `.lsp` and `.clj-kondo` cache directories into whichever directory it is rooted in. A guard for this was already sketched in the source as a commented-out TODO.

- Auto-start now requires the folder to hold Clojure, meaning a project root (`deps.edn`, `project.clj`, `shadow-cljs.edn`, `bb.edn`, `basilisp.edn` or an `.lsp` directory) or an open Clojure document. The containment check is scoped to the folder being used as the root, so in a multi-root workspace a non-Clojure folder is left alone even when a sibling folder is a Clojure project. The commented-out TODO went with it, since the fallback client it referred to is currently a no-op.
- Opening a Clojure file now also starts the client in that mode. This is what keeps the "folder of loose `.clj` scripts with no project file" case working, which would otherwise have regressed.
- `onDebugResolve:type` becomes `onDebugResolve:clojure`. `type` was the placeholder copied verbatim from the VS Code docs and matched nothing, since Calva's debug type is `clojure`. This is the activation event @bpringe suggested experimenting with in https://github.com/BetterThanTomorrow/calva/issues/2610#issuecomment-2953158684. Worth noting that, unlike `onCommand` and `onLanguage`, `onDebugResolve` is [deliberately not auto-generated](https://github.com/microsoft/vscode/issues/166624) from the manifest, so the entry does need to stay. Debugging via Calva's own commands is unaffected (Calva is already active by then); spelling the type correctly additionally makes a hand-written `launch.json` with `"type": "clojure"` resolve from a cold start.
- Added `workspaceContains:**/bb.edn`. `bb.edn` already counts as a project root everywhere else in Calva, so a Babashka-only project should activate the extension rather than wait for a Clojure file to be opened. (`basilisp.edn` is in the same boat and was left alone; happy to add it if you'd like.)

On how it was implemented: the decision logic sits in a new `src/lsp/auto-start.ts` that does not import `vscode`, so it is unit-testable, and `provider.ts` just gathers the inputs. An alternative was to reuse `isValidClojureProject`, but that only accepts a project file at the workspace root itself, which would have broken workspaces whose Clojure project lives in a subdirectory.

One behavioural note for reviewers: this mode now performs a `findFiles` glob it previously skipped. It is not awaited during activation, so it does not add startup latency, and it is the same search the `when-workspace-opened-use-workspace-root` mode already runs.

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [ ] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
    - Developed and verified on macOS. The path containment check uses `path.relative` on `fsPath` and is covered by unit tests, but **Windows and Remote/WSL verification would be welcome**, since path handling and workspace folder URIs are where this could differ. The issue was also reported on Windsurf, which shares the activation behaviour.
- [x] Added to or updated docs in this branch, if appropriate
    - Updated the `always-use-first-workspace-root` section of `docs/site/clojure-lsp.md`, which previously claimed it falls back to the fallback server.
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
    - 10 new unit tests in `src/extension-test/unit/lsp/auto-start-test.ts` cover nested project roots, cross-folder isolation in multi-root workspaces, open-file-only workspaces, untitled documents, and the sibling-directory-with-a-shared-name-prefix trap. Full unit suite passes (1653).
    - Side effects considered: the four `calva.enableClojureLspOnStart` modes (only `always-use-first-workspace-root` changes behaviour), manual start via `calva.clojureLsp.start` (unaffected), workspace folders being added at runtime, and projects whose only marker is `bb.edn` or an existing `.lsp` directory.
    - I did not run the e2e suite; there is no existing e2e coverage of LSP auto-start.
- [x] Formatted all JavaScript and TypeScript code that was changed.
- [x] Confirmed that there are no linter warnings or errors.
