### PR TITLE
More stable way to recreate the Calva Output terminal after the tab i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes to Calva.
 - Add: Let the Calva User Guide follow the system light/dark preference,
   with a manual theme toggle and a Calva-branded dark palette.
 - Bump deps-clj to v1.12.5.1664
+- Fix: More stable way to recreate the Calva Output terminal after the tab is closed. Mitigation for [Output terminal stops outputting in Cursor](https://github.com/BetterThanTomorrow/calva/issues/3267)
 
 ## [2.0.594] - 2026-07-14
 

--- a/src/cljs-lib/fiddles/cursor_host.cljs
+++ b/src/cljs-lib/fiddles/cursor_host.cljs
@@ -1,0 +1,67 @@
+(ns fiddles.cursor-host
+  (:require [calva.util :as util]))
+
+(comment
+  (do
+    (def vsc @util/vscode)
+    (def ext-get (fn [id] (.getExtension (.-extensions vsc) id)))
+    (def ext-row (fn [id]
+                   (when-let [e (ext-get id)]
+                     {:id (.-id e)
+                      :active (.-isActive e)}))))
+
+  {:app-name (.-appName (.-env vsc))
+   :app-root (.-appRoot (.-env vsc))
+   :has-cursor (exists? (.-cursor vsc))
+   :has-lm (exists? (.-lm vsc))
+   :has-chat (exists? (.-chat vsc))}
+
+  (try
+    {:cursor-keys (vec (js-keys (.-cursor vsc)))}
+    (catch js/Error e
+      {:cursor-gated? true
+       :error (.-message e)}))
+
+  {:mcp-keys (js-keys (.-mcp (.-cursor vsc)))
+   :plugin-keys (js-keys (.-plugins (.-cursor vsc)))
+   :register-server? (fn? (.-registerServer (.-mcp (.-cursor vsc))))}
+
+  {:joyride (ext-row "betterthantomorrow.joyride")
+   :backseat (ext-row "betterthantomorrow.calva-backseat-driver")
+   :agent-exec (ext-row "anysphere.cursor-agent-exec")}
+
+  (-> (.getCommands (.-commands vsc) true)
+      (.then (fn [cmds]
+               (def host-cmds
+                 (->> (js->clj cmds)
+                      (filter (fn [c]
+                                (or (.startsWith c "cursor-agent-exec.")
+                                    (.startsWith c "joyride.")
+                                    (re-find #"composer\.(new|send|start|create)" c))))
+                      sort
+                      vec))))
+      (.catch (fn [e]
+                (def host-cmds {:error (.-message e)}))))
+
+  host-cmds
+
+  ;; spawn candidates, not invoked here:
+  ;; composer.newAgentChat
+  ;; composer.sendToAgent
+  ;; composer.startComposerPrompt
+
+  (-> (.selectChatModels (.-lm vsc) #js {})
+      (.then (fn [models]
+               (def host-models
+                 (mapv (fn [m]
+                         {:id (.-id m)
+                          :vendor (.-vendor m)
+                          :family (.-family m)
+                          :name (.-name m)})
+                       models))))
+      (.catch (fn [e]
+                (def host-models {:error (.-message e)}))))
+
+  host-models
+
+  :rcf)

--- a/src/cljs-lib/fiddles/footing.cljs
+++ b/src/cljs-lib/fiddles/footing.cljs
@@ -1,0 +1,59 @@
+(ns fiddles.footing
+  (:require [calva.util :as util]))
+
+(comment
+  (do
+    (def vsc @util/vscode)
+    (def api (-> vsc .-extensions (.getExtension "betterthantomorrow.calva") .-exports))
+    (def v1 (.-v1 api)))
+
+  {:node-version (.-version js/process)
+   :cwd (js/process.cwd)
+   :extension-id (some-> @util/vscode-context .-extension .-id)
+   :extension-path (some-> @util/vscode-context .-extensionPath)
+   :extension-mode (some-> @util/vscode-context .-extensionMode)}
+
+  {:workspace-folders (mapv (fn [f]
+                              {:name (.-name f)
+                               :path (.-fsPath (.-uri f))})
+                            (.-workspaceFolders (.-workspace vsc)))
+   :active-file (some-> vsc .-window .-activeTextEditor .-document .-fileName)}
+
+  {:api-keys (js-keys api)
+   :v1-keys (js-keys v1)
+   :repl-keys (js-keys (.-repl v1))
+   :current-session-key (.currentSessionKey (.-repl v1))}
+
+  (js->clj (.listSessions (.-repl v1)) :keywordize-keys true)
+
+  (-> (.evaluate (.-repl v1)
+                 (str "{:ns (str *ns*)"
+                      " :clojure-version (clojure-version)"
+                      " :java-version (System/getProperty \"java.version\")"
+                      " :cwd (System/getProperty \"user.dir\")}")
+                 #js {:ns "user"
+                      :sessionKey "clj"
+                      :who "fiddle"
+                      :description "inner project identity"})
+      (.then (fn [r]
+               (def inner-footing (js->clj r :keywordize-keys true))))
+      (.catch (fn [e]
+                (def inner-footing {:error (.-message e)}))))
+
+  inner-footing
+
+  (-> (.evaluate (.-repl v1)
+                 "(require 'pez.pirate-lang) (pez.pirate-lang/to-pirate-talk \"Ahoy from the outer REPL\" pez.pirate-lang/english-o)"
+                 #js {:ns "user"
+                      :sessionKey "clj"
+                      :who "fiddle"
+                      :description "pirate-talk ping"})
+      (.then (fn [r]
+               (def pirate-talk (js->clj r :keywordize-keys true))))
+      (.catch (fn [e]
+                (def pirate-talk {:error (.-message e)}))))
+
+  pirate-talk
+  ;; last seen :result => "Ahohoyoy fofroromom tothohe outoteror RoREPoPLoL"
+
+  :rcf)

--- a/src/cljs-lib/fiddles/output_destinations.cljs
+++ b/src/cljs-lib/fiddles/output_destinations.cljs
@@ -1,0 +1,44 @@
+(ns fiddles.output-destinations
+  (:require [calva.util :as util]
+            [calva.repl.webview.core :as output-view]))
+
+(comment
+  (do
+    (def vsc @util/vscode)
+    (def api (-> vsc .-extensions (.getExtension "betterthantomorrow.calva") .-exports))
+    (def output-mod (js/require (str (.-extensionPath @util/vscode-context)
+                                     "/out/results-output/output"))))
+
+  (js->clj (.get (.getConfiguration (.-workspace vsc) "calva") "outputDestinations")
+           :keywordize-keys true)
+
+  (mapv (fn [t]
+          {:name (.-name t)
+           :exit-code (some-> t .-exitStatus .-code)
+           :exit-reason (some-> t .-exitStatus .-reason)})
+        (.. vsc -window -terminals))
+
+  {:title (some-> @output-view/output-view-webview-panel .-title)
+   :visible (some-> @output-view/output-view-webview-panel .-visible)}
+
+  (js->clj (.listSessions (.-repl (.-v1 api))) :keywordize-keys true)
+
+  (-> (.evaluate (.-repl (.-v1 api))
+                 "{:probe :fiddle :t (System/currentTimeMillis)}"
+                 #js {:ns "user"
+                      :sessionKey "clj"
+                      :who "fiddle"
+                      :description "fiddle pirate-lang ping"})
+      (.then (fn [r]
+               (def pirate-result (js->clj r :keywordize-keys true))))
+      (.catch (fn [e]
+                (def pirate-result {:error (.-message e)}))))
+
+  pirate-result
+
+  (.showOutputTerminal output-mod true)
+  (output-view/show-repl-output-webview-panel true)
+  (.appendClojureOther output-mod "fiddle ping")
+
+  :rcf)
+

--- a/src/cljs-lib/fiddles/output_heartbeat.clj
+++ b/src/cljs-lib/fiddles/output_heartbeat.clj
@@ -1,0 +1,51 @@
+(ns fiddles.output-heartbeat)
+
+(defn ping
+  "Writes a timestamp to *out* and returns it as the eval result."
+  []
+  (let [t (str (java.time.Instant/now))]
+    (println "evalOutput" t)
+    {:evalResults t}))
+
+(defonce !pinger
+  (atom {:future nil
+         :n 0
+         :started-at nil
+         :last-t nil}))
+
+(defn stop-pinger!
+  []
+  (when-let [f (:future @!pinger)]
+    (future-cancel f))
+  (swap! !pinger assoc :future nil)
+  :stopped)
+
+(defn start-pinger!
+  "Prints evalOutput beat N <instant> every 60 seconds."
+  []
+  (stop-pinger!)
+  (let [started (str (java.time.Instant/now))
+        f (future
+            (try
+              (loop []
+                (let [t (str (java.time.Instant/now))
+                      n (:n (swap! !pinger update :n inc))]
+                  (println "evalOutput beat" n t)
+                  (swap! !pinger assoc :last-t t)
+                  (Thread/sleep 60000)
+                  (recur)))
+              (catch InterruptedException _
+                :stopped)))]
+    (swap! !pinger assoc
+           :future f
+           :started-at started
+           :n 0
+           :last-t nil)
+    {:started-at started}))
+
+(comment
+  (ping)
+  (start-pinger!)
+  @!pinger
+  (stop-pinger!)
+  :rcf)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,6 +90,7 @@ async function activate(context: vscode.ExtensionContext) {
   cljsLib.initializeCljs(vscode, context);
 
   initializeState();
+  output.registerOutputTerminalLifecycle(context);
   state.setExtensionContext(context);
   state.initDepsEdnJackInExecutable();
   const isDramStart = await drams.dramStartConfigExists();

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -149,6 +149,23 @@ export const defaultDestinationConfiguration: OutputDestinationConfiguration = {
   otherOutput: 'repl-window',
 };
 
+let outputPTY: OutputTerminal | undefined;
+let outputTerminal: vscode.Terminal | undefined;
+
+function forgetOutputTerminal(pty?: OutputTerminal) {
+  if (pty !== undefined && outputPTY !== pty) {
+    return;
+  }
+  outputPTY = undefined;
+  outputTerminal = undefined;
+}
+
+function isOutputTerminalLive() {
+  return Boolean(
+    outputTerminal && !outputTerminal.exitStatus && vscode.window.terminals.includes(outputTerminal)
+  );
+}
+
 class OutputTerminal implements vscode.Pseudoterminal {
   private writeEmitter = new vscode.EventEmitter<string>();
   onDidWrite: vscode.Event<string> = this.writeEmitter.event;
@@ -182,23 +199,29 @@ Please consider sponsoring Calva: https://calva.io/sponsors ♥️
     this.writeEmitter.fire(message.replace(/\r?\n/g, '\r\n'));
   }
   close(): void {
-    outputPTY = undefined;
-    outputTerminal = undefined;
-    // TODO: Decide if we should just recreate the terminal like this
-    // getOutputPTY();
-    // It would still be emptied, so the win isn't that big.
+    forgetOutputTerminal(this);
   }
 }
 
-let outputPTY: OutputTerminal;
-let outputTerminal: vscode.Terminal;
-
 function getOutputPTY() {
+  if (outputPTY && !isOutputTerminalLive()) {
+    forgetOutputTerminal(outputPTY);
+  }
   if (!outputPTY) {
     outputPTY = new OutputTerminal();
     outputTerminal = vscode.window.createTerminal({ name: 'Calva Output', pty: outputPTY });
   }
   return outputPTY;
+}
+
+export function registerOutputTerminalLifecycle(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.window.onDidCloseTerminal((term) => {
+      if (term === outputTerminal) {
+        forgetOutputTerminal();
+      }
+    })
+  );
 }
 
 let outputChannel: vscode.OutputChannel;
@@ -211,10 +234,8 @@ export function showOutputChannel(preserveFocus = true) {
 }
 
 export function showOutputTerminal(preserveFocus = true) {
-  if (!outputTerminal) {
-    getOutputPTY();
-  }
-  outputTerminal.show(preserveFocus);
+  getOutputPTY();
+  outputTerminal?.show(preserveFocus);
 }
 
 export function showResultOutputDestination(preserveFocus = true) {


### PR DESCRIPTION
* Mitigating #3267

## What has changed?

When in Cursor and [the terminal output destination stops working](https://forum.cursor.com/t/output-to-vscode-pseudoterminal-stops-after-some-time-5-minutes-even-up-to-an-hour/169170), the `close` handler that Calva creates the terminal with also stops working. Which means that we do not recreate the terminal if the user closes it, so the only non-reload-everything workaround to get a working terminal output again is also lost. This change restores the workaround by:

- Changing how we check for “no output terminal”
- Adding a backup onDidCloseTerminal handler, that survives the Cursor bug


## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [ ] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

