### PR TITLE
3270 output view evaluation meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes to Calva.
   - Update default output destinations to all be `["terminal", "output-sidebar"]` (from `"terminal"`)
 - Output views (both variants): wrap **evalOutput** at view width, avoiding horizontal scroll of the view.
 - Output views (both variants): Add wrap toggle command for evaluated code and results
+- Fix: [The Output view isn't displaying evaluation meta](https://github.com/BetterThanTomorrow/calva/issues/3270)
 - Fix: [Terrible performance with large-ish numbers of cursors and
   paredit](https://github.com/BetterThanTomorrow/calva/issues/3268)
 - Fix: More stable way to recreate the Calva Output terminal after the tab is closed. Mitigation for [Output terminal stops outputting in Cursor](https://github.com/BetterThanTomorrow/calva/issues/3267)

--- a/repl-output-ui/css/main.css
+++ b/repl-output-ui/css/main.css
@@ -2,9 +2,22 @@
    padding-bottom: 5px;
 }
 
-pre[data-output-element-type="stdout"] {
+pre[data-output-element-type="stdout"],
+pre[data-output-element-type="evalOut"],
+pre[data-output-element-type="otherOut"],
+pre[data-output-element-type="evalErr"],
+pre[data-output-element-type="otherErr"] {
    white-space: pre-wrap;
    overflow-wrap: anywhere;
+}
+
+pre[data-output-element-type="otherOut"] {
+   color: var(--vscode-descriptionForeground, #858585);
+}
+
+pre[data-output-element-type="evalErr"],
+pre[data-output-element-type="otherErr"] {
+   color: var(--vscode-errorForeground, #f48771);
 }
 
 body.word-wrap code.hljs {

--- a/repl-output-ui/css/main.css
+++ b/repl-output-ui/css/main.css
@@ -49,3 +49,45 @@ body.word-wrap code.hljs {
    margin-left: 10px;
    background-color: var(--vscode-editor-background);
 }
+
+.ns-info-container {
+   display: flex;
+   align-items: center;
+   gap: 4px;
+   margin-top: 14px;
+   margin-bottom: 2px;
+   font-family: var(--vscode-editor-font-family, monospace);
+   font-size: var(--vscode-editor-font-size, 12px);
+   line-height: 1.2;
+}
+
+.ns-info-prefix {
+   color: var(--vscode-editorLineNumber-foreground, #858585);
+   margin-right: 2px;
+   font-weight: bold;
+}
+
+.ns-info-badge {
+   padding: 1px 6px;
+   border-radius: 2px;
+   font-size: 0.9em;
+   white-space: nowrap;
+   border: 1px solid var(--vscode-contrastBorder, transparent);
+}
+
+.ns-info-who {
+   background-color: #00bcd4;
+   color: #000000;
+   font-weight: 500;
+}
+
+.ns-info-session {
+   background-color: var(--vscode-badge-background, #4d4d4d);
+   color: var(--vscode-badge-foreground, #ffffff);
+}
+
+.ns-info-ns {
+   background-color: var(--vscode-editor-foreground, #cccccc);
+   color: var(--vscode-editor-background, #1e1e1e);
+   font-weight: 500;
+}

--- a/src/cljs-lib/src/calva/repl/webview/app_db.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/app_db.cljs
@@ -13,7 +13,7 @@
      :uf/fxs [[:fx/clear-dom]]}
 
     :msg/output
-    (let [{:keys [command/name output meta]} payload
+    (let [{:keys [command/name output meta output-category]} payload
           {:meta/keys [ns who repl-session-key shadow-build shadow-runtime-id]} meta
           ns (or ns (:ns meta))
           who (or who (:who meta))
@@ -28,7 +28,7 @@
                  context-changed? (conj [:fx/append-ns-info meta])
                  (= name "show-result") (conj [:fx/append-result output])
                  (= name "show-evaluated-code") (conj [:fx/append-evaluated-code output])
-                 (= name "show-stdout") (conj [:fx/append-stdout output]))})
+                 (= name "show-stdout") (conj [:fx/append-stdout output (or output-category "evalOut")]))})
 
     :msg/set-code-theme
     {:uf/db db

--- a/src/cljs-lib/src/calva/repl/webview/app_db.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/app_db.cljs
@@ -5,10 +5,41 @@
 
 (defonce !app-db (atom initial-db))
 
-(defn set-last-context
-  [db context]
-  (assoc db :output/last-context context))
+(defn handle-action
+  [db [action-type payload]]
+  (case action-type
+    :msg/clear-output-view
+    {:uf/db  (assoc db :output/last-context nil)
+     :uf/fxs [[:fx/clear-dom]]}
 
-(defn clear-last-context
-  [db]
-  (assoc db :output/last-context nil))
+    :msg/output
+    (let [{:keys [command/name output meta]} payload
+          {:meta/keys [ns who repl-session-key shadow-build shadow-runtime-id]} meta
+          ns (or ns (:ns meta))
+          who (or who (:who meta))
+          repl-session-key (or repl-session-key (:repl-session-key meta))
+          shadow-build (or shadow-build (:shadow-build meta))
+          shadow-runtime-id (or shadow-runtime-id (:shadow-runtime-id meta))
+          context-key (when ns [who repl-session-key shadow-build shadow-runtime-id ns])
+          context-changed? (and context-key (not= context-key (:output/last-context db)))]
+      {:uf/db  (cond-> db
+                 context-changed? (assoc :output/last-context context-key))
+       :uf/fxs (cond-> []
+                 context-changed? (conj [:fx/append-ns-info meta])
+                 (= name "show-result") (conj [:fx/append-result output])
+                 (= name "show-evaluated-code") (conj [:fx/append-evaluated-code output])
+                 (= name "show-stdout") (conj [:fx/append-stdout output]))})
+
+    :msg/set-code-theme
+    {:uf/db db
+     :uf/fxs [[:fx/set-code-theme (:code-theme payload)]]}
+
+    :msg/set-word-wrap
+    {:uf/db db
+     :uf/fxs [[:fx/set-word-wrap (:word-wrap payload)]]}
+
+    :msg/scroll-to
+    {:uf/db db
+     :uf/fxs [[:fx/scroll-to payload]]}
+
+    {:uf/db db}))

--- a/src/cljs-lib/src/calva/repl/webview/app_db.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/app_db.cljs
@@ -1,0 +1,14 @@
+(ns calva.repl.webview.app-db)
+
+(def initial-db
+  {:output/last-context nil})
+
+(defonce !app-db (atom initial-db))
+
+(defn set-last-context
+  [db context]
+  (assoc db :output/last-context context))
+
+(defn clear-last-context
+  [db]
+  (assoc db :output/last-context nil))

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -322,13 +322,35 @@
    "otherErr" "show-stdout"
    "clojure" "show-result"})
 
+(defn options->meta
+  [^js options]
+  (when options
+    (let [who (or (and (map? options) (:who options))
+                  (and (some? options) (.-who options)))
+          ns (or (and (map? options) (:ns options))
+                 (and (some? options) (.-ns options)))
+          repl-session-key (or (and (map? options) (or (:replSessionKey options) (:replSessionType options) (:repl-session-key options) (:repl-session-type options)))
+                               (and (some? options) (or (.-replSessionKey options) (.-replSessionType options))))
+          shadow-build (or (and (map? options) (or (:shadowBuild options) (:shadow-build options)))
+                           (and (some? options) (.-shadowBuild options)))
+          shadow-runtime-id (or (and (map? options) (or (:shadowRuntimeId options) (:shadow-runtime-id options)))
+                                (and (some? options) (.-shadowRuntimeId options)))]
+      (cond-> {}
+        who (assoc :who who)
+        ns (assoc :ns ns)
+        repl-session-key (assoc :repl-session-key repl-session-key)
+        shadow-build (assoc :shadow-build shadow-build)
+        (some? shadow-runtime-id) (assoc :shadow-runtime-id shadow-runtime-id)))))
+
 (defn ^:export append
   [^js options message]
-  (let [output-category (.-outputCategory options)
-        command-name (get output-category->command-name output-category)]
+  (let [output-category (if (map? options) (:outputCategory options) (.-outputCategory options))
+        command-name (get output-category->command-name output-category)
+        meta-data (options->meta options)]
     (if command-name
-      (post-message-to-webview (ensure-output-view-panel) {:command/name command-name
-                                                           :output message})
+      (post-message-to-webview (ensure-output-view-panel) (cond-> {:command/name command-name
+                                                                   :output message}
+                                                            (seq meta-data) (assoc :meta meta-data)))
       (util/log-to-console
        :error
        (str "Cannot append output to output webview. No outputCategory matches \"" output-category "\"")))))

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -325,22 +325,31 @@
 (defn options->meta
   [^js options]
   (when options
-    (let [who (or (and (map? options) (:who options))
+    (let [who (or (and (map? options) (or (:meta/who options) (:who options)))
                   (and (some? options) (.-who options)))
-          ns (or (and (map? options) (:ns options))
+          ns (or (and (map? options) (or (:meta/ns options) (:ns options)))
                  (and (some? options) (.-ns options)))
-          repl-session-key (or (and (map? options) (or (:replSessionKey options) (:replSessionType options) (:repl-session-key options) (:repl-session-type options)))
+          repl-session-key (or (and (map? options) (or (:meta/repl-session-key options)
+                                                       (:meta/repl-session-type options)
+                                                       (:replSessionKey options)
+                                                       (:replSessionType options)
+                                                       (:repl-session-key options)
+                                                       (:repl-session-type options)))
                                (and (some? options) (or (.-replSessionKey options) (.-replSessionType options))))
-          shadow-build (or (and (map? options) (or (:shadowBuild options) (:shadow-build options)))
+          shadow-build (or (and (map? options) (or (:meta/shadow-build options)
+                                                   (:shadowBuild options)
+                                                   (:shadow-build options)))
                            (and (some? options) (.-shadowBuild options)))
-          shadow-runtime-id (or (and (map? options) (or (:shadowRuntimeId options) (:shadow-runtime-id options)))
+          shadow-runtime-id (or (and (map? options) (or (:meta/shadow-runtime-id options)
+                                                        (:shadowRuntimeId options)
+                                                        (:shadow-runtime-id options)))
                                 (and (some? options) (.-shadowRuntimeId options)))]
       (cond-> {}
-        who (assoc :who who)
-        ns (assoc :ns ns)
-        repl-session-key (assoc :repl-session-key repl-session-key)
-        shadow-build (assoc :shadow-build shadow-build)
-        (some? shadow-runtime-id) (assoc :shadow-runtime-id shadow-runtime-id)))))
+        who (assoc :meta/who who)
+        ns (assoc :meta/ns ns)
+        repl-session-key (assoc :meta/repl-session-key repl-session-key)
+        shadow-build (assoc :meta/shadow-build shadow-build)
+        (some? shadow-runtime-id) (assoc :meta/shadow-runtime-id shadow-runtime-id)))))
 
 (defn ^:export append
   [^js options message]

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -358,6 +358,7 @@
         meta-data (options->meta options)]
     (if command-name
       (post-message-to-webview (ensure-output-view-panel) (cond-> {:command/name command-name
+                                                                   :output-category output-category
                                                                    :output message}
                                                             (seq meta-data) (assoc :meta meta-data)))
       (util/log-to-console
@@ -388,6 +389,7 @@
   (let [stacktrace (js->clj stacktrace :keywordize-keys true)
         stacktrace-message (stacktrace->message stacktrace)]
     (post-message-to-webview (ensure-output-view-panel) {:command/name "show-stdout"
+                                                         :output-category "evalErr"
                                                          :output stacktrace-message})))
 
 (defn ^:export clear-output-view

--- a/src/cljs-lib/src/calva/repl/webview/sidebar.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/sidebar.cljs
@@ -140,11 +140,13 @@
 
 (defn ^:export append
   [^js options message]
-  (let [output-category (.-outputCategory options)
-        command-name (get core/output-category->command-name output-category)]
+  (let [output-category (if (map? options) (:outputCategory options) (.-outputCategory options))
+        command-name (get core/output-category->command-name output-category)
+        meta-data (core/options->meta options)]
     (if command-name
-      (add-output-sidebar-message! {:command/name command-name
-                                    :output message})
+      (add-output-sidebar-message! (cond-> {:command/name command-name
+                                            :output message}
+                                     (seq meta-data) (assoc :meta meta-data)))
       (util/log-to-console
        :error
        (str "Cannot append output to output sidebar. No outputCategory matches \"" output-category "\"")))))

--- a/src/cljs-lib/src/calva/repl/webview/sidebar.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/sidebar.cljs
@@ -145,6 +145,7 @@
         meta-data (core/options->meta options)]
     (if command-name
       (add-output-sidebar-message! (cond-> {:command/name command-name
+                                            :output-category output-category
                                             :output message}
                                      (seq meta-data) (assoc :meta meta-data)))
       (util/log-to-console
@@ -155,6 +156,7 @@
   [^js stacktrace]
   (add-output-sidebar-message!
    {:command/name "show-stdout"
+    :output-category "evalErr"
     :output (core/stacktrace->message (js->clj stacktrace :keywordize-keys true))}))
 
 (defn ^:export clear-output-sidebar

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -91,25 +91,26 @@
 
 (defn create-and-append-stdout-element
   "Creates a new stdout element and appends it to the given DOM element."
-  [dom-element text-node]
+  [dom-element text-node category]
   (let [pre-element (js/document.createElement "pre")]
     (.. pre-element (appendChild text-node))
-    (.. pre-element (setAttribute "data-output-element-type" "stdout"))
+    (.. pre-element (setAttribute "data-output-element-type" (or category "evalOut")))
     (.. dom-element (appendChild pre-element))
     (.. dom-element (dispatchEvent (output-appended-event pre-element)))))
 
 (defn append-stdout
-  "Appends stdout content to the given DOM element, unless the last element is already a stdout element,
+  "Appends stdout content to the given DOM element, unless the last element is already a stdout element with the same category,
    in which case it appends the content to that element instead."
-  [^js dom-element output]
-  (let [text-node (js/document.createTextNode (strip-ansi output))]
+  [^js dom-element output category]
+  (let [category (or category "evalOut")
+        text-node (js/document.createTextNode (strip-ansi output))]
     (if-let [last-output-element (.. dom-element -lastElementChild)]
-      (if (= "stdout" (.. last-output-element -dataset -outputElementType))
+      (if (= category (.. last-output-element -dataset -outputElementType))
         (do
           (.. last-output-element (appendChild text-node))
           (.. dom-element (dispatchEvent (output-appended-event last-output-element))))
-        (create-and-append-stdout-element dom-element text-node))
-      (create-and-append-stdout-element dom-element text-node))))
+        (create-and-append-stdout-element dom-element text-node category))
+      (create-and-append-stdout-element dom-element text-node category))))
 
 (defn session-str
   [{:meta/keys [repl-session-key shadow-build shadow-runtime-id]}]
@@ -198,7 +199,7 @@
     :fx/append-ns-info (append-ns-info output-dom-element (first args))
     :fx/append-result (append-eval-result output-dom-element (first args))
     :fx/append-evaluated-code (append-evaluated-code output-dom-element (first args))
-    :fx/append-stdout (append-stdout output-dom-element (first args))
+    :fx/append-stdout (append-stdout output-dom-element (first args) (second args))
     :fx/clear-dom (clear-output-dom output-dom-element)
     :fx/set-code-theme (set-code-theme! (first args))
     :fx/set-word-wrap (set-word-wrap! (first args))

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -68,7 +68,7 @@
 
 (defn append-evaluated-code
   "Appends evaluated code to the given dom element."
-  [^js dom-element {:keys [output]}]
+  [^js dom-element output]
   (let [div (js/document.createElement "div")
         span (js/document.createElement "span")
         span-text-node (js/document.createTextNode "Evaluated code")
@@ -83,7 +83,7 @@
     (.. dom-element (dispatchEvent (output-appended-event div)))))
 
 (defn append-eval-result
-  [^js dom-element {:keys [output]}]
+  [^js dom-element output]
   (let [{:keys [code-element container-element]} (clojure-code-element output)]
     (.. dom-element (appendChild container-element))
     (.. hljs (highlightElement code-element))
@@ -101,7 +101,7 @@
 (defn append-stdout
   "Appends stdout content to the given DOM element, unless the last element is already a stdout element,
    in which case it appends the content to that element instead."
-  [^js dom-element {:keys [output]}]
+  [^js dom-element output]
   (let [text-node (js/document.createTextNode (strip-ansi output))]
     (if-let [last-output-element (.. dom-element -lastElementChild)]
       (if (= "stdout" (.. last-output-element -dataset -outputElementType))
@@ -146,23 +146,14 @@
         (.. container (appendChild ns-badge))))
     container))
 
-(defn maybe-append-ns-info
-  [^js dom-element !app-db {:output/keys [last-context]} {:keys [meta]}]
-  (when-let [ns (or (:meta/ns meta) (:ns meta))]
-    (let [who (or (:meta/who meta) (:who meta))
-          repl-session-key (or (:meta/repl-session-key meta) (:repl-session-key meta))
-          shadow-build (or (:meta/shadow-build meta) (:shadow-build meta))
-          shadow-runtime-id (or (:meta/shadow-runtime-id meta) (:shadow-runtime-id meta))
-          context-key [who repl-session-key shadow-build shadow-runtime-id ns]]
-      (when (not= context-key last-context)
-        (swap! !app-db app-db/set-last-context context-key)
-        (let [ns-info-el (create-ns-info-element meta)]
-          (.. dom-element (appendChild ns-info-el))
-          (.. dom-element (dispatchEvent (output-appended-event ns-info-el))))))))
+(defn append-ns-info
+  [^js dom-element meta-data]
+  (let [ns-info-el (create-ns-info-element meta-data)]
+    (.. dom-element (appendChild ns-info-el))
+    (.. dom-element (dispatchEvent (output-appended-event ns-info-el)))))
 
-(defn ^:export clear-output-view
-  [^js output-dom-element !app-db]
-  (swap! !app-db app-db/clear-last-context)
+(defn clear-output-dom
+  [^js output-dom-element]
   (set! (.-innerHTML output-dom-element) ""))
 
 (defn update-theme-of-copy-buttons
@@ -180,7 +171,7 @@
                    (.. copy-container-node -style (setProperty "--hljs-theme-padding" code-padding)))))))
 
 (defn set-code-theme!
-  [{:keys [code-theme]}]
+  [code-theme]
   (let [code-theme-link-nodes (js/document.querySelectorAll "[data-code-theme]")]
     (.. code-theme-link-nodes (forEach (fn [^js node]
                                          (let [current-code-theme (.. node -dataset -codeTheme)]
@@ -191,7 +182,7 @@
     (js/setTimeout update-theme-of-copy-buttons 100)))
 
 (defn set-word-wrap!
-  [{:keys [word-wrap]}]
+  [word-wrap]
   (let [body js/document.body]
     (if word-wrap
       (.. body -classList (add "word-wrap"))
@@ -201,39 +192,58 @@
   [{:keys [x y]}]
   (js/scrollTo x y))
 
+(declare dispatch!)
+
+(defn exec-effect!
+  [^js output-dom-element [fx-type & args]]
+  (case fx-type
+    :fx/append-ns-info (append-ns-info output-dom-element (first args))
+    :fx/append-result (append-eval-result output-dom-element (first args))
+    :fx/append-evaluated-code (append-evaluated-code output-dom-element (first args))
+    :fx/append-stdout (append-stdout output-dom-element (first args))
+    :fx/clear-dom (clear-output-dom output-dom-element)
+    :fx/set-code-theme (set-code-theme! (first args))
+    :fx/set-word-wrap (set-word-wrap! (first args))
+    :fx/scroll-to (scroll-to (first args))))
+
+(defn dispatch!
+  [action]
+  (let [current-db @app-db/!app-db
+        {:uf/keys [db fxs dxs]} (app-db/handle-action current-db action)]
+    (when (and db (not= db current-db))
+      (reset! app-db/!app-db db))
+    (run! #(exec-effect! output-dom-element %) fxs)
+    (run! dispatch! dxs)))
+
+(defn ^:export clear-output-view
+  []
+  (dispatch! [:msg/clear-output-view]))
+
 (defn handle-message
-  [^js output-dom-element !app-db ^js message]
+  [^js message]
   (ensure-dom-content-loaded
    (fn []
      (let [message-data (reader/read-string (.-data message))
-           command-name (:command/name message-data)
-           db @!app-db]
+           command-name (:command/name message-data)]
        (case command-name
-         "show-result" (do
-                         (maybe-append-ns-info output-dom-element !app-db db message-data)
-                         (append-eval-result output-dom-element message-data))
-         "show-evaluated-code" (do
-                                 (maybe-append-ns-info output-dom-element !app-db db message-data)
-                                 (append-evaluated-code output-dom-element message-data))
-         "show-stdout" (do
-                         (maybe-append-ns-info output-dom-element !app-db db message-data)
-                         (append-stdout output-dom-element message-data))
-         "clear-output-view" (clear-output-view output-dom-element !app-db)
-         "set-code-theme" (set-code-theme! message-data)
-         "set-word-wrap" (set-word-wrap! message-data)
-         "scroll-to" (scroll-to message-data))))))
+         "clear-output-view" (dispatch! [:msg/clear-output-view])
+         "set-code-theme"    (dispatch! [:msg/set-code-theme message-data])
+         "set-word-wrap"     (dispatch! [:msg/set-word-wrap message-data])
+         "scroll-to"         (dispatch! [:msg/scroll-to message-data])
+         ("show-result" "show-evaluated-code" "show-stdout")
+         (dispatch! [:msg/output message-data]))))))
 
 (defn handle-output-appended
   [^js _event]
   (throttled-scroll-to-bottom))
 
 (defn add-event-listeners
-  [^js output-dom-element !app-db]
-  (.. js/window (addEventListener "message" (partial handle-message output-dom-element !app-db)))
+  [^js output-dom-element]
+  (.. js/window (addEventListener "message" handle-message))
   (.. output-dom-element (addEventListener "output-appended" handle-output-appended)))
 
 (defn ^:export main []
-  (add-event-listeners output-dom-element app-db/!app-db)
+  (add-event-listeners output-dom-element)
   (.. hljs (registerLanguage "clojure" clojure))
   (ensure-dom-content-loaded (fn []
                                (.. hljs (addPlugin (CopyButtonPlugin. #js {:autohide true}))))))

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -123,13 +123,9 @@
 (defn create-ns-info-element
   [{:meta/keys [who ns] :as meta-data}]
   (let [container (js/document.createElement "div")
-        prefix (js/document.createElement "span")
         sess (session-str meta-data)]
     (.. container -classList (add "ns-info-container"))
     (.. container (setAttribute "data-output-element-type" "ns-info"))
-    (.. prefix -classList (add "ns-info-prefix"))
-    (.. prefix (appendChild (js/document.createTextNode ";")))
-    (.. container (appendChild prefix))
     (when (and who (not= who "ui"))
       (let [who-badge (js/document.createElement "span")]
         (.. who-badge -classList (add "ns-info-badge" "ns-info-who"))

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -1,5 +1,6 @@
 (ns calva.repl.webview.ui
   (:require
+   [calva.repl.webview.app-db :as app-db]
    [cljs.reader :as reader]
    [clojure.string :as str]
    ["strip-ansi" :default strip-ansi]
@@ -9,8 +10,6 @@
 
 ;; The DOM element where output is written
 (def output-dom-element (js/document.getElementById "output"))
-
-(defonce last-context (atom nil))
 
 (defn ensure-dom-content-loaded
   "Ensures the DOM is ready before executing the callback"
@@ -113,7 +112,7 @@
       (create-and-append-stdout-element dom-element text-node))))
 
 (defn session-str
-  [{:keys [repl-session-key shadow-build shadow-runtime-id]}]
+  [{:meta/keys [repl-session-key shadow-build shadow-runtime-id]}]
   (let [parts (cond-> []
                 repl-session-key (conj (str repl-session-key))
                 shadow-build (conj (str shadow-build))
@@ -121,7 +120,7 @@
     (str/join " " parts)))
 
 (defn create-ns-info-element
-  [{:keys [who ns] :as meta-data}]
+  [{:meta/keys [who ns] :as meta-data}]
   (let [container (js/document.createElement "div")
         prefix (js/document.createElement "span")
         sess (session-str meta-data)]
@@ -148,18 +147,22 @@
     container))
 
 (defn maybe-append-ns-info
-  [^js dom-element {:keys [meta]}]
-  (when-let [ns (:ns meta)]
-    (let [context-key [(:who meta) (:repl-session-key meta) (:shadow-build meta) (:shadow-runtime-id meta) ns]]
-      (when (not= context-key @last-context)
-        (reset! last-context context-key)
+  [^js dom-element !app-db {:output/keys [last-context]} {:keys [meta]}]
+  (when-let [ns (or (:meta/ns meta) (:ns meta))]
+    (let [who (or (:meta/who meta) (:who meta))
+          repl-session-key (or (:meta/repl-session-key meta) (:repl-session-key meta))
+          shadow-build (or (:meta/shadow-build meta) (:shadow-build meta))
+          shadow-runtime-id (or (:meta/shadow-runtime-id meta) (:shadow-runtime-id meta))
+          context-key [who repl-session-key shadow-build shadow-runtime-id ns]]
+      (when (not= context-key last-context)
+        (swap! !app-db app-db/set-last-context context-key)
         (let [ns-info-el (create-ns-info-element meta)]
           (.. dom-element (appendChild ns-info-el))
           (.. dom-element (dispatchEvent (output-appended-event ns-info-el))))))))
 
 (defn ^:export clear-output-view
-  [^js output-dom-element]
-  (reset! last-context nil)
+  [^js output-dom-element !app-db]
+  (swap! !app-db app-db/clear-last-context)
   (set! (.-innerHTML output-dom-element) ""))
 
 (defn update-theme-of-copy-buttons
@@ -199,22 +202,23 @@
   (js/scrollTo x y))
 
 (defn handle-message
-  [^js output-dom-element ^js message]
+  [^js output-dom-element !app-db ^js message]
   (ensure-dom-content-loaded
    (fn []
      (let [message-data (reader/read-string (.-data message))
-           command-name (:command/name message-data)]
+           command-name (:command/name message-data)
+           db @!app-db]
        (case command-name
          "show-result" (do
-                         (maybe-append-ns-info output-dom-element message-data)
+                         (maybe-append-ns-info output-dom-element !app-db db message-data)
                          (append-eval-result output-dom-element message-data))
          "show-evaluated-code" (do
-                                 (maybe-append-ns-info output-dom-element message-data)
+                                 (maybe-append-ns-info output-dom-element !app-db db message-data)
                                  (append-evaluated-code output-dom-element message-data))
          "show-stdout" (do
-                         (maybe-append-ns-info output-dom-element message-data)
+                         (maybe-append-ns-info output-dom-element !app-db db message-data)
                          (append-stdout output-dom-element message-data))
-         "clear-output-view" (clear-output-view output-dom-element)
+         "clear-output-view" (clear-output-view output-dom-element !app-db)
          "set-code-theme" (set-code-theme! message-data)
          "set-word-wrap" (set-word-wrap! message-data)
          "scroll-to" (scroll-to message-data))))))
@@ -224,12 +228,12 @@
   (throttled-scroll-to-bottom))
 
 (defn add-event-listeners
-  [^js output-dom-element]
-  (.. js/window (addEventListener "message" (partial handle-message output-dom-element)))
+  [^js output-dom-element !app-db]
+  (.. js/window (addEventListener "message" (partial handle-message output-dom-element !app-db)))
   (.. output-dom-element (addEventListener "output-appended" handle-output-appended)))
 
 (defn ^:export main []
-  (add-event-listeners output-dom-element)
+  (add-event-listeners output-dom-element app-db/!app-db)
   (.. hljs (registerLanguage "clojure" clojure))
   (ensure-dom-content-loaded (fn []
                                (.. hljs (addPlugin (CopyButtonPlugin. #js {:autohide true}))))))

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -1,6 +1,7 @@
 (ns calva.repl.webview.ui
   (:require
    [cljs.reader :as reader]
+   [clojure.string :as str]
    ["strip-ansi" :default strip-ansi]
    ["highlightjs-copy" :as CopyButtonPlugin]
    ["highlight.js/lib/core" :as hljs]
@@ -8,6 +9,8 @@
 
 ;; The DOM element where output is written
 (def output-dom-element (js/document.getElementById "output"))
+
+(defonce last-context (atom nil))
 
 (defn ensure-dom-content-loaded
   "Ensures the DOM is ready before executing the callback"
@@ -109,8 +112,54 @@
         (create-and-append-stdout-element dom-element text-node))
       (create-and-append-stdout-element dom-element text-node))))
 
+(defn session-str
+  [{:keys [repl-session-key shadow-build shadow-runtime-id]}]
+  (let [parts (cond-> []
+                repl-session-key (conj (str repl-session-key))
+                shadow-build (conj (str shadow-build))
+                (some? shadow-runtime-id) (conj (str shadow-runtime-id)))]
+    (str/join " " parts)))
+
+(defn create-ns-info-element
+  [{:keys [who ns] :as meta-data}]
+  (let [container (js/document.createElement "div")
+        prefix (js/document.createElement "span")
+        sess (session-str meta-data)]
+    (.. container -classList (add "ns-info-container"))
+    (.. container (setAttribute "data-output-element-type" "ns-info"))
+    (.. prefix -classList (add "ns-info-prefix"))
+    (.. prefix (appendChild (js/document.createTextNode ";")))
+    (.. container (appendChild prefix))
+    (when (and who (not= who "ui"))
+      (let [who-badge (js/document.createElement "span")]
+        (.. who-badge -classList (add "ns-info-badge" "ns-info-who"))
+        (.. who-badge (appendChild (js/document.createTextNode who)))
+        (.. container (appendChild who-badge))))
+    (when (seq sess)
+      (let [sess-badge (js/document.createElement "span")]
+        (.. sess-badge -classList (add "ns-info-badge" "ns-info-session"))
+        (.. sess-badge (appendChild (js/document.createTextNode sess)))
+        (.. container (appendChild sess-badge))))
+    (when ns
+      (let [ns-badge (js/document.createElement "span")]
+        (.. ns-badge -classList (add "ns-info-badge" "ns-info-ns"))
+        (.. ns-badge (appendChild (js/document.createTextNode ns)))
+        (.. container (appendChild ns-badge))))
+    container))
+
+(defn maybe-append-ns-info
+  [^js dom-element {:keys [meta]}]
+  (when-let [ns (:ns meta)]
+    (let [context-key [(:who meta) (:repl-session-key meta) (:shadow-build meta) (:shadow-runtime-id meta) ns]]
+      (when (not= context-key @last-context)
+        (reset! last-context context-key)
+        (let [ns-info-el (create-ns-info-element meta)]
+          (.. dom-element (appendChild ns-info-el))
+          (.. dom-element (dispatchEvent (output-appended-event ns-info-el))))))))
+
 (defn ^:export clear-output-view
   [^js output-dom-element]
+  (reset! last-context nil)
   (set! (.-innerHTML output-dom-element) ""))
 
 (defn update-theme-of-copy-buttons
@@ -156,9 +205,15 @@
      (let [message-data (reader/read-string (.-data message))
            command-name (:command/name message-data)]
        (case command-name
-         "show-result" (append-eval-result output-dom-element message-data)
-         "show-evaluated-code" (append-evaluated-code output-dom-element message-data)
-         "show-stdout" (append-stdout output-dom-element message-data)
+         "show-result" (do
+                         (maybe-append-ns-info output-dom-element message-data)
+                         (append-eval-result output-dom-element message-data))
+         "show-evaluated-code" (do
+                                 (maybe-append-ns-info output-dom-element message-data)
+                                 (append-evaluated-code output-dom-element message-data))
+         "show-stdout" (do
+                         (maybe-append-ns-info output-dom-element message-data)
+                         (append-stdout output-dom-element message-data))
          "clear-output-view" (clear-output-view output-dom-element)
          "set-code-theme" (set-code-theme! message-data)
          "set-word-wrap" (set-word-wrap! message-data)

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -192,8 +192,6 @@
   [{:keys [x y]}]
   (js/scrollTo x y))
 
-(declare dispatch!)
-
 (defn exec-effect!
   [^js output-dom-element [fx-type & args]]
   (case fx-type

--- a/src/cljs-lib/test/calva/repl/webview/app_db_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/app_db_test.cljs
@@ -31,6 +31,16 @@
       (is (= ["tester" "clj" nil nil "my.ns"] (get-in result [:uf/db :output/last-context])))
       (is (= [[:fx/append-result "42"]] (:uf/fxs result)))))
 
+  (testing ":msg/output show-stdout with an output-category"
+    (let [payload {:command/name "show-stdout" :output "text" :output-category "otherOut"}
+          result (sut/handle-action sut/initial-db [:msg/output payload])]
+      (is (= [[:fx/append-stdout "text" "otherOut"]] (:uf/fxs result)))))
+
+  (testing ":msg/output show-stdout without an output-category defaults to evalOut"
+    (let [payload {:command/name "show-stdout" :output "text"}
+          result (sut/handle-action sut/initial-db [:msg/output payload])]
+      (is (= [[:fx/append-stdout "text" "evalOut"]] (:uf/fxs result)))))
+
   (testing ":msg/set-code-theme"
     (let [result (sut/handle-action sut/initial-db [:msg/set-code-theme {:code-theme "dark"}])]
       (is (= sut/initial-db (:uf/db result)))

--- a/src/cljs-lib/test/calva/repl/webview/app_db_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/app_db_test.cljs
@@ -1,0 +1,16 @@
+(ns calva.repl.webview.app-db-test
+  (:require
+   [calva.repl.webview.app-db :as sut]
+   [cljs.test :refer-macros [deftest testing is]]))
+
+(deftest app-db-test
+  (testing "initial-db has nil :output/last-context"
+    (is (nil? (:output/last-context sut/initial-db))))
+  (testing "set-last-context updates :output/last-context"
+    (let [ctx ["who" "session" "build" 1 "my.ns"]
+          updated (sut/set-last-context sut/initial-db ctx)]
+      (is (= ctx (:output/last-context updated)))))
+  (testing "clear-last-context sets :output/last-context to nil"
+    (let [db {:output/last-context ["who" "session" "build" 1 "my.ns"]}
+          cleared (sut/clear-last-context db)]
+      (is (nil? (:output/last-context cleared))))))

--- a/src/cljs-lib/test/calva/repl/webview/app_db_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/app_db_test.cljs
@@ -3,14 +3,45 @@
    [calva.repl.webview.app-db :as sut]
    [cljs.test :refer-macros [deftest testing is]]))
 
-(deftest app-db-test
+(deftest initial-db-test
   (testing "initial-db has nil :output/last-context"
-    (is (nil? (:output/last-context sut/initial-db))))
-  (testing "set-last-context updates :output/last-context"
-    (let [ctx ["who" "session" "build" 1 "my.ns"]
-          updated (sut/set-last-context sut/initial-db ctx)]
-      (is (= ctx (:output/last-context updated)))))
-  (testing "clear-last-context sets :output/last-context to nil"
+    (is (nil? (:output/last-context sut/initial-db)))))
+
+(deftest handle-action-test
+  (testing ":msg/clear-output-view action"
     (let [db {:output/last-context ["who" "session" "build" 1 "my.ns"]}
-          cleared (sut/clear-last-context db)]
-      (is (nil? (:output/last-context cleared))))))
+          result (sut/handle-action db [:msg/clear-output-view])]
+      (is (nil? (get-in result [:uf/db :output/last-context])))
+      (is (= [[:fx/clear-dom]] (:uf/fxs result)))))
+
+  (testing ":msg/output with new context"
+    (let [meta {:meta/who "tester" :meta/ns "my.ns" :meta/repl-session-key "clj"}
+          payload {:command/name "show-result" :output "42" :meta meta}
+          result (sut/handle-action sut/initial-db [:msg/output payload])]
+      (is (= ["tester" "clj" nil nil "my.ns"] (get-in result [:uf/db :output/last-context])))
+      (is (= [[:fx/append-ns-info meta]
+              [:fx/append-result "42"]]
+             (:uf/fxs result)))))
+
+  (testing ":msg/output with unchanged context"
+    (let [meta {:meta/who "tester" :meta/ns "my.ns" :meta/repl-session-key "clj"}
+          db {:output/last-context ["tester" "clj" nil nil "my.ns"]}
+          payload {:command/name "show-result" :output "42" :meta meta}
+          result (sut/handle-action db [:msg/output payload])]
+      (is (= ["tester" "clj" nil nil "my.ns"] (get-in result [:uf/db :output/last-context])))
+      (is (= [[:fx/append-result "42"]] (:uf/fxs result)))))
+
+  (testing ":msg/set-code-theme"
+    (let [result (sut/handle-action sut/initial-db [:msg/set-code-theme {:code-theme "dark"}])]
+      (is (= sut/initial-db (:uf/db result)))
+      (is (= [[:fx/set-code-theme "dark"]] (:uf/fxs result)))))
+
+  (testing ":msg/set-word-wrap"
+    (let [result (sut/handle-action sut/initial-db [:msg/set-word-wrap {:word-wrap true}])]
+      (is (= sut/initial-db (:uf/db result)))
+      (is (= [[:fx/set-word-wrap true]] (:uf/fxs result)))))
+
+  (testing ":msg/scroll-to"
+    (let [result (sut/handle-action sut/initial-db [:msg/scroll-to {:x 0 :y 100}])]
+      (is (= sut/initial-db (:uf/db result)))
+      (is (= [[:fx/scroll-to {:x 0 :y 100}]] (:uf/fxs result))))))

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -355,6 +355,40 @@
         (testing "should call set-code-theme! with expected args"
           (is (spy/called-once-with? set-code-theme!-spy expected-context expected-theme-args)))))))
 
+(deftest options->meta-test
+  (testing "Given nil options, should return nil"
+    (is (nil? (sut/options->meta nil))))
+  (testing "Given a map of options with only :who, should return a map with only :who"
+    (is (= {:who "repl"}
+           (sut/options->meta {:who "repl"}))))
+  (testing "Given a map of options with all supported keys, should return the expected map"
+    (is (= {:who "repl"
+            :ns "user"
+            :repl-session-key "clj"
+            :shadow-build "app"
+            :shadow-runtime-id 1}
+           (sut/options->meta {:who "repl"
+                               :ns "user"
+                               :replSessionKey "clj"
+                               :shadowBuild "app"
+                               :shadowRuntimeId 1}))))
+  (testing "Given a JS object with all supported keys, should return the expected map"
+    (is (= {:who "repl"
+            :ns "user"
+            :repl-session-key "clj"
+            :shadow-build "app"
+            :shadow-runtime-id 1}
+           (sut/options->meta (clj->js {:who "repl"
+                                        :ns "user"
+                                        :replSessionKey "clj"
+                                        :shadowBuild "app"
+                                        :shadowRuntimeId 1})))))
+  (testing "Given options with no recognized keys, should return an empty map"
+    (is (= {} (sut/options->meta {:outputCategory "evalOut"}))))
+  (testing "Given options with shadow-runtime-id 0, should include it"
+    (is (= {:shadow-runtime-id 0}
+           (sut/options->meta {:shadowRuntimeId 0})))))
+
 (deftest append-test
   (testing "Given options and a message,"
     (testing "when command exists for output category, should call post-message-to-webview with expected args"
@@ -369,6 +403,24 @@
                                      "webview-panel-stub"
                                      {:command/name "show-stdout"
                                       :output message})))))
+    (testing "when options carry metadata, should include :meta in the posted message"
+      (let [options (clj->js {:outputCategory "evalOut"
+                              :who "repl"
+                              :ns "user"
+                              :replSessionKey "clj"})
+            message "some-message"
+            post-message-to-webview-spy (spy/spy)]
+        (with-redefs [sut/output-category->command-name {"evalOut" "show-stdout"}
+                      sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)
+                      sut/output-view-webview-panel (atom "webview-panel-stub")]
+          (sut/append options message)
+          (is (spy/called-once-with? post-message-to-webview-spy
+                                     "webview-panel-stub"
+                                     {:command/name "show-stdout"
+                                      :output message
+                                      :meta {:who "repl"
+                                             :ns "user"
+                                             :repl-session-key "clj"}})))))
     (testing "when the webview panel does not exist, should create it before posting"
       (let [options (clj->js {:outputCategory "evalOut"})
             create-repl-output-webview-panel-spy (spy/stub "created-webview-panel")

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -358,26 +358,26 @@
 (deftest options->meta-test
   (testing "Given nil options, should return nil"
     (is (nil? (sut/options->meta nil))))
-  (testing "Given a map of options with only :who, should return a map with only :who"
-    (is (= {:who "repl"}
+  (testing "Given a map of options with only :who, should return a map with only :meta/who"
+    (is (= {:meta/who "repl"}
            (sut/options->meta {:who "repl"}))))
   (testing "Given a map of options with all supported keys, should return the expected map"
-    (is (= {:who "repl"
-            :ns "user"
-            :repl-session-key "clj"
-            :shadow-build "app"
-            :shadow-runtime-id 1}
+    (is (= {:meta/who "repl"
+            :meta/ns "user"
+            :meta/repl-session-key "clj"
+            :meta/shadow-build "app"
+            :meta/shadow-runtime-id 1}
            (sut/options->meta {:who "repl"
                                :ns "user"
                                :replSessionKey "clj"
                                :shadowBuild "app"
                                :shadowRuntimeId 1}))))
   (testing "Given a JS object with all supported keys, should return the expected map"
-    (is (= {:who "repl"
-            :ns "user"
-            :repl-session-key "clj"
-            :shadow-build "app"
-            :shadow-runtime-id 1}
+    (is (= {:meta/who "repl"
+            :meta/ns "user"
+            :meta/repl-session-key "clj"
+            :meta/shadow-build "app"
+            :meta/shadow-runtime-id 1}
            (sut/options->meta (clj->js {:who "repl"
                                         :ns "user"
                                         :replSessionKey "clj"
@@ -386,7 +386,7 @@
   (testing "Given options with no recognized keys, should return an empty map"
     (is (= {} (sut/options->meta {:outputCategory "evalOut"}))))
   (testing "Given options with shadow-runtime-id 0, should include it"
-    (is (= {:shadow-runtime-id 0}
+    (is (= {:meta/shadow-runtime-id 0}
            (sut/options->meta {:shadowRuntimeId 0})))))
 
 (deftest append-test
@@ -418,9 +418,9 @@
                                      "webview-panel-stub"
                                      {:command/name "show-stdout"
                                       :output message
-                                      :meta {:who "repl"
-                                             :ns "user"
-                                             :repl-session-key "clj"}})))))
+                                      :meta {:meta/who "repl"
+                                             :meta/ns "user"
+                                             :meta/repl-session-key "clj"}})))))
     (testing "when the webview panel does not exist, should create it before posting"
       (let [options (clj->js {:outputCategory "evalOut"})
             create-repl-output-webview-panel-spy (spy/stub "created-webview-panel")

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -402,6 +402,7 @@
           (is (spy/called-once-with? post-message-to-webview-spy
                                      "webview-panel-stub"
                                      {:command/name "show-stdout"
+                                      :output-category "evalOut"
                                       :output message})))))
     (testing "when options carry metadata, should include :meta in the posted message"
       (let [options (clj->js {:outputCategory "evalOut"
@@ -417,6 +418,7 @@
           (is (spy/called-once-with? post-message-to-webview-spy
                                      "webview-panel-stub"
                                      {:command/name "show-stdout"
+                                      :output-category "evalOut"
                                       :output message
                                       :meta {:meta/who "repl"
                                              :meta/ns "user"
@@ -442,6 +444,7 @@
           (is (spy/called-once-with? post-message-to-webview-spy
                                      "created-webview-panel"
                                      {:command/name "show-stdout"
+                                      :output-category "evalOut"
                                       :output "some-message"})))))
     (testing "when command does not exist for output category,"
       (let [options (clj->js {:outputCategory "nonexistent-category"})
@@ -538,6 +541,7 @@
         (is (spy/called-once-with? post-message-to-webview-spy
                                    "webview-panel-stub"
                                    {:command/name "show-stdout"
+                                    :output-category "evalErr"
                                     :output "some-message"})))))
   (testing "when the webview panel does not exist, should create it before posting"
     (let [create-repl-output-webview-panel-spy (spy/stub "created-webview-panel")
@@ -558,6 +562,7 @@
         (is (spy/called-once-with? post-message-to-webview-spy
                                    "created-webview-panel"
                                    {:command/name "show-stdout"
+                                    :output-category "evalErr"
                                     :output ""}))))))
 
 (deftest clear-output-view-test

--- a/src/cljs-lib/test/calva/repl/webview/sidebar_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/sidebar_test.cljs
@@ -83,7 +83,24 @@
       (sut/append options "some-output")
       (is (= [{:command/name "show-stdout" :output "some-output"}]
              @sut/output-sidebar-log))
-      (is (spy/not-called? post-message-to-webview-spy)))))
+      (is (spy/not-called? post-message-to-webview-spy))))
+  (testing "when options carry metadata, should include :meta in the logged message"
+    (let [post-message-to-webview-spy (spy/spy)
+          options (clj->js {:outputCategory "evalOut"
+                            :who "repl"
+                            :ns "user"
+                            :replSessionKey "clj"})]
+      (with-redefs [sut/current-output-destinations (constantly {:evalOutput "output-sidebar"})
+                    sut/output-sidebar-webview-view (atom nil)
+                    sut/output-sidebar-log (atom [])
+                    core/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)]
+        (sut/append options "some-output")
+        (is (= [{:command/name "show-stdout"
+                 :output "some-output"
+                 :meta {:who "repl"
+                        :ns "user"
+                        :repl-session-key "clj"}}]
+               @sut/output-sidebar-log))))))
 
 (deftest append-stacktrace-test
   (let [post-message-to-webview-spy (spy/spy)

--- a/src/cljs-lib/test/calva/repl/webview/sidebar_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/sidebar_test.cljs
@@ -97,9 +97,9 @@
         (sut/append options "some-output")
         (is (= [{:command/name "show-stdout"
                  :output "some-output"
-                 :meta {:who "repl"
-                        :ns "user"
-                        :repl-session-key "clj"}}]
+                 :meta {:meta/who "repl"
+                        :meta/ns "user"
+                        :meta/repl-session-key "clj"}}]
                @sut/output-sidebar-log))))))
 
 (deftest append-stacktrace-test

--- a/src/cljs-lib/test/calva/repl/webview/sidebar_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/sidebar_test.cljs
@@ -81,7 +81,7 @@
                   sut/output-sidebar-log (atom [])
                   core/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)]
       (sut/append options "some-output")
-      (is (= [{:command/name "show-stdout" :output "some-output"}]
+      (is (= [{:command/name "show-stdout" :output-category "evalOut" :output "some-output"}]
              @sut/output-sidebar-log))
       (is (spy/not-called? post-message-to-webview-spy))))
   (testing "when options carry metadata, should include :meta in the logged message"
@@ -96,6 +96,7 @@
                     core/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)]
         (sut/append options "some-output")
         (is (= [{:command/name "show-stdout"
+                 :output-category "evalOut"
                  :output "some-output"
                  :meta {:meta/who "repl"
                         :meta/ns "user"
@@ -111,11 +112,12 @@
                   core/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)
                   core/stacktrace->message (constantly "stacktrace")]
       (sut/append-stacktrace (clj->js []))
-      (is (= [{:command/name "show-stdout" :output "stacktrace"}]
+      (is (= [{:command/name "show-stdout" :output-category "evalErr" :output "stacktrace"}]
              @sut/output-sidebar-log))
       (is (spy/called-once-with? post-message-to-webview-spy
                                  webview-view
                                  {:command/name "show-stdout"
+                                  :output-category "evalErr"
                                   :output "stacktrace"})))))
 
 (deftest clear-output-sidebar-test

--- a/src/extension-test/e2e/suite/repl-window-targeting-test.ts
+++ b/src/extension-test/e2e/suite/repl-window-targeting-test.ts
@@ -5,11 +5,12 @@ import * as testUtil from './util';
 import * as clientRegistry from '../../../nrepl/client-registry';
 import * as sessionRegistry from '../../../nrepl/session-registry';
 import * as replSession from '../../../nrepl/repl-session';
+import * as sessionRouting from '../../../nrepl/session-routing';
 import * as outputWindow from '../../../repl-window/repl-window-doc';
 import * as replSessionsMenu from '../../../repl-sessions-menu';
-import * as jackIn from '../../../nrepl/jack-in';
+import * as cljsLib from '../../../../out/cljs-lib/cljs-lib';
 import * as vscode from 'vscode';
-import * as connector from '../../../connector';
+import type * as nrepl from '../../../nrepl';
 
 const suiteName = 'REPL Window Targeting';
 
@@ -17,6 +18,14 @@ const suiteName = 'REPL Window Targeting';
 const projectDir = path.join(testUtil.testDataDir, '..', 'projects', 'cljs-only');
 const cljsFile = path.join(projectDir, 'src', 'hello_world', 'core.cljs');
 const cljcFile = path.join(projectDir, 'src', 'hello_world', 'core.cljc');
+
+const clientKey = 'test-client-targeting';
+
+const createSession = (replType: string, clientKey?: string): nrepl.NReplSession =>
+  ({
+    replType,
+    client: clientKey ? { clientKey } : undefined,
+  } as nrepl.NReplSession);
 
 async function waitForReplWindowRouting(expectedSessionKey?: string): Promise<void> {
   await testUtil.waitForCondition(
@@ -36,61 +45,66 @@ async function waitForReplWindowRouting(expectedSessionKey?: string): Promise<vo
 }
 
 suite('REPL Window Targeting suite', function () {
-  // Increase timeout for the entire suite since we jack-in once
-  this.timeout(180_000);
-
-  let clientKey: string;
+  let initialConnectionState: boolean | undefined;
+  let initialCurrentSessionType: string | undefined;
+  let initialOutputSessionType: string | undefined;
+  let initialOutputNamespace: string | undefined;
 
   mocha.before(async () => {
     testUtil.showMessage(suiteName, `suite starting!`);
     await testUtil.ensureOutputDir(testUtil.testDataDir);
 
-    // Clean up any stale clients
-    const existingClients = clientRegistry.listClients();
-    for (const client of existingClients) {
-      try {
-        await connector.disconnect({ clientKey: client.key });
-      } catch {
-        // Ignore errors during cleanup
-      }
-    }
-
-    // Jack-in once for all tests
-    await jackInToClojureScriptProject();
-
-    // Verify we have both clj and cljs sessions
-    const clients = clientRegistry.listClients();
-    assert.strictEqual(clients.length, 1, 'Should have one client after jack-in');
-    clientKey = clients[0].key;
-
-    const sessions = sessionRegistry.listSessionsByClient(clientKey);
-    const sessionKeys = sessions.map((s) => s.key);
-    testUtil.log(suiteName, 'Session keys:', sessionKeys);
-
-    assert.ok(sessionKeys.includes('clj'), 'Should have clj session');
-    assert.ok(sessionKeys.includes('cljs'), 'Should have cljs session');
+    initialConnectionState = cljsLib.getStateValue('connected');
+    initialCurrentSessionType = cljsLib.getStateValue('current-session-type');
+    initialOutputSessionType = outputWindow.getSessionType();
+    initialOutputNamespace = outputWindow.getNs();
+    await outputWindow.initReplWindowDoc();
   });
 
-  mocha.after(async () => {
+  mocha.after(() => {
     testUtil.showMessage(suiteName, `suite done!`);
-
-    // Kill jack-in processes to prevent orphaned Java processes
-    testUtil.log(suiteName, 'Suite cleanup: killing all jack-in processes');
-    await jackIn.calvaJackout({ force: true });
-    await testUtil.waitForJackOutComplete(suiteName);
-
-    // Disconnect after all tests
-    const clients = clientRegistry.listClients();
-    for (const client of clients) {
-      try {
-        await connector.disconnect({ clientKey: client.key });
-      } catch {
-        // Ignore errors during cleanup
-      }
-    }
+    sessionRegistry._testUtility_registeredSessions.clear();
+    clientRegistry._testUtility_registeredClients.clear();
+    sessionRouting.resetRouting();
+    cljsLib.setStateValue('connected', initialConnectionState);
+    cljsLib.setStateValue('current-session-type', initialCurrentSessionType);
+    const fallbackSessionType = initialOutputSessionType ?? 'clj';
+    const fallbackNamespace = initialOutputNamespace ?? 'user';
+    outputWindow.setSession(
+      createSession(fallbackSessionType),
+      fallbackNamespace,
+      fallbackSessionType
+    );
   });
 
   mocha.beforeEach(async () => {
+    sessionRegistry._testUtility_registeredSessions.clear();
+    clientRegistry._testUtility_registeredClients.clear();
+    sessionRouting.resetRouting();
+    cljsLib.setStateValue('connected', true);
+    cljsLib.setStateValue('current-session-type', undefined);
+
+    const stubClient = {
+      clientKey,
+    } as unknown as nrepl.NReplClient;
+
+    clientRegistry.registerClient(stubClient, {
+      connectSequenceName: 'Test Connection Targeting',
+    });
+
+    const projectUri = vscode.Uri.file(projectDir).toString();
+
+    sessionRegistry.registerSession('clj', createSession('clj', clientKey), {
+      projectRoot: projectUri,
+      globs: ['**/*.clj', '**/*.cljc', '**/*.edn'],
+      isSecondary: false,
+    });
+    sessionRegistry.registerSession('cljs', createSession('cljs', clientKey), {
+      projectRoot: projectUri,
+      globs: ['**/*.cljs', '**/*.cljc'],
+      isSecondary: true,
+    });
+
     // Reset REPL window to clj session before each test
     replSessionsMenu.setReplWindowSession('clj');
     await testUtil.waitForCondition(
@@ -249,26 +263,4 @@ suite('REPL Window Targeting suite', function () {
     assert.strictEqual(result, true, 'Should return true for valid session');
     assert.strictEqual(outputWindow.getSessionType(), 'cljs', 'Session should be updated');
   });
-
-  async function jackInToClojureScriptProject(): Promise<void> {
-    const { clientKey: key } = await testUtil.withJackInRetry(
-      suiteName,
-      async () => {
-        await testUtil.openFile(cljsFile);
-        testUtil.log(suiteName, `Opened file for jack-in: ${cljsFile}`);
-        await vscode.commands.executeCommand('calva.jackIn', {
-          connectSequence: {
-            name: 'repl-window-targeting-test-cljs-node',
-            projectType: 'deps.edn',
-            cljsType: 'ClojureScript built-in for node',
-            projectRootPath: [projectDir],
-          },
-          disableAutoSelect: true,
-        });
-      },
-      { expectedSessionKeys: ['clj', 'cljs'] }
-    );
-    clientKey = key;
-    testUtil.log(suiteName, 'Jack-in complete');
-  }
 });

--- a/src/extension-test/unit/results-output/output-test.ts
+++ b/src/extension-test/unit/results-output/output-test.ts
@@ -29,7 +29,7 @@ describe('routeEvaluatedCode', () => {
       {
         code: '(inc 1)',
         didLastTerminateLine: true,
-        outputCategory: 'evalResults',
+        outputCategory: 'evaluatedCode',
       },
     ]);
   });

--- a/src/results-output/evaluated-code.ts
+++ b/src/results-output/evaluated-code.ts
@@ -43,7 +43,7 @@ export function routeEvaluatedCode(options: {
     replSessionKey,
     shadowBuild,
     shadowRuntimeId,
-    visibleOutputCategory = 'evalResults',
+    visibleOutputCategory = 'evaluatedCode',
     emit,
     writeVisible,
   } = options;

--- a/src/results-output/output.ts
+++ b/src/results-output/output.ts
@@ -504,7 +504,7 @@ export function appendEvaluatedCode(
     additionalDestinations = [],
     sinkDestination = destination,
     writeVisible = true,
-    visibleOutputCategory = 'evalResults',
+    visibleOutputCategory = 'evaluatedCode',
     ...metadataOptions
   } = options;
   const normalizedDestination = normalizeDestinations(destination);


### PR DESCRIPTION
* Fixes #3270

## What has changed?

Adding the missing display of evaluation meta data that the output emitter provides. Also:

- Fix styling of evals from API (e.g. agents) to match that of other evals
- Style otherOutput (info color/muted) and errorOutput (error color)
- Introduce an app-db and a micro one-directional dataflow effect/update dispatch framework (I call it Uniflow)

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

