### PR TITLE
3274 subscribing to repl session updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes to Calva.
 
 - Fix: [Inconsistency in how the Output views follow editor font size](https://github.com/BetterThanTomorrow/calva/issues/3276)
 - Add settings: `calva.outputViews.fontSizeScale`, and `calva.outputViews.wordWrap`
+- [Add API for subscribing to REPL session updates (connect/disconnect, etc)](https://github.com/BetterThanTomorrow/calva/issues/3274)
 
 ## [2.0.595] - 2026-08-24
 

--- a/docs/site/api.md
+++ b/docs/site/api.md
@@ -147,6 +147,72 @@ Use `repl.listSessionsAndRuntimes()` to asynchronously inspect every registered 
   }
   ```
 
+### `repl.onSessionsChanged()`
+
+Subscribe to real-time REPL session, connection, and runtime lifecycle changes. Calva fires notifications immediately whenever a connection is established or closed, sessions are registered, unregistered, or renamed, or Shadow-cljs runtimes connect or disconnect.
+
+Returns a `vscode.Disposable` that you should dispose when you no longer need updates. (Push it onto `context.subscriptions` for automatic cleanup).
+
+Event payloads are intentionally lightweight notifications. To inspect full project roots, globs, available builds, or runtime trees, query [`repl.listSessionsAndRuntimes()`](#repllistsessionsandruntimes) when receiving an event.
+
+TypeScript signature:
+
+```typescript
+export function onSessionsChanged(
+  listener: (event: SessionsChangedEvent) => void
+): vscode.Disposable;
+
+export type SessionsChangedEventType =
+  | 'session-added'
+  | 'session-removed'
+  | 'session-renamed'
+  | 'runtime-connected'
+  | 'runtime-disconnected'
+  | 'connection-added'
+  | 'connection-removed';
+
+export interface SessionsChangedEvent {
+  type: SessionsChangedEventType;
+  clientKey?: string;
+  sessionKey?: string;
+  previousSessionKey?: string; // Present only on 'session-renamed'
+  runtime?: ShadowRuntimeInfo; // Present on 'runtime-connected' / 'runtime-disconnected'
+}
+```
+
+#### Event Types
+
+* `'connection-added'` / `'connection-removed'` — An nREPL client connected or disconnected (`clientKey` provided).
+* `'session-added'` / `'session-removed'` — A session was registered or unregistered (`sessionKey` and `clientKey` provided).
+* `'session-renamed'` — A session was renamed (`sessionKey` is the new key, `previousSessionKey` is the old key).
+* `'runtime-connected'` / `'runtime-disconnected'` — A Shadow-cljs runtime connected or disconnected (`runtime` provides the [`ShadowRuntimeInfo`](#repllistsessionsandruntimes) object).
+
+#### Examples
+
+=== "Joyride"
+
+    ```clojure
+    (def sub
+      (calva/repl.onSessionsChanged
+       (fn [e]
+         (println "Session event:" (.-type e) (.-sessionKey e)))))
+
+    ;; When done:
+    ;; (.dispose sub)
+    ```
+
+=== "JavaScript"
+
+    ```javascript
+    const disposable = calva.repl.onSessionsChanged((event) => {
+      console.log(`Session change: ${event.type}`, event);
+      if (event.type === 'runtime-connected') {
+        console.log(`New runtime connected on ${event.sessionKey}:`, event.runtime?.description);
+      }
+    });
+
+    // context.subscriptions.push(disposable);
+    ```
 
 ### `repl.evaluate()`
 

--- a/src/api/repl-v1.ts
+++ b/src/api/repl-v1.ts
@@ -562,8 +562,22 @@ export function onOutputLogged(callback: (msg: OutputMessage) => void): vscode.D
   return new vscode.Disposable(unsubscribe);
 }
 
-export type SessionsChangedEventType = sessionEvents.SessionsChangedEventType;
-export type SessionsChangedEvent = sessionEvents.SessionsChangedEvent;
+export type SessionsChangedEventType =
+  | 'session-added'
+  | 'session-removed'
+  | 'session-renamed'
+  | 'runtime-connected'
+  | 'runtime-disconnected'
+  | 'connection-added'
+  | 'connection-removed';
+
+export interface SessionsChangedEvent {
+  type: SessionsChangedEventType;
+  clientKey?: string;
+  sessionKey?: string;
+  previousSessionKey?: string;
+  runtime?: ShadowRuntimeInfo;
+}
 
 export function onSessionsChanged(
   listener: (event: SessionsChangedEvent) => void

--- a/src/api/repl-v1.ts
+++ b/src/api/repl-v1.ts
@@ -10,6 +10,7 @@ import * as outputDestinations from '../results-output/output-destinations';
 import * as logUtil from './log-util';
 import * as clientRegistry from '../nrepl/client-registry';
 import * as shadowCljsRuntime from '../shadow-cljs-runtime';
+import * as sessionEvents from '../nrepl/session-events';
 
 type Result = {
   result: string;
@@ -559,4 +560,14 @@ export function onOutputLogged(callback: (msg: OutputMessage) => void): vscode.D
     }
   });
   return new vscode.Disposable(unsubscribe);
+}
+
+export type SessionsChangedEventType = sessionEvents.SessionsChangedEventType;
+export type SessionsChangedEvent = sessionEvents.SessionsChangedEvent;
+
+export function onSessionsChanged(
+  listener: (event: SessionsChangedEvent) => void
+): vscode.Disposable {
+  const disposable = sessionEvents.onSessionsChanged(listener);
+  return new vscode.Disposable(() => disposable.dispose());
 }

--- a/src/extension-test/unit/api/repl-v1-session-events-test.ts
+++ b/src/extension-test/unit/api/repl-v1-session-events-test.ts
@@ -1,0 +1,117 @@
+import * as expectLib from 'expect';
+import type * as nrepl from '../../../nrepl';
+import * as sessionEvents from '../../../nrepl/session-events';
+import * as clientRegistry from '../../../nrepl/client-registry';
+import * as sessionRegistry from '../../../nrepl/session-registry';
+
+const expect = expectLib.default;
+
+const createClient = (key: string): nrepl.NReplClient =>
+  ({
+    clientKey: key,
+  } as unknown as nrepl.NReplClient);
+
+const createSession = (clientKey: string): nrepl.NReplSession =>
+  ({
+    client: { clientKey },
+  } as unknown as nrepl.NReplSession);
+
+describe('session-events and onSessionsChanged', () => {
+  let receivedEvents: sessionEvents.SessionsChangedEvent[] = [];
+  let subscription: sessionEvents.Disposable | undefined;
+
+  beforeEach(() => {
+    receivedEvents = [];
+    subscription = sessionEvents.onSessionsChanged((event) => {
+      receivedEvents.push(event);
+    });
+    // Clean up registries
+    clientRegistry._testUtility_registeredClients.clear();
+    sessionRegistry._testUtility_registeredSessions.clear();
+  });
+
+  afterEach(() => {
+    subscription?.dispose();
+    clientRegistry._testUtility_registeredClients.clear();
+    sessionRegistry._testUtility_registeredSessions.clear();
+  });
+
+  it('delivers fired events to active listeners', () => {
+    sessionEvents.fireSessionsChanged({
+      type: 'connection-added',
+      clientKey: 'localhost:1234',
+    });
+
+    expect(receivedEvents.length).toBe(1);
+    expect(receivedEvents[0]).toEqual({
+      type: 'connection-added',
+      clientKey: 'localhost:1234',
+    });
+  });
+
+  it('stops delivering events after subscription is disposed', () => {
+    subscription?.dispose();
+
+    sessionEvents.fireSessionsChanged({
+      type: 'connection-added',
+      clientKey: 'localhost:1234',
+    });
+
+    expect(receivedEvents.length).toBe(0);
+  });
+
+  it('fires connection-added on registerClient and connection-removed on unregisterClient', () => {
+    const client = createClient('client-1');
+    clientRegistry.registerClient(client, { connectSequenceName: 'Test' });
+
+    expect(receivedEvents.length).toBe(1);
+    expect(receivedEvents[0]).toEqual({
+      type: 'connection-added',
+      clientKey: 'client-1',
+    });
+
+    clientRegistry.unregisterClient('client-1');
+
+    expect(receivedEvents.length).toBe(2);
+    expect(receivedEvents[1]).toEqual({
+      type: 'connection-removed',
+      clientKey: 'client-1',
+    });
+  });
+
+  it('fires session-added on registerSession and session-removed on unregisterSession', () => {
+    const session = createSession('client-1');
+    sessionRegistry.registerSession('clj', session, { connectionOwnerId: 'client-1' });
+
+    expect(receivedEvents.length).toBe(1);
+    expect(receivedEvents[0]).toEqual({
+      type: 'session-added',
+      sessionKey: 'clj',
+      clientKey: 'client-1',
+    });
+
+    sessionRegistry.unregisterSession('clj');
+
+    expect(receivedEvents.length).toBe(2);
+    expect(receivedEvents[1]).toEqual({
+      type: 'session-removed',
+      sessionKey: 'clj',
+      clientKey: 'client-1',
+    });
+  });
+
+  it('fires session-renamed on renameSession', () => {
+    const session = createSession('client-1');
+    sessionRegistry.registerSession('clj', session, { connectionOwnerId: 'client-1' });
+
+    sessionRegistry.renameSession('clj', 'clj-main');
+
+    expect(receivedEvents.length).toBe(2);
+    expect(receivedEvents[1]).toEqual({
+      type: 'session-renamed',
+      sessionKey: 'clj-main',
+      previousSessionKey: 'clj',
+      clientKey: 'client-1',
+    });
+  });
+});

--- a/src/nrepl/client-registry.ts
+++ b/src/nrepl/client-registry.ts
@@ -1,6 +1,7 @@
 import type * as connectSequence from './connectSequence';
 import type * as nrepl from './index';
 import type * as sessionRoleUtils from './session-role-utils';
+import * as sessionEvents from './session-events';
 
 export type CljcTargetRole = 'primary' | 'secondary';
 
@@ -64,6 +65,11 @@ export function registerClient(
 
   registeredClients.set(entry.key, entry);
 
+  sessionEvents.fireSessionsChanged({
+    type: 'connection-added',
+    clientKey: entry.key,
+  });
+
   return entry;
 }
 
@@ -74,6 +80,11 @@ export function unregisterClient(clientKey: string): RegisteredClient | undefine
   }
 
   registeredClients.delete(clientKey);
+
+  sessionEvents.fireSessionsChanged({
+    type: 'connection-removed',
+    clientKey,
+  });
 
   return entry;
 }

--- a/src/nrepl/session-events.ts
+++ b/src/nrepl/session-events.ts
@@ -1,30 +1,10 @@
-export type SessionsChangedEventType =
-  | 'session-added'
-  | 'session-removed'
-  | 'session-renamed'
-  | 'runtime-connected'
-  | 'runtime-disconnected'
-  | 'connection-added'
-  | 'connection-removed';
+import type {
+  SessionsChangedEvent,
+  SessionsChangedEventType,
+  ShadowRuntimeInfo,
+} from '../api/repl-v1';
 
-export interface ShadowRuntimeInfo {
-  runtimeId: number;
-  description: string;
-  buildId: string;
-  host: string;
-  workerId: number;
-  sinceInst: number;
-  sinceDescription: string;
-  lastActivity?: number;
-}
-
-export interface SessionsChangedEvent {
-  type: SessionsChangedEventType;
-  clientKey?: string;
-  sessionKey?: string;
-  previousSessionKey?: string;
-  runtime?: ShadowRuntimeInfo;
-}
+export type { SessionsChangedEvent, SessionsChangedEventType, ShadowRuntimeInfo };
 
 export interface Disposable {
   dispose(): void;

--- a/src/nrepl/session-events.ts
+++ b/src/nrepl/session-events.ts
@@ -1,0 +1,61 @@
+export type SessionsChangedEventType =
+  | 'session-added'
+  | 'session-removed'
+  | 'session-renamed'
+  | 'runtime-connected'
+  | 'runtime-disconnected'
+  | 'connection-added'
+  | 'connection-removed';
+
+export interface ShadowRuntimeInfo {
+  runtimeId: number;
+  description: string;
+  buildId: string;
+  host: string;
+  workerId: number;
+  sinceInst: number;
+  sinceDescription: string;
+  lastActivity?: number;
+}
+
+export interface SessionsChangedEvent {
+  type: SessionsChangedEventType;
+  clientKey?: string;
+  sessionKey?: string;
+  previousSessionKey?: string;
+  runtime?: ShadowRuntimeInfo;
+}
+
+export interface Disposable {
+  dispose(): void;
+}
+
+export type SessionsChangedListener = (event: SessionsChangedEvent) => void;
+
+const listeners = new Set<SessionsChangedListener>();
+
+export function onSessionsChanged(listener: SessionsChangedListener): Disposable {
+  listeners.add(listener);
+  return {
+    dispose: () => {
+      listeners.delete(listener);
+    },
+  };
+}
+
+export function fireSessionsChanged(event: SessionsChangedEvent): void {
+  listeners.forEach((listener) => {
+    try {
+      listener(event);
+    } catch (e) {
+      console.error('Error in onSessionsChanged listener:', e);
+    }
+  });
+}
+
+/**
+ * Test utility: reset all listeners.
+ */
+export function _testUtility_resetSessionEvents(): void {
+  listeners.clear();
+}

--- a/src/nrepl/session-registry.ts
+++ b/src/nrepl/session-registry.ts
@@ -2,6 +2,7 @@ import type * as globs from './globs';
 import type * as nrepl from './index';
 import * as clientRegistry from './client-registry';
 import * as sessionNameSuffix from './session-name-suffix';
+import * as sessionEvents from './session-events';
 
 export interface SessionMetadata {
   key: string;
@@ -30,6 +31,12 @@ export function registerSession(
   registeredSessions.set(key, session);
 
   (session as any)._calvaSessionMetadata = fullMetadata;
+
+  sessionEvents.fireSessionsChanged({
+    type: 'session-added',
+    sessionKey: key,
+    clientKey: computedOwnerId,
+  });
 }
 
 export function getSession(key: string): nrepl.NReplSession | undefined {
@@ -37,7 +44,17 @@ export function getSession(key: string): nrepl.NReplSession | undefined {
 }
 
 export function unregisterSession(key: string): void {
+  const session = registeredSessions.get(key);
+  const metadata = (session as any)?._calvaSessionMetadata as SessionMetadata | undefined;
+  const clientKey = metadata?.connectionOwnerId ?? session?.client?.clientKey;
+
   registeredSessions.delete(key);
+
+  sessionEvents.fireSessionsChanged({
+    type: 'session-removed',
+    sessionKey: key,
+    clientKey,
+  });
 }
 
 export function listSessions(): SessionMetadata[] {
@@ -224,6 +241,13 @@ export function renameSession(oldKey: string, newKey: string): boolean {
   if (suffix) {
     sessionNameSuffix.releaseSuffix(suffix);
   }
+
+  sessionEvents.fireSessionsChanged({
+    type: 'session-renamed',
+    sessionKey: newKey,
+    previousSessionKey: oldKey,
+    clientKey,
+  });
 
   return true;
 }

--- a/src/shadow-cljs-runtime.ts
+++ b/src/shadow-cljs-runtime.ts
@@ -278,7 +278,8 @@ export async function selectShadowRuntime(): Promise<RuntimeQuickPickItem | null
  */
 export async function switchToRuntime(
   runtimeInfo: shadowRuntimeCore.RuntimeInfo,
-  clientKey?: string
+  clientKey?: string,
+  options?: { isNewConnection?: boolean }
 ): Promise<boolean> {
   try {
     let cljSession;
@@ -305,7 +306,7 @@ export async function switchToRuntime(
 
     await cljSession.eval(selectRuntimeCode, 'user').value;
 
-    updateRuntimeState(runtimeId, runtimeInfo, clientKey);
+    updateRuntimeState(runtimeId, runtimeInfo, clientKey, options);
 
     // Update status bar to show the new runtime
     status.update();
@@ -383,7 +384,7 @@ export async function detectInitialRuntime(clientKey?: string): Promise<void> {
     const runtime = runtimes[0];
     const runtimeId = runtime.runtimeId;
 
-    updateRuntimeState(runtimeId, runtime, effectiveClientKey);
+    updateRuntimeState(runtimeId, runtime, effectiveClientKey, { isNewConnection: true });
 
     status.update();
     if (runtimes.length > 1) {
@@ -406,7 +407,8 @@ export { canonicalBuildId } from './shadow-cljs-runtime-core';
 export function updateRuntimeState(
   runtimeId: number,
   runtimeInfo: shadowRuntimeCore.RuntimeInfo,
-  clientKey?: string
+  clientKey?: string,
+  options?: { isNewConnection?: boolean }
 ): void {
   const effectiveClientKey = clientKey ?? getConnectionContextForCurrentSession()?.clientKey;
   if (effectiveClientKey) {
@@ -417,22 +419,24 @@ export function updateRuntimeState(
   }
   status.update();
 
-  const sessionKey = effectiveClientKey
-    ? sessionRegistry.getSecondarySessionKeyForClient(effectiveClientKey) ??
-      sessionRegistry.getPrimarySessionKeyForClient(effectiveClientKey)
-    : replSession.getReplSessionTypeFromState();
+  if (options?.isNewConnection) {
+    const sessionKey = effectiveClientKey
+      ? sessionRegistry.getSecondarySessionKeyForClient(effectiveClientKey) ??
+        sessionRegistry.getPrimarySessionKeyForClient(effectiveClientKey)
+      : replSession.getReplSessionTypeFromState();
 
-  const runtimeWithActivity: sessionEvents.ShadowRuntimeInfo = {
-    ...runtimeInfo,
-    lastActivity: getRuntimeLastActivity(runtimeId),
-  };
+    const runtimeWithActivity: sessionEvents.ShadowRuntimeInfo = {
+      ...runtimeInfo,
+      lastActivity: getRuntimeLastActivity(runtimeId),
+    };
 
-  sessionEvents.fireSessionsChanged({
-    type: 'runtime-connected',
-    clientKey: effectiveClientKey,
-    sessionKey,
-    runtime: runtimeWithActivity,
-  });
+    sessionEvents.fireSessionsChanged({
+      type: 'runtime-connected',
+      clientKey: effectiveClientKey,
+      sessionKey,
+      runtime: runtimeWithActivity,
+    });
+  }
 }
 
 export function clearRuntimeState(clientKey?: string): void {
@@ -501,7 +505,9 @@ export async function handleShadowRemoteMessage(msgData: any, clientKey: string)
           break;
         }
         case 'runtime-connected': {
-          const success = await switchToRuntime(action.runtimeInfo, clientKey);
+          const success = await switchToRuntime(action.runtimeInfo, clientKey, {
+            isNewConnection: true,
+          });
           if (success) {
             output.appendLineOtherOut(
               `shadow-cljs runtime connected: ${action.runtimeId}, ${action.runtimeInfo.description}`

--- a/src/shadow-cljs-runtime.ts
+++ b/src/shadow-cljs-runtime.ts
@@ -7,6 +7,7 @@ import * as cljsLib from '../out/cljs-lib/cljs-lib';
 import * as output from './results-output/output';
 import * as status from './status';
 import * as shadowRuntimeCore from './shadow-cljs-runtime-core';
+import * as sessionEvents from './nrepl/session-events';
 
 /**
  * Tracks the last time Calva evaluated code on each runtime ID.
@@ -407,39 +408,69 @@ export function updateRuntimeState(
   runtimeInfo: shadowRuntimeCore.RuntimeInfo,
   clientKey?: string
 ): void {
-  if (clientKey) {
-    clientRegistry.setConnectionState(clientKey, {
+  const effectiveClientKey = clientKey ?? getConnectionContextForCurrentSession()?.clientKey;
+  if (effectiveClientKey) {
+    clientRegistry.setConnectionState(effectiveClientKey, {
       shadowCljsRuntimeId: runtimeId,
       shadowCljsRuntimeInfo: runtimeInfo,
     });
-  } else {
-    const ctx = getConnectionContextForCurrentSession();
-    if (ctx) {
-      clientRegistry.setConnectionState(ctx.clientKey, {
-        shadowCljsRuntimeId: runtimeId,
-        shadowCljsRuntimeInfo: runtimeInfo,
-      });
-    }
   }
   status.update();
+
+  const sessionKey = effectiveClientKey
+    ? sessionRegistry.getSecondarySessionKeyForClient(effectiveClientKey) ??
+      sessionRegistry.getPrimarySessionKeyForClient(effectiveClientKey)
+    : replSession.getReplSessionTypeFromState();
+
+  const runtimeWithActivity: sessionEvents.ShadowRuntimeInfo = {
+    ...runtimeInfo,
+    lastActivity: getRuntimeLastActivity(runtimeId),
+  };
+
+  sessionEvents.fireSessionsChanged({
+    type: 'runtime-connected',
+    clientKey: effectiveClientKey,
+    sessionKey,
+    runtime: runtimeWithActivity,
+  });
 }
 
 export function clearRuntimeState(clientKey?: string): void {
-  if (clientKey) {
-    clientRegistry.setConnectionState(clientKey, {
+  const effectiveClientKey = clientKey ?? getConnectionContextForCurrentSession()?.clientKey;
+  const previousRuntimeInfo = effectiveClientKey
+    ? clientRegistry.getConnectionState(effectiveClientKey)?.shadowCljsRuntimeInfo
+    : undefined;
+  const previousRuntimeId = effectiveClientKey
+    ? clientRegistry.getConnectionState(effectiveClientKey)?.shadowCljsRuntimeId
+    : undefined;
+
+  if (effectiveClientKey) {
+    clientRegistry.setConnectionState(effectiveClientKey, {
       shadowCljsRuntimeId: undefined,
       shadowCljsRuntimeInfo: undefined,
     });
-  } else {
-    const ctx = getConnectionContextForCurrentSession();
-    if (ctx) {
-      clientRegistry.setConnectionState(ctx.clientKey, {
-        shadowCljsRuntimeId: undefined,
-        shadowCljsRuntimeInfo: undefined,
-      });
-    }
   }
   status.update();
+
+  const sessionKey = effectiveClientKey
+    ? sessionRegistry.getSecondarySessionKeyForClient(effectiveClientKey) ??
+      sessionRegistry.getPrimarySessionKeyForClient(effectiveClientKey)
+    : replSession.getReplSessionTypeFromState();
+
+  const runtimeWithActivity: sessionEvents.ShadowRuntimeInfo | undefined =
+    previousRuntimeInfo && previousRuntimeId !== undefined
+      ? {
+          ...previousRuntimeInfo,
+          lastActivity: getRuntimeLastActivity(previousRuntimeId),
+        }
+      : undefined;
+
+  sessionEvents.fireSessionsChanged({
+    type: 'runtime-disconnected',
+    clientKey: effectiveClientKey,
+    sessionKey,
+    runtime: runtimeWithActivity,
+  });
 }
 
 /**


### PR DESCRIPTION
* Fixes #3274

## What has changed?

Adding API `repl.onSessionsChanged()`, for subscribing to session updates.


## My Calva PR Checklist


I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

