### PR TITLE
3276 inconsistent output view font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva.
 
 ## [Unreleased]
 
+- Fix: [Inconsistency in how the Output views follow editor font size](https://github.com/BetterThanTomorrow/calva/issues/3276)
+
 ## [2.0.595] - 2026-08-24
 
 - Add: [REPL output sidebar destination (Output view, but for sidebar placement)](https://github.com/BetterThanTomorrow/calva/issues/2813)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to Calva.
 ## [Unreleased]
 
 - Fix: [Inconsistency in how the Output views follow editor font size](https://github.com/BetterThanTomorrow/calva/issues/3276)
+- Add settings: `calva.outputViews.fontSizeScale`, and `calva.outputViews.wordWrap`
 
 ## [2.0.595] - 2026-08-24
 

--- a/docs/site/output-view.md
+++ b/docs/site/output-view.md
@@ -5,7 +5,7 @@ description: Read-only webviews for REPL output.
 
 The `output-view` editor tab and `output-sidebar` sidebar are separate destinations that share the same read-only webview page. They are more performant than [the editor-based REPL window](repl-window.md). To see a feature comparison of all output destinations, see [Output Destinations Feature Comparison](output.md#output-destinations-feature-comparison).
 
-The output views are two, performant, custom web views which can be configured as [Output Destinationsn](output.md). They largely share features (and implementation), the main difference being their placement in the VS Code UI.
+The output views are two, performant, custom web views which can be configured as [Output Destinations](output.md). They largely share features (and implementation), the main difference being their placement in the VS Code UI.
 
 * `output-view` is an editor tab, which can be placed anywhere an editor can be placed.
 * `output-sidebar` is a sidebar/panel view, which can be placed in the sidebars, or in the Panel view container.
@@ -16,13 +16,27 @@ The output views are two, performant, custom web views which can be configured a
 
 Run **Calva: Show/Open the REPL output view** for the editor tab or **Calva: Show/Open the REPL output sidebar** for the sidebar.
 
+## Font Size and Scaling
+
+The output views follow the editor font family (`editor.fontFamily`) and editor font size (`editor.fontSize`).
+
+You can adjust the scale of the font size in the output views relative to the editor font size using the setting `calva.outputViews.fontSizeScale` (default `1.0`, range `0.5` to `1.5`).
+
+You can also adjust the font size in-session, across both views using commands:
+
+* **Calva: Increase Output View Font Size**
+* **Calva: Decrease Output View Font Size**
+* **Calva: Reset Output View Font Size**
+
+The sidebar view has **Zoom Out** and **Zoom In** title bar buttons for quick adjustments.
+
 ## Wrap Evaluated Code and Results
 
 The evaluated code and results are wrapped according to the setting for the editors, `editor.wordWrap`. There is a command for toggling the wrap in the output views: **Calva: Toggle REPL Output Word Wrap**. This command toggles the wrap setting in both views. The toggling is not persisted. The sidebar view has a button for issuing the command.
 
 ## Clear Output
 
-Use the commands **Calva: Clear Ouput View** and **Calva: Clear Ouput Sidebar** to clear the respective view. The sidebar view also has a title  clear button.
+Use the commands **Calva: Clear Output View** and **Calva: Clear Output Sidebar** to clear the respective view. The sidebar view also has a title clear button.
 
 ## Search/Find
 

--- a/docs/site/output-view.md
+++ b/docs/site/output-view.md
@@ -32,7 +32,13 @@ The sidebar view has **Zoom Out** and **Zoom In** title bar buttons for quick ad
 
 ## Wrap Evaluated Code and Results
 
-The evaluated code and results are wrapped according to the setting for the editors, `editor.wordWrap`. There is a command for toggling the wrap in the output views: **Calva: Toggle REPL Output Word Wrap**. This command toggles the wrap setting in both views. The toggling is not persisted. The sidebar view has a button for issuing the command.
+Word wrapping for evaluated code and results in the output views can be configured via the `calva.outputViews.wordWrap` setting. It accepts:
+
+* `"follow-editor"` (default) – follows VS Code's `editor.wordWrap` setting.
+* `"on"` – always wraps output in the output views.
+* `"off"` – disables word wrapping in the output views.
+
+There is also a command for toggling word wrap in-session across both views: **Calva: Toggle REPL Output Word Wrap**. This in-session toggle is not persisted. The sidebar view has a title bar button for issuing the command.
 
 ## Clear Output
 

--- a/package.json
+++ b/package.json
@@ -347,6 +347,16 @@
             "maximum": 1.5,
             "description": "Scale factor for the Output views font size relative to the editor font size. Accepts values between 0.5 and 1.5."
           },
+          "calva.outputViews.wordWrap": {
+            "type": "string",
+            "enum": [
+              "follow-editor",
+              "on",
+              "off"
+            ],
+            "default": "follow-editor",
+            "description": "Word wrap setting for Output views. \"follow-editor\" follows the editor.wordWrap setting."
+          },
           "calva.fiddleFilePaths": {
             "type": "array",
             "markdownDescription": "An array of `source` and `fiddle` root paths, relative to the project root. This is used by the commands **Calva: Open Fiddle File for Current File**, and **Calva: Evaluate Fiddle File for Current File**. Example:\n\n```json\n\"calva.fiddleFilePaths\": [\n  {\n    \"source\": [\"src\"],\n    \"fiddle\": [\"env\", \"dev\", \"fiddles\"]\n  }\n]\n```\n\nThe default is `null`, which will make Calva associate files with a `.fiddle` file extension as the fiddle file for a Clojure file. E.g. a file `src/foo/bar/baz_main.cljc`, will have an associated fiddle file named `src/foo/bar/baz_main.fiddle`. See [calva.io/fiddle](https://calva.io/fiddle-files/) for more info.",

--- a/package.json
+++ b/package.json
@@ -1839,14 +1839,16 @@
         "icon": "$(word-wrap)"
       },
       {
-        "command": "calva.increaseOutputViewFontSize",
-        "title": "Increase Output View Font Size",
-        "category": "Calva"
-      },
-      {
         "command": "calva.decreaseOutputViewFontSize",
         "title": "Decrease Output View Font Size",
-        "category": "Calva"
+        "category": "Calva",
+        "icon": "$(zoom-out)"
+      },
+      {
+        "command": "calva.increaseOutputViewFontSize",
+        "title": "Increase Output View Font Size",
+        "category": "Calva",
+        "icon": "$(zoom-in)"
       },
       {
         "command": "calva.resetOutputViewFontSize",
@@ -3792,14 +3794,24 @@
       ],
       "view/title": [
         {
-          "command": "calva.toggleReplOutputWordWrap",
+          "command": "calva.decreaseOutputViewFontSize",
           "when": "view == calva.output-sidebar",
           "group": "navigation@1"
         },
         {
-          "command": "calva.clearReplOutputSidebar",
+          "command": "calva.increaseOutputViewFontSize",
           "when": "view == calva.output-sidebar",
           "group": "navigation@2"
+        },
+        {
+          "command": "calva.toggleReplOutputWordWrap",
+          "when": "view == calva.output-sidebar",
+          "group": "navigation@3"
+        },
+        {
+          "command": "calva.clearReplOutputSidebar",
+          "when": "view == calva.output-sidebar",
+          "group": "navigation@4"
         },
         {
           "command": "calva.pasteAsInspectorItem",

--- a/package.json
+++ b/package.json
@@ -340,6 +340,13 @@
               ]
             }
           },
+          "calva.outputViews.fontSizeScale": {
+            "type": "number",
+            "default": 1.0,
+            "minimum": 0.5,
+            "maximum": 1.5,
+            "description": "Scale factor for the Output views font size relative to the editor font size. Accepts values between 0.5 and 1.5."
+          },
           "calva.fiddleFilePaths": {
             "type": "array",
             "markdownDescription": "An array of `source` and `fiddle` root paths, relative to the project root. This is used by the commands **Calva: Open Fiddle File for Current File**, and **Calva: Evaluate Fiddle File for Current File**. Example:\n\n```json\n\"calva.fiddleFilePaths\": [\n  {\n    \"source\": [\"src\"],\n    \"fiddle\": [\"env\", \"dev\", \"fiddles\"]\n  }\n]\n```\n\nThe default is `null`, which will make Calva associate files with a `.fiddle` file extension as the fiddle file for a Clojure file. E.g. a file `src/foo/bar/baz_main.cljc`, will have an associated fiddle file named `src/foo/bar/baz_main.fiddle`. See [calva.io/fiddle](https://calva.io/fiddle-files/) for more info.",
@@ -1830,6 +1837,21 @@
         "title": "Toggle REPL Output Word Wrap",
         "category": "Calva",
         "icon": "$(word-wrap)"
+      },
+      {
+        "command": "calva.increaseOutputViewFontSize",
+        "title": "Increase Output View Font Size",
+        "category": "Calva"
+      },
+      {
+        "command": "calva.decreaseOutputViewFontSize",
+        "title": "Decrease Output View Font Size",
+        "category": "Calva"
+      },
+      {
+        "command": "calva.resetOutputViewFontSize",
+        "title": "Reset Output View Font Size",
+        "category": "Calva"
       },
       {
         "command": "calva.interruptAllEvaluations",

--- a/repl-output-ui/css/main.css
+++ b/repl-output-ui/css/main.css
@@ -1,3 +1,14 @@
+:root {
+   --calva-output-font-scale: 1;
+}
+
+body,
+pre,
+code {
+   font-family: var(--vscode-editor-font-family, monospace);
+   font-size: calc(var(--vscode-editor-font-size, 12px) * var(--calva-output-font-scale, 1));
+}
+
 .output-element-container {
    padding-bottom: 5px;
 }
@@ -70,7 +81,7 @@ body.word-wrap code.hljs {
    margin-top: 14px;
    margin-bottom: 2px;
    font-family: var(--vscode-editor-font-family, monospace);
-   font-size: var(--vscode-editor-font-size, 12px);
+   font-size: calc(var(--vscode-editor-font-size, 12px) * var(--calva-output-font-scale, 1));
    line-height: 1.2;
 }
 

--- a/repl-output-ui/css/main.css
+++ b/repl-output-ui/css/main.css
@@ -2,9 +2,12 @@
    --calva-output-font-scale: 1;
 }
 
-body,
-pre,
-code {
+pre[data-output-element-type],
+.evaluated-code-container pre,
+.evaluated-code-container code,
+.output-element-container > pre,
+.output-element-container > pre > code,
+.ns-info-container {
    font-family: var(--vscode-editor-font-family, monospace);
    font-size: calc(var(--vscode-editor-font-size, 12px) * var(--calva-output-font-scale, 1));
 }
@@ -80,8 +83,6 @@ body.word-wrap code.hljs {
    gap: 4px;
    margin-top: 14px;
    margin-bottom: 2px;
-   font-family: var(--vscode-editor-font-family, monospace);
-   font-size: calc(var(--vscode-editor-font-size, 12px) * var(--calva-output-font-scale, 1));
    line-height: 1.2;
 }
 

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -32,6 +32,10 @@
                              :clearReplOutputView calva.repl.webview.core/clear-output-view
                              :toggleReplOutputWordWrap calva.repl.webview.core/toggle-word-wrap
                              :initReplOutputWordWrap calva.repl.webview.core/init-word-wrap!
+                             :increaseOutputViewFontSize calva.repl.webview.core/increase-font-size
+                             :decreaseOutputViewFontSize calva.repl.webview.core/decrease-font-size
+                             :resetOutputViewFontSize calva.repl.webview.core/reset-font-size
+                             :initReplOutputFontSizeScale calva.repl.webview.core/init-font-size-scale!
                              :createReplOutputSidebarProvider calva.repl.webview.sidebar/create-repl-output-sidebar-provider
                              :showReplOutputSidebar calva.repl.webview.sidebar/show-repl-output-sidebar
                              :appendToReplOutputSidebar calva.repl.webview.sidebar/append

--- a/src/cljs-lib/src/calva/repl/webview/app_db.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/app_db.cljs
@@ -12,7 +12,7 @@
   (let [base (or base-font-scale 1.0)
         adj (or font-size-adjustment 0.0)
         scale (+ base adj)]
-    (-> (max 0.2 (min 3.0 scale))
+    (-> (max 0.5 (min 1.5 scale))
         (* 100)
         js/Math.round
         (/ 100))))

--- a/src/cljs-lib/src/calva/repl/webview/app_db.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/app_db.cljs
@@ -1,9 +1,21 @@
 (ns calva.repl.webview.app-db)
 
 (def initial-db
-  {:output/last-context nil})
+  {:output/last-context nil
+   :output/base-font-scale 1.0
+   :output/font-size-adjustment 0.0})
 
 (defonce !app-db (atom initial-db))
+
+(defn compute-effective-scale
+  [{:output/keys [base-font-scale font-size-adjustment]}]
+  (let [base (or base-font-scale 1.0)
+        adj (or font-size-adjustment 0.0)
+        scale (+ base adj)]
+    (-> (max 0.2 (min 3.0 scale))
+        (* 100)
+        js/Math.round
+        (/ 100))))
 
 (defn handle-action
   [db [action-type payload]]
@@ -37,6 +49,27 @@
     :msg/set-word-wrap
     {:uf/db db
      :uf/fxs [[:fx/set-word-wrap (:word-wrap payload)]]}
+
+    :msg/set-base-font-scale
+    (let [new-db (assoc db :output/base-font-scale (:scale payload 1.0))
+          effective-scale (compute-effective-scale new-db)]
+      {:uf/db new-db
+       :uf/fxs [[:fx/set-font-scale effective-scale]]})
+
+    :msg/adjust-font-size
+    (let [delta (:delta payload 0.1)
+          current-adj (or (:output/font-size-adjustment db) 0.0)
+          new-adj (+ current-adj delta)
+          new-db (assoc db :output/font-size-adjustment new-adj)
+          effective-scale (compute-effective-scale new-db)]
+      {:uf/db new-db
+       :uf/fxs [[:fx/set-font-scale effective-scale]]})
+
+    :msg/reset-font-size
+    (let [new-db (assoc db :output/font-size-adjustment 0.0)
+          effective-scale (compute-effective-scale new-db)]
+      {:uf/db new-db
+       :uf/fxs [[:fx/set-font-scale effective-scale]]})
 
     :msg/scroll-to
     {:uf/db db

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -86,7 +86,7 @@
   []
   (if-let [vscode @util/vscode]
     (let [setting (.. ^js vscode -workspace (getConfiguration "calva") (get "outputViews.fontSizeScale"))]
-      (if (number? setting) setting 1.0))
+      (if (and (number? setting) (js/isFinite setting)) setting 1.0))
     1.0))
 
 (defn post-font-scale-to-all-views!

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -82,6 +82,46 @@
     (when-let [listener (create-word-wrap-change-listener)]
       (.. ^js vscode-context -subscriptions (push listener)))))
 
+(defn get-output-views-font-scale-setting
+  []
+  (if-let [vscode @util/vscode]
+    (let [setting (.. ^js vscode -workspace (getConfiguration "calva") (get "outputViews.fontSizeScale"))]
+      (if (number? setting) setting 1.0))
+    1.0))
+
+(defn post-font-scale-to-all-views!
+  [msg]
+  (run! #(post-message-to-webview % msg) @registered-webviews))
+
+(defn ^:export increase-font-size
+  []
+  (post-font-scale-to-all-views! {:command/name "adjust-font-size" :delta 0.1}))
+
+(defn ^:export decrease-font-size
+  []
+  (post-font-scale-to-all-views! {:command/name "adjust-font-size" :delta -0.1}))
+
+(defn ^:export reset-font-size
+  []
+  (post-font-scale-to-all-views! {:command/name "reset-font-size"}))
+
+(defn create-font-scale-change-listener
+  []
+  (when-let [vscode @util/vscode]
+    (.. ^js vscode -workspace
+        (onDidChangeConfiguration
+         (fn [^js event]
+           (when (.affectsConfiguration event "calva.outputViews.fontSizeScale")
+             (post-font-scale-to-all-views!
+              {:command/name "set-base-font-scale"
+               :scale (get-output-views-font-scale-setting)})))))))
+
+(defn ^:export init-font-size-scale!
+  []
+  (when-let [vscode-context @util/vscode-context]
+    (when-let [listener (create-font-scale-change-listener)]
+      (.. ^js vscode-context -subscriptions (push listener)))))
+
 (def highlight-js-code-theme-stylesheet-data
   [["dark" "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css"]
    ["light" "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css"]
@@ -124,10 +164,10 @@
 ;; dev workflow to function properly
 
 (defn get-webview-html
-  [{:env/keys [is-debug]} {:keys [js-source css-href csp-source code-theme greeting-html word-wrap?]}]
+  [{:env/keys [is-debug]} {:keys [js-source css-href csp-source code-theme greeting-html word-wrap? font-scale]}]
   (str "
 <!DOCTYPE html>
-<html lang=\"en\">
+<html lang=\"en\" style=\"--calva-output-font-scale: " (or font-scale 1.0) ";\">
   <head>
     <meta charset=\"UTF-8\" />
 
@@ -196,7 +236,8 @@
                                                 :csp-source csp-source
                                                 :code-theme (code-theme-from-context context)
                                                 :greeting-html greeting-html
-                                                :word-wrap? (word-wrap?)})]
+                                                :word-wrap? (word-wrap?)
+                                                :font-scale (get-output-views-font-scale-setting)})]
     (set! (.. webview-panel -webview -html) webview-html)))
 
 (defn set-code-theme!

--- a/src/cljs-lib/src/calva/repl/webview/core.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/core.cljs
@@ -23,11 +23,22 @@
       (not= "off" setting))
     false))
 
+(defn get-output-views-word-wrap-setting
+  []
+  (if-let [vscode @util/vscode]
+    (let [setting (.. ^js vscode -workspace (getConfiguration "calva") (get "outputViews.wordWrap"))]
+      (case setting
+        "on" true
+        "off" false
+        "follow-editor" (get-editor-word-wrap-setting)
+        (get-editor-word-wrap-setting)))
+    false))
+
 (defn word-wrap?
   []
   (if (some? @word-wrap-override)
     @word-wrap-override
-    (get-editor-word-wrap-setting)))
+    (get-output-views-word-wrap-setting)))
 
 (defn set-word-wrap-context!
   [wrap?]
@@ -69,7 +80,8 @@
     (.. ^js vscode -workspace
         (onDidChangeConfiguration
          (fn [^js event]
-           (when (.affectsConfiguration event "editor.wordWrap")
+           (when (or (.affectsConfiguration event "editor.wordWrap")
+                     (.affectsConfiguration event "calva.outputViews.wordWrap"))
              (reset! word-wrap-override nil)
              (let [wrap? (word-wrap?)]
                (set-word-wrap-context! wrap?)

--- a/src/cljs-lib/src/calva/repl/webview/ui.cljs
+++ b/src/cljs-lib/src/calva/repl/webview/ui.cljs
@@ -185,6 +185,10 @@
       (.. body -classList (add "word-wrap"))
       (.. body -classList (remove "word-wrap")))))
 
+(defn set-font-scale!
+  [scale]
+  (.. js/document -documentElement -style (setProperty "--calva-output-font-scale" (str scale))))
+
 (defn scroll-to
   [{:keys [x y]}]
   (js/scrollTo x y))
@@ -199,6 +203,7 @@
     :fx/clear-dom (clear-output-dom output-dom-element)
     :fx/set-code-theme (set-code-theme! (first args))
     :fx/set-word-wrap (set-word-wrap! (first args))
+    :fx/set-font-scale (set-font-scale! (first args))
     :fx/scroll-to (scroll-to (first args))))
 
 (defn dispatch!
@@ -221,10 +226,13 @@
      (let [message-data (reader/read-string (.-data message))
            command-name (:command/name message-data)]
        (case command-name
-         "clear-output-view" (dispatch! [:msg/clear-output-view])
-         "set-code-theme"    (dispatch! [:msg/set-code-theme message-data])
-         "set-word-wrap"     (dispatch! [:msg/set-word-wrap message-data])
-         "scroll-to"         (dispatch! [:msg/scroll-to message-data])
+         "clear-output-view"    (dispatch! [:msg/clear-output-view])
+         "set-code-theme"       (dispatch! [:msg/set-code-theme message-data])
+         "set-word-wrap"        (dispatch! [:msg/set-word-wrap message-data])
+         "set-base-font-scale"  (dispatch! [:msg/set-base-font-scale message-data])
+         "adjust-font-size"     (dispatch! [:msg/adjust-font-size message-data])
+         "reset-font-size"      (dispatch! [:msg/reset-font-size message-data])
+         "scroll-to"            (dispatch! [:msg/scroll-to message-data])
          ("show-result" "show-evaluated-code" "show-stdout")
          (dispatch! [:msg/output message-data]))))))
 

--- a/src/cljs-lib/test/calva/repl/webview/app_db_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/app_db_test.cljs
@@ -63,11 +63,11 @@
   (testing "defaults missing keys to 1.0 and 0.0"
     (is (= 1.0 (sut/compute-effective-scale {}))))
 
-  (testing "clamps to a minimum of 0.2"
-    (is (= 0.2 (sut/compute-effective-scale {:output/base-font-scale 0.1 :output/font-size-adjustment -1.0}))))
+  (testing "clamps to a minimum of 0.5"
+    (is (= 0.5 (sut/compute-effective-scale {:output/base-font-scale 0.4 :output/font-size-adjustment -0.5}))))
 
-  (testing "clamps to a maximum of 3.0"
-    (is (= 3.0 (sut/compute-effective-scale {:output/base-font-scale 2.5 :output/font-size-adjustment 1.0}))))
+  (testing "clamps to a maximum of 1.5"
+    (is (= 1.5 (sut/compute-effective-scale {:output/base-font-scale 1.4 :output/font-size-adjustment 0.5}))))
 
   (testing "rounds to two decimal places"
     (is (= 1.23 (sut/compute-effective-scale {:output/base-font-scale 1.0 :output/font-size-adjustment 0.234})))))

--- a/src/cljs-lib/test/calva/repl/webview/app_db_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/app_db_test.cljs
@@ -55,3 +55,52 @@
     (let [result (sut/handle-action sut/initial-db [:msg/scroll-to {:x 0 :y 100}])]
       (is (= sut/initial-db (:uf/db result)))
       (is (= [[:fx/scroll-to {:x 0 :y 100}]] (:uf/fxs result))))))
+
+(deftest compute-effective-scale-test
+  (testing "combines base scale and adjustment"
+    (is (= 1.1 (sut/compute-effective-scale {:output/base-font-scale 1.0 :output/font-size-adjustment 0.1}))))
+
+  (testing "defaults missing keys to 1.0 and 0.0"
+    (is (= 1.0 (sut/compute-effective-scale {}))))
+
+  (testing "clamps to a minimum of 0.2"
+    (is (= 0.2 (sut/compute-effective-scale {:output/base-font-scale 0.1 :output/font-size-adjustment -1.0}))))
+
+  (testing "clamps to a maximum of 3.0"
+    (is (= 3.0 (sut/compute-effective-scale {:output/base-font-scale 2.5 :output/font-size-adjustment 1.0}))))
+
+  (testing "rounds to two decimal places"
+    (is (= 1.23 (sut/compute-effective-scale {:output/base-font-scale 1.0 :output/font-size-adjustment 0.234})))))
+
+(deftest set-base-font-scale-test
+  (testing ":msg/set-base-font-scale sets the base scale and returns the effective scale fx"
+    (let [result (sut/handle-action sut/initial-db [:msg/set-base-font-scale {:scale 1.5}])]
+      (is (= 1.5 (get-in result [:uf/db :output/base-font-scale])))
+      (is (= [[:fx/set-font-scale 1.5]] (:uf/fxs result)))))
+
+  (testing "defaults to 1.0 when no scale is given"
+    (let [result (sut/handle-action sut/initial-db [:msg/set-base-font-scale {}])]
+      (is (= 1.0 (get-in result [:uf/db :output/base-font-scale])))
+      (is (= [[:fx/set-font-scale 1.0]] (:uf/fxs result))))))
+
+(deftest adjust-font-size-test
+  (testing ":msg/adjust-font-size increases the adjustment by the given delta"
+    (let [result (sut/handle-action sut/initial-db [:msg/adjust-font-size {:delta 0.1}])]
+      (is (= 0.1 (get-in result [:uf/db :output/font-size-adjustment])))
+      (is (= [[:fx/set-font-scale 1.1]] (:uf/fxs result)))))
+
+  (testing "accumulates on top of an existing adjustment"
+    (let [db (assoc sut/initial-db :output/font-size-adjustment 0.2)
+          result (sut/handle-action db [:msg/adjust-font-size {:delta 0.1}])]
+      (is (< (js/Math.abs (- 0.3 (get-in result [:uf/db :output/font-size-adjustment]))) 0.0001))))
+
+  (testing "defaults to a delta of 0.1 when none given"
+    (let [result (sut/handle-action sut/initial-db [:msg/adjust-font-size {}])]
+      (is (= 0.1 (get-in result [:uf/db :output/font-size-adjustment]))))))
+
+(deftest reset-font-size-test
+  (testing ":msg/reset-font-size resets the adjustment to 0.0"
+    (let [db (assoc sut/initial-db :output/font-size-adjustment 0.5)
+          result (sut/handle-action db [:msg/reset-font-size {}])]
+      (is (= 0.0 (get-in result [:uf/db :output/font-size-adjustment])))
+      (is (= [[:fx/set-font-scale 1.0]] (:uf/fxs result))))))

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -615,11 +615,14 @@
   (testing "returns 1.0 when VS Code is not available"
     (with-redefs [util/vscode (atom nil)]
       (is (= 1.0 (sut/get-output-views-font-scale-setting)))))
-  (testing "returns the configured setting when it is a number"
+  (testing "returns the configured setting when it is a valid number"
     (with-redefs [util/vscode (atom (vscode-with-font-scale-setting 1.5))]
       (is (= 1.5 (sut/get-output-views-font-scale-setting)))))
-  (testing "returns 1.0 when the configured setting is not a number"
+  (testing "returns 1.0 when the configured setting is nil"
     (with-redefs [util/vscode (atom (vscode-with-font-scale-setting nil))]
+      (is (= 1.0 (sut/get-output-views-font-scale-setting)))))
+  (testing "returns 1.0 when the configured setting is NaN"
+    (with-redefs [util/vscode (atom (vscode-with-font-scale-setting js/NaN))]
       (is (= 1.0 (sut/get-output-views-font-scale-setting))))))
 
 (deftest increase-font-size-test

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -42,14 +42,37 @@
         (sut/unregister-webview! webview-a)
         (is (= #{webview-b} @sut/registered-webviews))))))
 
-(deftest word-wrap-test
-  (testing "uses the editor wordWrap setting when there is no override"
-    (with-redefs [sut/word-wrap-override (atom nil)
+(defn vscode-with-output-views-word-wrap-setting
+  [setting]
+  #js {:workspace #js {:getConfiguration (fn [_section] #js {:get (fn [_setting] setting)})}})
+
+(deftest get-output-views-word-wrap-setting-test
+  (testing "returns true when setting is \"on\""
+    (with-redefs [util/vscode (atom (vscode-with-output-views-word-wrap-setting "on"))]
+      (is (true? (sut/get-output-views-word-wrap-setting)))))
+  (testing "returns false when setting is \"off\""
+    (with-redefs [util/vscode (atom (vscode-with-output-views-word-wrap-setting "off"))]
+      (is (false? (sut/get-output-views-word-wrap-setting)))))
+  (testing "follows the editor word wrap setting when setting is \"follow-editor\""
+    (with-redefs [util/vscode (atom (vscode-with-output-views-word-wrap-setting "follow-editor"))
                   sut/get-editor-word-wrap-setting (constantly true)]
+      (is (true? (sut/get-output-views-word-wrap-setting)))))
+  (testing "follows the editor word wrap setting when the setting is not present"
+    (with-redefs [util/vscode (atom (vscode-with-output-views-word-wrap-setting nil))
+                  sut/get-editor-word-wrap-setting (constantly true)]
+      (is (true? (sut/get-output-views-word-wrap-setting)))))
+  (testing "returns false when VS Code is not available"
+    (with-redefs [util/vscode (atom nil)]
+      (is (false? (sut/get-output-views-word-wrap-setting))))))
+
+(deftest word-wrap-test
+  (testing "uses get-output-views-word-wrap-setting when there is no override"
+    (with-redefs [sut/word-wrap-override (atom nil)
+                  sut/get-output-views-word-wrap-setting (constantly true)]
       (is (true? (sut/word-wrap?)))))
   (testing "uses override when present"
     (with-redefs [sut/word-wrap-override (atom false)
-                  sut/get-editor-word-wrap-setting (constantly true)]
+                  sut/get-output-views-word-wrap-setting (constantly true)]
       (is (false? (sut/word-wrap?))))))
 
 (deftest get-editor-word-wrap-setting-test

--- a/src/cljs-lib/test/calva/repl/webview/core_test.cljs
+++ b/src/cljs-lib/test/calva/repl/webview/core_test.cljs
@@ -112,7 +112,20 @@
                                        {:js-source "js-source"
                                         :css-href "css-href"
                                         :csp-source "csp-source"
-                                        :word-wrap? false})))))
+                                        :word-wrap? false}))))
+  (testing "Given a font-scale, should set the font scale css variable on the html element"
+    (is (re-find #"<html lang=\"en\" style=\"--calva-output-font-scale: 1.25;\">"
+                 (sut/get-webview-html {:env/is-debug false}
+                                       {:js-source "js-source"
+                                        :css-href "css-href"
+                                        :csp-source "csp-source"
+                                        :font-scale 1.25}))))
+  (testing "Given no font-scale, should default the font scale css variable to 1"
+    (is (re-find #"<html lang=\"en\" style=\"--calva-output-font-scale: 1;\">"
+                 (sut/get-webview-html {:env/is-debug false}
+                                       {:js-source "js-source"
+                                        :css-href "css-href"
+                                        :csp-source "csp-source"})))))
 
 (deftest get-js-source-test
   (testing "Given a context and a webview-panel,"
@@ -156,6 +169,7 @@
                     greeting/logo-webview-uri (constantly "some-logo-href")
                     greeting/html-for-view (constantly "some-greeting")
                     sut/word-wrap? (constantly true)
+                    sut/get-output-views-font-scale-setting (constantly 1.5)
                     sut/get-webview-html (test-util/wrap-spy get-webview-html-spy)]
         (sut/set-webview-html! context {:webview-panel webview-panel})
         (testing "should call get-js-source with expected args"
@@ -170,7 +184,8 @@
                                                                    :csp-source "some-csp-source"
                                                                    :code-theme nil
                                                                    :greeting-html "some-greeting"
-                                                                   :word-wrap? true})))
+                                                                   :word-wrap? true
+                                                                   :font-scale 1.5})))
         (testing "should set webview html to result of call to get-webview-html"
           (is (= "some-html" (.. webview-panel -webview -html))))))))
 
@@ -591,3 +606,63 @@
         (is (spy/not-called? post-message-to-webview-spy))))))
 
 #_(run-tests)
+
+(defn vscode-with-font-scale-setting
+  [setting]
+  #js {:workspace #js {:getConfiguration (fn [_section] #js {:get (fn [_setting] setting)})}})
+
+(deftest get-output-views-font-scale-setting-test
+  (testing "returns 1.0 when VS Code is not available"
+    (with-redefs [util/vscode (atom nil)]
+      (is (= 1.0 (sut/get-output-views-font-scale-setting)))))
+  (testing "returns the configured setting when it is a number"
+    (with-redefs [util/vscode (atom (vscode-with-font-scale-setting 1.5))]
+      (is (= 1.5 (sut/get-output-views-font-scale-setting)))))
+  (testing "returns 1.0 when the configured setting is not a number"
+    (with-redefs [util/vscode (atom (vscode-with-font-scale-setting nil))]
+      (is (= 1.0 (sut/get-output-views-font-scale-setting))))))
+
+(deftest increase-font-size-test
+  (testing "posts an adjust-font-size message with a positive delta to all registered webviews"
+    (let [post-message-to-webview-spy (spy/spy)
+          webview-a #js {}
+          webview-b #js {}]
+      (with-redefs [sut/registered-webviews (atom #{webview-a webview-b})
+                    sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)]
+        (sut/increase-font-size)
+        (let [calls (spy/calls post-message-to-webview-spy)]
+          (is (= 2 (count calls)))
+          (is (every? #(= {:command/name "adjust-font-size" :delta 0.1} (second %)) calls)))))))
+
+(deftest decrease-font-size-test
+  (testing "posts an adjust-font-size message with a negative delta to all registered webviews"
+    (let [post-message-to-webview-spy (spy/spy)
+          webview-a #js {}]
+      (with-redefs [sut/registered-webviews (atom #{webview-a})
+                    sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)]
+        (sut/decrease-font-size)
+        (is (spy/called-once-with? post-message-to-webview-spy webview-a {:command/name "adjust-font-size" :delta -0.1}))))))
+
+(deftest reset-font-size-test
+  (testing "posts a reset-font-size message to all registered webviews"
+    (let [post-message-to-webview-spy (spy/spy)
+          webview-a #js {}]
+      (with-redefs [sut/registered-webviews (atom #{webview-a})
+                    sut/post-message-to-webview (test-util/wrap-spy post-message-to-webview-spy)]
+        (sut/reset-font-size)
+        (is (spy/called-once-with? post-message-to-webview-spy webview-a {:command/name "reset-font-size"}))))))
+
+(deftest init-font-size-scale!-test
+  (testing "registers a configuration change listener as a subscription"
+    (let [push-spy (spy/spy)
+          vscode-context-stub #js {:subscriptions #js {:push (test-util/wrap-spy push-spy)}}]
+      (with-redefs [util/vscode-context (atom vscode-context-stub)
+                    sut/create-font-scale-change-listener (constantly "some-listener")]
+        (sut/init-font-size-scale!)
+        (is (spy/called-once-with? push-spy "some-listener")))))
+  (testing "does nothing when there is no vscode-context"
+    (let [push-spy (spy/spy)]
+      (with-redefs [util/vscode-context (atom nil)
+                    sut/create-font-scale-change-listener (test-util/wrap-spy push-spy)]
+        (sut/init-font-size-scale!)
+        (is (spy/not-called? push-spy))))))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,6 +90,7 @@ async function activate(context: vscode.ExtensionContext) {
   // We cannot run unit tests on code that imports the vscode API, because it's only available at runtime.
   cljsLib.initializeCljs(vscode, context);
   cljsLib.initReplOutputWordWrap();
+  cljsLib.initReplOutputFontSizeScale();
 
   initializeState();
   output.registerOutputTerminalLifecycle(context);
@@ -242,6 +243,9 @@ async function activate(context: vscode.ExtensionContext) {
     clearReplOutputView: cljsLib.clearReplOutputView,
     clearReplOutputSidebar: cljsLib.clearReplOutputSidebar,
     toggleReplOutputWordWrap: cljsLib.toggleReplOutputWordWrap,
+    increaseOutputViewFontSize: cljsLib.increaseOutputViewFontSize,
+    decreaseOutputViewFontSize: cljsLib.decreaseOutputViewFontSize,
+    resetOutputViewFontSize: cljsLib.resetOutputViewFontSize,
     clearReplHistory: replHistory.clearHistory,
     connect: connector.connectCommand,
     connectNonProjectREPL: () => {


### PR DESCRIPTION
* Fixes #3276

## What has changed?

Makes the output view follow the editor font size, and adds a setting for scaling that font size between 0.5 -> 1.5. Plus commands for adjusting the scaling in-session.

Also adding a setting for word-wrap, so that this preference can be persisted, while keeping the in-session toggle.

## My Calva PR Checklist

I have:

- [x] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [x] Directed this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [x] Made sure I have changed the PR base branch, so that it is not `published`. (Sorry for the nagging.)
- [x] Made sure there is an issue registered with a clear problem statement that this PR addresses, (created the issue if it was not present).
    - [x] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.
- [x] Figured if **anything** about the fix warrants tests on Mac/Linux/Windows/Remote/Whatever, and either tested it there if so, or mentioned it in the PR.
- [x] Added to or updated docs in this branch, if appropriate
- [x] Tests
  - [x] Tested the particular change
  - [x] Figured if the change might have some side effects and tested those as well.
- [x] Formatted all JavaScript and TypeScript code that was changed. (use the [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or run `npm run prettier-format`)
- [x] Confirmed that there are no linter warnings or errors (use the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), run `npm run eslint` before creating your PR, or run `npm run eslint-watch` to eslint as you go).

